### PR TITLE
feat: refresh REF field results on save and in note stories

### DIFF
--- a/.changeset/ref-results-save-and-notes.md
+++ b/.changeset/ref-results-save-and-notes.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': minor
+---
+
+Saving now rewrites stale REF field results into the exported bytes, and REF fields inside footnotes and endnotes paint live values. Fixes #606.

--- a/docs/api/docx-editor-core/editor.api.md
+++ b/docs/api/docx-editor-core/editor.api.md
@@ -1464,6 +1464,7 @@ export interface PaginatedSurface {
     publishedLayout(): SemanticLayout;
     // (undocumented)
     redo(): void;
+    refreshRefFieldResults(): boolean;
     refreshTableInteractionLabels(): void;
     refreshToc(tocId?: string, mode?: 'entire' | 'pageNumbers'): boolean;
     releaseSelection(pin: SelectionPin): void;

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -1638,6 +1638,7 @@ export interface NotesLayoutInput {
     // (undocumented)
     readonly projectFieldLink?: FieldLinkProjector;
     readonly projectLink?: HyperlinkProjector;
+    readonly refFields?: RefFieldContext;
     // (undocumented)
     readonly styleCascade?: StyleCascadeTable;
 }
@@ -2059,6 +2060,9 @@ export function paragraphTextFromLayout(layout: SemanticLayout, paragraphId: str
 export function parsePageNumbering(sectPr: OoxmlNode): SectionPageNumbering | undefined;
 
 // @public
+export function parseRefInstruction(raw: string): RefFieldSpec | null;
+
+// @public
 export function parseSectionProperties(sectPr: OoxmlNode | null | undefined): SectionProperties;
 
 // @public
@@ -2077,6 +2081,9 @@ export interface PlacedCell {
     // (undocumented)
     readonly tableId: string;
 }
+
+// @public
+export function planRefFieldResultRefresh(part: OoxmlPart, options: RefFieldRefreshOptions): RefreshFieldResultsOp | null;
 
 // @public
 export function positionPastDeletion(layout: SemanticLayout, position: SemanticPosition): SemanticPosition;
@@ -2118,6 +2125,39 @@ export function readTableBorders(tblPr: OoxmlElement | undefined): TableBorderBo
 // @public
 export function readTableStructure(table: OoxmlNode, contentWidthPt: number, depth: number, styleCascade?: StyleCascadeTable,
 displayMode?: RevisionDisplayMode): SemanticTableStructure | null;
+
+// @public
+export interface RefFieldContext {
+    liveValueOf(anchorId: string, spec: RefFieldSpec): string | null;
+    tokenForParagraph(paragraphId: string): string;
+    readonly valuesToken: string;
+}
+
+// @public (undocumented)
+export interface RefFieldRefreshOptions {
+    readonly displayMode?: RevisionDisplayMode;
+    // (undocumented)
+    readonly numberingIndex?: NumberingIndex;
+    readonly package?: OoxmlPackage;
+    // (undocumented)
+    readonly styleCascade?: StyleCascadeTable;
+}
+
+// @public
+export interface RefFieldSpec {
+    // (undocumented)
+    readonly bookmark: string;
+    readonly hyperlink: boolean;
+    readonly numberSwitch: 'r' | 'w' | 'n' | null;
+}
+
+// @public
+export interface RefNoteParts {
+    // (undocumented)
+    readonly endnotesPart: OoxmlPart | null;
+    // (undocumented)
+    readonly footnotesPart: OoxmlPart | null;
+}
 
 // @public
 export function resetGraphemeBoundary(): void;
@@ -2295,6 +2335,9 @@ export function resolveRunStyle(props: readonly OoxmlProperty[], themeFonts?: Th
 
 // @public
 export function resolveStoryListItems(blocks: readonly OoxmlElement[], index: NumberingIndex, styleCascade: StyleCascadeTable | undefined, isFontAvailable?: (family: string) => boolean): ReadonlyMap<string, ResolvedListItem>;
+
+// @public
+export function resolveStoryRefFields(blocks: readonly OoxmlElement[], listItems: ReadonlyMap<string, ResolvedListItem> | undefined, notes?: RefNoteParts): RefFieldContext | null;
 
 // @public
 export function resolveStrictHexFill(raw: string | undefined): string | undefined;

--- a/docs/api/docx-editor-core/store.api.md
+++ b/docs/api/docx-editor-core/store.api.md
@@ -4044,7 +4044,7 @@ export interface TransportPort {
 }
 
 // @public
-export const TREE_DOC_OP_KINDS: readonly ["replaceStoryBlocks", "insertText", "deleteText", "setParagraphMarkRevision", "proposeParagraphMerge", "insertCommentMarker", "acceptRevision", "rejectRevision", "acceptAllRevisions", "rejectAllRevisions", "insertTab", "insertHardBreak", "insertPageBreak", "insertPageField", "setListLevel", "setListNumbering", "setParagraphTabStops", "setParagraphMarkProperties", "splitParagraph", "splitParagraphMany", "joinParagraphs", "setRunProperties", "setParagraphProperties", "setSectionProperties", "setSectionMark", "insertHyperlink", "setHyperlinkTarget", "removeHyperlink", "setMathEquation", "removeMathEquation", "setContentControlValue", "removeContentControl", "insertInlineContentControl", "addRepeatingSectionItem", "removeRepeatingSectionItem", "deleteBlock", "insertTable", "insertTableRow", "deleteTableRow", "insertTableColumn", "deleteTableColumn", "setTableColumnWidths", "setTableRightEdgeWidth", "setTableRowHeight", "setTableCellBorders", "setTableCellFill", "setTableCellVerticalAlignment", "createHeaderFooter", "deleteHeaderFooter", "linkToPrevious", "unlinkFromPrevious", "setSectionFurnitureOptions", "insertNote", "deleteNote", "convertNote", "convertAllNotes", "setNoteProperties", "setContentControlProperties", "insertContentControl", "insertFragment", "insertDrawing", "replaceDrawingResource", "deleteDrawing", "resizeDrawing", "cropDrawing", "positionDrawing", "setDrawingWrap", "setDrawingMetadata", "setDrawingLocks", "transformDrawing", "insertToc", "replaceTocResult", "rewriteTocPageNumbers"];
+export const TREE_DOC_OP_KINDS: readonly ["replaceStoryBlocks", "insertText", "deleteText", "setParagraphMarkRevision", "proposeParagraphMerge", "insertCommentMarker", "acceptRevision", "rejectRevision", "acceptAllRevisions", "rejectAllRevisions", "insertTab", "insertHardBreak", "insertPageBreak", "insertPageField", "setListLevel", "setListNumbering", "setParagraphTabStops", "setParagraphMarkProperties", "splitParagraph", "splitParagraphMany", "joinParagraphs", "setRunProperties", "setParagraphProperties", "setSectionProperties", "setSectionMark", "insertHyperlink", "setHyperlinkTarget", "removeHyperlink", "setMathEquation", "removeMathEquation", "setContentControlValue", "removeContentControl", "insertInlineContentControl", "addRepeatingSectionItem", "removeRepeatingSectionItem", "deleteBlock", "insertTable", "insertTableRow", "deleteTableRow", "insertTableColumn", "deleteTableColumn", "setTableColumnWidths", "setTableRightEdgeWidth", "setTableRowHeight", "setTableCellBorders", "setTableCellFill", "setTableCellVerticalAlignment", "createHeaderFooter", "deleteHeaderFooter", "linkToPrevious", "unlinkFromPrevious", "setSectionFurnitureOptions", "insertNote", "deleteNote", "convertNote", "convertAllNotes", "setNoteProperties", "setContentControlProperties", "insertContentControl", "insertFragment", "insertDrawing", "replaceDrawingResource", "deleteDrawing", "resizeDrawing", "cropDrawing", "positionDrawing", "setDrawingWrap", "setDrawingMetadata", "setDrawingLocks", "transformDrawing", "insertToc", "replaceTocResult", "rewriteTocPageNumbers", "refreshFieldResults"];
 
 // @public
 export type TreeDocOp = {
@@ -4470,6 +4470,13 @@ export type TreeDocOp = {
     readonly updates: readonly {
         readonly pageNumberText: string;
         readonly paragraphId: string;
+    }[];
+} | {
+    readonly op: 'refreshFieldResults';
+    readonly updates: readonly {
+        readonly fieldNodeId: string;
+        readonly paragraphId: string;
+        readonly text: string;
     }[];
 };
 

--- a/openspec/changes/full-document-yjs-collaboration/authorable-mutation-manifest.json
+++ b/openspec/changes/full-document-yjs-collaboration/authorable-mutation-manifest.json
@@ -7,8 +7,8 @@
   "baseGitCommitDate": "2026-08-24 14:45:47 +0200",
   "inventoryNote": "Kinds, reach, properties, chrome slots, and lifecycle sets are taken from the implementation after rebase onto origin/main. Main added replaceStoryBlocks, setMathEquation, removeMathEquation, and insertFragment (rich-clipboard-fidelity).",
   "counts": {
-    "treeDocOpKinds": 73,
-    "singlePartApply": 61,
+    "treeDocOpKinds": 74,
+    "singlePartApply": 62,
     "headerFooterLifecycle": 5,
     "noteLifecycle": 5,
     "treeDocOpUnsupported": 2,
@@ -109,7 +109,8 @@
       "transformDrawing",
       "insertToc",
       "replaceTocResult",
-      "rewriteTocPageNumbers"
+      "rewriteTocPageNumbers",
+      "refreshFieldResults"
     ],
     "headerFooterLifecycle": [
       "createHeaderFooter",
@@ -200,7 +201,8 @@
     "transformDrawing",
     "insertToc",
     "replaceTocResult",
-    "rewriteTocPageNumbers"
+    "rewriteTocPageNumbers",
+    "refreshFieldResults"
   ],
   "authorableVariants": {
     "insertText": {
@@ -1019,6 +1021,15 @@
       "commandExposure": ["refreshToc"],
       "packageIntents": [],
       "openSpec": ["typed-toc-refresh"]
+    },
+    {
+      "kind": "refreshFieldResults",
+      "commitPath": "applyTreeOp",
+      "storyScopes": ["body"],
+      "storyParity": "bodyOnly",
+      "commandExposure": ["refreshRefFieldResults"],
+      "packageIntents": [],
+      "openSpec": []
     }
   ],
   "packageIntents": [

--- a/packages/core/src/editor/__tests__/ref-field-save-refresh.test.ts
+++ b/packages/core/src/editor/__tests__/ref-field-save-refresh.test.ts
@@ -1,0 +1,197 @@
+// The save path refreshes stale REF field results, and ONLY stale ones.
+//
+// What these tests pin down: after an edit, `editor.save()` exports the value the pages
+// paint (the cached result runs are rewritten first); a document whose results are already
+// fresh saves byte-identically with no revision bump and no undo entry; revision-marked
+// results are left untouched; and a refresh+save+reopen document digests identically across
+// a second save (the D9 oracle for the rewrite being a fixed point). Fixtures mount FRESH —
+// the calibration gate requires a field's computed value to reproduce its cache once before
+// it goes live, so the refreshable states are the ones an edit creates afterwards.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { strFromU8, strToU8, unzipSync, zipSync } from 'fflate';
+import { readOoxmlPackage } from '../../store/package/ooxml-package.ts';
+import { semanticDigest } from '../../store/package/ooxml-digest.ts';
+import { createDocxEditor, type DocxEditorInstance } from '../docx-editor.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+
+function docx(body: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        `<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>`
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
+    ),
+  });
+}
+
+const bookmarked = (name: string, text: string) =>
+  `<w:bookmarkStart w:id="1" w:name="${name}"/><w:r><w:t>${text}</w:t></w:r>` +
+  `<w:bookmarkEnd w:id="1"/>`;
+const refField = (instr: string, result: string) =>
+  '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+  `<w:r><w:instrText xml:space="preserve">${instr}</w:instrText></w:r>` +
+  '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+  result +
+  '<w:r><w:fldChar w:fldCharType="end"/></w:r>';
+
+// FRESH on load: both caches reproduce the bookmarked text, so calibration passes and the
+// fields go live. The edit below then makes those caches stale.
+const FRESH_BODY =
+  `<w:p>${bookmarked('term', 'Closing Date')}</w:p>` +
+  `<w:p>${refField(' REF term \\h ', '<w:r><w:t>Closing Date</w:t></w:r>')}</w:p>` +
+  '<w:p><w:fldSimple w:instr=" REF term "><w:r><w:t>Closing Date</w:t></w:r></w:fldSimple></w:p>' +
+  '<w:sectPr/>';
+
+function mount(body: string): DocxEditorInstance {
+  const container = document.createElement('div');
+  const editor = createDocxEditor({ container, document: docx(body) });
+  if (!editor.surface) throw new Error('surface failed to mount');
+  return editor;
+}
+
+function firstParagraphId(editor: DocxEditorInstance): string {
+  const part = editor.surface!.session.part();
+  let found: string | undefined;
+  const walk = (node: (typeof part)['root']): void => {
+    if (found) return;
+    if (node.kind === 'paragraph') {
+      found = node.id;
+      return;
+    }
+    for (const child of node.children) {
+      if (child.kind !== 'textValue') walk(child);
+    }
+  };
+  walk(part.root);
+  if (!found) throw new Error('missing paragraph');
+  return found;
+}
+
+/** Append one character to the bookmarked target text, so both REF caches go stale. */
+function editTarget(editor: DocxEditorInstance): void {
+  const result = editor.surface!.session.applyTreeOps([
+    {
+      op: 'insertText',
+      paragraphId: firstParagraphId(editor),
+      offset: 'Closing Date'.length,
+      text: 's',
+    },
+  ]);
+  expect(result.committed).toBe(true);
+}
+
+async function savedDocumentXml(editor: DocxEditorInstance): Promise<string> {
+  const bytes = new Uint8Array(await editor.save());
+  return strFromU8(unzipSync(bytes)['word/document.xml']!);
+}
+
+describe('save() refreshes stale REF results', () => {
+  test('after an edit the exported bytes carry the live value; the instruction survives', async () => {
+    const editor = mount(FRESH_BODY);
+    editTarget(editor);
+    const xml = await savedDocumentXml(editor);
+    expect(xml).toContain(' REF term \\h ');
+    // BOTH result caches now read the edited text (the target run serializes as two w:t).
+    expect(xml).toContain(
+      '<w:fldChar w:fldCharType="separate"/></w:r><w:r><w:t>Closing Dates</w:t></w:r>'
+    );
+    expect(xml).toContain('<w:fldSimple w:instr=" REF term "><w:r><w:t>Closing Dates</w:t>');
+    editor.destroy();
+  });
+
+  test('fresh results save byte-identically, with no revision bump and no undo entry', async () => {
+    const editor = mount(FRESH_BODY);
+    const surface = editor.surface!;
+    const revisionBefore = editor.getDocumentHandle().revision;
+    // The oracle: a serialize with NO refresh in front of it.
+    const withoutRefresh = surface.session.save();
+    const withRefresh = new Uint8Array(await editor.save());
+    expect(withRefresh).toEqual(withoutRefresh);
+    expect(editor.getDocumentHandle().revision).toBe(revisionBefore);
+    expect(surface.session.canUndo()).toBe(false);
+    editor.destroy();
+  });
+
+  test('a stale refresh is one ordinary transaction: revision bumps and it is undoable', async () => {
+    const editor = mount(FRESH_BODY);
+    editTarget(editor);
+    const revisionAfterEdit = editor.getDocumentHandle().revision;
+    await editor.save();
+    expect(editor.getDocumentHandle().revision).toBeGreaterThan(revisionAfterEdit);
+    expect(editor.surface!.session.canUndo()).toBe(true);
+    editor.destroy();
+  });
+
+  test('a result wrapped in revision markup is skipped and saved exactly as loaded', async () => {
+    const editor = mount(
+      `<w:p>${bookmarked('term', 'Closing Date')}</w:p>` +
+        `<w:p>${refField(
+          ' REF term ',
+          '<w:ins w:id="9" w:author="QA" w:date="2020-01-01T00:00:00Z">' +
+            '<w:r><w:t>Closing Date</w:t></w:r></w:ins>'
+        )}</w:p>` +
+        '<w:sectPr/>'
+    );
+    editTarget(editor);
+    const revisionAfterEdit = editor.getDocumentHandle().revision;
+    const xml = await savedDocumentXml(editor);
+    // The stale result stays exactly as loaded, revision markup and all — no refresh
+    // transaction ran for a document whose only REF result is revision content.
+    expect(xml).toContain('<w:ins');
+    expect(xml).toContain('<w:t>Closing Date</w:t>');
+    expect(xml).toContain('<w:t>s</w:t>');
+    expect(editor.getDocumentHandle().revision).toBe(revisionAfterEdit);
+    editor.destroy();
+  });
+
+  test('refresh + save + reopen digests identically across a second save', async () => {
+    const editor = mount(FRESH_BODY);
+    editTarget(editor);
+    const firstSave = new Uint8Array(await editor.save());
+    editor.destroy();
+
+    const container = document.createElement('div');
+    const reopened = createDocxEditor({ container, document: firstSave });
+    const secondSave = new Uint8Array(await reopened.save());
+    // The rewrite is a fixed point: nothing was stale on reopen, so the second save is the
+    // byte-identical serialization, and the semantic digests agree.
+    expect(secondSave).toEqual(firstSave);
+    const digestOf = (bytes: Uint8Array) => {
+      const loaded = readOoxmlPackage(bytes);
+      if (!loaded.ok) throw new Error(loaded.reason);
+      return semanticDigest(loaded.package.parts.values());
+    };
+    expect(digestOf(secondSave)).toEqual(digestOf(firstSave));
+    reopened.destroy();
+  });
+
+  test('a document opened for viewing is never rewritten by save', async () => {
+    const container = document.createElement('div');
+    const editor = createDocxEditor({
+      container,
+      document: docx(
+        `<w:p>${bookmarked('term', 'Closing Date')}</w:p>` +
+          `<w:p>${refField(' REF term ', '<w:r><w:t>Old</w:t></w:r>')}</w:p>` +
+          '<w:sectPr/>'
+      ),
+      mode: 'view',
+    });
+    if (!editor.surface) throw new Error('surface failed to mount');
+    const xml = await savedDocumentXml(editor);
+    expect(xml).toContain('Old');
+    editor.destroy();
+  });
+});

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -1838,6 +1838,8 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
       if (!surface) return Promise.reject(editorError('notFound', 'no document is loaded'));
       // Ctrl+S can race a typing burst: queued keystrokes belong in the bytes.
       surface.flushPendingInput();
+      // Stale REF results rewrite first (bytes carry the paint); fresh commits nothing.
+      surface.refreshRefFieldResults();
       // A fresh copy, so the returned ArrayBuffer is exactly the document — not a window
       // into a larger allocation.
       const bytes = surface.session.save();

--- a/packages/core/src/editor/paginated-surface-contract.ts
+++ b/packages/core/src/editor/paginated-surface-contract.ts
@@ -714,6 +714,12 @@ export interface PaginatedSurface {
   insertToc(): boolean;
   /** Refresh cached TOC entries and/or page numbers through the two-pass layout pipeline. */
   refreshToc(tocId?: string, mode?: 'entire' | 'pageNumbers'): boolean;
+  /**
+   * Rewrite stale REF field results in the body story so a save exports what the pages
+   * paint. Fresh results commit nothing (no transaction, no revision bump, no undo entry);
+   * a rewrite is one ordinary journaled transaction. Viewing writes nothing.
+   */
+  refreshRefFieldResults(): boolean;
   /** Whether a body paragraph belongs to a detected TOC boundary or cached result. */
   isInsideToc(paragraphId: string): boolean;
   /**

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -54,6 +54,7 @@ import {
   contentControlRecordsInPart,
   contentControlsInLayout,
   layoutSemanticDocument,
+  planRefFieldResultRefresh,
   resolveNumberingLevel,
   positionPastDeletion,
   withNumberingStyleLinks,
@@ -4483,6 +4484,25 @@ export function mountPaginatedSurface(
     return true;
   }
 
+  /**
+   * Rewrite stale REF field results in the body story, so a save exports what the pages
+   * paint. Planning is read-only: a document whose results are already fresh commits no
+   * transaction, bumps no revision and adds no undo entry. A refresh that does rewrite is
+   * one ordinary journaled transaction — undoable, like a TOC refresh. Viewing writes
+   * nothing; note-part results still save cached (see `field-ref-refresh.ts`).
+   */
+  function refreshRefFieldResults(): boolean {
+    if (editingMode === 'view') return true;
+    const op = planRefFieldResultRefresh(session.part(), {
+      package: session.currentPackage(),
+      styleCascade: styleCascade(),
+      numberingIndex: numberingIndex(),
+      displayMode: revisionDisplayMode(),
+    });
+    if (!op) return true;
+    return applyJournaledOps([op], undefined, undefined, BODY_STORY).committed;
+  }
+
   // Which range a destructive or replacing gesture acts on, and where content replacing it
   // lands once a tracked strike has had its say. Wired ABOVE the surface object on purpose:
   // `createHeaderFooterOps` and `createImageOps` below take `deleteSelectionOps`,
@@ -5144,6 +5164,7 @@ export function mountPaginatedSurface(
     insertToc,
     canRefreshToc,
     refreshToc,
+    refreshRefFieldResults,
     isInsideToc: (paragraphId) =>
       detectBodyTocs(session.part()).some(
         (toc) =>

--- a/packages/core/src/layout/__tests__/field-ref-notes-layout.test.ts
+++ b/packages/core/src/layout/__tests__/field-ref-notes-layout.test.ts
@@ -1,0 +1,227 @@
+// REF fields inside footnote stories: live values from BODY bookmarks and numbering.
+//
+// A footnote citing "see Section 2" targets a body paragraph, so the note story must share
+// the body's resolution context — and a renumbering edit that the note part cannot see (its
+// own nodes survive by identity) must still repaint the note. That repaint hangs on two
+// keys: the paragraph's resolved-value token in the note flow's break key, and the values
+// token in the notes-pass fingerprint. The calibration gate applies unchanged: a footnote
+// field goes live only after its computed value reproduced its authored cache once, and a
+// field that never matched paints (and saves) that cache.
+
+import { describe, expect, test } from 'bun:test';
+import { strToU8, zipSync } from 'fflate';
+import { readOoxmlPackage, readOoxmlPart } from '@docx-editor.dev/core/store';
+import type { OoxmlElement, OoxmlPart } from '@docx-editor.dev/core/store';
+import { resolveNotesPart } from '../../store/package/note-references.ts';
+import {
+  authoredDocumentEndnoteProperties,
+  authoredDocumentFootnoteProperties,
+  resolveEndnoteProperties,
+  resolveFootnoteProperties,
+  settingsPartOf,
+} from '../../store/package/note-properties.ts';
+import { createFixedMeasurer } from '../fixed-measurer.ts';
+import { layoutSemanticDocument } from '../semantic-layout.ts';
+import { createLayoutSession } from '../layout-session.ts';
+import { createParagraphLayoutCache } from '../layout-cache.ts';
+import type { NotesLayoutInput } from '../note-pagination.ts';
+import type { SemanticLayout } from '../index.ts';
+import { buildNumberingIndex } from '../numbering-index.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+
+const NUMBERING = `
+  <w:abstractNum w:abstractNumId="0">
+    <w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/>
+      <w:lvlText w:val="%1."/><w:lvlJc w:val="left"/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="5"><w:abstractNumId w:val="0"/></w:num>
+`;
+
+function numberingIndexOf() {
+  const result = readOoxmlPart(`<w:numbering xmlns:w="${W}">${NUMBERING}</w:numbering>`, {
+    name: '/word/numbering.xml',
+    contentType: 'application/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return buildNumberingIndex(result.part.root);
+}
+const numberingIndex = numberingIndexOf();
+
+const numbered = (inner: string) =>
+  `<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="5"/></w:numPr></w:pPr>${inner}</w:p>`;
+const bookmarked = (name: string, text: string) =>
+  `<w:bookmarkStart w:id="1" w:name="${name}"/><w:r><w:t>${text}</w:t></w:r>` +
+  `<w:bookmarkEnd w:id="1"/>`;
+const refField = (instr: string, cached: string) =>
+  '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+  `<w:r><w:instrText>${instr}</w:instrText></w:r>` +
+  '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+  `<w:r><w:t>${cached}</w:t></w:r>` +
+  '<w:r><w:fldChar w:fldCharType="end"/></w:r>';
+
+function notesDoc(body: string, footnoteContent: string): Uint8Array {
+  const footnotes =
+    `<w:footnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:footnote>` +
+    `<w:footnote w:id="1"><w:p>${footnoteContent}</w:p></w:footnote>`;
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '<Override PartName="/word/footnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rIdFn" Type="${R}/footnotes" Target="footnotes.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}" xmlns:r="${R}"><w:body>${body}<w:sectPr/></w:body></w:document>`
+    ),
+    'word/footnotes.xml': strToU8(`<w:footnotes xmlns:w="${W}">${footnotes}</w:footnotes>`),
+  });
+}
+
+function openNotesDoc(bytes: Uint8Array): { part: OoxmlPart; notes: NotesLayoutInput } {
+  const loaded = readOoxmlPackage(bytes);
+  if (!loaded.ok) throw new Error(loaded.reason);
+  const part = loaded.package.parts.get(loaded.package.mainDocumentPart)!;
+  const settings = settingsPartOf(loaded.package);
+  const documentFootnoteProps = resolveFootnoteProperties(
+    undefined,
+    authoredDocumentFootnoteProperties(settings)
+  );
+  const documentEndnoteProps = resolveEndnoteProperties(
+    undefined,
+    authoredDocumentEndnoteProperties(settings)
+  );
+  const notes: NotesLayoutInput = {
+    footnotesPart: resolveNotesPart(loaded.package, 'footnote'),
+    endnotesPart: null,
+    footnotePropsBySection: [documentFootnoteProps],
+    endnotePropsBySection: [documentEndnoteProps],
+    documentFootnoteProps,
+    documentEndnoteProps,
+    measurer: createFixedMeasurer(6, 14),
+    producer: 'note-ref',
+  };
+  return { part, notes };
+}
+
+function footnoteTexts(layout: SemanticLayout): string[] {
+  return layout.pages
+    .flatMap((page) => page.footnotes?.notes ?? [])
+    .flatMap((note) => note.fragments)
+    .map((fragment) =>
+      (fragment.kind === 'paragraph' ? fragment.lines : [])
+        .flatMap((line) => line.spans.map((span) => span.text))
+        .join('')
+        .trim()
+    );
+}
+
+/** Structural-sharing body edit: every surviving node kept BY IDENTITY, like a store commit. */
+function withBlocks(
+  part: OoxmlPart,
+  edit: (blocks: readonly OoxmlElement[]) => readonly OoxmlElement[]
+): OoxmlPart {
+  const body = part.root.children.find(
+    (child): child is OoxmlElement => child.kind !== 'textValue' && child.localName === 'body'
+  )!;
+  const blocks = body.children.filter(
+    (child): child is OoxmlElement => child.kind === 'paragraph' || child.kind === 'table'
+  );
+  const edited = edit(blocks);
+  const nextChildren = [
+    ...edited,
+    ...body.children.filter(
+      (child) =>
+        child.kind === 'textValue' || (child.kind !== 'paragraph' && child.kind !== 'table')
+    ),
+  ];
+  const nextBody = { ...body, children: nextChildren } as OoxmlElement;
+  const nextRoot = {
+    ...part.root,
+    children: part.root.children.map((child) => (child === body ? nextBody : child)),
+  } as OoxmlElement;
+  return { ...part, root: nextRoot };
+}
+
+const BODY =
+  numbered('<w:r><w:t>gone soon</w:t></w:r>') +
+  numbered(bookmarked('target', 'The section')) +
+  '<w:p><w:r><w:t>cites</w:t><w:footnoteReference w:id="1"/></w:r></w:p>';
+
+describe('REF fields in footnote stories', () => {
+  test('a plain footnote REF with an empty cache paints the bookmarked body text', () => {
+    // No result run at all — always calibration-eligible, so the live value paints.
+    const { part, notes } = openNotesDoc(
+      notesDoc(BODY, `<w:r><w:t>see </w:t></w:r>${refField(' REF target ', '')}`)
+    );
+    const layout = layoutSemanticDocument(part, 1, {
+      measurer: notes.measurer,
+      numberingIndex,
+      notes,
+      producer: 'note-ref',
+    });
+    expect(footnoteTexts(layout).join('|')).toContain('see The section');
+  });
+
+  test('a footnote REF that fails calibration paints its cached result', () => {
+    // 'IX' cannot be reproduced from the target's numbering, so the field keeps its cache —
+    // the note never renders worse than the saved file.
+    const { part, notes } = openNotesDoc(
+      notesDoc(BODY, `<w:r><w:t>see </w:t></w:r>${refField(' REF target \\r \\h ', 'IX')}`)
+    );
+    const layout = layoutSemanticDocument(part, 1, {
+      measurer: notes.measurer,
+      numberingIndex,
+      notes,
+      producer: 'note-ref',
+    });
+    const texts = footnoteTexts(layout);
+    expect(texts.join('|')).toContain('see IX');
+    expect(texts.join('|')).not.toContain('see 2');
+  });
+
+  test('a calibrated footnote REF tracks a renumbering body edit on a warm session', () => {
+    // The cache ('2') reproduces the computed value, so the field calibrates LIVE on the
+    // first pass; the verdict then sticks across the edit that makes the cache stale.
+    const { part, notes } = openNotesDoc(
+      notesDoc(BODY, `<w:r><w:t>see </w:t></w:r>${refField(' REF target \\r \\h ', '2')}`)
+    );
+    const options = {
+      measurer: notes.measurer,
+      numberingIndex,
+      notes,
+      producer: 'note-ref',
+      session: createLayoutSession(),
+      cache: createParagraphLayoutCache(),
+    };
+    const first = layoutSemanticDocument(part, 1, options);
+    expect(footnoteTexts(first).join('|')).toContain('see 2');
+
+    // Remove the first numbered paragraph: the footnote part is untouched by identity, so
+    // only the resolved-value keys can repaint the note. The notes pass had SETTLED its
+    // reserve answer for the first part; the new part identity plus the refFields token in
+    // the notes-input fingerprint must retire that answer rather than republish it.
+    const after = withBlocks(part, (blocks) => blocks.filter((_, index) => index !== 0));
+    const warm = layoutSemanticDocument(after, 2, options);
+    const texts = footnoteTexts(warm);
+    expect(texts.join('|')).toContain('see 1');
+    expect(texts.join('|')).not.toContain('see 2');
+
+    // And the settled path is live for the NEW state: a no-change pass reuses every page
+    // (the settled reserve answer republishes) and still paints the repainted value — the
+    // settled memo serves the fresh REF value, never the pre-edit one.
+    const resettled = layoutSemanticDocument(after, 3, options);
+    expect(footnoteTexts(resettled).join('|')).toContain('see 1');
+    expect(options.session.stats.reusedPages).toBe(warm.pages.length);
+  });
+});

--- a/packages/core/src/layout/__tests__/field-ref-refresh.test.ts
+++ b/packages/core/src/layout/__tests__/field-ref-refresh.test.ts
@@ -1,0 +1,291 @@
+// Save-time REF result refresh: the planner reuses the layout's resolution AND its
+// per-field calibration verdict, the op rewrites only plain-run results, and a fresh
+// document plans nothing at all.
+//
+// Calibration shapes every fixture here: a field goes live only after its computed value
+// reproduced its authored cache once, so the stale states worth refreshing are the ones an
+// EDIT creates after that calibration. A field that never matched its cache paints the
+// cache — and must save it too.
+
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, type OoxmlElement, type OoxmlPart } from '@docx-editor.dev/core/store';
+import { applyTreeOp } from '../../store/store/tree-op-apply.ts';
+import { validateTreeOp } from '../../store/store/tree-op-validate.ts';
+import { locateFieldResults } from '../../store/store/tree-op-field-results.ts';
+import { planRefFieldResultRefresh } from '../field-ref-refresh.ts';
+import { buildNumberingIndex } from '../numbering-index.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+const NUMBERING = `
+  <w:abstractNum w:abstractNumId="0">
+    <w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/>
+      <w:lvlText w:val="%1."/><w:lvlJc w:val="left"/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="5"><w:abstractNumId w:val="0"/></w:num>
+`;
+
+function numberingIndexOf() {
+  const result = readOoxmlPart(`<w:numbering xmlns:w="${W}">${NUMBERING}</w:numbering>`, {
+    name: '/word/numbering.xml',
+    contentType: 'application/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return buildNumberingIndex(result.part.root);
+}
+const numberingIndex = numberingIndexOf();
+
+function load(body: string): OoxmlPart {
+  const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'application/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+const numbered = (inner: string) =>
+  `<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="5"/></w:numPr></w:pPr>${inner}</w:p>`;
+const bookmarked = (name: string, text: string) =>
+  `<w:bookmarkStart w:id="1" w:name="${name}"/><w:r><w:t>${text}</w:t></w:r>` +
+  `<w:bookmarkEnd w:id="1"/>`;
+const refField = (instr: string, result: string) =>
+  '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+  `<w:r><w:instrText>${instr}</w:instrText></w:r>` +
+  '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+  result +
+  '<w:r><w:fldChar w:fldCharType="end"/></w:r>';
+
+function paragraphs(part: OoxmlPart): OoxmlElement[] {
+  const found: OoxmlElement[] = [];
+  const walk = (node: OoxmlElement): void => {
+    if (node.kind === 'paragraph') found.push(node);
+    for (const child of node.children) {
+      if (child.kind !== 'textValue') walk(child);
+    }
+  };
+  walk(part.root);
+  return found;
+}
+
+/**
+ * Structural-sharing body edit — every surviving node kept BY IDENTITY, like a store commit.
+ * Keeping the ends intact is what carries the sticky calibration verdicts across the edit.
+ */
+function withBlocks(
+  part: OoxmlPart,
+  edit: (blocks: readonly OoxmlElement[]) => readonly OoxmlElement[]
+): OoxmlPart {
+  const body = part.root.children.find(
+    (child): child is OoxmlElement => child.kind !== 'textValue' && child.localName === 'body'
+  )!;
+  const blocks = body.children.filter(
+    (child): child is OoxmlElement => child.kind === 'paragraph' || child.kind === 'table'
+  );
+  const edited = edit(blocks);
+  const nextChildren = [
+    ...edited,
+    ...body.children.filter(
+      (child) =>
+        child.kind === 'textValue' || (child.kind !== 'paragraph' && child.kind !== 'table')
+    ),
+  ];
+  const nextBody = { ...body, children: nextChildren } as OoxmlElement;
+  const nextRoot = {
+    ...part.root,
+    children: part.root.children.map((child) => (child === body ? nextBody : child)),
+  } as OoxmlElement;
+  return { ...part, root: nextRoot };
+}
+
+/** Plan, validate and apply the refresh; answers the refreshed part (or the same one). */
+function refresh(part: OoxmlPart): { part: OoxmlPart; planned: boolean } {
+  const op = planRefFieldResultRefresh(part, { numberingIndex });
+  if (op === null) return { part, planned: false };
+  expect(validateTreeOp(part, op)).toBeNull();
+  const applied = applyTreeOp(part, op);
+  expect(applied.ok).toBe(true);
+  if (!applied.ok || !applied.part) throw new Error('apply failed');
+  return { part: applied.part, planned: true };
+}
+
+/** The instruction/cachedText pairs the store locator reads back, in document order. */
+function fieldsOf(part: OoxmlPart) {
+  return paragraphs(part).flatMap((paragraph) =>
+    locateFieldResults(paragraph).map((field) => ({
+      instruction: field.instruction,
+      cachedText: field.cachedText,
+    }))
+  );
+}
+
+// A calibration-eligible document: the cache reproduces the computed value ('2'), and the
+// REF paragraph sits LAST so the verdict registry's anchor block survives the edit below.
+const calibratedBody =
+  numbered('<w:r><w:t>gone soon</w:t></w:r>') +
+  numbered(bookmarked('target', 'The section')) +
+  `<w:p>${refField(' REF target \\r \\h \\* MERGEFORMAT ', '<w:r><w:t>2</w:t></w:r>')}</w:p>`;
+
+describe('planRefFieldResultRefresh', () => {
+  test('a calibrated field gone stale after a renumbering edit is rewritten', () => {
+    const before = load(calibratedBody);
+    // Calibration pass: the cache matches, so nothing is planned and the verdict sticks.
+    const calibrated = refresh(before);
+    expect(calibrated.planned).toBe(false);
+    expect(calibrated.part).toBe(before);
+
+    // The edit renumbers the target from 2 to 1; the cache now trails the live value.
+    const after = withBlocks(before, (blocks) => blocks.filter((_, index) => index !== 0));
+    const { part, planned } = refresh(after);
+    expect(planned).toBe(true);
+    expect(fieldsOf(part)).toEqual([
+      { instruction: ' REF target \\r \\h \\* MERGEFORMAT ', cachedText: '1' },
+    ]);
+  });
+
+  test('a field whose computed value never matched its cache is NOT in the plan', () => {
+    // Stale from birth: '9.9' cannot be reproduced, so the field fails calibration, paints
+    // its cache, and must keep that cache on save — rewriting it would export the very
+    // value the calibration gate suppresses.
+    const before = load(
+      numbered(bookmarked('_RefA', 'First')) +
+        numbered(bookmarked('_RefB', 'Second')) +
+        `<w:p>${refField(' REF _RefB \\r \\h ', '<w:r><w:t>9.9</w:t></w:r>')}</w:p>`
+    );
+    expect(planRefFieldResultRefresh(before, { numberingIndex })).toBeNull();
+  });
+
+  test('calibration is whitespace-tolerant, and the rewrite then aligns bytes with paint', () => {
+    // NBSP and doubled spaces normalize for the verdict, so these fields go LIVE — and the
+    // painted value differs from the raw cache, so the save rewrites both shapes.
+    const before = load(
+      `<w:p>${bookmarked('term', 'Closing Date')}</w:p>` +
+        `<w:p>${refField(' REF term ', '<w:r><w:t>Closing Date</w:t></w:r>')}</w:p>` +
+        '<w:p><w:fldSimple w:instr=" REF term ">' +
+        '<w:r><w:t xml:space="preserve">Closing  Date</w:t></w:r></w:fldSimple></w:p>'
+    );
+    const { part, planned } = refresh(before);
+    expect(planned).toBe(true);
+    expect(fieldsOf(part).map((field) => field.cachedText)).toEqual([
+      'Closing Date',
+      'Closing Date',
+    ]);
+  });
+
+  test('preserves the first result run properties and empties surplus result runs', () => {
+    // Two result runs whose combined text ('2 ') normalizes to the computed value: the
+    // field calibrates live, and the raw difference drives one rewrite.
+    const before = load(
+      numbered(bookmarked('_RefA', 'First')) +
+        numbered(bookmarked('_RefB', 'Second')) +
+        `<w:p>${refField(
+          ' REF _RefB \\r ',
+          '<w:r><w:rPr><w:b/></w:rPr><w:t>2</w:t></w:r>' +
+            '<w:r><w:rPr><w:i/></w:rPr><w:t xml:space="preserve"> </w:t></w:r>'
+        )}</w:p>`
+    );
+    const { part, planned } = refresh(before);
+    expect(planned).toBe(true);
+    const field = paragraphs(part)
+      .flatMap((paragraph) => locateFieldResults(paragraph))
+      .find((entry) => entry.instruction.includes('REF'))!;
+    expect(field.cachedText).toBe('2');
+    // Bold survives on the rewritten run; the surplus run keeps its italic properties and
+    // holds no text.
+    const shapes: string[] = [];
+    const walk = (node: OoxmlElement): void => {
+      if (node.kind === 'run') {
+        const hasBold = JSON.stringify(node).includes('"localName":"b"');
+        const hasItalic = JSON.stringify(node).includes('"localName":"i"');
+        const text = JSON.stringify(node).includes('"kind":"text"');
+        shapes.push(`${hasBold ? 'b' : ''}${hasItalic ? 'i' : ''}${text ? 't' : ''}`);
+      }
+      for (const child of node.children) {
+        if (child.kind !== 'textValue') walk(child);
+      }
+    };
+    walk(paragraphs(part)[2]!);
+    expect(shapes).toContain('bt');
+    expect(shapes).toContain('i');
+    expect(shapes).not.toContain('it');
+  });
+
+  test('a fresh document plans nothing and the part is untouched by identity', () => {
+    const before = load(
+      numbered(bookmarked('_RefA', 'First')) +
+        numbered(bookmarked('_RefB', 'Second')) +
+        `<w:p>${refField(' REF _RefB \\r \\h ', '<w:r><w:t>2</w:t></w:r>')}</w:p>` +
+        '<w:p><w:fldSimple w:instr=" REF _RefA \\r "><w:r><w:t>1</w:t></w:r></w:fldSimple></w:p>'
+    );
+    const { part, planned } = refresh(before);
+    expect(planned).toBe(false);
+    expect(part).toBe(before);
+  });
+
+  test('a calibrated result holding revision markup is skipped, never rewritten', () => {
+    const before = load(
+      numbered('<w:r><w:t>gone soon</w:t></w:r>') +
+        numbered(bookmarked('target', 'The section')) +
+        `<w:p>${refField(
+          ' REF target \\r ',
+          '<w:ins w:id="9" w:author="QA" w:date="2020-01-01T00:00:00Z">' +
+            '<w:r><w:t>2</w:t></w:r></w:ins>'
+        )}</w:p>`
+    );
+    expect(planRefFieldResultRefresh(before, { numberingIndex })).toBeNull();
+    // The edit makes the (calibrated, live-painting) field stale — but its result carries
+    // revision markup, so the refresh leaves it alone rather than corrupting the w:ins.
+    const after = withBlocks(before, (blocks) => blocks.filter((_, index) => index !== 0));
+    expect(planRefFieldResultRefresh(after, { numberingIndex })).toBeNull();
+  });
+
+  test('a tracked formatting change on a result run (w:rPrChange) is skipped', () => {
+    const before = load(
+      numbered('<w:r><w:t>gone soon</w:t></w:r>') +
+        numbered(bookmarked('target', 'The section')) +
+        `<w:p>${refField(
+          ' REF target \\r ',
+          '<w:r><w:rPr><w:b/><w:rPrChange w:id="3" w:author="QA" ' +
+            'w:date="2020-01-01T00:00:00Z"><w:rPr/></w:rPrChange></w:rPr><w:t>2</w:t></w:r>'
+        )}</w:p>`
+    );
+    expect(planRefFieldResultRefresh(before, { numberingIndex })).toBeNull();
+    const after = withBlocks(before, (blocks) => blocks.filter((_, index) => index !== 0));
+    expect(planRefFieldResultRefresh(after, { numberingIndex })).toBeNull();
+  });
+
+  test('a locked field (w:fldLock) is skipped', () => {
+    const before = load(
+      numbered('<w:r><w:t>gone soon</w:t></w:r>') +
+        numbered(bookmarked('target', 'The section')) +
+        '<w:p><w:r><w:fldChar w:fldCharType="begin" w:fldLock="1"/></w:r>' +
+        '<w:r><w:instrText> REF target \\r </w:instrText></w:r>' +
+        '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+        '<w:r><w:t>2</w:t></w:r>' +
+        '<w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>'
+    );
+    expect(planRefFieldResultRefresh(before, { numberingIndex })).toBeNull();
+    const after = withBlocks(before, (blocks) => blocks.filter((_, index) => index !== 0));
+    expect(planRefFieldResultRefresh(after, { numberingIndex })).toBeNull();
+  });
+
+  test('an unsupported switch and a missing bookmark keep their cached results', () => {
+    const before = load(
+      numbered(bookmarked('_RefA', 'First')) +
+        `<w:p>${refField(' REF _RefA \\p ', '<w:r><w:t>kept-a</w:t></w:r>')}</w:p>` +
+        `<w:p>${refField(' REF _Gone \\r ', '<w:r><w:t>kept-b</w:t></w:r>')}</w:p>`
+    );
+    expect(planRefFieldResultRefresh(before, { numberingIndex })).toBeNull();
+  });
+
+  test('a second refresh after a first one plans nothing (idempotent)', () => {
+    const before = load(calibratedBody);
+    expect(refresh(before).planned).toBe(false);
+    const after = withBlocks(before, (blocks) => blocks.filter((_, index) => index !== 0));
+    const first = refresh(after);
+    expect(first.planned).toBe(true);
+    const second = refresh(first.part);
+    expect(second.planned).toBe(false);
+    expect(second.part).toBe(first.part);
+  });
+});

--- a/packages/core/src/layout/field-ref-refresh.ts
+++ b/packages/core/src/layout/field-ref-refresh.ts
@@ -1,0 +1,103 @@
+// Save-time REF result refresh: plan the one `refreshFieldResults` op that makes the saved
+// bytes carry what the pages paint.
+//
+// Painted REF values are a layout projection; the file keeps Word's cached result runs, so
+// an export after a renumbering edit is stale until Word refreshes fields. The plan reuses
+// the layout's own resolution (`resolveStoryRefFields` — grammar, bookmark index, number
+// composition AND the per-field calibration verdict, all shared, so save and paint cannot
+// drift) and pairs it with the store's result locator, then keeps only the fields whose
+// plain-run cached text differs from the LIVE value. `liveValueOf` answers null for a field
+// that failed calibration, so a field painting its cache keeps that cache on save too —
+// rewriting it would export the very value the calibration gate exists to suppress. A fresh
+// document plans NOTHING: the caller sees null, runs no transaction, bumps no revision, and
+// the save is byte-identical to one without the refresh.
+//
+// Scope: the BODY story. Note-story results still paint live through the shared context but
+// keep their cached runs on save — rewriting them needs per-note-part transactions, tracked
+// with the notes half of the follow-up. The field INSTRUCTION is never modified, and any
+// result the locator calls non-rewritable (revision markup, nested fields, locks, anything
+// but plain runs) keeps its cache untouched.
+
+import type { OoxmlPart } from '@docx-editor.dev/core/store';
+import { resolveNotesPart } from '../store/package/note-references.ts';
+import type { OoxmlPackage } from '../store/package/ooxml-package.ts';
+import {
+  locateFieldResults,
+  MAX_FIELD_RESULT_TEXT_CHARS,
+  MAX_FIELD_RESULT_UPDATES,
+  type RefreshFieldResultsOp,
+} from '../store/store/tree-op-field-results.ts';
+import { parseRefInstruction, resolveStoryRefFields, type RefNoteParts } from './field-ref.ts';
+import { walkStoryParagraphs, withResolvedListItems } from './list-resolve.ts';
+import type { NumberingIndex } from './numbering-index.ts';
+import { DEFAULT_REVISION_DISPLAY_MODE } from './revision-projection.ts';
+import type { RevisionDisplayMode } from './revision-projection.ts';
+import { storyBlocks } from './story-roots.ts';
+import type { StyleCascadeTable } from './style-cascade.ts';
+
+export interface RefFieldRefreshOptions {
+  /**
+   * The package the part belongs to, for the note-part half of the resolution context —
+   * the same context paint uses, so a body REF that targets a footnote bookmark computes
+   * the same value both places. Absent narrows resolution to body-declared bookmarks.
+   */
+  readonly package?: OoxmlPackage;
+  readonly styleCascade?: StyleCascadeTable;
+  readonly numberingIndex?: NumberingIndex;
+  /** The mode the surface painted under, so the saved values match the painted ones. */
+  readonly displayMode?: RevisionDisplayMode;
+}
+
+/**
+ * Plan the refresh for one body part, or null when every supported REF result is already
+ * fresh (the no-op save path — no transaction, no revision bump, no undo entry).
+ *
+ * Every skip is conservative and per-field: an unrecognized instruction or switch, a
+ * missing bookmark, an unnumbered target under a number switch, a non-plain result, a
+ * locked field and a field whose calibration verdict is "keeps the cache" all keep their
+ * cached runs exactly as loaded.
+ */
+export function planRefFieldResultRefresh(
+  part: OoxmlPart,
+  options: RefFieldRefreshOptions
+): RefreshFieldResultsOp | null {
+  const blocks = storyBlocks(part, options.displayMode ?? DEFAULT_REVISION_DISPLAY_MODE);
+  const listItems = withResolvedListItems(
+    { numberingIndex: options.numberingIndex, styleCascade: options.styleCascade },
+    blocks
+  ).listItems;
+  const notes: RefNoteParts | undefined = options.package
+    ? {
+        footnotesPart: resolveNotesPart(options.package, 'footnote'),
+        endnotesPart: resolveNotesPart(options.package, 'endnote'),
+      }
+    : undefined;
+  const context = resolveStoryRefFields(blocks, listItems, notes);
+  if (context === null) return null;
+
+  const updates: { paragraphId: string; fieldNodeId: string; text: string }[] = [];
+  for (const paragraph of walkStoryParagraphs(blocks)) {
+    if (updates.length >= MAX_FIELD_RESULT_UPDATES) break;
+    // The context already scanned every paragraph; only the ones holding recognized REF
+    // specs are worth the locate walk.
+    if (context.tokenForParagraph(paragraph.id) === '') continue;
+    for (const located of locateFieldResults(paragraph)) {
+      if (updates.length >= MAX_FIELD_RESULT_UPDATES) break;
+      if (!located.rewritable) continue;
+      const spec = parseRefInstruction(located.instruction);
+      if (spec === null) continue;
+      // The locator's field id IS the calibration anchor (begin fldChar / fldSimple node),
+      // so this read returns exactly what the pages paint — or null for a field painting
+      // its cache, which then saves as loaded.
+      const value = context.liveValueOf(located.fieldNodeId, spec);
+      if (value === null || value === located.cachedText) continue;
+      // The op's own bounds, applied per field so one outlier cannot refuse the whole plan:
+      // length-capped, and no line breaks (a rewrite expresses tabs, never `w:br`).
+      if (value.length > MAX_FIELD_RESULT_TEXT_CHARS) continue;
+      if (value.includes('\n') || value.includes('\r')) continue;
+      updates.push({ paragraphId: paragraph.id, fieldNodeId: located.fieldNodeId, text: value });
+    }
+  }
+  if (updates.length === 0) return null;
+  return { op: 'refreshFieldResults', updates };
+}

--- a/packages/core/src/layout/field-ref.ts
+++ b/packages/core/src/layout/field-ref.ts
@@ -51,7 +51,10 @@ import {
   WML_NAMESPACE_URI,
   type OoxmlElement,
   type OoxmlNode,
+  type OoxmlPart,
 } from '@docx-editor.dev/core/store';
+import { isNormalNote, notesOf, MAX_NOTES_PER_PART } from '../store/package/note-nodes.ts';
+import { noteStoryBlocks } from './story-roots.ts';
 import {
   consumeScanNode,
   createFieldParseState,
@@ -172,7 +175,8 @@ export function parseRefInstruction(raw: string): RefFieldSpec | null {
  * Threaded as a runtime rider on the layout options (see `layoutSemanticDocument`) rather
  * than a `SemanticLayoutOptions` member, so the public options surface stays put. Absent
  * means every REF field paints its cached result — the pre-existing degradation, and the one
- * header/footer, note and text-box stories still take.
+ * header/footer and text-box stories still take. Note stories receive the body's context
+ * through `NotesLayoutInput.refFields`.
  */
 export interface RefFieldContext {
   /**
@@ -525,8 +529,39 @@ function bookmarkRangeText(paragraph: OoxmlElement, name: string): string {
   return text;
 }
 
+/**
+ * Note parts whose stories join the context: their REF fields resolve against the body's
+ * bookmarks and numbering (a footnote citing "Section 1.2(c)" targets a body paragraph),
+ * and their bookmark declarations become plain-REF targets. Number switches aimed AT a
+ * note paragraph still fall back to the cached result — the list map is the body's.
+ */
+export interface RefNoteParts {
+  readonly footnotesPart: OoxmlPart | null;
+  readonly endnotesPart: OoxmlPart | null;
+}
+
+/** Normal-note story block arrays of one notes part, memoized on the immutable part. */
+const notePartStories = new WeakMap<OoxmlPart, readonly (readonly OoxmlElement[])[]>();
+
+function noteStoriesOfPart(part: OoxmlPart | null): readonly (readonly OoxmlElement[])[] {
+  if (!part) return [];
+  const cached = notePartStories.get(part);
+  if (cached) return cached;
+  const stories: (readonly OoxmlElement[])[] = [];
+  for (const note of notesOf(part.root)) {
+    if (stories.length >= MAX_NOTES_PER_PART) break;
+    if (!isNormalNote(note)) continue;
+    const blocks = noteStoryBlocks(note);
+    if (blocks.length > 0) stories.push(blocks);
+  }
+  notePartStories.set(part, stories);
+  return stories;
+}
+
 interface RefContextMemoEntry {
   readonly listItems: ReadonlyMap<string, ResolvedListItem> | undefined;
+  readonly footnotesPart: OoxmlPart | null;
+  readonly endnotesPart: OoxmlPart | null;
   readonly context: RefFieldContext | null;
 }
 /**
@@ -539,20 +574,30 @@ const refContextMemos = new WeakMap<readonly OoxmlElement[], RefContextMemoEntry
 
 function buildRefFieldContext(
   blocks: readonly OoxmlElement[],
-  listItems: ReadonlyMap<string, ResolvedListItem> | undefined
+  listItems: ReadonlyMap<string, ResolvedListItem> | undefined,
+  notes: RefNoteParts | undefined
 ): RefFieldContext | null {
   const fieldsByParagraph = new Map<string, readonly ScannedRefField[]>();
   const blockScans: BlockRefScan[] = [];
   let totalFields = 0;
-  for (const block of blocks) {
-    const scan = scanBlockRefs(block);
-    blockScans.push(scan);
-    if (!scan.fieldsByParagraph) continue;
-    for (const [paragraphId, fields] of scan.fieldsByParagraph) {
-      if (totalFields >= MAX_REF_FIELDS_PER_STORY) break;
-      fieldsByParagraph.set(paragraphId, fields);
-      totalFields += fields.length;
+  const scanStory = (storyBlocks: readonly OoxmlElement[]): void => {
+    for (const block of storyBlocks) {
+      const scan = scanBlockRefs(block);
+      blockScans.push(scan);
+      if (!scan.fieldsByParagraph) continue;
+      for (const [paragraphId, fields] of scan.fieldsByParagraph) {
+        if (totalFields >= MAX_REF_FIELDS_PER_STORY) break;
+        fieldsByParagraph.set(paragraphId, fields);
+        totalFields += fields.length;
+      }
     }
+  };
+  scanStory(blocks);
+  // Note stories join AFTER the body, so the shared cap and the first-declaration rule
+  // both prefer body content — the story a reference overwhelmingly lives in and targets.
+  if (notes) {
+    for (const story of noteStoriesOfPart(notes.footnotesPart)) scanStory(story);
+    for (const story of noteStoriesOfPart(notes.endnotesPart)) scanStory(story);
   }
   if (fieldsByParagraph.size === 0) return null;
 
@@ -659,20 +704,31 @@ function buildRefFieldContext(
 }
 
 /**
- * Resolve the story's REF fields for one layout pass, or null when it has none.
+ * Resolve the document's REF fields for one layout pass, or null when it has none.
  *
- * Bookmarks and REF fields resolve within one story: a body REF finds body bookmarks. Other
- * stories (headers, footers, notes, text boxes) are not given a context and keep painting
- * cached results.
+ * Bookmarks and REF fields resolve across the body story and (when `notes` is given) the
+ * footnote/endnote stories, against ONE shared target index — a footnote REF finds the
+ * body bookmark it cites. Header/footer and text-box stories are not given a context and
+ * keep painting cached results.
  */
 export function resolveStoryRefFields(
   blocks: readonly OoxmlElement[],
-  listItems: ReadonlyMap<string, ResolvedListItem> | undefined
+  listItems: ReadonlyMap<string, ResolvedListItem> | undefined,
+  notes?: RefNoteParts
 ): RefFieldContext | null {
+  const footnotesPart = notes?.footnotesPart ?? null;
+  const endnotesPart = notes?.endnotesPart ?? null;
   const memo = refContextMemos.get(blocks);
-  if (memo && memo.listItems === listItems) return memo.context;
-  const context = buildRefFieldContext(blocks, listItems);
-  refContextMemos.set(blocks, { listItems, context });
+  if (
+    memo &&
+    memo.listItems === listItems &&
+    memo.footnotesPart === footnotesPart &&
+    memo.endnotesPart === endnotesPart
+  ) {
+    return memo.context;
+  }
+  const context = buildRefFieldContext(blocks, listItems, notes);
+  refContextMemos.set(blocks, { listItems, footnotesPart, endnotesPart, context });
   return context;
 }
 

--- a/packages/core/src/layout/index.ts
+++ b/packages/core/src/layout/index.ts
@@ -351,6 +351,14 @@ export {
   type PageRefIndex,
 } from './note-pagination.ts';
 export { noteMarkKey, projectedNoteMarkText, type NoteMarkContext } from './note-projection.ts';
+export {
+  parseRefInstruction,
+  resolveStoryRefFields,
+  type RefFieldContext,
+  type RefFieldSpec,
+  type RefNoteParts,
+} from './field-ref.ts';
+export { planRefFieldResultRefresh, type RefFieldRefreshOptions } from './field-ref-refresh.ts';
 export { storyBlocks, noteStoryBlocks, MAX_SDT_NESTING } from './story-roots.ts';
 export {
   emptyTocPlaceholderParagraphIds,

--- a/packages/core/src/layout/note-layout.ts
+++ b/packages/core/src/layout/note-layout.ts
@@ -152,6 +152,12 @@ export interface LayoutNoteStoryOptions {
   readonly projectFieldLink?: FieldLinkProjector;
   /** Document properties for a document-property field inside a note story. */
   readonly documentProperties?: import('@docx-editor.dev/core/store').DocumentProperties;
+  /**
+   * The document's resolved REF inputs, so a footnote's cross-reference paints the live
+   * value the body paints. The flow folds each paragraph's resolved values into its break
+   * key, which is what repaints a note after a renumbering edit it cannot otherwise see.
+   */
+  readonly refFields?: import('./field-ref.ts').RefFieldContext;
   /** Derived display marks for noteRef projection inside the note body. */
   readonly noteMarks?: NoteMarkContext;
   /**
@@ -249,6 +255,7 @@ export function layoutNoteStory(
     ...(options.projectLink ? { projectLink: options.projectLink } : {}),
     ...(options.projectFieldLink ? { projectFieldLink: options.projectFieldLink } : {}),
     ...(options.documentProperties ? { documentProperties: options.documentProperties } : {}),
+    ...(options.refFields ? { refFields: options.refFields } : {}),
     ...(options.defaultTabStopPt !== undefined
       ? { defaultTabStopPt: options.defaultTabStopPt }
       : {}),

--- a/packages/core/src/layout/note-pagination.ts
+++ b/packages/core/src/layout/note-pagination.ts
@@ -183,6 +183,13 @@ export interface NotesLayoutInput {
   /** Document properties for a document-property field inside a note story. */
   readonly documentProperties?: import('@docx-editor.dev/core/store').DocumentProperties;
   /**
+   * The document's resolved REF inputs, so a footnote's cross-reference paints the live
+   * value the body paints. Normally injected by `semantic-layout` from the context it built
+   * over the body and note stories; its values token joins the notes-pass fingerprint so a
+   * renumbering edit repaints the notes that cite the renumbered target.
+   */
+  readonly refFields?: import('./field-ref.ts').RefFieldContext;
+  /**
    * Inline drawing support per notes part. Absent means note paragraphs flow without
    * drawing records, which is what a headless caller with no image port wants.
    */
@@ -280,6 +287,9 @@ function fingerprintNotesInput(input: NotesLayoutInput): string | null {
     input.producer,
     input.defaultTabStopPt ?? '',
     input.drawingLayoutEpoch ?? '',
+    // By CONTENT, not identity: a keystroke rebuilds the context object while every
+    // resolved value stands still, and only a value move should invalidate the memo.
+    input.refFields?.valuesToken ?? '',
     fingerprintNoteProps(input.documentFootnoteProps),
     fingerprintNoteProps(input.documentEndnoteProps),
     input.footnotePropsBySection.map(fingerprintNoteProps).join(';'),
@@ -589,6 +599,7 @@ function layoutOpts(input: NotesLayoutInput, noteMarks?: NoteMarkContext): Layou
     projectLink: input.projectLink,
     projectFieldLink: input.projectFieldLink,
     documentProperties: input.documentProperties,
+    refFields: input.refFields,
     noteMarks,
     drawingsForPart: input.drawingsForPart,
   };
@@ -2814,16 +2825,19 @@ export function inheritNotesLayoutInput(
     readonly projectLink?: NotesLayoutInput['projectLink'];
     readonly projectFieldLink?: NotesLayoutInput['projectFieldLink'];
     readonly documentProperties?: NotesLayoutInput['documentProperties'];
+    readonly refFields?: NotesLayoutInput['refFields'];
   }
 ): NotesLayoutInput {
   const projectLink = notes.projectLink ?? body.projectLink;
   const projectFieldLink = notes.projectFieldLink ?? body.projectFieldLink;
   const documentProperties = notes.documentProperties ?? body.documentProperties;
+  const refFields = notes.refFields ?? body.refFields;
   return {
     ...notes,
     ...(projectLink ? { projectLink } : {}),
     ...(projectFieldLink ? { projectFieldLink } : {}),
     ...(documentProperties ? { documentProperties } : {}),
+    ...(refFields ? { refFields } : {}),
   };
 }
 

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -610,10 +610,17 @@ export function layoutSemanticDocument(
         blocks
       );
 
-  // REF cross-references resolve against the whole story's bookmarks and resolved numbering,
+  // REF cross-references resolve against the document's bookmarks and resolved numbering,
   // so the context is built here — the one place that sees both — and rides the options
-  // spreads into every section pass. Null for the common REF-free document.
-  const refFields = resolveStoryRefFields(blocks, optionsWithLists.listItems);
+  // spreads into every section pass. Note stories join the context (their REF fields cite
+  // body targets), so paint agrees across stories. Null for the common REF-free document.
+  const refFields = resolveStoryRefFields(
+    blocks,
+    optionsWithLists.listItems,
+    options.notes
+      ? { footnotesPart: options.notes.footnotesPart, endnotesPart: options.notes.endnotesPart }
+      : undefined
+  );
   const optionsForBody = refFields === null ? optionsWithLists : { ...optionsWithLists, refFields };
 
   const runBody = (opts: SemanticLayoutOptions): SemanticLayout => {
@@ -678,10 +685,13 @@ export function layoutSemanticDocument(
 
   // Notes inherit the body's projector seams and document properties (link, field link, doc
   // props) unless the notes input pinned its own — see `inheritNotesLayoutInput`. The REF
-  // context deliberately does NOT ride along: note stories keep painting cached REF results
-  // until their flow keys learn to fold the resolved values (threading the values without
-  // keying on them would serve stale note breaks after a renumbering edit).
-  const notesInput = inheritNotesLayoutInput(options.notes, options);
+  // context rides along the same way: the note flow folds each paragraph's resolved values
+  // into its break key and the notes-pass fingerprint folds the values token, so a
+  // renumbering edit repaints the notes that cite the renumbered target.
+  const notesInput = inheritNotesLayoutInput(
+    options.notes,
+    refFields ? { ...options, refFields } : options
+  );
   return finish(
     layoutSemanticDocumentWithNotes(part, sections, optionsForBody, notesInput, runBody)
   );

--- a/packages/core/src/store/__tests__/canonical-primitive-journal-coverage-ops.ts
+++ b/packages/core/src/store/__tests__/canonical-primitive-journal-coverage-ops.ts
@@ -27,6 +27,15 @@ import {
 const TWO_P =
   '<w:p><w:r><w:t>Hello</w:t></w:r></w:p><w:p><w:r><w:t>World</w:t></w:r></w:p><w:sectPr/>';
 
+const REF_FIELD_BODY =
+  '<w:p><w:bookmarkStart w:id="1" w:name="_Ref1"/><w:r><w:t>Target</w:t></w:r>' +
+  '<w:bookmarkEnd w:id="1"/></w:p>' +
+  '<w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+  '<w:r><w:instrText xml:space="preserve"> REF _Ref1 \\h </w:instrText></w:r>' +
+  '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+  '<w:r><w:t>old</w:t></w:r>' +
+  '<w:r><w:fldChar w:fldCharType="end"/></w:r></w:p><w:sectPr/>';
+
 const MATH_P =
   '<w:p><w:r><w:t>A</w:t></w:r><m:oMath><m:r><m:t>x</m:t></m:r></m:oMath>' +
   '<w:r><w:t>Z</w:t></w:r></w:p><w:p><w:r><w:t>y</w:t></w:r></w:p><w:sectPr/>';
@@ -657,6 +666,18 @@ export function authorableCoverageFixtures(): JournalCoverageFixture[] {
         op: 'rewriteTocPageNumbers',
         tocId: toc.id,
         updates: [{ paragraphId: toc.resultParagraphIds[0]!, pageNumberText: '9' }],
+      };
+    }),
+    story('refreshFieldResults', zipDoc({ body: REF_FIELD_BODY }), (store) => {
+      // The field anchor is the begin `w:fldChar` node — the first one in document order.
+      let beginId: string | undefined;
+      walkNodes(store.bodyStore().part.root, (node) => {
+        if (beginId === undefined && node.kind === 'fldChar') beginId = node.id;
+      });
+      if (beginId === undefined) throw new Error('missing field begin fldChar');
+      return {
+        op: 'refreshFieldResults',
+        updates: [{ paragraphId: paragraphIds(store)[1]!, fieldNodeId: beginId, text: 'new' }],
       };
     }),
   ];

--- a/packages/core/src/store/store/tree-op-apply.ts
+++ b/packages/core/src/store/store/tree-op-apply.ts
@@ -124,6 +124,7 @@ import {
   applyReplaceTocResult,
   applyRewriteTocPageNumbers,
 } from './tree-op-toc.ts';
+import { applyRefreshFieldResults } from './tree-op-field-results.ts';
 import { applyInsertTable } from './tree-op-insert-table.ts';
 import { applyReplaceStoryBlocks } from './tree-op-story-replace.ts';
 import type {
@@ -298,6 +299,7 @@ export function applyTreeOp(part: OoxmlPart, op: TreeDocOp, options?: EditOption
   if (op.op === 'insertToc') return applyInsertToc(part, op, options);
   if (op.op === 'replaceTocResult') return applyReplaceTocResult(part, op, options);
   if (op.op === 'rewriteTocPageNumbers') return applyRewriteTocPageNumbers(part, op, options);
+  if (op.op === 'refreshFieldResults') return applyRefreshFieldResults(part, op, options);
   if (op.op === 'joinParagraphs') return applyJoin(part, op.firstId, op.secondId, options);
   if (op.op === 'setHyperlinkTarget') return applySetHyperlinkTarget(part, op, options);
   if (op.op === 'removeHyperlink') return applyRemoveHyperlink(part, op.linkId, options);

--- a/packages/core/src/store/store/tree-op-content-controls.ts
+++ b/packages/core/src/store/store/tree-op-content-controls.ts
@@ -478,6 +478,8 @@ const TREE_OP_REACH: {
   }),
   // Page numbers rewrite runs in the result paragraphs the op names, and nothing else.
   rewriteTocPageNumbers: (op) => ({ kind: 'nodes', targets: inParagraphs(op.updates) }),
+  // A field-result refresh rewrites result runs in the paragraphs the op names, nothing else.
+  refreshFieldResults: (op) => ({ kind: 'nodes', targets: inParagraphs(op.updates) }),
   replaceStoryBlocks: (op) => ({
     kind: 'nodes',
     targets: [{ nodeId: op.storyRootId, structural: true }],

--- a/packages/core/src/store/store/tree-op-field-results.ts
+++ b/packages/core/src/store/store/tree-op-field-results.ts
@@ -1,0 +1,436 @@
+// Field-result refresh TreeDocOp — rewrite a field's cached RESULT runs in place.
+//
+// The op carries the paragraph, the field anchor (the run holding the `begin` fldChar, or
+// the `w:fldSimple` element) and the new result text; the INSTRUCTION is never modified.
+// The rewrite is fail-closed per field: it re-locates the anchor at apply time and touches
+// only a result made of plain runs (`w:rPr` / `w:t` / `w:tab`). A result carrying revision
+// markup, nested fields, bookmarks or any other structure is left exactly as it was — a
+// stale cached value is recoverable in Word; a corrupted revision is not.
+
+import {
+  fieldOnOffAttribute,
+  fldSimpleInstr,
+  instrTextValue,
+  isFldChar,
+  isFldSimple,
+  isInstrText,
+} from '../package/field-nodes.ts';
+import {
+  createNodeIdAllocator,
+  findNode,
+  replaceChildren,
+  type EditOptions,
+} from '../package/ooxml-edit.ts';
+import { WML_NAMESPACE_URI } from '../package/ooxml-shared.ts';
+import type { OoxmlElement, OoxmlNode, OoxmlPart } from '../package/ooxml-tree.ts';
+import { isValidXmlText } from '../package/sinks.ts';
+import { effectiveContentLockAt, isBoundAt, ok, parentOf } from './tree-op-nodes.ts';
+import type { TreeDocOp, TreeOpRejection, TreeOpResult } from './tree-op-types.ts';
+
+export type RefreshFieldResultsOp = Extract<TreeDocOp, { op: 'refreshFieldResults' }>;
+
+/** Ceiling on updates per op — mirrors the layout-side cap on live-resolved fields. */
+export const MAX_FIELD_RESULT_UPDATES = 512;
+/** Length cap on one rewritten result — a computed value must not inflate the tree. */
+export const MAX_FIELD_RESULT_TEXT_CHARS = 2048;
+/** Node budget for one paragraph's locate walk (hostile fan-out fails closed to "not found"). */
+const MAX_LOCATE_NODES = 4096;
+const MAX_LOCATE_DEPTH = 16;
+
+/**
+ * One field whose cached result the refresh op can address, as the planner sees it.
+ *
+ * `rewritable` is the whole plainness contract: the field is unlocked (`w:fldLock`), its
+ * boundaries sit under one parent, and the result region is plain runs only, at least one.
+ * The planner never emits an update for a non-rewritable field, and the applier re-checks,
+ * so a hand-crafted op degrades to a skip rather than a structural rewrite.
+ */
+export interface LocatedFieldResult {
+  /**
+   * The field's begin `w:fldChar` node, or the `w:fldSimple` element itself — the SAME key
+   * the layout's calibration registry uses, so a planner can pair a located result with the
+   * field's live-vs-cached verdict without a second identity vocabulary.
+   */
+  readonly fieldNodeId: string;
+  /** Raw instruction text (concatenated `w:instrText`, or `@w:instr`). Never executed. */
+  readonly instruction: string;
+  /** The cached result's text (`w:t` values, `w:tab` as `\t`) — `''` when not rewritable. */
+  readonly cachedText: string;
+  readonly rewritable: boolean;
+}
+
+interface LocatedField extends LocatedFieldResult {
+  /** Element whose child list holds the field (paragraph, hyperlink, …) or the fldSimple. */
+  readonly containerId: string;
+  /** Result runs in order; the first receives the new text, the rest lose theirs. */
+  readonly resultRunIds: readonly string[];
+}
+
+interface LocateBudget {
+  nodes: number;
+}
+
+function isElement(node: OoxmlNode): node is OoxmlElement {
+  return node.kind !== 'textValue';
+}
+
+/** Text of one plain result run: `w:t` values and `w:tab` as `\t`. */
+function plainRunText(run: OoxmlElement): string {
+  let text = '';
+  for (const child of run.children) {
+    if (child.kind === 'text') {
+      for (const value of child.children) {
+        if (value.kind === 'textValue') text += value.value;
+      }
+    } else if (child.kind === 'tab') {
+      text += '\t';
+    }
+  }
+  return text;
+}
+
+/**
+ * Whether a run is PLAIN — only `w:rPr`, `w:t` and `w:tab` children, and an `w:rPr` free of
+ * `w:rPrChange` (a tracked formatting change is revision markup the rewrite must not touch).
+ */
+function isPlainResultRun(node: OoxmlNode): node is OoxmlElement {
+  if (node.kind !== 'run') return false;
+  for (const child of node.children) {
+    if (child.kind === 'runProperties') {
+      const properties: readonly OoxmlNode[] = child.children;
+      for (const property of properties) {
+        if (property.kind !== 'textValue' && property.localName === 'rPrChange') return false;
+      }
+      continue;
+    }
+    if (child.kind === 'text') {
+      if (child.children.some((value) => value.kind !== 'textValue')) return false;
+      continue;
+    }
+    if (child.kind === 'tab') continue;
+    return false;
+  }
+  return true;
+}
+
+/** Whether a run holds exactly one field boundary (`w:fldChar`) beside its `w:rPr`. */
+function isBoundaryOnlyRun(run: OoxmlElement, type: 'separate' | 'end'): boolean {
+  let sawBoundary = false;
+  for (const child of run.children) {
+    if (child.kind === 'runProperties') continue;
+    if (isFldChar(child, type) && !sawBoundary) {
+      sawBoundary = true;
+      continue;
+    }
+    return false;
+  }
+  return sawBoundary;
+}
+
+/**
+ * Consume one complex field starting at `children[beginIndex]` (a run whose children include
+ * the `begin` fldChar). Returns the located field, or null when the field does not close
+ * inside this child list — nested fields, boundaries split across containers, and anything
+ * else outside the plain shape either fail the locate or mark the field non-rewritable.
+ */
+function consumeComplexField(
+  containerId: string,
+  children: readonly OoxmlNode[],
+  beginIndex: number,
+  budget: LocateBudget
+): { field: LocatedField | null; nextIndex: number } {
+  const beginRun = children[beginIndex] as OoxmlElement;
+  let anchorId: string | null = null;
+  let instruction = '';
+  let locked = false;
+  let plain = true;
+  let phase: 'instruction' | 'result' = 'instruction';
+  const resultRunIds: string[] = [];
+  let cachedText = '';
+
+  // The begin run itself: instruction text may share the run with the `begin` marker.
+  for (const child of beginRun.children) {
+    if (isFldChar(child, 'begin')) {
+      if (anchorId !== null) return { field: null, nextIndex: beginIndex + 1 };
+      anchorId = child.id;
+      if (fieldOnOffAttribute(child, 'fldLock') === true) locked = true;
+      continue;
+    }
+    if (child.kind === 'runProperties') continue;
+    if (isInstrText(child)) {
+      instruction += instrTextValue(child);
+      continue;
+    }
+    // A second `begin` (nested field) or any other content makes the shape unsupported.
+    return { field: null, nextIndex: beginIndex + 1 };
+  }
+
+  for (let index = beginIndex + 1; index < children.length; index += 1) {
+    budget.nodes -= 1;
+    if (budget.nodes <= 0) return { field: null, nextIndex: children.length };
+    const node = children[index]!;
+    // Only sibling RUNS are understood; a hyperlink, bookmark, SDT or revision wrapper
+    // inside the field means the boundaries cannot be tracked here — fail the locate.
+    if (node.kind !== 'run') return { field: null, nextIndex: index + 1 };
+    if (node.children.some((child) => isFldChar(child, 'begin'))) {
+      // A nested field anywhere within this one is out of scope for the rewrite.
+      return { field: null, nextIndex: index + 1 };
+    }
+    if (node.children.some((child) => isFldChar(child, 'end'))) {
+      if (!isBoundaryOnlyRun(node, 'end')) plain = false;
+      if (anchorId === null) return { field: null, nextIndex: index + 1 };
+      const rewritable = plain && !locked && phase === 'result' && resultRunIds.length > 0;
+      return {
+        field: {
+          fieldNodeId: anchorId,
+          instruction,
+          cachedText: rewritable ? cachedText : '',
+          rewritable,
+          containerId,
+          resultRunIds,
+        },
+        nextIndex: index + 1,
+      };
+    }
+    if (node.children.some((child) => isFldChar(child, 'separate'))) {
+      if (phase !== 'instruction' || !isBoundaryOnlyRun(node, 'separate')) plain = false;
+      phase = 'result';
+      continue;
+    }
+    if (phase === 'instruction') {
+      for (const child of node.children) {
+        if (child.kind === 'runProperties') continue;
+        if (isInstrText(child)) instruction += instrTextValue(child);
+        // Non-instruction content before `separate` is tolerated; the parse decides.
+      }
+      continue;
+    }
+    if (!isPlainResultRun(node)) {
+      plain = false;
+      continue;
+    }
+    resultRunIds.push(node.id);
+    cachedText += plainRunText(node);
+  }
+  // The field never closed in this child list.
+  return { field: null, nextIndex: children.length };
+}
+
+/** A `w:fldSimple`: the element is both anchor and result container. */
+function locateSimpleField(node: OoxmlElement): LocatedField {
+  const instruction = fldSimpleInstr(node) ?? '';
+  const locked = fieldOnOffAttribute(node, 'fldLock') === true;
+  let plain = true;
+  const resultRunIds: string[] = [];
+  let cachedText = '';
+  for (const child of node.children) {
+    if (!isPlainResultRun(child)) {
+      plain = false;
+      continue;
+    }
+    resultRunIds.push(child.id);
+    cachedText += plainRunText(child);
+  }
+  const rewritable = plain && !locked && resultRunIds.length > 0;
+  return {
+    fieldNodeId: node.id,
+    instruction,
+    cachedText: rewritable ? cachedText : '',
+    rewritable,
+    containerId: node.id,
+    resultRunIds,
+  };
+}
+
+function isDrawingContainer(node: OoxmlElement): boolean {
+  return node.kind === 'drawing' || node.localName === 'drawing' || node.localName === 'pict';
+}
+
+/** A field under `w:ins` / `w:del` is revision content; the refresh leaves it untouched. */
+function isRevisionContainer(node: OoxmlElement): boolean {
+  return node.localName === 'ins' || node.localName === 'del';
+}
+
+function locateFieldsInContainer(
+  container: OoxmlElement,
+  depth: number,
+  budget: LocateBudget,
+  out: LocatedField[]
+): void {
+  if (depth > MAX_LOCATE_DEPTH) return;
+  const children = container.children;
+  let index = 0;
+  while (index < children.length) {
+    budget.nodes -= 1;
+    if (budget.nodes <= 0) return;
+    const node = children[index]!;
+    if (!isElement(node)) {
+      index += 1;
+      continue;
+    }
+    if (isFldSimple(node)) {
+      // The OUTER field only — content nested in a cached result is never live-refreshed.
+      out.push(locateSimpleField(node));
+      index += 1;
+      continue;
+    }
+    if (node.kind === 'run') {
+      if (node.children.some((child) => isFldChar(child, 'begin'))) {
+        const consumed = consumeComplexField(container.id, children, index, budget);
+        if (consumed.field) out.push(consumed.field);
+        index = consumed.nextIndex;
+        continue;
+      }
+      index += 1;
+      continue;
+    }
+    if (!isDrawingContainer(node) && !isRevisionContainer(node)) {
+      locateFieldsInContainer(node, depth + 1, budget, out);
+    }
+    index += 1;
+  }
+}
+
+/**
+ * The fields inside one paragraph whose cached results this op could address, in document
+ * order. Bounded walk; a paragraph past the budget answers what it found so far.
+ */
+export function locateFieldResults(paragraph: OoxmlElement): readonly LocatedFieldResult[] {
+  const out: LocatedField[] = [];
+  locateFieldsInContainer(paragraph, 0, { nodes: MAX_LOCATE_NODES }, out);
+  return out;
+}
+
+export function validateRefreshFieldResults(
+  part: OoxmlPart,
+  op: RefreshFieldResultsOp
+): TreeOpRejection | null {
+  if (!Array.isArray(op.updates) || op.updates.length > MAX_FIELD_RESULT_UPDATES) {
+    return 'invalidArgs';
+  }
+  for (const update of op.updates) {
+    if (
+      typeof update.paragraphId !== 'string' ||
+      update.paragraphId.length === 0 ||
+      typeof update.fieldNodeId !== 'string' ||
+      update.fieldNodeId.length === 0 ||
+      typeof update.text !== 'string' ||
+      update.text.length > MAX_FIELD_RESULT_TEXT_CHARS ||
+      !isValidXmlText(update.text) ||
+      // Tab is the one control character the rewrite can express (`w:tab`); a newline
+      // would need `w:br`, which is not a shape a field result refresh writes.
+      update.text.includes('\n') ||
+      update.text.includes('\r')
+    ) {
+      return 'invalidArgs';
+    }
+    const paragraph = findNode(part, update.paragraphId);
+    if (!paragraph || paragraph.kind !== 'paragraph') return 'unknown-paragraph';
+    if (isBoundAt(part, update.paragraphId)) return 'bound';
+    if (effectiveContentLockAt(part, update.paragraphId).content) return 'locked';
+  }
+  return null;
+}
+
+/** Fresh `w:t` / `w:tab` children for one rewritten result run, splitting on `\t`. */
+function resultRunContent(text: string, mint: () => string): OoxmlNode[] {
+  const content: OoxmlNode[] = [];
+  const pieces = text.split('\t');
+  pieces.forEach((piece, index) => {
+    if (index > 0) {
+      content.push({
+        id: mint(),
+        kind: 'tab',
+        namespaceUri: WML_NAMESPACE_URI,
+        localName: 'tab',
+        prefix: 'w',
+        namespaceBindings: [],
+        attributes: [],
+        children: [],
+      } as unknown as OoxmlNode);
+    }
+    if (piece.length > 0) {
+      content.push({
+        id: mint(),
+        kind: 'text',
+        namespaceUri: WML_NAMESPACE_URI,
+        localName: 't',
+        prefix: 'w',
+        namespaceBindings: [],
+        // `xml:space` is not set here: the serializer owns lexical form and adds
+        // `preserve` when boundary whitespace requires it.
+        attributes: [],
+        children: [{ id: mint(), kind: 'textValue', value: piece }],
+      } as unknown as OoxmlNode);
+    }
+  });
+  return content;
+}
+
+/**
+ * Rewrite one located field's result inside an immutable paragraph rebuild: the first
+ * result run keeps its `w:rPr` and receives the new text; surplus result runs keep their
+ * `w:rPr` and lose their `w:t` / `w:tab` children. Nothing else in the paragraph moves.
+ */
+function rewriteFieldResult(
+  paragraph: OoxmlElement,
+  field: LocatedField,
+  text: string,
+  mint: () => string
+): OoxmlElement {
+  const firstRunId = field.resultRunIds[0]!;
+  const surplus = new Set(field.resultRunIds.slice(1));
+  const rewrite = (node: OoxmlNode): OoxmlNode => {
+    if (node.kind === 'textValue') return node;
+    if (node.id === firstRunId || surplus.has(node.id)) {
+      const properties = node.children.filter((child) => child.kind === 'runProperties');
+      const content = node.id === firstRunId ? resultRunContent(text, mint) : [];
+      return { ...node, children: [...properties, ...content] } as OoxmlNode;
+    }
+    const children = node.children.map(rewrite);
+    return children.some((child, index) => child !== node.children[index])
+      ? ({ ...node, children } as OoxmlNode)
+      : node;
+  };
+  return rewrite(paragraph) as OoxmlElement;
+}
+
+/**
+ * Apply the refresh: every update re-locates its field in the CURRENT paragraph and skips —
+ * without failing the op — when the field is gone, not rewritable, or already carries the
+ * text. An op whose every update skips commits no change (`dirty` empty, same part).
+ */
+export function applyRefreshFieldResults(
+  part: OoxmlPart,
+  op: RefreshFieldResultsOp,
+  options?: EditOptions
+): TreeOpResult {
+  let current = part;
+  const dirty: string[] = [];
+  for (const update of op.updates) {
+    const paragraph = findNode(current, update.paragraphId);
+    if (!paragraph || paragraph.kind !== 'paragraph') continue;
+    const located: LocatedField[] = [];
+    locateFieldsInContainer(paragraph, 0, { nodes: MAX_LOCATE_NODES }, located);
+    const field = located.find((entry) => entry.fieldNodeId === update.fieldNodeId);
+    if (!field || !field.rewritable || field.cachedText === update.text) continue;
+    const mint = createNodeIdAllocator(current);
+    const rewritten = rewriteFieldResult(paragraph, field, update.text, mint);
+    const parent = parentOf(current, paragraph.id);
+    if (!parent) return { ok: false, reason: 'unknown-paragraph' };
+    const siblings = parent.children.map((child) =>
+      child.id === paragraph.id ? rewritten : child
+    );
+    const replaced = replaceChildren(current, parent.id, siblings, options);
+    if (!replaced.ok) return { ok: false, reason: 'tree-invariant' };
+    current = replaced.part;
+    dirty.push(update.paragraphId);
+  }
+  return ok(current, {
+    dirty,
+    created: [],
+    deleted: [],
+    dependencyKeys: dirty,
+    impact: 'text-local',
+  });
+}

--- a/packages/core/src/store/store/tree-op-types.ts
+++ b/packages/core/src/store/store/tree-op-types.ts
@@ -1024,6 +1024,20 @@ export type TreeDocOp =
         readonly paragraphId: string;
         readonly pageNumberText: string;
       }[];
+    }
+  | {
+      /**
+       * Rewrite recognized fields' cached RESULT runs in place — between the `separate` and
+       * `end` fldChars, or a `w:fldSimple`'s content. The instruction is never modified; a
+       * result holding anything but plain runs is skipped (see `tree-op-field-results.ts`).
+       */
+      readonly op: 'refreshFieldResults';
+      readonly updates: readonly {
+        readonly paragraphId: string;
+        /** Node id of the field's begin `w:fldChar`, or of the `w:fldSimple` element. */
+        readonly fieldNodeId: string;
+        readonly text: string;
+      }[];
     };
 
 /** Drawing mutation ops from typed-drawings-and-images task 11. */
@@ -1122,6 +1136,7 @@ export const TREE_DOC_OP_KINDS = [
   'insertToc',
   'replaceTocResult',
   'rewriteTocPageNumbers',
+  'refreshFieldResults',
 ] as const satisfies readonly TreeDocOpKind[];
 
 // Compile-time exhaustiveness, matching the legacy `DOC_OP_KINDS` guard: a new op must be

--- a/packages/core/src/store/store/tree-op-validate.ts
+++ b/packages/core/src/store/store/tree-op-validate.ts
@@ -67,6 +67,7 @@ import {
   validateReplaceTocResult,
   validateRewriteTocPageNumbers,
 } from './tree-op-toc.ts';
+import { validateRefreshFieldResults } from './tree-op-field-results.ts';
 import { validateInsertTable } from './tree-op-insert-table.ts';
 import { validateReplaceStoryBlocks } from './tree-op-story-replace.ts';
 import {
@@ -374,6 +375,9 @@ export function validateTreeOp(part: OoxmlPart, op: TreeDocOp): TreeOpRejection 
   }
   if (op.op === 'rewriteTocPageNumbers') {
     return validateRewriteTocPageNumbers(part, op);
+  }
+  if (op.op === 'refreshFieldResults') {
+    return validateRefreshFieldResults(part, op);
   }
 
   if (op.op === 'setSectionProperties') {

--- a/scripts/check-eslint-max-lines-globs.mjs
+++ b/scripts/check-eslint-max-lines-globs.mjs
@@ -42,10 +42,10 @@ const SLACK_EXEMPT = new Map([
  * diff where a reviewer sees it, instead of the file quietly gaining a thousand lines.
  */
 const BLANKET_DISABLES = new Map([
-  ['packages/core/src/editor/paginated-surface.ts', 6215],
-  ['packages/core/src/store/store/tree-op-apply.ts', 3493],
+  ['packages/core/src/editor/paginated-surface.ts', 6223],
+  ['packages/core/src/store/store/tree-op-apply.ts', 3495],
   ['packages/core/src/output/semantic-paint.ts', 3005],
-  ['packages/core/src/layout/note-pagination.ts', 2853],
+  ['packages/core/src/layout/note-pagination.ts', 2852],
   ['packages/core/src/store/package/note-lifecycle.ts', 1320],
 ]);
 


### PR DESCRIPTION
Stacked on #607. Two gaps remained after live `REF` painting: saved bytes kept Word's old cached results, and footnote/endnote stories stayed on the cache.

Save freshness: a new `refreshFieldResults` op rewrites the result runs of supported `REF` fields through `TreeDocumentStore.transact`. The planner reuses the layout resolution and emits an update only where the calibrated live value differs from the plain-run cached text, so a fresh document saves byte-identical with no transaction, no revision bump, and no undo entry. A stale refresh is one ordinary undoable transaction. Fields with revision markup, `w:fldLock`, or a failed calibration verdict are skipped and save exactly what they paint. `editor.save()` runs the refresh before serializing.

Note stories: footnote and endnote stories join the shared bookmark and spec scan, calibrate through the same per-field gate, and fold resolved values into the note flow keys, so a renumbering edit repaints citing notes. Note-part results still save cached; the seam carries a constraint comment.

Fixes #606

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790593398&installation_model_id=422592&pr_number=609&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F609&signature=150b9780b8ae5f38c9beea6bfed571e76478fe67db5ace32d7f5ea957a94a383"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->