### PR TITLE
feat: compute REF cross-reference results from bookmarks and numbering

### DIFF
--- a/.changeset/ref-fields-live-results.md
+++ b/.changeset/ref-fields-live-results.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': minor
+---
+
+REF cross-reference fields now compute their results live from the bookmark target and the resolved numbering, so references such as "Section 1.2" track renumbering edits instead of painting the saved result forever. Fixes #601.

--- a/packages/core/src/layout/__tests__/field-ref-layout.test.ts
+++ b/packages/core/src/layout/__tests__/field-ref-layout.test.ts
@@ -260,3 +260,75 @@ describe('a renumbering edit repaints dependent REF fields incrementally', () =>
     expect(layoutSemanticDocument(part, 2, options).pages).toBe(first.pages);
   });
 });
+
+/** The standard legal shape: deep levels state only their own placeholder. */
+const LEGAL_NUMBERING = `
+  <w:abstractNum w:abstractNumId="1">
+    <w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/>
+      <w:lvlText w:val="%1."/><w:lvlJc w:val="left"/></w:lvl>
+    <w:lvl w:ilvl="1"><w:start w:val="1"/><w:numFmt w:val="decimal"/>
+      <w:lvlText w:val="%1.%2"/><w:lvlJc w:val="left"/></w:lvl>
+    <w:lvl w:ilvl="2"><w:start w:val="1"/><w:numFmt w:val="lowerLetter"/>
+      <w:lvlText w:val="(%3)"/><w:lvlJc w:val="left"/></w:lvl>
+    <w:lvl w:ilvl="3"><w:start w:val="1"/><w:numFmt w:val="lowerRoman"/>
+      <w:lvlText w:val="(%4)"/><w:lvlJc w:val="left"/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="9"><w:abstractNumId w:val="1"/></w:num>
+`;
+
+function legalNumberingIndexOf() {
+  const result = readOoxmlPart(`<w:numbering xmlns:w="${W}">${LEGAL_NUMBERING}</w:numbering>`, {
+    name: '/word/numbering.xml',
+    contentType: 'application/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return buildNumberingIndex(result.part.root);
+}
+const legalNumberingIndex = legalNumberingIndexOf();
+
+const legalNumbered = (ilvl: number, inner: string) =>
+  `<w:p><w:pPr><w:numPr><w:ilvl w:val="${ilvl}"/><w:numId w:val="9"/></w:numPr></w:pPr>${inner}</w:p>`;
+
+describe('self-oracle: on an unedited document the live value equals the cached result', () => {
+  // Word's own cached results for the two deep targets are `1.2(c)` and `1.2(c)(ii)`. The
+  // live path replaces them — with the SAME strings, because nothing has been edited. Any
+  // divergence here is a composition bug, not a stale cache.
+  const chain =
+    legalNumbered(0, '<w:r><w:t>Article</w:t></w:r>') +
+    legalNumbered(1, '<w:r><w:t>1.1</w:t></w:r>') +
+    legalNumbered(1, '<w:r><w:t>1.2</w:t></w:r>') +
+    legalNumbered(2, '<w:r><w:t>(a)</w:t></w:r>') +
+    legalNumbered(2, '<w:r><w:t>(b)</w:t></w:r>') +
+    legalNumbered(2, bookmarked('clause', 'Clause')) +
+    legalNumbered(3, '<w:r><w:t>(i)</w:t></w:r>') +
+    legalNumbered(3, bookmarked('item', 'Item'));
+
+  test('deep \\w and \\r values reproduce the authored caches exactly', () => {
+    const layout = layoutSemanticDocument(
+      load(
+        chain +
+          refParagraph(' REF clause \\w \\h ', '1.2(c)') +
+          refParagraph(' REF item \\r \\h \\* MERGEFORMAT ', '1.2(c)(ii)')
+      ),
+      1,
+      { measurer, numberingIndex: legalNumberingIndex }
+    );
+    const texts = textsOf(layout);
+    expect(texts).toContain('see 1.2(c)');
+    expect(texts).toContain('see 1.2(c)(ii)');
+  });
+
+  test('after a renumbering edit the live value wins over the now-stale cache', () => {
+    // Dropping the `(a)` clause shifts the target from `(c)` to `(b)`; the cache still says
+    // `1.2(c)` and must lose.
+    const edited = chain.replace(legalNumbered(2, '<w:r><w:t>(a)</w:t></w:r>'), '');
+    const layout = layoutSemanticDocument(
+      load(edited + refParagraph(' REF clause \\w \\h ', '1.2(c)')),
+      1,
+      { measurer, numberingIndex: legalNumberingIndex }
+    );
+    const texts = textsOf(layout);
+    expect(texts).toContain('see 1.2(b)');
+    expect(texts.join('|')).not.toContain('1.2(c)');
+  });
+});

--- a/packages/core/src/layout/__tests__/field-ref-layout.test.ts
+++ b/packages/core/src/layout/__tests__/field-ref-layout.test.ts
@@ -1,0 +1,262 @@
+// REF fields through full layout: live values from bookmark targets and resolved numbering.
+//
+// The stale-cache scenario this pins: a REF field's paragraph is byte-identical after a
+// renumbering edit elsewhere — its node, width and producer all validate every other memo —
+// so only the resolved-value token in its cache and flow keys can repaint it. The sharp test
+// below edits the tree the way the store does (structural sharing: every unchanged node kept
+// BY IDENTITY) and compares the warm session pass against a cold oracle.
+
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, type OoxmlElement, type OoxmlPart } from '@docx-editor.dev/core/store';
+import { createFixedMeasurer, layoutSemanticDocument } from '../semantic-layout.ts';
+import { createLayoutSession } from '../layout-session.ts';
+import { createParagraphLayoutCache } from '../layout-cache.ts';
+import { paragraphFragmentsOf } from '../index.ts';
+import type { SemanticLayout } from '../index.ts';
+import { buildNumberingIndex } from '../numbering-index.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const measurer = createFixedMeasurer(6, 14);
+
+const NUMBERING = `
+  <w:abstractNum w:abstractNumId="0">
+    <w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/>
+      <w:lvlText w:val="%1."/><w:lvlJc w:val="left"/></w:lvl>
+    <w:lvl w:ilvl="1"><w:start w:val="1"/><w:numFmt w:val="decimal"/>
+      <w:lvlText w:val="%1.%2"/><w:lvlJc w:val="left"/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="5"><w:abstractNumId w:val="0"/></w:num>
+`;
+
+function numberingIndexOf() {
+  const result = readOoxmlPart(`<w:numbering xmlns:w="${W}">${NUMBERING}</w:numbering>`, {
+    name: '/word/numbering.xml',
+    contentType: 'application/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return buildNumberingIndex(result.part.root);
+}
+const numberingIndex = numberingIndexOf();
+
+function load(body: string): OoxmlPart {
+  const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'application/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+const numbered = (inner: string) =>
+  `<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="5"/></w:numPr></w:pPr>${inner}</w:p>`;
+const bookmarked = (name: string, text: string) =>
+  `<w:bookmarkStart w:id="1" w:name="${name}"/><w:r><w:t>${text}</w:t></w:r>` +
+  `<w:bookmarkEnd w:id="1"/>`;
+/** A complex REF with a deliberately stale cached result. */
+const refField = (instr: string, cached = 'stale') =>
+  '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+  `<w:r><w:instrText>${instr}</w:instrText></w:r>` +
+  '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+  `<w:r><w:t>${cached}</w:t></w:r>` +
+  '<w:r><w:fldChar w:fldCharType="end"/></w:r>';
+const refParagraph = (instr: string, cached = 'stale') =>
+  `<w:p><w:r><w:t>see </w:t></w:r>${refField(instr, cached)}</w:p>`;
+
+/** Every fragment's text per page — what a reader sees, independent of node identity. */
+const shapeOf = (layout: SemanticLayout): unknown =>
+  layout.pages.map((page) =>
+    paragraphFragmentsOf(page).map((fragment) => ({
+      y: fragment.box.y,
+      text: fragment.lines
+        .flatMap((line) => line.spans.map((span) => span.text))
+        .join('')
+        .trim(),
+    }))
+  );
+
+const textsOf = (layout: SemanticLayout): string[] =>
+  layout.pages.flatMap((page) =>
+    paragraphFragmentsOf(page).map((fragment) =>
+      fragment.lines
+        .flatMap((line) => line.spans.map((span) => span.text))
+        .join('')
+        .trim()
+    )
+  );
+
+function layoutOf(body: string): SemanticLayout {
+  return layoutSemanticDocument(load(body), 1, { measurer, numberingIndex });
+}
+
+describe('complex REF fields resolve live in body layout', () => {
+  test('a number-switch REF paints the resolved number over the stale cache', () => {
+    const layout = layoutOf(
+      numbered(bookmarked('_RefA', 'First')) +
+        numbered(bookmarked('_RefB', 'Second')) +
+        refParagraph(' REF _RefB \\r \\h \\* MERGEFORMAT ', '9.9')
+    );
+    expect(textsOf(layout)).toContain('see 2');
+    expect(textsOf(layout).join('|')).not.toContain('9.9');
+  });
+
+  test('an instruction split across several w:instrText runs still resolves', () => {
+    const split =
+      '<w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+      '<w:r><w:instrText> REF _Re</w:instrText></w:r>' +
+      '<w:r><w:instrText>fB \\r </w:instrText></w:r>' +
+      '<w:r><w:instrText>\\* MERGEFORMAT </w:instrText></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+      '<w:r><w:t>9.9</w:t></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>';
+    const layout = layoutOf(
+      numbered(bookmarked('_RefA', 'First')) + numbered(bookmarked('_RefB', 'Second')) + split
+    );
+    expect(textsOf(layout)).toContain('2');
+  });
+
+  test('a plain REF paints the bookmarked text', () => {
+    const layout = layoutOf(
+      `<w:p><w:r><w:t>The </w:t></w:r>${bookmarked('term', 'Closing Date')}` +
+        `<w:r><w:t> occurs.</w:t></w:r></w:p>` +
+        refParagraph(' REF term ')
+    );
+    expect(textsOf(layout)).toContain('see Closing Date');
+  });
+
+  test('missing bookmark, unnumbered target and unknown switch keep the cached result', () => {
+    const layout = layoutOf(
+      `<w:p>${bookmarked('plain', 'unnumbered')}</w:p>` +
+        refParagraph(' REF _Nope \\r ', 'kept-a') +
+        refParagraph(' REF plain \\r ', 'kept-b') +
+        refParagraph(' REF plain \\p ', 'kept-c')
+    );
+    const texts = textsOf(layout);
+    expect(texts).toContain('see kept-a');
+    expect(texts).toContain('see kept-b');
+    expect(texts).toContain('see kept-c');
+  });
+
+  test('\\n paints the number without its trailing period', () => {
+    const layout = layoutOf(
+      numbered(bookmarked('one', 'First')) + refParagraph(' REF one \\n ', '7')
+    );
+    expect(textsOf(layout)).toContain('see 1');
+  });
+});
+
+describe('w:fldSimple REF fields resolve live', () => {
+  test('the simple shape replaces its stale cached display', () => {
+    const layout = layoutOf(
+      numbered(bookmarked('_RefA', 'First')) +
+        numbered(bookmarked('_RefB', 'Second')) +
+        '<w:p><w:fldSimple w:instr=" REF _RefB \\r \\h "><w:r><w:t>9.9</w:t></w:r></w:fldSimple></w:p>'
+    );
+    expect(textsOf(layout)).toContain('2');
+    expect(textsOf(layout).join('|')).not.toContain('9.9');
+  });
+
+  test('an unsupported simple REF keeps its cached display', () => {
+    const layout = layoutOf(
+      numbered(bookmarked('_RefA', 'First')) +
+        '<w:p><w:fldSimple w:instr=" REF _RefA \\p "><w:r><w:t>cached</w:t></w:r></w:fldSimple></w:p>'
+    );
+    expect(textsOf(layout)).toContain('cached');
+  });
+});
+
+describe('a REF inside a table cell resolves live', () => {
+  test('cell paragraphs project the resolved number', () => {
+    const table =
+      '<w:tbl><w:tblPr/><w:tblGrid><w:gridCol w:w="4000"/></w:tblGrid>' +
+      '<w:tr><w:tc><w:tcPr/>' +
+      refParagraph(' REF _RefB \\r ', '9.9') +
+      '</w:tc></w:tr></w:tbl>';
+    const layout = layoutOf(
+      numbered(bookmarked('_RefA', 'First')) + numbered(bookmarked('_RefB', 'Second')) + table
+    );
+    expect(textsOf(layout)).toContain('see 2');
+  });
+});
+
+/**
+ * Replace the body's block list while keeping every surviving node BY IDENTITY — the shape a
+ * `TreeDocumentStore` commit publishes, and the one that can leave per-node memos stale.
+ */
+function withBlocks(
+  part: OoxmlPart,
+  edit: (blocks: readonly OoxmlElement[]) => readonly OoxmlElement[]
+): OoxmlPart {
+  const body = part.root.children.find(
+    (child): child is OoxmlElement => child.kind !== 'textValue' && child.localName === 'body'
+  )!;
+  const blocks = body.children.filter(
+    (child): child is OoxmlElement => child.kind === 'paragraph' || child.kind === 'table'
+  );
+  const edited = edit(blocks);
+  const nextChildren = [
+    ...edited,
+    ...body.children.filter(
+      (child) =>
+        child.kind === 'textValue' || (child.kind !== 'paragraph' && child.kind !== 'table')
+    ),
+  ];
+  const nextBody = { ...body, children: nextChildren } as OoxmlElement;
+  const nextRoot = {
+    ...part.root,
+    children: part.root.children.map((child) => (child === body ? nextBody : child)),
+  } as OoxmlElement;
+  return { ...part, root: nextRoot };
+}
+
+describe('a renumbering edit repaints dependent REF fields incrementally', () => {
+  // The REF paragraph comes FIRST and never changes: its node survives the edit by identity,
+  // so every memo keyed on it (prepared block, break cache, flow key) would happily serve the
+  // pre-edit value. Removing a numbered paragraph BELOW it renumbers the target from 2 to 1.
+  const body =
+    refParagraph(' REF target \\r ', '9.9') +
+    numbered('<w:r><w:t>gone soon</w:t></w:r>') +
+    numbered(bookmarked('target', 'The section')) +
+    '<w:p><w:r><w:t>tail</w:t></w:r></w:p>';
+
+  test('the warm session pass equals the cold oracle after the edit', () => {
+    const before = load(body);
+    const options = {
+      measurer,
+      numberingIndex,
+      session: createLayoutSession(),
+      cache: createParagraphLayoutCache(),
+    };
+    const first = layoutSemanticDocument(before, 1, options);
+    expect(textsOf(first)).toContain('see 2');
+
+    const after = withBlocks(before, (blocks) => blocks.filter((_, index) => index !== 1));
+    // The REF paragraph node really is the same object — the hazard under test.
+    expect(after.root === before.root).toBe(false);
+    const warm = layoutSemanticDocument(after, 2, options);
+    const oracle = layoutSemanticDocument(after, 1, { measurer, numberingIndex });
+    expect(shapeOf(warm)).toEqual(shapeOf(oracle));
+    expect(textsOf(warm)).toContain('see 1');
+    expect(textsOf(warm).join('|')).not.toContain('see 2');
+  });
+
+  test('the differential is not vacuous: the two trees paint different references', () => {
+    const before = layoutOf(body);
+    const afterBody =
+      refParagraph(' REF target \\r ', '9.9') +
+      numbered(bookmarked('target', 'The section')) +
+      '<w:p><w:r><w:t>tail</w:t></w:r></w:p>';
+    expect(shapeOf(before)).not.toEqual(shapeOf(layoutOf(afterBody)));
+  });
+
+  test('a no-change pass over a REF document returns the previous pages by identity', () => {
+    const part = load(body);
+    const options = {
+      measurer,
+      numberingIndex,
+      session: createLayoutSession(),
+      cache: createParagraphLayoutCache(),
+    };
+    const first = layoutSemanticDocument(part, 1, options);
+    expect(layoutSemanticDocument(part, 2, options).pages).toBe(first.pages);
+  });
+});

--- a/packages/core/src/layout/__tests__/field-ref-layout.test.ts
+++ b/packages/core/src/layout/__tests__/field-ref-layout.test.ts
@@ -52,14 +52,17 @@ const numbered = (inner: string) =>
 const bookmarked = (name: string, text: string) =>
   `<w:bookmarkStart w:id="1" w:name="${name}"/><w:r><w:t>${text}</w:t></w:r>` +
   `<w:bookmarkEnd w:id="1"/>`;
-/** A complex REF with a deliberately stale cached result. */
-const refField = (instr: string, cached = 'stale') =>
+/**
+ * A complex REF. An empty `cached` writes NO result run — always calibration-eligible; a
+ * non-empty one is the authored cache the computed value must reproduce to go live.
+ */
+const refField = (instr: string, cached = '') =>
   '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
   `<w:r><w:instrText>${instr}</w:instrText></w:r>` +
   '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
-  `<w:r><w:t>${cached}</w:t></w:r>` +
+  (cached ? `<w:r><w:t>${cached}</w:t></w:r>` : '') +
   '<w:r><w:fldChar w:fldCharType="end"/></w:r>';
-const refParagraph = (instr: string, cached = 'stale') =>
+const refParagraph = (instr: string, cached = '') =>
   `<w:p><w:r><w:t>see </w:t></w:r>${refField(instr, cached)}</w:p>`;
 
 /** Every fragment's text per page — what a reader sees, independent of node identity. */
@@ -89,14 +92,24 @@ function layoutOf(body: string): SemanticLayout {
 }
 
 describe('complex REF fields resolve live in body layout', () => {
-  test('a number-switch REF paints the resolved number over the stale cache', () => {
+  test('a number-switch REF with no cached result paints the resolved number', () => {
     const layout = layoutOf(
       numbered(bookmarked('_RefA', 'First')) +
         numbered(bookmarked('_RefB', 'Second')) +
-        refParagraph(' REF _RefB \\r \\h \\* MERGEFORMAT ', '9.9')
+        refParagraph(' REF _RefB \\r \\h \\* MERGEFORMAT ')
     );
     expect(textsOf(layout)).toContain('see 2');
-    expect(textsOf(layout).join('|')).not.toContain('9.9');
+  });
+
+  test('a cached result the computed value cannot reproduce paints verbatim', () => {
+    // The reference resolves ('2'), but the authored cache disagrees — the document's own
+    // cache is the calibration oracle, so this field never goes live.
+    const layout = layoutOf(
+      numbered(bookmarked('_RefA', 'First')) +
+        numbered(bookmarked('_RefB', 'Second')) +
+        refParagraph(' REF _RefB \\r ', 'Section 2 of Annex A')
+    );
+    expect(textsOf(layout)).toContain('see Section 2 of Annex A');
   });
 
   test('an instruction split across several w:instrText runs still resolves', () => {
@@ -106,7 +119,6 @@ describe('complex REF fields resolve live in body layout', () => {
       '<w:r><w:instrText>fB \\r </w:instrText></w:r>' +
       '<w:r><w:instrText>\\* MERGEFORMAT </w:instrText></w:r>' +
       '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
-      '<w:r><w:t>9.9</w:t></w:r>' +
       '<w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>';
     const layout = layoutOf(
       numbered(bookmarked('_RefA', 'First')) + numbered(bookmarked('_RefB', 'Second')) + split
@@ -137,22 +149,28 @@ describe('complex REF fields resolve live in body layout', () => {
   });
 
   test('\\n paints the number without its trailing period', () => {
-    const layout = layoutOf(
-      numbered(bookmarked('one', 'First')) + refParagraph(' REF one \\n ', '7')
-    );
+    const layout = layoutOf(numbered(bookmarked('one', 'First')) + refParagraph(' REF one \\n '));
     expect(textsOf(layout)).toContain('see 1');
   });
 });
 
 describe('w:fldSimple REF fields resolve live', () => {
-  test('the simple shape replaces its stale cached display', () => {
+  test('the simple shape with no cached display paints the resolved number', () => {
     const layout = layoutOf(
       numbered(bookmarked('_RefA', 'First')) +
         numbered(bookmarked('_RefB', 'Second')) +
-        '<w:p><w:fldSimple w:instr=" REF _RefB \\r \\h "><w:r><w:t>9.9</w:t></w:r></w:fldSimple></w:p>'
+        '<w:p><w:fldSimple w:instr=" REF _RefB \\r \\h "/></w:p>'
     );
     expect(textsOf(layout)).toContain('2');
-    expect(textsOf(layout).join('|')).not.toContain('9.9');
+  });
+
+  test('a matching simple cached display calibrates and goes live', () => {
+    const layout = layoutOf(
+      numbered(bookmarked('_RefA', 'First')) +
+        numbered(bookmarked('_RefB', 'Second')) +
+        '<w:p><w:fldSimple w:instr=" REF _RefB \\r "><w:r><w:t>2</w:t></w:r></w:fldSimple></w:p>'
+    );
+    expect(textsOf(layout)).toContain('2');
   });
 
   test('an unsupported simple REF keeps its cached display', () => {
@@ -169,7 +187,7 @@ describe('a REF inside a table cell resolves live', () => {
     const table =
       '<w:tbl><w:tblPr/><w:tblGrid><w:gridCol w:w="4000"/></w:tblGrid>' +
       '<w:tr><w:tc><w:tcPr/>' +
-      refParagraph(' REF _RefB \\r ', '9.9') +
+      refParagraph(' REF _RefB \\r ') +
       '</w:tc></w:tr></w:tbl>';
     const layout = layoutOf(
       numbered(bookmarked('_RefA', 'First')) + numbered(bookmarked('_RefB', 'Second')) + table
@@ -212,8 +230,11 @@ describe('a renumbering edit repaints dependent REF fields incrementally', () =>
   // The REF paragraph comes FIRST and never changes: its node survives the edit by identity,
   // so every memo keyed on it (prepared block, break cache, flow key) would happily serve the
   // pre-edit value. Removing a numbered paragraph BELOW it renumbers the target from 2 to 1.
+  // The cache is EMPTY so the field is live in both the warm and the cold pass — that keeps
+  // the cold oracle valid (a sticky calibrated cache diverges from a cold pass by design; see
+  // the sticky test below).
   const body =
-    refParagraph(' REF target \\r ', '9.9') +
+    refParagraph(' REF target \\r ') +
     numbered('<w:r><w:t>gone soon</w:t></w:r>') +
     numbered(bookmarked('target', 'The section')) +
     '<w:p><w:r><w:t>tail</w:t></w:r></w:p>';
@@ -242,10 +263,42 @@ describe('a renumbering edit repaints dependent REF fields incrementally', () =>
   test('the differential is not vacuous: the two trees paint different references', () => {
     const before = layoutOf(body);
     const afterBody =
-      refParagraph(' REF target \\r ', '9.9') +
+      refParagraph(' REF target \\r ') +
       numbered(bookmarked('target', 'The section')) +
       '<w:p><w:r><w:t>tail</w:t></w:r></w:p>';
     expect(shapeOf(before)).not.toEqual(shapeOf(layoutOf(afterBody)));
+  });
+
+  test('a calibrated field stays live across the edit (sticky verdict)', () => {
+    // The authored cache MATCHES the initial computed value ('2'), so the field calibrates
+    // live; the session edit then renumbers the target and the live value must keep winning
+    // even though it no longer matches the cache. A FRESH OPEN of the same edited markup has
+    // no verdict registry (all-new nodes), re-calibrates against the now-stale cache, and
+    // keeps it — by design, so an opened stale document never renders worse than its cache.
+    const editedMarkup =
+      refParagraph(' REF target \\r ', '2') +
+      numbered(bookmarked('target', 'The section')) +
+      '<w:p><w:r><w:t>tail</w:t></w:r></w:p>';
+    const before = load(
+      refParagraph(' REF target \\r ', '2') +
+        numbered('<w:r><w:t>gone soon</w:t></w:r>') +
+        numbered(bookmarked('target', 'The section')) +
+        '<w:p><w:r><w:t>tail</w:t></w:r></w:p>'
+    );
+    const options = {
+      measurer,
+      numberingIndex,
+      session: createLayoutSession(),
+      cache: createParagraphLayoutCache(),
+    };
+    const first = layoutSemanticDocument(before, 1, options);
+    expect(textsOf(first)).toContain('see 2');
+
+    const after = withBlocks(before, (blocks) => blocks.filter((_, index) => index !== 1));
+    const warm = layoutSemanticDocument(after, 2, options);
+    expect(textsOf(warm)).toContain('see 1');
+    const freshOpen = layoutSemanticDocument(load(editedMarkup), 1, { measurer, numberingIndex });
+    expect(textsOf(freshOpen)).toContain('see 2');
   });
 
   test('a no-change pass over a REF document returns the previous pages by identity', () => {
@@ -318,16 +371,24 @@ describe('self-oracle: on an unedited document the live value equals the cached 
     expect(texts).toContain('see 1.2(c)(ii)');
   });
 
-  test('after a renumbering edit the live value wins over the now-stale cache', () => {
-    // Dropping the `(a)` clause shifts the target from `(c)` to `(b)`; the cache still says
+  test('after a session renumbering edit the calibrated live value wins over the cache', () => {
+    // First pass calibrates: `1.2(c)` reproduces the cache, so the field is live. Dropping
+    // the `(a)` clause then shifts the target from `(c)` to `(b)`; the cache still says
     // `1.2(c)` and must lose.
-    const edited = chain.replace(legalNumbered(2, '<w:r><w:t>(a)</w:t></w:r>'), '');
-    const layout = layoutSemanticDocument(
-      load(edited + refParagraph(' REF clause \\w \\h ', '1.2(c)')),
-      1,
-      { measurer, numberingIndex: legalNumberingIndex }
-    );
-    const texts = textsOf(layout);
+    const before = load(chain + refParagraph(' REF clause \\w \\h ', '1.2(c)'));
+    const options = {
+      measurer,
+      numberingIndex: legalNumberingIndex,
+      session: createLayoutSession(),
+      cache: createParagraphLayoutCache(),
+    };
+    const first = layoutSemanticDocument(before, 1, options);
+    expect(textsOf(first)).toContain('see 1.2(c)');
+
+    // Blocks: 0..7 are the chain; index 3 is the `(a)` clause. Surviving nodes keep identity.
+    const after = withBlocks(before, (blocks) => blocks.filter((_, index) => index !== 3));
+    const warm = layoutSemanticDocument(after, 2, options);
+    const texts = textsOf(warm);
     expect(texts).toContain('see 1.2(b)');
     expect(texts.join('|')).not.toContain('1.2(c)');
   });

--- a/packages/core/src/layout/__tests__/field-ref.test.ts
+++ b/packages/core/src/layout/__tests__/field-ref.test.ts
@@ -196,3 +196,101 @@ describe('resolveStoryRefFields', () => {
     expect(beforeContext.tokenForParagraph(blocksOf(before)[0]!.id)).toBe('');
   });
 });
+
+/** The standard legal shape: deep levels state only their OWN placeholder. */
+const LEGAL_NUMBERING = `
+  <w:abstractNum w:abstractNumId="0">
+    <w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/>
+      <w:lvlText w:val="%1."/><w:lvlJc w:val="left"/></w:lvl>
+    <w:lvl w:ilvl="1"><w:start w:val="1"/><w:numFmt w:val="decimal"/>
+      <w:lvlText w:val="%1.%2"/><w:lvlJc w:val="left"/></w:lvl>
+    <w:lvl w:ilvl="2"><w:start w:val="1"/><w:numFmt w:val="lowerLetter"/>
+      <w:lvlText w:val="(%3)"/><w:lvlJc w:val="left"/></w:lvl>
+    <w:lvl w:ilvl="3"><w:start w:val="1"/><w:numFmt w:val="lowerRoman"/>
+      <w:lvlText w:val="(%4)"/><w:lvlJc w:val="left"/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="5"><w:abstractNumId w:val="0"/></w:num>
+`;
+
+function contextUnder(numberingXml: string, part: OoxmlPart) {
+  const result = readOoxmlPart(`<w:numbering xmlns:w="${W}">${numberingXml}</w:numbering>`, {
+    name: '/word/numbering.xml',
+    contentType: 'application/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  const blocks = blocksOf(part);
+  const listItems = resolveStoryListItems(blocks, buildNumberingIndex(result.part.root), undefined);
+  return resolveStoryRefFields(blocks, listItems);
+}
+
+describe('number switches compose the FULL-CONTEXT number from the counter path', () => {
+  // Counters at the deep targets: 1, 2, 3, 2 — the `(c)` marker alone is not the number a
+  // reader cites; Word's cached result says `1.2(c)`, and the live value must match it.
+  const body =
+    numbered(0, bookmarked('art', 'Article one')) +
+    numbered(1, '<w:r><w:t>1.1</w:t></w:r>') +
+    numbered(1, bookmarked('sec', 'Section 1.2')) +
+    numbered(2, '<w:r><w:t>(a)</w:t></w:r>') +
+    numbered(2, '<w:r><w:t>(b)</w:t></w:r>') +
+    numbered(2, bookmarked('clause', 'Clause (c)')) +
+    numbered(3, '<w:r><w:t>(i)</w:t></w:r>') +
+    numbered(3, bookmarked('item', 'Item (ii)')) +
+    // The target index only holds REFERENCED names, so every probed bookmark needs a field.
+    refField(' REF clause \\w ') +
+    refField(' REF item \\r ') +
+    refField(' REF sec \\w ') +
+    refField(' REF art \\r ');
+
+  const value = (bookmark: string, numberSwitch: 'r' | 'w' | 'n') =>
+    contextUnder(LEGAL_NUMBERING, document(body))!.valueOf({
+      bookmark,
+      numberSwitch,
+      hyperlink: false,
+    });
+
+  test('a deep target paints its ancestors, not its bare marker', () => {
+    expect(value('clause', 'w')).toBe('1.2(c)');
+    expect(value('item', 'r')).toBe('1.2(c)(ii)');
+  });
+
+  test('a level whose placeholder a deeper kept text displays is dropped once, not twice', () => {
+    // lvl0's %1 appears in lvl1's `%1.%2`, so `1.` is dropped and the result is not `1.1.2`.
+    expect(value('sec', 'w')).toBe('1.2');
+    // The shallowest target keeps only itself; the bare trailing period trims.
+    expect(value('art', 'r')).toBe('1');
+  });
+
+  test('w:isLgl renders inherited placeholders decimal in the composition too', () => {
+    const numbering = `
+      <w:abstractNum w:abstractNumId="0">
+        <w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="upperRoman"/>
+          <w:lvlText w:val="%1."/><w:lvlJc w:val="left"/></w:lvl>
+        <w:lvl w:ilvl="1"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:isLgl/>
+          <w:lvlText w:val="%1.%2"/><w:lvlJc w:val="left"/></w:lvl>
+      </w:abstractNum>
+      <w:num w:numId="5"><w:abstractNumId w:val="0"/></w:num>
+    `;
+    const part = document(
+      numbered(0, '<w:r><w:t>I.</w:t></w:r>') +
+        numbered(1, bookmarked('lgl', 'legal item')) +
+        refField(' REF lgl \\w ')
+    );
+    const context = contextUnder(numbering, part)!;
+    // The upperRoman `%1` renders decimal under the legal level, exactly as its marker does:
+    // `1.1`, never `I.1`.
+    expect(context.valueOf({ bookmark: 'lgl', numberSwitch: 'w', hyperlink: false })).toBe('1.1');
+  });
+
+  test('a bullet target still falls back to the cached result, never a glyph', () => {
+    const numbering = `
+      <w:abstractNum w:abstractNumId="0">
+        <w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="bullet"/>
+          <w:lvlText w:val="•"/><w:lvlJc w:val="left"/></w:lvl>
+      </w:abstractNum>
+      <w:num w:numId="5"><w:abstractNumId w:val="0"/></w:num>
+    `;
+    const part = document(numbered(0, bookmarked('b', 'bulleted')) + refField(' REF b \\r '));
+    const context = contextUnder(numbering, part)!;
+    expect(context.valueOf({ bookmark: 'b', numberSwitch: 'r', hyperlink: false })).toBeNull();
+  });
+});

--- a/packages/core/src/layout/__tests__/field-ref.test.ts
+++ b/packages/core/src/layout/__tests__/field-ref.test.ts
@@ -1,0 +1,198 @@
+// REF instruction recognition and story resolution (field-ref.ts).
+//
+// The instruction is attacker-controlled: everything outside the supported grammar must
+// resolve to null so the field keeps its cached result. Resolution reads the bookmark target
+// and the resolved list items; a missing bookmark or an unnumbered target under a number
+// switch resolves to null the same way.
+
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, type OoxmlElement, type OoxmlPart } from '@docx-editor.dev/core/store';
+import { parseRefInstruction, resolveStoryRefFields } from '../field-ref.ts';
+import { buildNumberingIndex } from '../numbering-index.ts';
+import { resolveStoryListItems } from '../list-resolve.ts';
+import { MAX_FIELD_INSTRUCTION_CHARS } from '../field-instruction.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+describe('parseRefInstruction', () => {
+  test('recognizes the bare form and each supported switch', () => {
+    expect(parseRefInstruction(' REF _Ref137575642 ')).toEqual({
+      bookmark: '_Ref137575642',
+      numberSwitch: null,
+      hyperlink: false,
+    });
+    expect(parseRefInstruction(' REF _Ref137575642 \\r \\h \\* MERGEFORMAT ')).toEqual({
+      bookmark: '_Ref137575642',
+      numberSwitch: 'r',
+      hyperlink: true,
+    });
+    expect(parseRefInstruction('REF target \\w')?.numberSwitch).toBe('w');
+    expect(parseRefInstruction('REF target \\n')?.numberSwitch).toBe('n');
+    // The keyword matches case-insensitively; the bookmark name keeps its authored case.
+    expect(parseRefInstruction('ref MixedCase \\R')).toEqual({
+      bookmark: 'MixedCase',
+      numberSwitch: 'r',
+      hyperlink: false,
+    });
+    expect(parseRefInstruction('REF "quoted name" \\h')?.bookmark).toBe('quoted name');
+  });
+
+  test('anything outside the supported grammar stays inert (null)', () => {
+    // Unknown switches fall back to the cached result — never a guess.
+    expect(parseRefInstruction('REF target \\p')).toBeNull();
+    expect(parseRefInstruction('REF target \\f')).toBeNull();
+    expect(parseRefInstruction('REF target \\d "-"')).toBeNull();
+    expect(parseRefInstruction('REF target \\# 0.00')).toBeNull();
+    expect(parseRefInstruction('REF target \\* Upper')).toBeNull();
+    // Missing or malformed bookmark argument.
+    expect(parseRefInstruction('REF')).toBeNull();
+    expect(parseRefInstruction('REF \\r')).toBeNull();
+    expect(parseRefInstruction(`REF ${'x'.repeat(257)}`)).toBeNull();
+    expect(parseRefInstruction('REF "unterminated')).toBeNull();
+    // Other keywords are not this field.
+    expect(parseRefInstruction('NOTEREF _Ref1 \\r')).toBeNull();
+    expect(parseRefInstruction('PAGEREF _Ref1 \\h')).toBeNull();
+    // Over the shared instruction cap fails closed.
+    expect(parseRefInstruction(`REF ${'y'.repeat(MAX_FIELD_INSTRUCTION_CHARS)}`)).toBeNull();
+  });
+
+  test('a hostile bookmark name is only ever a Map key', () => {
+    // `__proto__` parses as an ordinary name; resolution looks it up in a Map and finds
+    // nothing, polluting nothing.
+    expect(parseRefInstruction('REF __proto__ \\r')?.bookmark).toBe('__proto__');
+  });
+});
+
+const NUMBERING = `
+  <w:abstractNum w:abstractNumId="0">
+    <w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/>
+      <w:lvlText w:val="%1."/><w:lvlJc w:val="left"/></w:lvl>
+    <w:lvl w:ilvl="1"><w:start w:val="1"/><w:numFmt w:val="decimal"/>
+      <w:lvlText w:val="%1.%2"/><w:lvlJc w:val="left"/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="5"><w:abstractNumId w:val="0"/></w:num>
+`;
+
+function numberingIndex() {
+  const result = readOoxmlPart(`<w:numbering xmlns:w="${W}">${NUMBERING}</w:numbering>`, {
+    name: '/word/numbering.xml',
+    contentType: 'application/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return buildNumberingIndex(result.part.root);
+}
+
+function document(body: string): OoxmlPart {
+  const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'application/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+function blocksOf(part: OoxmlPart): OoxmlElement[] {
+  const body = part.root.children.find(
+    (child): child is OoxmlElement => child.kind !== 'textValue' && child.localName === 'body'
+  )!;
+  return body.children.filter(
+    (child): child is OoxmlElement => child.kind === 'paragraph' || child.kind === 'table'
+  );
+}
+
+const numbered = (ilvl: number, inner: string) =>
+  `<w:p><w:pPr><w:numPr><w:ilvl w:val="${ilvl}"/><w:numId w:val="5"/></w:numPr></w:pPr>${inner}</w:p>`;
+const bookmarked = (name: string, text: string) =>
+  `<w:bookmarkStart w:id="1" w:name="${name}"/><w:r><w:t>${text}</w:t></w:r>` +
+  `<w:bookmarkEnd w:id="1"/>`;
+const refField = (instr: string) =>
+  '<w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+  `<w:r><w:instrText>${instr}</w:instrText></w:r>` +
+  '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+  '<w:r><w:t>stale</w:t></w:r>' +
+  '<w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>';
+
+function contextFor(part: OoxmlPart) {
+  const blocks = blocksOf(part);
+  const listItems = resolveStoryListItems(blocks, numberingIndex(), undefined);
+  return resolveStoryRefFields(blocks, listItems);
+}
+
+describe('resolveStoryRefFields', () => {
+  test('a story with no REF field resolves to null', () => {
+    const part = document(numbered(0, bookmarked('_Ref1', 'Heading')) + '<w:p/>');
+    expect(contextFor(part)).toBeNull();
+  });
+
+  test('number switches resolve the marker with the trailing period trimmed', () => {
+    const part = document(
+      numbered(0, bookmarked('top', 'One')) +
+        numbered(1, bookmarked('sub', 'One point one')) +
+        refField(' REF top \\r ') +
+        refField(' REF sub \\w ')
+    );
+    const context = contextFor(part)!;
+    // `1.` trims its bare trailing period; `1.1` keeps its interior one.
+    expect(context.valueOf({ bookmark: 'top', numberSwitch: 'r', hyperlink: false })).toBe('1');
+    expect(context.valueOf({ bookmark: 'sub', numberSwitch: 'w', hyperlink: false })).toBe('1.1');
+    expect(context.valueOf({ bookmark: 'sub', numberSwitch: 'n', hyperlink: false })).toBe('1.1');
+  });
+
+  test('a plain REF extracts the bookmarked text, capped inside the target paragraph', () => {
+    const part = document(
+      `<w:p><w:r><w:t>lead </w:t></w:r>${bookmarked('term', 'Closing Date')}` +
+        `<w:r><w:t> tail</w:t></w:r></w:p>` +
+        refField(' REF term ')
+    );
+    const context = contextFor(part)!;
+    expect(context.valueOf({ bookmark: 'term', numberSwitch: null, hyperlink: false })).toBe(
+      'Closing Date'
+    );
+  });
+
+  test('missing bookmark and unnumbered target resolve to null (cached fallback)', () => {
+    const part = document(
+      `<w:p>${bookmarked('plain', 'no number here')}</w:p>` + refField(' REF plain \\r ')
+    );
+    const context = contextFor(part)!;
+    expect(
+      context.valueOf({ bookmark: 'absent', numberSwitch: null, hyperlink: false })
+    ).toBeNull();
+    expect(context.valueOf({ bookmark: 'plain', numberSwitch: 'r', hyperlink: false })).toBeNull();
+  });
+
+  test('the first declaration of a duplicated name wins, in document order', () => {
+    const part = document(
+      numbered(0, bookmarked('dup', 'first')) +
+        numbered(0, bookmarked('dup', 'second')) +
+        refField(' REF dup \\r ')
+    );
+    const context = contextFor(part)!;
+    expect(context.valueOf({ bookmark: 'dup', numberSwitch: 'r', hyperlink: false })).toBe('1');
+  });
+
+  test('paragraph tokens and the story token move with the resolved values', () => {
+    const before = document(
+      numbered(0, bookmarked('t', 'A')) +
+        numbered(0, '<w:r><w:t>B</w:t></w:r>') +
+        refField(' REF t \\r ')
+    );
+    // Same markup with one numbered paragraph inserted ahead: the target renumbers 1 → 2.
+    const after = document(
+      numbered(0, '<w:r><w:t>Z</w:t></w:r>') +
+        numbered(0, bookmarked('t', 'A')) +
+        numbered(0, '<w:r><w:t>B</w:t></w:r>') +
+        refField(' REF t \\r ')
+    );
+    const beforeContext = contextFor(before)!;
+    const afterContext = contextFor(after)!;
+    expect(beforeContext.valuesToken).not.toBe(afterContext.valuesToken);
+    const refParagraphBefore = blocksOf(before).at(-1)!;
+    const refParagraphAfter = blocksOf(after).at(-1)!;
+    expect(beforeContext.tokenForParagraph(refParagraphBefore.id)).not.toBe(
+      afterContext.tokenForParagraph(refParagraphAfter.id)
+    );
+    // A paragraph with no REF field keys nothing.
+    expect(beforeContext.tokenForParagraph(blocksOf(before)[0]!.id)).toBe('');
+  });
+});

--- a/packages/core/src/layout/__tests__/field-ref.test.ts
+++ b/packages/core/src/layout/__tests__/field-ref.test.ts
@@ -1,16 +1,23 @@
-// REF instruction recognition and story resolution (field-ref.ts).
+// REF instruction recognition, story resolution and calibration (field-ref.ts).
 //
 // The instruction is attacker-controlled: everything outside the supported grammar must
 // resolve to null so the field keeps its cached result. Resolution reads the bookmark target
 // and the resolved list items; a missing bookmark or an unnumbered target under a number
-// switch resolves to null the same way.
+// switch resolves to null the same way. Live values are gated per field by CALIBRATION: a
+// non-empty authored cache the computed value cannot reproduce keeps that cache permanently.
 
 import { describe, expect, test } from 'bun:test';
-import { readOoxmlPart, type OoxmlElement, type OoxmlPart } from '@docx-editor.dev/core/store';
-import { parseRefInstruction, resolveStoryRefFields } from '../field-ref.ts';
+import {
+  isFldSimple,
+  readOoxmlPart,
+  type OoxmlElement,
+  type OoxmlNode,
+  type OoxmlPart,
+} from '@docx-editor.dev/core/store';
+import { parseRefInstruction, resolveStoryRefFields, type RefFieldSpec } from '../field-ref.ts';
 import { buildNumberingIndex } from '../numbering-index.ts';
 import { resolveStoryListItems } from '../list-resolve.ts';
-import { MAX_FIELD_INSTRUCTION_CHARS } from '../field-instruction.ts';
+import { isFldChar, MAX_FIELD_INSTRUCTION_CHARS } from '../field-instruction.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
@@ -37,8 +44,17 @@ describe('parseRefInstruction', () => {
     expect(parseRefInstruction('REF "quoted name" \\h')?.bookmark).toBe('quoted name');
   });
 
+  test('several number switches take the deterministic precedence n over r over w', () => {
+    // Real instructions write `\w \n \h` and cache the `\n`-shaped value.
+    expect(parseRefInstruction('REF x \\w \\n \\h')?.numberSwitch).toBe('n');
+    expect(parseRefInstruction('REF x \\r \\w')?.numberSwitch).toBe('r');
+    expect(parseRefInstruction('REF x \\w \\r')?.numberSwitch).toBe('r');
+  });
+
   test('anything outside the supported grammar stays inert (null)', () => {
-    // Unknown switches fall back to the cached result — never a guess.
+    // Unknown switches fall back to the cached result — never a guess. `\t` in particular is
+    // common in real documents and stays unsupported on purpose.
+    expect(parseRefInstruction('REF target \\t')).toBeNull();
     expect(parseRefInstruction('REF target \\p')).toBeNull();
     expect(parseRefInstruction('REF target \\f')).toBeNull();
     expect(parseRefInstruction('REF target \\d "-"')).toBeNull();
@@ -63,18 +79,8 @@ describe('parseRefInstruction', () => {
   });
 });
 
-const NUMBERING = `
-  <w:abstractNum w:abstractNumId="0">
-    <w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/>
-      <w:lvlText w:val="%1."/><w:lvlJc w:val="left"/></w:lvl>
-    <w:lvl w:ilvl="1"><w:start w:val="1"/><w:numFmt w:val="decimal"/>
-      <w:lvlText w:val="%1.%2"/><w:lvlJc w:val="left"/></w:lvl>
-  </w:abstractNum>
-  <w:num w:numId="5"><w:abstractNumId w:val="0"/></w:num>
-`;
-
-function numberingIndex() {
-  const result = readOoxmlPart(`<w:numbering xmlns:w="${W}">${NUMBERING}</w:numbering>`, {
+function numberingOf(xml: string) {
+  const result = readOoxmlPart(`<w:numbering xmlns:w="${W}">${xml}</w:numbering>`, {
     name: '/word/numbering.xml',
     contentType: 'application/xml',
   });
@@ -100,42 +106,83 @@ function blocksOf(part: OoxmlPart): OoxmlElement[] {
   );
 }
 
+/** Field anchor ids (begin `w:fldChar` / `w:fldSimple`) in document order, for lookups. */
+function refAnchorIds(part: OoxmlPart): string[] {
+  const ids: string[] = [];
+  const visit = (node: OoxmlNode): void => {
+    if (node.kind === 'textValue') return;
+    if (isFldChar(node, 'begin') || isFldSimple(node)) ids.push(node.id);
+    for (const child of node.children) visit(child);
+  };
+  visit(part.root);
+  return ids;
+}
+
 const numbered = (ilvl: number, inner: string) =>
   `<w:p><w:pPr><w:numPr><w:ilvl w:val="${ilvl}"/><w:numId w:val="5"/></w:numPr></w:pPr>${inner}</w:p>`;
 const bookmarked = (name: string, text: string) =>
   `<w:bookmarkStart w:id="1" w:name="${name}"/><w:r><w:t>${text}</w:t></w:r>` +
   `<w:bookmarkEnd w:id="1"/>`;
-const refField = (instr: string) =>
+/** A complex REF; an empty `cached` writes NO result run (always calibration-eligible). */
+const refField = (instr: string, cached = '') =>
   '<w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
   `<w:r><w:instrText>${instr}</w:instrText></w:r>` +
   '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
-  '<w:r><w:t>stale</w:t></w:r>' +
+  (cached ? `<w:r><w:t>${cached}</w:t></w:r>` : '') +
   '<w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>';
 
-function contextFor(part: OoxmlPart) {
+const TWO_LEVEL_NUMBERING = `
+  <w:abstractNum w:abstractNumId="0">
+    <w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/>
+      <w:lvlText w:val="%1."/><w:lvlJc w:val="left"/></w:lvl>
+    <w:lvl w:ilvl="1"><w:start w:val="1"/><w:numFmt w:val="decimal"/>
+      <w:lvlText w:val="%1.%2"/><w:lvlJc w:val="left"/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="5"><w:abstractNumId w:val="0"/></w:num>
+`;
+
+function contextUnder(numberingXml: string, part: OoxmlPart) {
   const blocks = blocksOf(part);
-  const listItems = resolveStoryListItems(blocks, numberingIndex(), undefined);
+  const listItems = resolveStoryListItems(blocks, numberingOf(numberingXml), undefined);
   return resolveStoryRefFields(blocks, listItems);
 }
+
+/** The live value the `ordinal`-th field (document order) paints, or null for its cache. */
+function liveAt(
+  part: OoxmlPart,
+  context: ReturnType<typeof resolveStoryRefFields>,
+  ordinal: number,
+  spec: RefFieldSpec
+): string | null {
+  const anchorId = refAnchorIds(part)[ordinal];
+  if (anchorId === undefined) throw new Error('no such field');
+  return context!.liveValueOf(anchorId, spec);
+}
+
+const spec = (
+  bookmark: string,
+  numberSwitch: RefFieldSpec['numberSwitch'] = null
+): RefFieldSpec => ({ bookmark, numberSwitch, hyperlink: false });
 
 describe('resolveStoryRefFields', () => {
   test('a story with no REF field resolves to null', () => {
     const part = document(numbered(0, bookmarked('_Ref1', 'Heading')) + '<w:p/>');
-    expect(contextFor(part)).toBeNull();
+    expect(contextUnder(TWO_LEVEL_NUMBERING, part)).toBeNull();
   });
 
-  test('number switches resolve the marker with the trailing period trimmed', () => {
+  test('number switches resolve the number with the trailing period trimmed', () => {
     const part = document(
       numbered(0, bookmarked('top', 'One')) +
         numbered(1, bookmarked('sub', 'One point one')) +
         refField(' REF top \\r ') +
-        refField(' REF sub \\w ')
+        refField(' REF sub \\w ') +
+        refField(' REF sub \\n ')
     );
-    const context = contextFor(part)!;
+    const context = contextUnder(TWO_LEVEL_NUMBERING, part);
     // `1.` trims its bare trailing period; `1.1` keeps its interior one.
-    expect(context.valueOf({ bookmark: 'top', numberSwitch: 'r', hyperlink: false })).toBe('1');
-    expect(context.valueOf({ bookmark: 'sub', numberSwitch: 'w', hyperlink: false })).toBe('1.1');
-    expect(context.valueOf({ bookmark: 'sub', numberSwitch: 'n', hyperlink: false })).toBe('1.1');
+    expect(liveAt(part, context, 0, spec('top', 'r'))).toBe('1');
+    expect(liveAt(part, context, 1, spec('sub', 'w'))).toBe('1.1');
+    expect(liveAt(part, context, 2, spec('sub', 'n'))).toBe('1.1');
   });
 
   test('a plain REF extracts the bookmarked text, capped inside the target paragraph', () => {
@@ -144,21 +191,19 @@ describe('resolveStoryRefFields', () => {
         `<w:r><w:t> tail</w:t></w:r></w:p>` +
         refField(' REF term ')
     );
-    const context = contextFor(part)!;
-    expect(context.valueOf({ bookmark: 'term', numberSwitch: null, hyperlink: false })).toBe(
-      'Closing Date'
-    );
+    const context = contextUnder(TWO_LEVEL_NUMBERING, part);
+    expect(liveAt(part, context, 0, spec('term'))).toBe('Closing Date');
   });
 
   test('missing bookmark and unnumbered target resolve to null (cached fallback)', () => {
     const part = document(
-      `<w:p>${bookmarked('plain', 'no number here')}</w:p>` + refField(' REF plain \\r ')
+      `<w:p>${bookmarked('plain', 'no number here')}</w:p>` +
+        refField(' REF absent ') +
+        refField(' REF plain \\r ')
     );
-    const context = contextFor(part)!;
-    expect(
-      context.valueOf({ bookmark: 'absent', numberSwitch: null, hyperlink: false })
-    ).toBeNull();
-    expect(context.valueOf({ bookmark: 'plain', numberSwitch: 'r', hyperlink: false })).toBeNull();
+    const context = contextUnder(TWO_LEVEL_NUMBERING, part);
+    expect(liveAt(part, context, 0, spec('absent'))).toBeNull();
+    expect(liveAt(part, context, 1, spec('plain', 'r'))).toBeNull();
   });
 
   test('the first declaration of a duplicated name wins, in document order', () => {
@@ -167,8 +212,15 @@ describe('resolveStoryRefFields', () => {
         numbered(0, bookmarked('dup', 'second')) +
         refField(' REF dup \\r ')
     );
-    const context = contextFor(part)!;
-    expect(context.valueOf({ bookmark: 'dup', numberSwitch: 'r', hyperlink: false })).toBe('1');
+    const context = contextUnder(TWO_LEVEL_NUMBERING, part);
+    expect(liveAt(part, context, 0, spec('dup', 'r'))).toBe('1');
+  });
+
+  test('a spec that disagrees with the scanned field fails to the cache', () => {
+    const part = document(numbered(0, bookmarked('t', 'A')) + refField(' REF t \\r '));
+    const context = contextUnder(TWO_LEVEL_NUMBERING, part);
+    expect(liveAt(part, context, 0, spec('t', 'w'))).toBeNull();
+    expect(liveAt(part, context, 0, spec('other', 'r'))).toBeNull();
   });
 
   test('paragraph tokens and the story token move with the resolved values', () => {
@@ -184,8 +236,8 @@ describe('resolveStoryRefFields', () => {
         numbered(0, '<w:r><w:t>B</w:t></w:r>') +
         refField(' REF t \\r ')
     );
-    const beforeContext = contextFor(before)!;
-    const afterContext = contextFor(after)!;
+    const beforeContext = contextUnder(TWO_LEVEL_NUMBERING, before)!;
+    const afterContext = contextUnder(TWO_LEVEL_NUMBERING, after)!;
     expect(beforeContext.valuesToken).not.toBe(afterContext.valuesToken);
     const refParagraphBefore = blocksOf(before).at(-1)!;
     const refParagraphAfter = blocksOf(after).at(-1)!;
@@ -212,18 +264,7 @@ const LEGAL_NUMBERING = `
   <w:num w:numId="5"><w:abstractNumId w:val="0"/></w:num>
 `;
 
-function contextUnder(numberingXml: string, part: OoxmlPart) {
-  const result = readOoxmlPart(`<w:numbering xmlns:w="${W}">${numberingXml}</w:numbering>`, {
-    name: '/word/numbering.xml',
-    contentType: 'application/xml',
-  });
-  if (!result.ok) throw new Error(result.reason);
-  const blocks = blocksOf(part);
-  const listItems = resolveStoryListItems(blocks, buildNumberingIndex(result.part.root), undefined);
-  return resolveStoryRefFields(blocks, listItems);
-}
-
-describe('number switches compose the FULL-CONTEXT number from the counter path', () => {
+describe('number switches compose from the counter path', () => {
   // Counters at the deep targets: 1, 2, 3, 2 — the `(c)` marker alone is not the number a
   // reader cites; Word's cached result says `1.2(c)`, and the live value must match it.
   const body =
@@ -235,29 +276,30 @@ describe('number switches compose the FULL-CONTEXT number from the counter path'
     numbered(2, bookmarked('clause', 'Clause (c)')) +
     numbered(3, '<w:r><w:t>(i)</w:t></w:r>') +
     numbered(3, bookmarked('item', 'Item (ii)')) +
-    // The target index only holds REFERENCED names, so every probed bookmark needs a field.
     refField(' REF clause \\w ') +
     refField(' REF item \\r ') +
     refField(' REF sec \\w ') +
-    refField(' REF art \\r ');
+    refField(' REF art \\r ') +
+    refField(' REF clause \\n ') +
+    refField(' REF item \\n ');
+  const part = document(body);
+  const context = contextUnder(LEGAL_NUMBERING, part);
 
-  const value = (bookmark: string, numberSwitch: 'r' | 'w' | 'n') =>
-    contextUnder(LEGAL_NUMBERING, document(body))!.valueOf({
-      bookmark,
-      numberSwitch,
-      hyperlink: false,
-    });
-
-  test('a deep target paints its ancestors, not its bare marker', () => {
-    expect(value('clause', 'w')).toBe('1.2(c)');
-    expect(value('item', 'r')).toBe('1.2(c)(ii)');
+  test('`\\r` / `\\w` paint the full context, not the bare marker', () => {
+    expect(liveAt(part, context, 0, spec('clause', 'w'))).toBe('1.2(c)');
+    expect(liveAt(part, context, 1, spec('item', 'r'))).toBe('1.2(c)(ii)');
   });
 
   test('a level whose placeholder a deeper kept text displays is dropped once, not twice', () => {
     // lvl0's %1 appears in lvl1's `%1.%2`, so `1.` is dropped and the result is not `1.1.2`.
-    expect(value('sec', 'w')).toBe('1.2');
+    expect(liveAt(part, context, 2, spec('sec', 'w'))).toBe('1.2');
     // The shallowest target keeps only itself; the bare trailing period trims.
-    expect(value('art', 'r')).toBe('1');
+    expect(liveAt(part, context, 3, spec('art', 'r'))).toBe('1');
+  });
+
+  test('`\\n` paints the target level alone, without its ancestors', () => {
+    expect(liveAt(part, context, 4, spec('clause', 'n'))).toBe('(c)');
+    expect(liveAt(part, context, 5, spec('item', 'n'))).toBe('(ii)');
   });
 
   test('w:isLgl renders inherited placeholders decimal in the composition too', () => {
@@ -270,15 +312,15 @@ describe('number switches compose the FULL-CONTEXT number from the counter path'
       </w:abstractNum>
       <w:num w:numId="5"><w:abstractNumId w:val="0"/></w:num>
     `;
-    const part = document(
+    const lglPart = document(
       numbered(0, '<w:r><w:t>I.</w:t></w:r>') +
         numbered(1, bookmarked('lgl', 'legal item')) +
         refField(' REF lgl \\w ')
     );
-    const context = contextUnder(numbering, part)!;
+    const lglContext = contextUnder(numbering, lglPart);
     // The upperRoman `%1` renders decimal under the legal level, exactly as its marker does:
     // `1.1`, never `I.1`.
-    expect(context.valueOf({ bookmark: 'lgl', numberSwitch: 'w', hyperlink: false })).toBe('1.1');
+    expect(liveAt(lglPart, lglContext, 0, spec('lgl', 'w'))).toBe('1.1');
   });
 
   test('a bullet target still falls back to the cached result, never a glyph', () => {
@@ -289,8 +331,58 @@ describe('number switches compose the FULL-CONTEXT number from the counter path'
       </w:abstractNum>
       <w:num w:numId="5"><w:abstractNumId w:val="0"/></w:num>
     `;
-    const part = document(numbered(0, bookmarked('b', 'bulleted')) + refField(' REF b \\r '));
-    const context = contextUnder(numbering, part)!;
-    expect(context.valueOf({ bookmark: 'b', numberSwitch: 'r', hyperlink: false })).toBeNull();
+    const bulletPart = document(numbered(0, bookmarked('b', 'bulleted')) + refField(' REF b \\r '));
+    const bulletContext = contextUnder(numbering, bulletPart);
+    expect(liveAt(bulletPart, bulletContext, 0, spec('b', 'r'))).toBeNull();
+  });
+});
+
+describe('calibration: the authored cache is the oracle', () => {
+  // A mixed roman/letter/decimal chain whose level texts never chain: the composition joins
+  // every ancestor (`II` + `b.3`) while Word's cache reads `2.3`. Such a field must stay on
+  // its cache verbatim, while a field the composition reproduces goes live.
+  const MIXED_NUMBERING = `
+    <w:abstractNum w:abstractNumId="0">
+      <w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="upperRoman"/>
+        <w:lvlText w:val="%1"/><w:lvlJc w:val="left"/></w:lvl>
+      <w:lvl w:ilvl="1"><w:start w:val="1"/><w:numFmt w:val="lowerLetter"/>
+        <w:lvlText w:val="%2."/><w:lvlJc w:val="left"/></w:lvl>
+      <w:lvl w:ilvl="2"><w:start w:val="1"/><w:numFmt w:val="decimal"/>
+        <w:lvlText w:val="%2.%3"/><w:lvlJc w:val="left"/></w:lvl>
+    </w:abstractNum>
+    <w:num w:numId="5"><w:abstractNumId w:val="0"/></w:num>
+  `;
+  const body =
+    numbered(0, '<w:r><w:t>First</w:t></w:r>') +
+    numbered(0, '<w:r><w:t>Second</w:t></w:r>') +
+    numbered(1, '<w:r><w:t>a</w:t></w:r>') +
+    numbered(1, '<w:r><w:t>b</w:t></w:r>') +
+    numbered(2, '<w:r><w:t>one</w:t></w:r>') +
+    numbered(2, '<w:r><w:t>two</w:t></w:r>') +
+    numbered(2, bookmarked('deep', 'three')) +
+    // Word's cache is `2.3`; the composition joins `IIb.3` — this field must stay cached.
+    refField(' REF deep \\w ', '2.3') +
+    // The own-level `\n` value IS `b.3`; this field calibrates and goes live.
+    refField(' REF deep \\n ', 'b.3');
+
+  test('a mismatching field keeps its cache, a matching one goes live', () => {
+    const part = document(body);
+    const context = contextUnder(MIXED_NUMBERING, part)!;
+    expect(liveAt(part, context, 0, spec('deep', 'w'))).toBeNull();
+    expect(liveAt(part, context, 1, spec('deep', 'n'))).toBe('b.3');
+    // The token carries the painted output of both: the constant cache and the live value.
+    const refParagraphs = blocksOf(part).slice(-2);
+    expect(context.tokenForParagraph(refParagraphs[0]!.id)).toContain('2.3');
+    expect(context.tokenForParagraph(refParagraphs[1]!.id)).toContain('b.3');
+  });
+
+  test('normalization: NBSP and whitespace runs do not fail an otherwise exact match', () => {
+    const part = document(
+      numbered(0, bookmarked('t', 'A')) +
+        // The cache says `1` with a leading NBSP and a trailing space.
+        refField(' REF t \\r ', '\u00A01 ')
+    );
+    const context = contextUnder(TWO_LEVEL_NUMBERING, part);
+    expect(liveAt(part, context, 0, spec('t', 'r'))).toBe('1');
   });
 });

--- a/packages/core/src/layout/field-form.ts
+++ b/packages/core/src/layout/field-form.ts
@@ -20,6 +20,7 @@ import { parseButtonInstruction, type ButtonFieldSpec } from './field-button.ts'
 import { parseDocPropertyInstruction, type DocPropertyField } from './field-doc-property.ts';
 import { normalizeFieldInstruction } from './field-instruction.ts';
 import { parseHyperlinkInstruction, type HyperlinkFieldSpec } from './field-link.ts';
+import { parseRefInstruction, type RefFieldSpec } from './field-ref.ts';
 import { parseSymbolInstruction, type SymbolFieldSpec } from './field-symbol.ts';
 import { resolveRunStyle, type ResolvedRunStyle, type ThemeFonts } from './run-style.ts';
 
@@ -54,6 +55,7 @@ export interface CapturedInstructionSpecs {
   formSpec: FormFieldKind | null;
   buttonSpec: ButtonFieldSpec | null;
   docPropertySpec: DocPropertyField | null;
+  refSpec: RefFieldSpec | null;
 }
 
 /**
@@ -71,6 +73,8 @@ export function captureInstructionSpecs(pending: CapturedInstructionSpecs, raw: 
   pending.buttonSpec = parseButtonInstruction(raw);
   if (pending.buttonSpec) return;
   pending.docPropertySpec = parseDocPropertyInstruction(raw);
+  if (pending.docPropertySpec) return;
+  pending.refSpec = parseRefInstruction(raw);
 }
 
 /** The synthesized form-field result: text plus the props/style the piece should carry. */

--- a/packages/core/src/layout/field-pieces.ts
+++ b/packages/core/src/layout/field-pieces.ts
@@ -282,6 +282,14 @@ export interface PendingFieldProjection {
    * ffData present with an unreadable payload still shades as a form field.
    */
   formData: LegacyFormFieldData | null;
+  /**
+   * Canonical node id of the field's begin `w:fldChar`.
+   *
+   * The per-field key REF calibration verdicts live under (`RefFieldContext.liveValueOf`):
+   * node ids survive edits, so the projection and the context's token fold read the same
+   * verdict for the same field however either walk collected its cached text.
+   */
+  beginId: string;
   /** True when this pending field is a well-formed atomic unit (begin will close). */
   atomic: boolean;
   /** True when this closed FORMTEXT field exposes its authored result as ordinary text. */

--- a/packages/core/src/layout/field-pieces.ts
+++ b/packages/core/src/layout/field-pieces.ts
@@ -17,6 +17,7 @@ import type { DocPropertyField } from './field-doc-property.ts';
 import type { FormFieldKind } from './field-form.ts';
 import type { AllowlistedPageField } from './field-instruction.ts';
 import type { HyperlinkFieldSpec } from './field-link.ts';
+import type { RefFieldSpec } from './field-ref.ts';
 import type { SymbolFieldSpec } from './field-symbol.ts';
 import type { RevisionAttribution } from './revision-projection.ts';
 import type { ResolvedRunStyle } from './run-style.ts';
@@ -266,6 +267,15 @@ export interface PendingFieldProjection {
    * empty cache.
    */
   docPropertySpec: DocPropertyField | null;
+  /**
+   * Recognized REF cross-reference instruction, or null when the field is not one.
+   *
+   * Captured at the same points as {@link symbolSpec}. Unlike {@link buttonSpec}, a resolved
+   * value WINS over a non-empty cached result — the stale cache is exactly what a REF field
+   * exists to replace — and an unresolvable spec (missing bookmark, unnumbered target for a
+   * number switch) falls back to the cache, never to the raw instruction.
+   */
+  refSpec: RefFieldSpec | null;
   /**
    * Bounded `w:ffData` render state read at `begin` (`legacyFormFieldDataOf` — state only,
    * macros never), or null when absent or malformed. {@link formField} stays presence-based:

--- a/packages/core/src/layout/field-projection.ts
+++ b/packages/core/src/layout/field-projection.ts
@@ -567,6 +567,7 @@ export function piecesOfParagraph(
             // macros never); `formField` below stays presence-based so an unreadable payload
             // still shades.
             formData: legacyFormFieldDataOf(grand),
+            beginId: grand.id,
             atomic,
             editableResult: editableResultBeginIds.has(grand.id),
             atomStart: offset,

--- a/packages/core/src/layout/field-projection.ts
+++ b/packages/core/src/layout/field-projection.ts
@@ -74,6 +74,7 @@ import {
   type RunPropertyCascader,
 } from './field-run-text.ts';
 import { captureInstructionSpecs } from './field-form.ts';
+import type { RefFieldContext } from './field-ref.ts';
 import { synthesizeAtomicField } from './field-synthesis.ts';
 import { isSymbolRunChild, symbolGlyphOf, symbolRunStyle } from './symbol-run.ts';
 import {
@@ -181,7 +182,8 @@ export function piecesOfParagraph(
   themeFonts?: ThemeFonts,
   projectFieldLink?: FieldLinkProjector,
   documentProperties?: DocumentProperties,
-  bodyPageFields: BodyPageFieldContext | false = false
+  bodyPageFields: BodyPageFieldContext | false = false,
+  refFields?: RefFieldContext
 ): FieldAwarePiece[] {
   if (paragraph.kind === 'textValue') return [];
   if (paragraph.kind !== 'paragraph') return [];
@@ -345,6 +347,7 @@ export function piecesOfParagraph(
       themeFonts,
       documentProperties,
       bodyPageFields,
+      ...(refFields ? { refFields } : {}),
     });
     if (synthesis) {
       const extras = carried();
@@ -559,6 +562,7 @@ export function piecesOfParagraph(
             formSpec: null,
             buttonSpec: null,
             docPropertySpec: null,
+            refSpec: null,
             // Bounded ffData STATE read (checkbox checked/size, dropdown entries/selection —
             // macros never); `formField` below stays presence-based so an unreadable payload
             // still shades.
@@ -891,6 +895,7 @@ export function piecesOfParagraph(
       projectFieldLink,
       documentProperties,
       bodyPageFields,
+      ...(refFields ? { refFields } : {}),
     });
     if (!projected) return;
     // `w:ffData` is a `w:fldChar` payload, so a simple field is never a legacy form field. A body

--- a/packages/core/src/layout/field-ref.ts
+++ b/packages/core/src/layout/field-ref.ts
@@ -10,14 +10,16 @@
 // Resolution reads three story-derived inputs, all bounded:
 //   - bookmark name → target paragraph, indexed ONLY for referenced names (the index can never
 //     outgrow the capped reference count), first declaration in document order wins;
-//   - a number switch (`\r` / `\w` / `\n`) → the target's `ResolvedListItem.markerText`;
+//   - a number switch (`\r` / `\w` / `\n`) → the target's number in FULL CONTEXT, composed
+//     from the counter path by `composeFullContextNumber` — a deep legal level like `(%3)`
+//     states only its own placeholder, so its marker (`(c)`) is not the number a reader
+//     cites; the composition paints `1.2(c)` the way Word's cached result does;
 //   - a plain REF → the bookmarked text inside the target paragraph, length-capped.
 //
 // DEVIATION: `\r` (relative context) and `\w` (full context) both paint the full-context
-// marker. For multilevel `w:lvlText` like `%1.%2` the marker text IS the full-context number;
-// deriving Word's relative form would need the referencing paragraph's own list position and
-// is out of scope. All three number switches share Word's trailing-period trim (`1.2` stays
-// `1.2`, a bare `1.` becomes `1`).
+// number. Deriving Word's relative form would need the referencing paragraph's own list
+// position and is out of scope. All three number switches share Word's trailing-period trim
+// (`1.2` stays `1.2`, a bare `1.` becomes `1`).
 //
 // DEVIATION: plain-REF extraction stays inside the target paragraph. A bookmark whose end
 // marker sits outside that paragraph contributes the start paragraph's tail only — the cap
@@ -49,7 +51,12 @@ import {
   onFldCharEnd,
   onFldCharSeparate,
 } from './field-instruction.ts';
-import { walkStoryParagraphs, type ResolvedListItem } from './list-resolve.ts';
+import { composeFullContextNumber } from './list-counters.ts';
+import {
+  listItemNumberSource,
+  walkStoryParagraphs,
+  type ResolvedListItem,
+} from './list-resolve.ts';
 
 /** Word's own bookmark-name limit is 40; this is the fail-closed bound, not a fidelity claim. */
 const MAX_REF_BOOKMARK_NAME_CHARS = 256;
@@ -435,9 +442,22 @@ function buildRefFieldContext(
     const target = targets.get(spec.bookmark);
     if (!target) return null;
     if (spec.numberSwitch !== null) {
-      const marker = listItems?.get(target.id)?.markerText ?? '';
-      if (marker.length === 0) return null;
-      return trimTrailingPeriod(marker);
+      const item = listItems?.get(target.id);
+      if (!item) return null;
+      // Full context first: a deep level's marker states only its own placeholder, and
+      // painting bare `(c)` for a `1.2(c)` target is worse than the stale cache. Items built
+      // outside `resolveStoryListItems` carry no counter source; their marker (already the
+      // full context in the shapes that reach them) is the bounded fallback.
+      const source = listItemNumberSource(item);
+      const composed = source !== undefined ? composeFullContextNumber(source) : null;
+      // A bullet has a marker but no number a reader can cite — cached fallback, not a glyph.
+      const fallback =
+        item.numFmt !== 'bullet' && item.numFmt !== 'none' && item.markerText.length > 0
+          ? item.markerText
+          : null;
+      const value = composed ?? fallback;
+      if (value === null) return null;
+      return trimTrailingPeriod(value);
     }
     const text = bookmarkRangeText(target, spec.bookmark);
     return text.length > 0 ? text : null;

--- a/packages/core/src/layout/field-ref.ts
+++ b/packages/core/src/layout/field-ref.ts
@@ -1,0 +1,508 @@
+// REF cross-reference fields (§17.16.5.45): live results from the bookmark target and the
+// resolved numbering, so a reference tracks its section instead of painting a stale cache.
+//
+// The instruction is attacker-controlled and NEVER executes. Recognition is one bounded,
+// quote-aware tokenize pass over a length-capped string; anything outside the supported
+// grammar — an unknown switch (`\p`, `\f`, `\d`, `\#`, …), a missing bookmark argument, an
+// over-long name — resolves to null and the field keeps painting its cached result exactly as
+// before. `\* MERGEFORMAT` is inert; `\h` only parses (navigation is not wired here).
+//
+// Resolution reads three story-derived inputs, all bounded:
+//   - bookmark name → target paragraph, indexed ONLY for referenced names (the index can never
+//     outgrow the capped reference count), first declaration in document order wins;
+//   - a number switch (`\r` / `\w` / `\n`) → the target's `ResolvedListItem.markerText`;
+//   - a plain REF → the bookmarked text inside the target paragraph, length-capped.
+//
+// DEVIATION: `\r` (relative context) and `\w` (full context) both paint the full-context
+// marker. For multilevel `w:lvlText` like `%1.%2` the marker text IS the full-context number;
+// deriving Word's relative form would need the referencing paragraph's own list position and
+// is out of scope. All three number switches share Word's trailing-period trim (`1.2` stays
+// `1.2`, a bare `1.` becomes `1`).
+//
+// DEVIATION: plain-REF extraction stays inside the target paragraph. A bookmark whose end
+// marker sits outside that paragraph contributes the start paragraph's tail only — the cap
+// that keeps a hostile range from inflating layout keys and painted spans.
+//
+// Every per-paragraph scan is memoized on the immutable paragraph node and every per-block
+// aggregate on the block node, so an incremental pass pays pointer lookups for unchanged
+// content. `resolveStoryRefFields` returns null for the common no-REF story, which costs
+// callers nothing downstream.
+
+import {
+  fldSimpleInstr,
+  isFldSimple,
+  WML_NAMESPACE_URI,
+  type OoxmlElement,
+  type OoxmlNode,
+} from '@docx-editor.dev/core/store';
+import {
+  consumeScanNode,
+  createFieldParseState,
+  createScanBudget,
+  effectiveFieldInstruction,
+  ingestInstrTextBounded,
+  isFldChar,
+  isInstrText,
+  MAX_FIELD_INSTRUCTION_CHARS,
+  MAX_STORY_FIELD_SCAN_DEPTH,
+  onFldCharBegin,
+  onFldCharEnd,
+  onFldCharSeparate,
+} from './field-instruction.ts';
+import { walkStoryParagraphs, type ResolvedListItem } from './list-resolve.ts';
+
+/** Word's own bookmark-name limit is 40; this is the fail-closed bound, not a fidelity claim. */
+const MAX_REF_BOOKMARK_NAME_CHARS = 256;
+/** Ceiling on live-resolved REF fields per story; fields past it keep their cached results. */
+const MAX_REF_FIELDS_PER_STORY = 512;
+/** Length cap on a plain REF's extracted text — file data must not inflate keys or spans. */
+const MAX_REF_TEXT_CHARS = 1024;
+/** Ceiling on bookmark names remembered per top-level block (hostile declaration spam). */
+const MAX_REF_BOOKMARKS_PER_BLOCK = 2048;
+
+/** One recognized REF instruction: the target name and the supported switches, nothing else. */
+export interface RefFieldSpec {
+  readonly bookmark: string;
+  /** `r` / `w` paint the target's number; `n` the same without context; null the range text. */
+  readonly numberSwitch: 'r' | 'w' | 'n' | null;
+  /** `\h` parsed and inert — the reference paints; navigation is a follow-up. */
+  readonly hyperlink: boolean;
+}
+
+/**
+ * Split a whitespace-collapsed instruction into space- or quote-delimited tokens.
+ *
+ * One linear pass, no regex over file-derived text. An unterminated quote fails the whole
+ * parse (null) rather than guessing where the argument ends.
+ */
+function tokenizeInstruction(collapsed: string): string[] | null {
+  const tokens: string[] = [];
+  let index = 0;
+  while (index < collapsed.length) {
+    const char = collapsed[index]!;
+    if (char === ' ') {
+      index += 1;
+      continue;
+    }
+    if (char === '"') {
+      const close = collapsed.indexOf('"', index + 1);
+      if (close === -1) return null;
+      tokens.push(collapsed.slice(index + 1, close));
+      index = close + 1;
+      continue;
+    }
+    let end = index;
+    while (end < collapsed.length && collapsed[end] !== ' ') end += 1;
+    tokens.push(collapsed.slice(index, end));
+    index = end;
+  }
+  return tokens;
+}
+
+/**
+ * Recognize `REF <bookmark> [\r|\w|\n] [\h] [\* MERGEFORMAT]`, or null for anything else.
+ *
+ * The keyword matches case-insensitively; the bookmark name keeps its authored case (it is a
+ * lookup key into a Map, never an object property, so hostile names like `__proto__` are just
+ * names that resolve to nothing). Any unrecognized switch fails the parse so the field falls
+ * back to its cached result — never the raw instruction, never a guess.
+ */
+export function parseRefInstruction(raw: string): RefFieldSpec | null {
+  if (raw.length > MAX_FIELD_INSTRUCTION_CHARS) return null;
+  const collapsed = raw.replace(/\s+/g, ' ').trim();
+  if (collapsed.length > MAX_FIELD_INSTRUCTION_CHARS) return null;
+  const tokens = tokenizeInstruction(collapsed);
+  if (tokens === null || tokens.length < 2) return null;
+  if (tokens[0]!.toUpperCase() !== 'REF') return null;
+  const bookmark = tokens[1]!;
+  if (
+    bookmark.length === 0 ||
+    bookmark.length > MAX_REF_BOOKMARK_NAME_CHARS ||
+    bookmark.startsWith('\\')
+  ) {
+    return null;
+  }
+  let numberSwitch: RefFieldSpec['numberSwitch'] = null;
+  let hyperlink = false;
+  for (let index = 2; index < tokens.length; index += 1) {
+    const token = tokens[index]!.toUpperCase();
+    if (token === '\\R') numberSwitch = 'r';
+    else if (token === '\\W') numberSwitch = 'w';
+    else if (token === '\\N') numberSwitch = 'n';
+    else if (token === '\\H') hyperlink = true;
+    else if (token === '\\*' && tokens[index + 1]?.toUpperCase() === 'MERGEFORMAT') index += 1;
+    else if (token === '\\*MERGEFORMAT') continue;
+    else return null;
+  }
+  return { bookmark, numberSwitch, hyperlink };
+}
+
+/**
+ * The story's resolved REF inputs for one layout pass.
+ *
+ * Threaded as a runtime rider on the layout options (see `layoutSemanticDocument`) rather
+ * than a `SemanticLayoutOptions` member, so the public options surface stays put. Absent
+ * means every REF field paints its cached result — the pre-existing degradation, and the one
+ * header/footer, note and text-box stories still take.
+ */
+export interface RefFieldContext {
+  /**
+   * Content token over every resolvable REF value in the story, for the section prepass
+   * memo. A renumbering edit can move a REF value in a section whose own blocks and list
+   * map are identity-unchanged, and this token is the only validator that sees it.
+   */
+  readonly valuesToken: string;
+  /** The paragraph's REF values folded for its block cache key; `''` when it holds none. */
+  tokenForParagraph(paragraphId: string): string;
+  /** Resolve one recognized instruction, or null to keep the cached result. */
+  valueOf(spec: RefFieldSpec): string | null;
+}
+
+function wmlAttribute(node: OoxmlElement, localName: string): string | undefined {
+  for (const attribute of node.attributes) {
+    if (attribute.namespaceUri === WML_NAMESPACE_URI && attribute.localName === localName) {
+      return attribute.value;
+    }
+  }
+  return undefined;
+}
+
+/** REF specs and bookmark names one paragraph carries; shared empty for the common case. */
+interface ParagraphRefScan {
+  readonly specs: readonly RefFieldSpec[];
+  readonly bookmarks: readonly string[];
+}
+const EMPTY_STRINGS: readonly string[] = Object.freeze([]);
+const EMPTY_SPECS: readonly RefFieldSpec[] = Object.freeze([]);
+const EMPTY_REF_SCAN: ParagraphRefScan = Object.freeze({
+  specs: EMPTY_SPECS,
+  bookmarks: EMPTY_STRINGS,
+});
+
+/** Memoized per immutable paragraph node — an edit republishes only touched paragraphs. */
+const paragraphRefScans = new WeakMap<OoxmlElement, ParagraphRefScan>();
+
+/** A drawing hosts its own story; its bookmarks and fields are not this paragraph's. */
+function isDrawingHost(node: OoxmlElement): boolean {
+  return node.kind === 'drawing' || node.localName === 'drawing' || node.localName === 'pict';
+}
+
+/**
+ * Bounded scan of one paragraph: level-1 complex REF instructions (the only ones projection
+ * live-paints), `w:fldSimple` REF instructions, and declared bookmark names.
+ *
+ * Mirrors the projection walk's capture sites — the outermost `separate`, the no-separate
+ * outermost `end` — so this is a superset of what synthesis will ask to resolve; a spec seen
+ * here and never painted only widens a cache token, which can cost a re-measure but never
+ * leave one stale.
+ */
+function scanParagraphRefs(paragraph: OoxmlElement): ParagraphRefScan {
+  const cached = paragraphRefScans.get(paragraph);
+  if (cached) return cached;
+  let specs: RefFieldSpec[] | null = null;
+  let bookmarks: string[] | null = null;
+  const budget = createScanBudget();
+  const field = createFieldParseState();
+
+  const pushSpec = (raw: string): void => {
+    const spec = parseRefInstruction(raw);
+    if (spec) (specs ??= []).push(spec);
+  };
+  const captureLevelOne = (): void => {
+    if (field.nesting !== 1 || field.phase !== 'instruction' || field.nestingOverflow) return;
+    const effective = effectiveFieldInstruction(field);
+    if (!effective.overflow) pushSpec(effective.instruction);
+  };
+
+  const visit = (node: OoxmlNode, depth: number): void => {
+    if (node.kind === 'textValue') return;
+    if (budget.exhausted || depth > MAX_STORY_FIELD_SCAN_DEPTH) return;
+    if (node.kind === 'bookmarkStart') {
+      const name = wmlAttribute(node, 'name');
+      if (name !== undefined && name.length > 0 && name.length <= MAX_REF_BOOKMARK_NAME_CHARS) {
+        (bookmarks ??= []).push(name);
+      }
+      return;
+    }
+    if (node.kind === 'run') {
+      for (const grand of node.children) {
+        if (!consumeScanNode(budget)) return;
+        if (grand.kind === 'runProperties') continue;
+        if (isFldChar(grand, 'begin')) {
+          onFldCharBegin(field);
+          continue;
+        }
+        if (isInstrText(grand)) {
+          ingestInstrTextBounded(field, grand, budget, depth + 1);
+          continue;
+        }
+        if (isFldChar(grand, 'separate')) {
+          captureLevelOne();
+          onFldCharSeparate(field);
+          continue;
+        }
+        if (isFldChar(grand, 'end')) {
+          captureLevelOne();
+          onFldCharEnd(field);
+        }
+      }
+      return;
+    }
+    if (isFldSimple(node)) {
+      // The outer instruction only: a field nested in a simple field's cached result is never
+      // live-projected as a REF, so descending would key on values nothing paints.
+      pushSpec(fldSimpleInstr(node) ?? '');
+      return;
+    }
+    if (isDrawingHost(node)) return;
+    if (!consumeScanNode(budget)) return;
+    for (const child of node.children) visit(child, depth + 1);
+  };
+  for (const child of paragraph.children) {
+    if (!consumeScanNode(budget)) break;
+    visit(child, 1);
+  }
+
+  const scan: ParagraphRefScan =
+    specs === null && bookmarks === null
+      ? EMPTY_REF_SCAN
+      : Object.freeze({ specs: specs ?? EMPTY_SPECS, bookmarks: bookmarks ?? EMPTY_STRINGS });
+  paragraphRefScans.set(paragraph, scan);
+  return scan;
+}
+
+/** One top-level block's aggregate, memoized on the block node (tables included). */
+interface BlockRefScan {
+  readonly specsByParagraph: ReadonlyMap<string, readonly RefFieldSpec[]> | null;
+  readonly bookmarkOwners: ReadonlyMap<string, OoxmlElement> | null;
+}
+const EMPTY_BLOCK_SCAN: BlockRefScan = Object.freeze({
+  specsByParagraph: null,
+  bookmarkOwners: null,
+});
+const blockRefScans = new WeakMap<OoxmlElement, BlockRefScan>();
+
+function scanBlockRefs(block: OoxmlElement): BlockRefScan {
+  const cached = blockRefScans.get(block);
+  if (cached) return cached;
+  let specsByParagraph: Map<string, readonly RefFieldSpec[]> | null = null;
+  let bookmarkOwners: Map<string, OoxmlElement> | null = null;
+  for (const paragraph of walkStoryParagraphs([block])) {
+    const scan = scanParagraphRefs(paragraph);
+    if (scan.specs.length > 0) (specsByParagraph ??= new Map()).set(paragraph.id, scan.specs);
+    for (const name of scan.bookmarks) {
+      bookmarkOwners ??= new Map();
+      // First declaration wins, the same rule the jump-target index applies: a duplicate name
+      // must not make a reference move when an unrelated edit re-declares it later.
+      if (!bookmarkOwners.has(name) && bookmarkOwners.size < MAX_REF_BOOKMARKS_PER_BLOCK) {
+        bookmarkOwners.set(name, paragraph);
+      }
+    }
+  }
+  const scan: BlockRefScan =
+    specsByParagraph === null && bookmarkOwners === null
+      ? EMPTY_BLOCK_SCAN
+      : Object.freeze({ specsByParagraph, bookmarkOwners });
+  blockRefScans.set(block, scan);
+  return scan;
+}
+
+/** Word trims one trailing period off a referenced number: `1.` → `1`, `1.2` stays `1.2`. */
+function trimTrailingPeriod(marker: string): string {
+  return marker.length > 1 && marker.endsWith('.') ? marker.slice(0, -1) : marker;
+}
+
+/** Plain-REF text per (target paragraph, name), memoized on the immutable paragraph. */
+const bookmarkTextMemos = new WeakMap<OoxmlElement, Map<string, string>>();
+
+/**
+ * The bookmarked text inside the target paragraph: from the named `w:bookmarkStart` to the
+ * `w:bookmarkEnd` carrying the same `w:id`, or to the paragraph's end when the range runs
+ * past it. Length-capped; collects `w:t` and tabs only — deleted text, field chrome and
+ * drawings never join a computed result.
+ */
+function bookmarkRangeText(paragraph: OoxmlElement, name: string): string {
+  let memo = bookmarkTextMemos.get(paragraph);
+  const cached = memo?.get(name);
+  if (cached !== undefined) return cached;
+
+  let collecting = false;
+  let done = false;
+  let endId: string | undefined;
+  let text = '';
+  const budget = createScanBudget();
+
+  const append = (value: string): void => {
+    const room = MAX_REF_TEXT_CHARS - text.length;
+    if (room <= 0) {
+      done = true;
+      return;
+    }
+    text += value.length > room ? value.slice(0, room) : value;
+  };
+
+  const visit = (node: OoxmlNode, depth: number): void => {
+    if (done || node.kind === 'textValue') return;
+    if (budget.exhausted || depth > MAX_STORY_FIELD_SCAN_DEPTH) return;
+    if (node.kind === 'bookmarkStart') {
+      if (!collecting && wmlAttribute(node, 'name') === name) {
+        collecting = true;
+        endId = wmlAttribute(node, 'id');
+      }
+      return;
+    }
+    if (node.kind === 'bookmarkEnd') {
+      if (collecting && endId !== undefined && wmlAttribute(node, 'id') === endId) done = true;
+      return;
+    }
+    if (node.kind === 'run') {
+      if (!collecting) return;
+      for (const grand of node.children) {
+        if (done || !consumeScanNode(budget)) return;
+        if (grand.kind === 'text') {
+          for (const value of grand.children) {
+            if (value.kind === 'textValue') append(value.value);
+          }
+        } else if (grand.kind === 'tab') {
+          append('\t');
+        }
+      }
+      return;
+    }
+    if (isDrawingHost(node) || isFldSimple(node)) return;
+    if (!consumeScanNode(budget)) return;
+    for (const child of node.children) visit(child, depth + 1);
+  };
+  for (const child of paragraph.children) {
+    if (done || !consumeScanNode(budget)) break;
+    visit(child, 1);
+  }
+
+  if (!memo) {
+    memo = new Map();
+    bookmarkTextMemos.set(paragraph, memo);
+  }
+  memo.set(name, text);
+  return text;
+}
+
+interface RefContextMemoEntry {
+  readonly listItems: ReadonlyMap<string, ResolvedListItem> | undefined;
+  readonly context: RefFieldContext | null;
+}
+/**
+ * Memo keyed on the story blocks array (stable per part and display mode via `storyBlocks`)
+ * and validated against the list map by identity — the two inputs every resolved value
+ * derives from. A keystroke publishes a new part, so a miss re-aggregates, but the per-block
+ * memos above make that pointer lookups over unchanged blocks.
+ */
+const refContextMemos = new WeakMap<readonly OoxmlElement[], RefContextMemoEntry>();
+
+function buildRefFieldContext(
+  blocks: readonly OoxmlElement[],
+  listItems: ReadonlyMap<string, ResolvedListItem> | undefined
+): RefFieldContext | null {
+  const specsByParagraph = new Map<string, readonly RefFieldSpec[]>();
+  const blockScans: BlockRefScan[] = [];
+  let totalSpecs = 0;
+  for (const block of blocks) {
+    const scan = scanBlockRefs(block);
+    blockScans.push(scan);
+    if (!scan.specsByParagraph) continue;
+    for (const [paragraphId, specs] of scan.specsByParagraph) {
+      if (totalSpecs >= MAX_REF_FIELDS_PER_STORY) break;
+      specsByParagraph.set(paragraphId, specs);
+      totalSpecs += specs.length;
+    }
+  }
+  if (specsByParagraph.size === 0) return null;
+
+  // Index only referenced names, so the map is bounded by the capped reference count. A Map,
+  // never an object: bookmark names are attacker-chosen keys.
+  const referenced = new Set<string>();
+  for (const specs of specsByParagraph.values()) {
+    for (const spec of specs) referenced.add(spec.bookmark);
+  }
+  const targets = new Map<string, OoxmlElement>();
+  for (const scan of blockScans) {
+    if (!scan.bookmarkOwners) continue;
+    for (const [name, paragraph] of scan.bookmarkOwners) {
+      if (referenced.has(name) && !targets.has(name)) targets.set(name, paragraph);
+    }
+  }
+
+  const resolve = (spec: RefFieldSpec): string | null => {
+    const target = targets.get(spec.bookmark);
+    if (!target) return null;
+    if (spec.numberSwitch !== null) {
+      const marker = listItems?.get(target.id)?.markerText ?? '';
+      if (marker.length === 0) return null;
+      return trimTrailingPeriod(marker);
+    }
+    const text = bookmarkRangeText(target, spec.bookmark);
+    return text.length > 0 ? text : null;
+  };
+
+  const values = new Map<string, string | null>();
+  const valueOf = (spec: RefFieldSpec): string | null => {
+    const key = `${spec.numberSwitch ?? 't'}\u0000${spec.bookmark}`;
+    const cached = values.get(key);
+    if (cached !== undefined || values.has(key)) return cached ?? null;
+    const value = resolve(spec);
+    values.set(key, value);
+    return value;
+  };
+
+  // `\u0002` marks an unresolved value so "resolves to nothing" and "resolves to empty" move
+  // the token when they trade places.
+  const tokens = new Map<string, string>();
+  const storyParts: string[] = [];
+  for (const [paragraphId, specs] of specsByParagraph) {
+    const token = specs
+      .map(
+        (spec) =>
+          `${spec.numberSwitch ?? 't'}\u0001${spec.bookmark}\u0001${valueOf(spec) ?? '\u0002'}`
+      )
+      .join('\u0003');
+    tokens.set(paragraphId, token);
+    storyParts.push(token);
+  }
+
+  return {
+    valuesToken: storyParts.join('\u0004'),
+    tokenForParagraph: (paragraphId) => tokens.get(paragraphId) ?? '',
+    valueOf,
+  };
+}
+
+/**
+ * Resolve the story's REF fields for one layout pass, or null when it has none.
+ *
+ * Bookmarks and REF fields resolve within one story: a body REF finds body bookmarks. Other
+ * stories (headers, footers, notes, text boxes) are not given a context and keep painting
+ * cached results.
+ */
+export function resolveStoryRefFields(
+  blocks: readonly OoxmlElement[],
+  listItems: ReadonlyMap<string, ResolvedListItem> | undefined
+): RefFieldContext | null {
+  const memo = refContextMemos.get(blocks);
+  if (memo && memo.listItems === listItems) return memo.context;
+  const context = buildRefFieldContext(blocks, listItems);
+  refContextMemos.set(blocks, { listItems, context });
+  return context;
+}
+
+/**
+ * Aggregate the REF tokens of every paragraph a table contains, for its prepared-block memo
+ * and cache key — the same shape as the table's list-token aggregate, for the same reason: a
+ * REF value change inside a cell moves nothing else in the table's key.
+ */
+export function refTokenForTableBlock(table: OoxmlElement, context: RefFieldContext): string {
+  const tokens: string[] = [];
+  for (const paragraph of walkStoryParagraphs([table])) {
+    const token = context.tokenForParagraph(paragraph.id);
+    if (token) tokens.push(token);
+  }
+  return tokens.join(';');
+}

--- a/packages/core/src/layout/field-ref.ts
+++ b/packages/core/src/layout/field-ref.ts
@@ -10,16 +10,31 @@
 // Resolution reads three story-derived inputs, all bounded:
 //   - bookmark name → target paragraph, indexed ONLY for referenced names (the index can never
 //     outgrow the capped reference count), first declaration in document order wins;
-//   - a number switch (`\r` / `\w` / `\n`) → the target's number in FULL CONTEXT, composed
-//     from the counter path by `composeFullContextNumber` — a deep legal level like `(%3)`
-//     states only its own placeholder, so its marker (`(c)`) is not the number a reader
-//     cites; the composition paints `1.2(c)` the way Word's cached result does;
+//   - `\r` / `\w` → the target's number in FULL CONTEXT, composed from the counter path by
+//     `composeFullContextNumber` — a deep legal level like `(%3)` states only its own
+//     placeholder, so its marker (`(c)`) is not the number a reader cites; `\n` → the
+//     target's OWN level expansion (`(c)`, `(ii)`), which is what Word's cached values show
+//     for that switch;
 //   - a plain REF → the bookmarked text inside the target paragraph, length-capped.
 //
-// DEVIATION: `\r` (relative context) and `\w` (full context) both paint the full-context
-// number. Deriving Word's relative form would need the referencing paragraph's own list
-// position and is out of scope. All three number switches share Word's trailing-period trim
-// (`1.2` stays `1.2`, a bare `1.` becomes `1`).
+// CALIBRATION — the document's own cached results are the oracle. Word's full-context join is
+// scheme-dependent in ways the composition cannot reproduce across every real numbering shape
+// (a mixed ordinalText/letter/decimal chain whose level texts never chain concatenates every
+// ancestor into garbage). So each field is gated ONCE: when its authored cache is non-empty,
+// the computed value must reproduce it (whitespace-collapsed, NBSP = space) or the field stays
+// on its cache permanently. The verdict is sticky per field — keyed by the begin / `w:fldSimple`
+// node id, which survives edits, and carried across passes on the story's first/last block —
+// because after a renumbering edit the live value DIVERGES from the cache by design, and
+// re-comparing would flip every calibrated field back to stale. A field with an empty cache
+// has nothing to regress against and stays eligible. Net: live updating everywhere composition
+// is provably right, and no document ever renders worse than its cache.
+//
+// DEVIATION: `\r` (relative context) paints the full-context number. Deriving Word's relative
+// form would need the referencing paragraph's own list position and is out of scope. All three
+// number switches share Word's trailing-period trim (`1.2` stays `1.2`, a bare `1.` becomes
+// `1`). When one instruction states several number switches, `\n` outranks `\r` outranks `\w`
+// — the cached evidence for `\w \n` instructions shows the `\n`-shaped value — and calibration
+// guards the rest.
 //
 // DEVIATION: plain-REF extraction stays inside the target paragraph. A bookmark whose end
 // marker sits outside that paragraph contributes the start paragraph's tail only — the cap
@@ -66,6 +81,8 @@ const MAX_REF_FIELDS_PER_STORY = 512;
 const MAX_REF_TEXT_CHARS = 1024;
 /** Ceiling on bookmark names remembered per top-level block (hostile declaration spam). */
 const MAX_REF_BOOKMARKS_PER_BLOCK = 2048;
+/** Ceiling on sticky calibration verdicts carried for one story across a session. */
+const MAX_REF_VERDICTS = 4096;
 
 /** One recognized REF instruction: the target name and the supported switches, nothing else. */
 export interface RefFieldSpec {
@@ -129,18 +146,23 @@ export function parseRefInstruction(raw: string): RefFieldSpec | null {
   ) {
     return null;
   }
-  let numberSwitch: RefFieldSpec['numberSwitch'] = null;
+  let sawN = false;
+  let sawR = false;
+  let sawW = false;
   let hyperlink = false;
   for (let index = 2; index < tokens.length; index += 1) {
     const token = tokens[index]!.toUpperCase();
-    if (token === '\\R') numberSwitch = 'r';
-    else if (token === '\\W') numberSwitch = 'w';
-    else if (token === '\\N') numberSwitch = 'n';
+    if (token === '\\R') sawR = true;
+    else if (token === '\\W') sawW = true;
+    else if (token === '\\N') sawN = true;
     else if (token === '\\H') hyperlink = true;
     else if (token === '\\*' && tokens[index + 1]?.toUpperCase() === 'MERGEFORMAT') index += 1;
     else if (token === '\\*MERGEFORMAT') continue;
     else return null;
   }
+  // Several number switches in one instruction: `\n` outranks `\r` outranks `\w`. Real
+  // documents write `\w \n \h` and cache the `\n`-shaped value; calibration guards the rest.
+  const numberSwitch: RefFieldSpec['numberSwitch'] = sawN ? 'n' : sawR ? 'r' : sawW ? 'w' : null;
   return { bookmark, numberSwitch, hyperlink };
 }
 
@@ -154,15 +176,22 @@ export function parseRefInstruction(raw: string): RefFieldSpec | null {
  */
 export interface RefFieldContext {
   /**
-   * Content token over every resolvable REF value in the story, for the section prepass
-   * memo. A renumbering edit can move a REF value in a section whose own blocks and list
-   * map are identity-unchanged, and this token is the only validator that sees it.
+   * Content token over every PAINTED REF output in the story, for the section prepass memo.
+   * A renumbering edit can move a REF value in a section whose own blocks and list map are
+   * identity-unchanged, and this token is the only validator that sees it. A field that
+   * failed calibration contributes its (session-constant) cached text, so the token still
+   * moves exactly when painted output moves.
    */
   readonly valuesToken: string;
-  /** The paragraph's REF values folded for its block cache key; `''` when it holds none. */
+  /** The paragraph's REF outputs folded for its block cache key; `''` when it holds none. */
   tokenForParagraph(paragraphId: string): string;
-  /** Resolve one recognized instruction, or null to keep the cached result. */
-  valueOf(spec: RefFieldSpec): string | null;
+  /**
+   * The live value ONE field paints, keyed by its begin / `w:fldSimple` node id, or null to
+   * keep the cached result (failed calibration, unresolvable, or an anchor this scan never
+   * saw). Anchor-keyed so the projection's paint and this context's token fold read the SAME
+   * calibration verdict, however each walk collected the field's cached text.
+   */
+  liveValueOf(anchorId: string, spec: RefFieldSpec): string | null;
 }
 
 function wmlAttribute(node: OoxmlElement, localName: string): string | undefined {
@@ -174,17 +203,34 @@ function wmlAttribute(node: OoxmlElement, localName: string): string | undefined
   return undefined;
 }
 
-/** REF specs and bookmark names one paragraph carries; shared empty for the common case. */
+/** One scanned REF field: its instruction, its anchor node id, and its NORMALIZED cache. */
+interface ScannedRefField {
+  readonly spec: RefFieldSpec;
+  /** Begin `w:fldChar` / `w:fldSimple` node id — stable across edits, the calibration key. */
+  readonly anchorId: string;
+  /** The authored cached result, whitespace-collapsed (NBSP = space) — the oracle. */
+  readonly cached: string;
+}
+
+/** REF fields and bookmark names one paragraph carries; shared empty for the common case. */
 interface ParagraphRefScan {
-  readonly specs: readonly RefFieldSpec[];
+  readonly fields: readonly ScannedRefField[];
   readonly bookmarks: readonly string[];
 }
 const EMPTY_STRINGS: readonly string[] = Object.freeze([]);
-const EMPTY_SPECS: readonly RefFieldSpec[] = Object.freeze([]);
+const EMPTY_FIELDS: readonly ScannedRefField[] = Object.freeze([]);
 const EMPTY_REF_SCAN: ParagraphRefScan = Object.freeze({
-  specs: EMPTY_SPECS,
+  fields: EMPTY_FIELDS,
   bookmarks: EMPTY_STRINGS,
 });
+
+/** The calibration comparison's vocabulary: collapsed whitespace, NBSP as space, trimmed. */
+function normalizeResultText(value: string): string {
+  return value
+    .replace(/\u00A0/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
 
 /** Memoized per immutable paragraph node — an edit republishes only touched paragraphs. */
 const paragraphRefScans = new WeakMap<OoxmlElement, ParagraphRefScan>();
@@ -194,31 +240,67 @@ function isDrawingHost(node: OoxmlElement): boolean {
   return node.kind === 'drawing' || node.localName === 'drawing' || node.localName === 'pict';
 }
 
+/** The `w:t` text of a `w:fldSimple`'s cached display, bounded and depth-capped. */
+function fldSimpleCachedText(
+  simple: OoxmlElement,
+  budget: ReturnType<typeof createScanBudget>
+): string {
+  let text = '';
+  const visit = (node: OoxmlNode, depth: number): void => {
+    if (node.kind === 'textValue' || text.length >= MAX_REF_TEXT_CHARS) return;
+    if (budget.exhausted || depth > MAX_STORY_FIELD_SCAN_DEPTH) return;
+    if (!consumeScanNode(budget)) return;
+    if (node.kind === 'text') {
+      for (const value of node.children) {
+        if (value.kind === 'textValue') {
+          text += value.value.slice(0, MAX_REF_TEXT_CHARS - text.length);
+        }
+      }
+      return;
+    }
+    for (const child of node.children) visit(child, depth + 1);
+  };
+  for (const child of simple.children) visit(child, 1);
+  return text;
+}
+
 /**
- * Bounded scan of one paragraph: level-1 complex REF instructions (the only ones projection
- * live-paints), `w:fldSimple` REF instructions, and declared bookmark names.
+ * Bounded scan of one paragraph: level-1 complex REF fields (the only ones projection
+ * live-paints) with their anchor ids and cached results, `w:fldSimple` REF fields, and
+ * declared bookmark names.
  *
  * Mirrors the projection walk's capture sites — the outermost `separate`, the no-separate
- * outermost `end` — so this is a superset of what synthesis will ask to resolve; a spec seen
+ * outermost `end` — so this is a superset of what synthesis will ask to resolve; a field seen
  * here and never painted only widens a cache token, which can cost a re-measure but never
- * leave one stale.
+ * leave one stale. An anchor the scan misses paints its cache (`liveValueOf` answers null).
  */
 function scanParagraphRefs(paragraph: OoxmlElement): ParagraphRefScan {
-  const cached = paragraphRefScans.get(paragraph);
-  if (cached) return cached;
-  let specs: RefFieldSpec[] | null = null;
+  const memo = paragraphRefScans.get(paragraph);
+  if (memo) return memo;
+  let fields: ScannedRefField[] | null = null;
   let bookmarks: string[] | null = null;
   const budget = createScanBudget();
   const field = createFieldParseState();
 
-  const pushSpec = (raw: string): void => {
-    const spec = parseRefInstruction(raw);
-    if (spec) (specs ??= []).push(spec);
-  };
+  /** The open level-1 REF field being collected, if its instruction parsed. */
+  let pending: { spec: RefFieldSpec; anchorId: string; cached: string } | null = null;
+  let levelOneBeginId: string | null = null;
+
   const captureLevelOne = (): void => {
     if (field.nesting !== 1 || field.phase !== 'instruction' || field.nestingOverflow) return;
     const effective = effectiveFieldInstruction(field);
-    if (!effective.overflow) pushSpec(effective.instruction);
+    if (effective.overflow || levelOneBeginId === null) return;
+    const spec = parseRefInstruction(effective.instruction);
+    if (spec) pending = { spec, anchorId: levelOneBeginId, cached: '' };
+  };
+  const finalizePending = (): void => {
+    if (!pending) return;
+    (fields ??= []).push({
+      spec: pending.spec,
+      anchorId: pending.anchorId,
+      cached: normalizeResultText(pending.cached),
+    });
+    pending = null;
   };
 
   const visit = (node: OoxmlNode, depth: number): void => {
@@ -237,6 +319,10 @@ function scanParagraphRefs(paragraph: OoxmlElement): ParagraphRefScan {
         if (grand.kind === 'runProperties') continue;
         if (isFldChar(grand, 'begin')) {
           onFldCharBegin(field);
+          if (field.nesting === 1) {
+            levelOneBeginId = grand.id;
+            pending = null;
+          }
           continue;
         }
         if (isInstrText(grand)) {
@@ -249,8 +335,24 @@ function scanParagraphRefs(paragraph: OoxmlElement): ParagraphRefScan {
           continue;
         }
         if (isFldChar(grand, 'end')) {
+          const outermost = field.nesting === 1;
           captureLevelOne();
           onFldCharEnd(field);
+          if (outermost) finalizePending();
+          continue;
+        }
+        // Level-1 result text is the field's authored cache — the calibration oracle. Nested
+        // fields sit at deeper nesting and never join it; deleted text never joins a result.
+        if (pending && field.nesting === 1 && field.phase === 'result') {
+          if (grand.kind === 'text') {
+            for (const value of grand.children) {
+              if (value.kind === 'textValue' && pending.cached.length < MAX_REF_TEXT_CHARS) {
+                pending.cached += value.value.slice(0, MAX_REF_TEXT_CHARS - pending.cached.length);
+              }
+            }
+          } else if (grand.kind === 'tab' && pending.cached.length < MAX_REF_TEXT_CHARS) {
+            pending.cached += ' ';
+          }
         }
       }
       return;
@@ -258,7 +360,14 @@ function scanParagraphRefs(paragraph: OoxmlElement): ParagraphRefScan {
     if (isFldSimple(node)) {
       // The outer instruction only: a field nested in a simple field's cached result is never
       // live-projected as a REF, so descending would key on values nothing paints.
-      pushSpec(fldSimpleInstr(node) ?? '');
+      const spec = parseRefInstruction(fldSimpleInstr(node) ?? '');
+      if (spec) {
+        (fields ??= []).push({
+          spec,
+          anchorId: node.id,
+          cached: normalizeResultText(fldSimpleCachedText(node, budget)),
+        });
+      }
       return;
     }
     if (isDrawingHost(node)) return;
@@ -271,20 +380,20 @@ function scanParagraphRefs(paragraph: OoxmlElement): ParagraphRefScan {
   }
 
   const scan: ParagraphRefScan =
-    specs === null && bookmarks === null
+    fields === null && bookmarks === null
       ? EMPTY_REF_SCAN
-      : Object.freeze({ specs: specs ?? EMPTY_SPECS, bookmarks: bookmarks ?? EMPTY_STRINGS });
+      : Object.freeze({ fields: fields ?? EMPTY_FIELDS, bookmarks: bookmarks ?? EMPTY_STRINGS });
   paragraphRefScans.set(paragraph, scan);
   return scan;
 }
 
 /** One top-level block's aggregate, memoized on the block node (tables included). */
 interface BlockRefScan {
-  readonly specsByParagraph: ReadonlyMap<string, readonly RefFieldSpec[]> | null;
+  readonly fieldsByParagraph: ReadonlyMap<string, readonly ScannedRefField[]> | null;
   readonly bookmarkOwners: ReadonlyMap<string, OoxmlElement> | null;
 }
 const EMPTY_BLOCK_SCAN: BlockRefScan = Object.freeze({
-  specsByParagraph: null,
+  fieldsByParagraph: null,
   bookmarkOwners: null,
 });
 const blockRefScans = new WeakMap<OoxmlElement, BlockRefScan>();
@@ -292,11 +401,11 @@ const blockRefScans = new WeakMap<OoxmlElement, BlockRefScan>();
 function scanBlockRefs(block: OoxmlElement): BlockRefScan {
   const cached = blockRefScans.get(block);
   if (cached) return cached;
-  let specsByParagraph: Map<string, readonly RefFieldSpec[]> | null = null;
+  let fieldsByParagraph: Map<string, readonly ScannedRefField[]> | null = null;
   let bookmarkOwners: Map<string, OoxmlElement> | null = null;
   for (const paragraph of walkStoryParagraphs([block])) {
     const scan = scanParagraphRefs(paragraph);
-    if (scan.specs.length > 0) (specsByParagraph ??= new Map()).set(paragraph.id, scan.specs);
+    if (scan.fields.length > 0) (fieldsByParagraph ??= new Map()).set(paragraph.id, scan.fields);
     for (const name of scan.bookmarks) {
       bookmarkOwners ??= new Map();
       // First declaration wins, the same rule the jump-target index applies: a duplicate name
@@ -307,11 +416,34 @@ function scanBlockRefs(block: OoxmlElement): BlockRefScan {
     }
   }
   const scan: BlockRefScan =
-    specsByParagraph === null && bookmarkOwners === null
+    fieldsByParagraph === null && bookmarkOwners === null
       ? EMPTY_BLOCK_SCAN
-      : Object.freeze({ specsByParagraph, bookmarkOwners });
+      : Object.freeze({ fieldsByParagraph, bookmarkOwners });
   blockRefScans.set(block, scan);
   return scan;
+}
+
+/**
+ * Sticky calibration verdicts for one story, keyed by field anchor id.
+ *
+ * Carried across passes on the story's FIRST or LAST block object — the same anchor idiom the
+ * list resolver's story memo uses — because a keystroke republishes the blocks array while
+ * usually keeping both ends. Losing the registry (both ends replaced in one commit) only
+ * re-calibrates: a live field whose value has already diverged from its cache falls back to
+ * that cache, which is the safe direction. Bounded; entries past the cap re-calibrate too.
+ */
+const refVerdictsByAnchorBlock = new WeakMap<OoxmlElement, Map<string, boolean>>();
+
+function carriedVerdicts(blocks: readonly OoxmlElement[]): Map<string, boolean> {
+  const first = blocks[0];
+  const last = blocks[blocks.length - 1];
+  const carried =
+    (first ? refVerdictsByAnchorBlock.get(first) : undefined) ??
+    (last ? refVerdictsByAnchorBlock.get(last) : undefined) ??
+    new Map<string, boolean>();
+  if (first) refVerdictsByAnchorBlock.set(first, carried);
+  if (last) refVerdictsByAnchorBlock.set(last, carried);
+  return carried;
 }
 
 /** Word trims one trailing period off a referenced number: `1.` → `1`, `1.2` stays `1.2`. */
@@ -409,26 +541,26 @@ function buildRefFieldContext(
   blocks: readonly OoxmlElement[],
   listItems: ReadonlyMap<string, ResolvedListItem> | undefined
 ): RefFieldContext | null {
-  const specsByParagraph = new Map<string, readonly RefFieldSpec[]>();
+  const fieldsByParagraph = new Map<string, readonly ScannedRefField[]>();
   const blockScans: BlockRefScan[] = [];
-  let totalSpecs = 0;
+  let totalFields = 0;
   for (const block of blocks) {
     const scan = scanBlockRefs(block);
     blockScans.push(scan);
-    if (!scan.specsByParagraph) continue;
-    for (const [paragraphId, specs] of scan.specsByParagraph) {
-      if (totalSpecs >= MAX_REF_FIELDS_PER_STORY) break;
-      specsByParagraph.set(paragraphId, specs);
-      totalSpecs += specs.length;
+    if (!scan.fieldsByParagraph) continue;
+    for (const [paragraphId, fields] of scan.fieldsByParagraph) {
+      if (totalFields >= MAX_REF_FIELDS_PER_STORY) break;
+      fieldsByParagraph.set(paragraphId, fields);
+      totalFields += fields.length;
     }
   }
-  if (specsByParagraph.size === 0) return null;
+  if (fieldsByParagraph.size === 0) return null;
 
   // Index only referenced names, so the map is bounded by the capped reference count. A Map,
   // never an object: bookmark names are attacker-chosen keys.
   const referenced = new Set<string>();
-  for (const specs of specsByParagraph.values()) {
-    for (const spec of specs) referenced.add(spec.bookmark);
+  for (const fields of fieldsByParagraph.values()) {
+    for (const field of fields) referenced.add(field.spec.bookmark);
   }
   const targets = new Map<string, OoxmlElement>();
   for (const scan of blockScans) {
@@ -444,12 +576,14 @@ function buildRefFieldContext(
     if (spec.numberSwitch !== null) {
       const item = listItems?.get(target.id);
       if (!item) return null;
-      // Full context first: a deep level's marker states only its own placeholder, and
-      // painting bare `(c)` for a `1.2(c)` target is worse than the stale cache. Items built
-      // outside `resolveStoryListItems` carry no counter source; their marker (already the
-      // full context in the shapes that reach them) is the bounded fallback.
+      // `\r` / `\w`: full context — a deep level's marker states only its own placeholder,
+      // and painting bare `(c)` for a `1.2(c)` target is worse than the stale cache. `\n`:
+      // the target's own level only, per Word's cached values for that switch. Items built
+      // outside `resolveStoryListItems` carry no counter source; their marker is the bounded
+      // fallback.
       const source = listItemNumberSource(item);
-      const composed = source !== undefined ? composeFullContextNumber(source) : null;
+      const composed =
+        source !== undefined ? composeFullContextNumber(source, spec.numberSwitch === 'n') : null;
       // A bullet has a marker but no number a reader can cite — cached fallback, not a glyph.
       const fallback =
         item.numFmt !== 'bullet' && item.numFmt !== 'none' && item.markerText.length > 0
@@ -463,27 +597,47 @@ function buildRefFieldContext(
     return text.length > 0 ? text : null;
   };
 
-  const values = new Map<string, string | null>();
-  const valueOf = (spec: RefFieldSpec): string | null => {
+  const computedValues = new Map<string, string | null>();
+  const computedOf = (spec: RefFieldSpec): string | null => {
     const key = `${spec.numberSwitch ?? 't'}\u0000${spec.bookmark}`;
-    const cached = values.get(key);
-    if (cached !== undefined || values.has(key)) return cached ?? null;
+    if (computedValues.has(key)) return computedValues.get(key) ?? null;
     const value = resolve(spec);
-    values.set(key, value);
+    computedValues.set(key, value);
     return value;
   };
 
-  // `\u0002` marks an unresolved value so "resolves to nothing" and "resolves to empty" move
-  // the token when they trade places.
+  // CALIBRATION, per field. A non-empty authored cache must be reproduced by the computed
+  // value or the field stays on that cache; the verdict is STICKY (registry above), because
+  // after an edit a live field's value diverges from its cache by design and re-comparing
+  // would flip it back to stale. The token folds the PAINTED output — the live value when
+  // calibrated, the session-constant cache otherwise — so it moves exactly when paint moves.
+  const verdicts = carriedVerdicts(blocks);
+  const liveByAnchor = new Map<
+    string,
+    { readonly spec: RefFieldSpec; readonly live: string | null }
+  >();
   const tokens = new Map<string, string>();
   const storyParts: string[] = [];
-  for (const [paragraphId, specs] of specsByParagraph) {
-    const token = specs
-      .map(
-        (spec) =>
-          `${spec.numberSwitch ?? 't'}\u0001${spec.bookmark}\u0001${valueOf(spec) ?? '\u0002'}`
-      )
-      .join('\u0003');
+  for (const [paragraphId, fields] of fieldsByParagraph) {
+    const pieces: string[] = [];
+    for (const field of fields) {
+      const computed = computedOf(field.spec);
+      let verdict = verdicts.get(field.anchorId);
+      if (verdict === undefined) {
+        verdict =
+          field.cached.length === 0 ||
+          (computed !== null && normalizeResultText(computed) === field.cached);
+        // An empty cache needs no sticky entry: it re-derives to "eligible" on every pass.
+        if (field.cached.length > 0 && verdicts.size < MAX_REF_VERDICTS) {
+          verdicts.set(field.anchorId, verdict);
+        }
+      }
+      const live = verdict ? computed : null;
+      liveByAnchor.set(field.anchorId, { spec: field.spec, live });
+      // `\u0002` marks "keeps the cache" so live-empty and cached-empty cannot collide.
+      pieces.push(live !== null ? `l\u0001${live}` : `c\u0002${field.cached}`);
+    }
+    const token = pieces.join('\u0003');
     tokens.set(paragraphId, token);
     storyParts.push(token);
   }
@@ -491,7 +645,16 @@ function buildRefFieldContext(
   return {
     valuesToken: storyParts.join('\u0004'),
     tokenForParagraph: (paragraphId) => tokens.get(paragraphId) ?? '',
-    valueOf,
+    liveValueOf: (anchorId, spec) => {
+      const entry = liveByAnchor.get(anchorId);
+      if (!entry || entry.live === null) return null;
+      // The projection parsed the same instruction this scan did; a disagreement means the
+      // anchor id names some other field now — fail to the cache.
+      if (entry.spec.bookmark !== spec.bookmark || entry.spec.numberSwitch !== spec.numberSwitch) {
+        return null;
+      }
+      return entry.live;
+    },
   };
 }
 

--- a/packages/core/src/layout/field-simple-result.ts
+++ b/packages/core/src/layout/field-simple-result.ts
@@ -19,6 +19,7 @@ import { parseButtonInstruction } from './field-button.ts';
 import { docPropertyValue, parseDocPropertyInstruction } from './field-doc-property.ts';
 import { parseHyperlinkInstruction } from './field-link.ts';
 import type { FieldLinkProjector } from './field-pieces.ts';
+import { parseRefInstruction, type RefFieldContext } from './field-ref.ts';
 import {
   modelTextOfRunChild,
   runPropertiesOf,
@@ -301,6 +302,8 @@ export function projectSimpleFieldResult(args: {
   readonly documentProperties?: DocumentProperties;
   /** True in BODY flow: an empty-cache page field paints a placeholder for finalize to fill. */
   readonly bodyPageFields?: BodyPageFieldContext | false;
+  /** The story's resolved REF inputs; absent keeps a REF simple field on its cached result. */
+  readonly refFields?: RefFieldContext;
 }): SimpleFieldProjection | null {
   const { simple, pageContext, inheritedRunProperties, themeFonts } = args;
   const display = collectSimpleFieldDisplay(args);
@@ -350,6 +353,20 @@ export function projectSimpleFieldResult(args: {
     if (glyph) {
       if (glyph.style.hidden) return null;
       return { text: glyph.text, props: glyph.props, style: glyph.style };
+    }
+  }
+
+  // A simple REF resolves live exactly like the complex shape: the value from the bookmark
+  // target wins over the stale cached display; an unresolvable reference falls through to it.
+  if (args.refFields) {
+    const refSpec = parseRefInstruction(instr);
+    if (refSpec) {
+      const value = args.refFields.valueOf(refSpec);
+      if (value !== null) {
+        const style = display.resultStyle ?? resolveRunStyle(inheritedRunProperties, themeFonts);
+        if (style.hidden) return null;
+        return { text: value, props, style };
+      }
     }
   }
 

--- a/packages/core/src/layout/field-simple-result.ts
+++ b/packages/core/src/layout/field-simple-result.ts
@@ -356,12 +356,13 @@ export function projectSimpleFieldResult(args: {
     }
   }
 
-  // A simple REF resolves live exactly like the complex shape: the value from the bookmark
-  // target wins over the stale cached display; an unresolvable reference falls through to it.
+  // A simple REF resolves live exactly like the complex shape, gated per field (by the
+  // `w:fldSimple` node id) on the calibration verdict; an unresolvable or uncalibrated
+  // reference falls through to the cached display.
   if (args.refFields) {
     const refSpec = parseRefInstruction(instr);
     if (refSpec) {
-      const value = args.refFields.valueOf(refSpec);
+      const value = args.refFields.liveValueOf(simple.id, refSpec);
       if (value !== null) {
         const style = display.resultStyle ?? resolveRunStyle(inheritedRunProperties, themeFonts);
         if (style.hidden) return null;

--- a/packages/core/src/layout/field-synthesis.ts
+++ b/packages/core/src/layout/field-synthesis.ts
@@ -97,11 +97,12 @@ export function synthesizeAtomicField(
   }
   // A REF resolves live from its bookmark target and the resolved numbering — the cached
   // result is exactly what goes stale after a renumbering edit, so here the live value wins
-  // over a non-empty cache. Unresolvable (missing bookmark, unnumbered target for a number
-  // switch, no context for this story) falls through to the cache below, never to the raw
-  // instruction. The result-run style captured off the cache keeps the field's formatting.
+  // over a non-empty cache. Gated per field (by begin node id) on the calibration verdict:
+  // a field whose computed value never matched its authored cache stays on that cache, and
+  // an unresolvable reference falls through to it too — never to the raw instruction. The
+  // result-run style captured off the cache keeps the field's formatting.
   if (pending.refSpec && ctx.refFields) {
-    const value = ctx.refFields.valueOf(pending.refSpec);
+    const value = ctx.refFields.liveValueOf(pending.beginId, pending.refSpec);
     if (value !== null) return { text: value, props: pending.props, style: pending.style };
   }
   // A non-empty cached result is what Word last painted; it wins over synthesis.

--- a/packages/core/src/layout/field-synthesis.ts
+++ b/packages/core/src/layout/field-synthesis.ts
@@ -10,8 +10,10 @@
 //   1. SYMBOL — synthesized glyph wins over any stale cached text.
 //   2. legacy form field — checkbox from ffData state, dropdown from the selected entry.
 //   3. allowlisted PAGE-family — live value from the page context.
-//   4. cached result — a non-empty cache is what Word last painted; it wins over synthesis.
-//   5. empty cache only (and no hidden-but-present result): a document-property value, else a
+//   4. REF — the value resolved from the bookmark target wins over the stale cache; an
+//      unresolvable reference falls through to it instead.
+//   5. cached result — a non-empty cache is what Word last painted; it wins over synthesis.
+//   6. empty cache only (and no hidden-but-present result): a document-property value, else a
 //      MACROBUTTON / GOTOBUTTON display.
 
 import type { OoxmlProperty } from '@docx-editor.dev/core/store';
@@ -27,6 +29,7 @@ import {
 } from './field-page-furniture.ts';
 import type { AllowlistedPageField } from './field-instruction.ts';
 import type { PendingFieldProjection } from './field-pieces.ts';
+import type { RefFieldContext } from './field-ref.ts';
 import { symbolFieldGlyph } from './field-symbol.ts';
 import type { ResolvedRunStyle, ThemeFonts } from './run-style.ts';
 
@@ -58,6 +61,11 @@ export interface AtomicSynthesisContext {
    * which keep their live path or deferral — a placeholder there would never be substituted.
    */
   readonly bodyPageFields?: BodyPageFieldContext | false;
+  /**
+   * The story's resolved REF inputs (bookmark targets + numbering), or absent for stories
+   * that keep REF fields on their cached results (headers/footers, notes, text boxes).
+   */
+  readonly refFields?: RefFieldContext;
 }
 
 /**
@@ -86,6 +94,15 @@ export function synthesizeAtomicField(
       props: pending.props,
       style: pending.style,
     };
+  }
+  // A REF resolves live from its bookmark target and the resolved numbering — the cached
+  // result is exactly what goes stale after a renumbering edit, so here the live value wins
+  // over a non-empty cache. Unresolvable (missing bookmark, unnumbered target for a number
+  // switch, no context for this story) falls through to the cache below, never to the raw
+  // instruction. The result-run style captured off the cache keeps the field's formatting.
+  if (pending.refSpec && ctx.refFields) {
+    const value = ctx.refFields.valueOf(pending.refSpec);
+    if (value !== null) return { text: value, props: pending.props, style: pending.style };
   }
   // A non-empty cached result is what Word last painted; it wins over synthesis.
   if (pending.cachedText.length > 0) {

--- a/packages/core/src/layout/list-counters.ts
+++ b/packages/core/src/layout/list-counters.ts
@@ -227,8 +227,14 @@ export interface FullContextNumberSource {
  * is dropped (the standard `%1.` / `%1.%2` shape would otherwise paint `1.1.2`). Bullet /
  * `none` / empty levels contribute nothing; a target that is one resolves to null (the caller
  * falls back). Bounded: at most nine levels, each expansion under the marker-length caps.
+ *
+ * `ownLevelOnly` keeps just the target level's expansion — what a `REF \n` paints (`(c)`,
+ * `(ii)`), per Word's own cached values for that switch.
  */
-export function composeFullContextNumber(source: FullContextNumberSource): string | null {
+export function composeFullContextNumber(
+  source: FullContextNumberSource,
+  ownLevelOnly = false
+): string | null {
   const { index, numId, ilvl, expandCounters } = source;
   if (ilvl < 0 || ilvl > 8) return null;
   const levels: (NumberingLevel | null)[] = [];
@@ -251,6 +257,7 @@ export function composeFullContextNumber(source: FullContextNumberSource): strin
   const kept: number[] = [];
   const keptTexts: string[] = [];
   for (let lvl = ilvl; lvl >= 0; lvl -= 1) {
+    if (ownLevelOnly && lvl !== ilvl) break;
     const level = levels[lvl];
     if (!numbered(level)) continue;
     if (lvl !== ilvl && keptTexts.some((text) => text.includes(`%${lvl + 1}`))) continue;

--- a/packages/core/src/layout/list-counters.ts
+++ b/packages/core/src/layout/list-counters.ts
@@ -77,6 +77,18 @@ function levelFormats(
 }
 
 /**
+ * `w:isLgl` (§17.9.9): a legal-numbering level renders EVERY level its `w:lvlText` references
+ * in decimal, whatever format those levels declare — `Artikel I.01` is authored, `Artikel 1.1`
+ * is what Word paints. `bullet` and `none` are left alone: neither prints a counter, so
+ * "display it as decimal" would invent one. ONE helper for marker expansion and for
+ * cross-reference composition below, so the two renderings of the same number cannot drift.
+ */
+function legalEffectiveFormats(formats: readonly string[], isLgl: boolean): readonly string[] {
+  if (!isLgl) return formats;
+  return formats.map((format) => (format === 'bullet' || format === 'none' ? format : 'decimal'));
+}
+
+/**
  * Highest ilvl whose use restarts level `targetIlvl`, per `w:lvlRestart` on that level.
  *
  * Returns null when the level never restarts (`lvlRestart` = 0 or trigger above target).
@@ -160,13 +172,7 @@ export function createListCounterState(index: NumberingIndex): ListCounterState 
         return value;
       });
 
-      // `w:isLgl` (§17.9.9): a legal-numbering level renders EVERY level its `w:lvlText`
-      // references in decimal, whatever format those levels declare — `Artikel I.01` is
-      // authored, `Artikel 1.1` is what Word paints. `bullet` and `none` are left alone:
-      // neither prints a counter, so "display it as decimal" would invent one.
-      const effectiveFormats = level.isLgl
-        ? formats.map((format) => (format === 'bullet' || format === 'none' ? format : 'decimal'))
-        : formats;
+      const effectiveFormats = legalEffectiveFormats(formats, level.isLgl);
 
       const markerText = level.vanish
         ? ''
@@ -174,7 +180,7 @@ export function createListCounterState(index: NumberingIndex): ListCounterState 
           ? level.lvlText
           : expandLvlText(level.lvlText, expandCounters, effectiveFormats);
 
-      return {
+      const advance: ListCounterAdvance = {
         abstractNumId,
         numId,
         ilvl,
@@ -182,6 +188,85 @@ export function createListCounterState(index: NumberingIndex): ListCounterState 
         counters: snapshot,
         markerText,
       };
+      // Side channel rather than a member: `ListCounterAdvance` is public API, and the
+      // substitution-ready vector (uninitialized levels already at their starts) cannot be
+      // rebuilt from `counters` alone — a level whose authored start IS its current value
+      // looks exactly like one that never emitted.
+      expandCountersByAdvance.set(advance, expandCounters);
+      return advance;
     },
   };
+}
+
+/** Substitution-ready counter vectors, keyed on the advance results that produced them. */
+const expandCountersByAdvance = new WeakMap<ListCounterAdvance, readonly number[]>();
+
+/** The substitution-ready vector behind one advance, for cross-reference composition. */
+export function expandCountersOf(advance: ListCounterAdvance): readonly number[] {
+  return expandCountersByAdvance.get(advance) ?? advance.counters;
+}
+
+/**
+ * What composing a paragraph's FULL-CONTEXT number needs: the linked index its levels resolve
+ * through and the substitution-ready counters captured when the paragraph was counted.
+ */
+export interface FullContextNumberSource {
+  readonly index: NumberingIndex;
+  readonly numId: string;
+  readonly ilvl: number;
+  readonly expandCounters: readonly number[];
+}
+
+/**
+ * The paragraph's number in full context — what a `REF \w` paints for a multilevel target.
+ *
+ * A level like `(%3)` states only its OWN placeholder, so its marker (`(c)`) is not the number
+ * a reader cites; Word's cross-reference shows `1.2(c)`. Composed by walking levels 0..ilvl:
+ * each level's `w:lvlText` expands through the SAME substitution and `w:isLgl` mapping the
+ * marker uses, and a level whose own placeholder already appears in a DEEPER kept level's text
+ * is dropped (the standard `%1.` / `%1.%2` shape would otherwise paint `1.1.2`). Bullet /
+ * `none` / empty levels contribute nothing; a target that is one resolves to null (the caller
+ * falls back). Bounded: at most nine levels, each expansion under the marker-length caps.
+ */
+export function composeFullContextNumber(source: FullContextNumberSource): string | null {
+  const { index, numId, ilvl, expandCounters } = source;
+  if (ilvl < 0 || ilvl > 8) return null;
+  const levels: (NumberingLevel | null)[] = [];
+  const formats: string[] = [];
+  for (let lvl = 0; lvl <= 8; lvl += 1) {
+    const resolved = resolveNumberingLevel(index, numId, lvl);
+    levels.push(lvl <= ilvl ? (resolved?.level ?? null) : null);
+    formats.push(resolved?.level.numFmt ?? 'decimal');
+  }
+  const numbered = (level: NumberingLevel | null): level is NumberingLevel =>
+    level !== null &&
+    level.numFmt !== 'bullet' &&
+    level.numFmt !== 'none' &&
+    level.lvlText.length > 0;
+  if (!numbered(levels[ilvl] ?? null)) return null;
+
+  // Deepest-up: keep the target, then keep each shallower numbered level unless a KEPT deeper
+  // text already displays its placeholder — a dropped level's text paints nothing, so only
+  // kept texts can stand in for it.
+  const kept: number[] = [];
+  const keptTexts: string[] = [];
+  for (let lvl = ilvl; lvl >= 0; lvl -= 1) {
+    const level = levels[lvl];
+    if (!numbered(level)) continue;
+    if (lvl !== ilvl && keptTexts.some((text) => text.includes(`%${lvl + 1}`))) continue;
+    kept.push(lvl);
+    keptTexts.push(level.lvlText);
+  }
+  kept.reverse();
+
+  let out = '';
+  for (const lvl of kept) {
+    const level = levels[lvl]!;
+    out += expandLvlText(
+      level.lvlText,
+      expandCounters,
+      legalEffectiveFormats(formats, level.isLgl)
+    );
+  }
+  return out.length > 0 ? out : null;
 }

--- a/packages/core/src/layout/list-resolve.ts
+++ b/packages/core/src/layout/list-resolve.ts
@@ -3,7 +3,11 @@
 
 import { flattenContentControls } from '@docx-editor.dev/core/store';
 import type { OoxmlElement, OoxmlNode, OoxmlProperty } from '@docx-editor.dev/core/store';
-import { createListCounterState } from './list-counters.ts';
+import {
+  createListCounterState,
+  expandCountersOf,
+  type FullContextNumberSource,
+} from './list-counters.ts';
 import {
   EMPTY_NUMBERING_INDEX,
   MAX_LEVEL_INDENT_PT,
@@ -123,6 +127,20 @@ export interface ResolvedListItem {
   readonly markerStyle: ResolvedRunStyle;
   /** Fingerprint for layout cache keys (indent, marker text, marker face). */
   readonly cacheToken: string;
+}
+
+/**
+ * What composing an item's full-context number needs, keyed on the item object itself.
+ *
+ * A side channel rather than a `ResolvedListItem` member because the item type is public API
+ * and only cross-reference resolution reads this. Entries ride the item maps the memos above
+ * reuse by identity, and die with them.
+ */
+const listItemNumberSources = new WeakMap<ResolvedListItem, FullContextNumberSource>();
+
+/** The composition inputs captured when `item` was counted, or undefined off this resolver. */
+export function listItemNumberSource(item: ResolvedListItem): FullContextNumberSource | undefined {
+  return listItemNumberSources.get(item);
 }
 
 function isElement(node: OoxmlNode): node is OoxmlElement {
@@ -492,7 +510,7 @@ export function resolveStoryListItems(
       markerMeasureToken(markerStyle),
     ].join('|');
 
-    map.set(paragraph.id, {
+    const item: ResolvedListItem = {
       numId: advanced.numId,
       ilvl: advanced.ilvl,
       abstractNumId: advanced.abstractNumId,
@@ -503,7 +521,14 @@ export function resolveStoryListItems(
       indent,
       markerStyle,
       cacheToken,
+    };
+    listItemNumberSources.set(item, {
+      index: linked,
+      numId: advanced.numId,
+      ilvl: advanced.ilvl,
+      expandCounters: expandCountersOf(advanced),
     });
+    map.set(paragraph.id, item);
   }
   return map;
 }

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -141,6 +141,15 @@ export interface ParagraphFlowOptions {
    */
   readonly bodyPageFields?: import('./field-page-furniture.ts').BodyPageFieldContext | false;
   /**
+   * The story's resolved REF inputs (bookmark targets + numbering), for live REF results.
+   *
+   * Supplied by the body flow, whose block cache keys fold the resolved values — a flow that
+   * threads this WITHOUT keying on those values would serve stale breaks after a renumbering
+   * edit. Absent means REF fields paint their cached results, the safe degradation every
+   * other story (headers/footers, notes, text boxes) currently takes.
+   */
+  readonly refFields?: import('./field-ref.ts').RefFieldContext;
+  /**
    * Which revisions this break resolves away.
    *
    * A different mode is a different break — the proposed result drops deleted text, so lines
@@ -618,7 +627,8 @@ export function breakParagraph(
     flow?.themeFonts,
     flow?.projectFieldLink,
     flow?.documentProperties,
-    flow?.bodyPageFields ?? false
+    flow?.bodyPageFields ?? false,
+    flow?.refFields
   );
   const startOffset = Math.max(0, flow?.startOffset ?? 0);
   const pieces = allPieces.flatMap((piece): FieldAwarePiece[] => {

--- a/packages/core/src/layout/section-prepass-guards.ts
+++ b/packages/core/src/layout/section-prepass-guards.ts
@@ -34,6 +34,9 @@ export const SECTION_PREPASS_GUARDS = {
   // tokens WITHOUT an epoch keeps the recompute path (`drawingEpoch !== null`).
   drawingEpoch: 'validity-checked',
   tocToken: 'validity-checked',
+  // The story-wide REF values token. A renumbering edit moves a REF value in a section whose
+  // blocks, list map and TOC shape are all identity-unchanged; this clause is what sees it.
+  refToken: 'validity-checked',
   prepared: 'derived-covered',
   keys: 'derived-covered',
   paragraphDocumentOrder: 'derived-covered',

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -171,6 +171,7 @@ import {
   withResolvedListItemsForSession,
   type ResolvedListItem,
 } from './list-resolve.ts';
+import { refTokenForTableBlock, resolveStoryRefFields, type RefFieldContext } from './field-ref.ts';
 import { publishListMarker } from './list-marker.ts';
 import {
   NO_DEFERRED_DRAWINGS,
@@ -409,6 +410,12 @@ interface PreparedBlockMemo {
    * that has to be right.
    */
   readonly listToken: string;
+  /**
+   * The resolved REF values this block paints, for the same reason {@link listToken} is
+   * here: a renumbering or bookmark edit moves a REF's painted text while the block's node,
+   * width and producer all stay identical. `''` for the common REF-free block.
+   */
+  readonly refToken: string;
   readonly entry: PreparedBlock;
 }
 
@@ -506,6 +513,12 @@ export interface SectionPrepass {
   readonly keepsNext: boolean[];
   readonly markerTexts: (string | undefined)[];
   readonly tocToken: string;
+  /**
+   * The story-wide REF values token. Compared WHOLE, like {@link tocToken} and for the same
+   * shape of reason: a renumbering edit in one section moves a REF value painted in another
+   * whose blocks and list map are identity-unchanged, so no per-section input sees it.
+   */
+  readonly refToken: string;
   readonly flowKeys: string[];
 }
 
@@ -597,6 +610,12 @@ export function layoutSemanticDocument(
         blocks
       );
 
+  // REF cross-references resolve against the whole story's bookmarks and resolved numbering,
+  // so the context is built here — the one place that sees both — and rides the options
+  // spreads into every section pass. Null for the common REF-free document.
+  const refFields = resolveStoryRefFields(blocks, optionsWithLists.listItems);
+  const optionsForBody = refFields === null ? optionsWithLists : { ...optionsWithLists, refFields };
+
   const runBody = (opts: SemanticLayoutOptions): SemanticLayout => {
     if (sections.length > 1) {
       return layoutMultiSectionDocument(blocks, sections, revision, opts, layoutBlocksWithGeometry);
@@ -654,14 +673,17 @@ export function layoutSemanticDocument(
       options.session.notes = null;
       options.session.notePageBottomReserves = null;
     }
-    return finish(runBody(optionsWithLists));
+    return finish(runBody(optionsForBody));
   }
 
   // Notes inherit the body's projector seams and document properties (link, field link, doc
-  // props) unless the notes input pinned its own — see `inheritNotesLayoutInput`.
+  // props) unless the notes input pinned its own — see `inheritNotesLayoutInput`. The REF
+  // context deliberately does NOT ride along: note stories keep painting cached REF results
+  // until their flow keys learn to fold the resolved values (threading the values without
+  // keying on them would serve stale note breaks after a renumbering edit).
   const notesInput = inheritNotesLayoutInput(options.notes, options);
   return finish(
-    layoutSemanticDocumentWithNotes(part, sections, optionsWithLists, notesInput, runBody)
+    layoutSemanticDocumentWithNotes(part, sections, optionsForBody, notesInput, runBody)
   );
 }
 
@@ -727,6 +749,13 @@ type BlockLayoutOptions = SemanticLayoutOptions & {
    * knows the format — see {@link numericPictureApplies}.
    */
   readonly bodyPageNumberFormat?: string;
+  /**
+   * The story's resolved REF inputs, built once in `layoutSemanticDocument` and riding the
+   * options spreads (single-section `runBody` and the multi-section `...rest`) as a runtime
+   * property — deliberately NOT a `SemanticLayoutOptions` member, so the public options
+   * surface stays put. Absent for stories without REF fields and for non-body lanes.
+   */
+  readonly refFields?: RefFieldContext;
 };
 
 /**
@@ -888,6 +917,7 @@ function layoutBlocksPass(
   // cannot reuse breaks measured under another inheritance table.
   const styleCascade = options.styleCascade;
   const listItems = options.listItems;
+  const refFields = options.refFields;
   // The default-tab interval moves every default-interval tab, and the prepared-block memo
   // is keyed by producer — so it belongs here rather than only in the per-paragraph token.
   const defaultTabStopPt = options.defaultTabStopPt;
@@ -1079,13 +1109,22 @@ function layoutBlocksPass(
       (block.kind === 'table'
         ? listTokenForTableBlock(block, listItems)
         : (listItems?.get(block.id)?.cacheToken ?? '')) + hostedListToken;
+    // The RESOLVED VALUES this block's REF fields paint. The block's own subtree is identical
+    // after a renumbering edit elsewhere, so only this token can invalidate its memo and key.
+    const refToken =
+      refFields === undefined
+        ? ''
+        : block.kind === 'table'
+          ? refTokenForTableBlock(block, refFields)
+          : refFields.tokenForParagraph(block.id);
     const memo = preparedBlocks.get(block);
     if (
       memo &&
       memo.contentWidth === availableWidth &&
       memo.producer === producer &&
       memo.drawingToken === paragraphDrawingToken &&
-      memo.listToken === listToken
+      memo.listToken === listToken &&
+      memo.refToken === refToken
     ) {
       return memo.entry;
     }
@@ -1097,9 +1136,12 @@ function layoutBlocksPass(
         table: block,
         key: paragraphLayoutKey({
           paragraph: block,
-          properties: hostedListToken
-            ? [{ localName: 'txbxList', attributes: { token: hostedListToken } }]
-            : [],
+          properties: [
+            ...(hostedListToken
+              ? [{ localName: 'txbxList', attributes: { token: hostedListToken } }]
+              : []),
+            ...(refToken ? [{ localName: 'refFields', attributes: { token: refToken } }] : []),
+          ],
           width: availableWidth,
           producer,
           ...(paragraphDrawingToken ? { drawingToken: paragraphDrawingToken } : {}),
@@ -1176,6 +1218,7 @@ function layoutBlocksPass(
             ...(hostedListToken
               ? [{ localName: 'txbxList', attributes: { token: hostedListToken } }]
               : []),
+            ...(refToken ? [{ localName: 'refFields', attributes: { token: refToken } }] : []),
           ],
           width: available,
           producer,
@@ -1188,6 +1231,7 @@ function layoutBlocksPass(
       producer,
       drawingToken: paragraphDrawingToken,
       listToken,
+      refToken,
       entry,
     });
     return entry;
@@ -1214,6 +1258,7 @@ function layoutBlocksPass(
     prepassMemo.styleCascade === styleCascade &&
     prepassMemo.listItems === listItems &&
     prepassMemo.tocToken === tocToken &&
+    prepassMemo.refToken === (refFields?.valuesToken ?? '') &&
     prepassMemo.bodies.length === bodies.length &&
     prepassMemo.bodies.every((block, index) => block === bodies[index]);
   const prepass: SectionPrepass = prepassValid ? prepassMemo : buildSectionPrepass();
@@ -1275,6 +1320,7 @@ function layoutBlocksPass(
       keepsNext,
       markerTexts,
       tocToken,
+      refToken: refFields?.valuesToken ?? '',
       flowKeys: flow,
     };
   }
@@ -1660,6 +1706,7 @@ function layoutBlocksPass(
     ...(options.documentProperties ? { documentProperties: options.documentProperties } : {}),
     // Body flow: page fields in table cells paint a placeholder for document finalize to fill.
     bodyPageFields: bodyPageFieldContext,
+    ...(refFields ? { refFields } : {}),
     ...(options.noteMarks ? { noteMarks: options.noteMarks } : {}),
     ...(options.inlineDrawingLayout ? { inlineDrawingLayout: options.inlineDrawingLayout } : {}),
     ...(options.drawingTokenForParagraph
@@ -1739,12 +1786,18 @@ function layoutBlocksPass(
       options.drawingTokenForParagraph?.(entry.paragraph) ??
       options.drawingLayoutToken ??
       (options.inlineDrawingLayout ? 'drawing' : undefined);
+    // The drawing/exclusion key path rebuilds from `entry.props`, which cannot see a REF
+    // value move — fold the paragraph's ref token in so a float-adjacent reference is not
+    // served its pre-renumber break.
+    const refToken = refFields?.tokenForParagraph(paragraphId) ?? '';
     const cacheKey =
       cache && !suppressChrome
         ? exclusionToken || drawingKeyed
           ? paragraphLayoutKey({
               paragraph: entry.paragraph,
-              properties: entry.props,
+              properties: refToken
+                ? [...entry.props, { localName: 'refFields', attributes: { token: refToken } }]
+                : entry.props,
               width: available,
               producer,
               ...(drawingKeyed ? { drawingToken: drawingKeyed } : {}),
@@ -1788,6 +1841,7 @@ function layoutBlocksPass(
         ...(options.documentProperties ? { documentProperties: options.documentProperties } : {}),
         // Body flow: an empty-cache page field paints a placeholder finalize substitutes per page.
         bodyPageFields: bodyPageFieldContext,
+        ...(refFields ? { refFields } : {}),
         displayMode,
         ...(options.noteMarks ? { noteMarks: options.noteMarks } : {}),
         ...(options.inlineDrawingLayout

--- a/packages/core/src/layout/semantic-table-layout.ts
+++ b/packages/core/src/layout/semantic-table-layout.ts
@@ -225,6 +225,11 @@ export interface TableFlowDeps {
    * in a header/footer keeps this false and its own live page path.
    */
   readonly bodyPageFields?: import('./field-page-furniture.ts').BodyPageFieldContext | false;
+  /**
+   * The story's resolved REF inputs — a REF field in a table cell is an ordinary field.
+   * Present only in body flow, which folds the resolved values into every cell break key.
+   */
+  readonly refFields?: import('./field-ref.ts').RefFieldContext;
   readonly inlineDrawingLayout?: import('./drawing-layout.ts').InlineDrawingLayoutContext;
   /** Per-paragraph drawing projection/resource token for break cache keys. */
   readonly drawingTokenForParagraph?: (paragraph: OoxmlNode) => string;
@@ -476,6 +481,9 @@ function placeCellParagraph(
   // the wrapped break of the one that does not.
   const exclusionToken = exclusionLayoutToken(pageZones);
   const positionedExclusionToken = exclusionToken ? `${top.toFixed(3)}|${exclusionToken}` : '';
+  // The cell paragraph's resolved REF values, keyed exactly as the body flow keys them: a
+  // renumbering edit moves the painted reference while the cell's subtree stays identical.
+  const refToken = deps.refFields?.tokenForParagraph(paragraphId) ?? '';
   const key = paragraphLayoutKey({
     paragraph,
     properties: [
@@ -484,6 +492,7 @@ function placeCellParagraph(
       ...markRunProperties,
       { localName: 'tabStops', attributes: { token: tabStopsCacheToken } },
       ...(listItem ? [{ localName: 'list', attributes: { token: listItem.cacheToken } }] : []),
+      ...(refToken ? [{ localName: 'refFields', attributes: { token: refToken } }] : []),
     ],
     width: available,
     producer: deps.producer,
@@ -519,6 +528,7 @@ function placeCellParagraph(
       ...(deps.projectFieldLink ? { projectFieldLink: deps.projectFieldLink } : {}),
       ...(deps.documentProperties ? { documentProperties: deps.documentProperties } : {}),
       ...(deps.bodyPageFields ? { bodyPageFields: deps.bodyPageFields } : {}),
+      ...(deps.refFields ? { refFields: deps.refFields } : {}),
       displayMode: deps.displayMode,
       ...(deps.noteMarks ? { noteMarks: deps.noteMarks } : {}),
       ...(deps.inlineDrawingLayout ? { inlineDrawingLayout: deps.inlineDrawingLayout } : {}),


### PR DESCRIPTION
`REF` fields painted their cached result forever, so cross-references to numbered paragraphs went stale after any edit that renumbers. The new `field-ref` module resolves `REF <bookmark> [\r|\w|\n] [\h] [\* MERGEFORMAT]` in the body story: number switches compose the target paragraph's full-context number from the counter path (`1.2(c)(ii)`, sharing the marker's substitution and `w:isLgl` mapping so the two renderings cannot drift), and a plain `REF` extracts the bookmarked text, length-capped. Unknown switches, missing bookmarks, and bullet targets fall back to the cached result; the raw instruction never paints.

Resolved values fold into the block cache keys and the section prepass token, so a renumbering edit repaints dependent references on otherwise unchanged pages. On an unedited document the computed values reproduce Word's cached results.

Cached results still serve footnote, text-box, and header/footer stories, and saved bytes keep the cached result runs; #606 tracks both.

Fixes #601

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/607"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790589255&installation_model_id=422592&pr_number=607&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F607&signature=c34774fa3399ad9817f4499ddd81eb960b810bbe492059ca514d71868d6e786a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->