### PR TITLE
fix: footnote reserves respect reference lines and converge instead of accumulating

### DIFF
--- a/.changeset/steady-footnotes-drain.md
+++ b/.changeset/steady-footnotes-drain.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': patch
 ---
 
-Footnotes taller than the remaining page now start on their reference page and release their space when drained, so footnote-heavy documents paginate at the correct density. Fixes #608.
+Footnotes taller than the remaining page now start on their reference page, share it correctly with other references, and release their space when drained, so footnote-heavy documents paginate at the correct density. A `w:cantSplit` table row taller than the band a footnote reserve leaves now takes the full page instead of failing the layout. Fixes #608.

--- a/.changeset/steady-footnotes-drain.md
+++ b/.changeset/steady-footnotes-drain.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Footnotes taller than the remaining page now start on their reference page and release their space when drained, so footnote-heavy documents paginate at the correct density. Fixes #608.

--- a/packages/core/src/layout/__tests__/footnote-page-overflow.test.ts
+++ b/packages/core/src/layout/__tests__/footnote-page-overflow.test.ts
@@ -226,6 +226,115 @@ describe('oversized footnote starts on its reference page (issue #608)', () => {
     expectNoStarvedPages(layout);
   });
 
+  test('a cantSplit table row taller than the reserve-shrunk band takes the full page', () => {
+    // Paragraph 2 references a footnote whose carry reserves most of the next page; the
+    // w:cantSplit row (40 lines, ~509pt) exceeds the band the reserve leaves but fits the
+    // full column. The paginator must place it against the full band — never abort layout
+    // over a row+reserve collision — and the notes then drain past the row's page.
+    const rowParas = Array.from(
+      { length: 40 },
+      (_, i) => `<w:p><w:r><w:t>Row line ${i}</w:t></w:r></w:p>`
+    ).join('');
+    const tableXml =
+      '<w:tbl><w:tblPr><w:tblW w:w="0" w:type="auto"/></w:tblPr>' +
+      '<w:tblGrid><w:gridCol w:w="9360"/></w:tblGrid>' +
+      '<w:tr><w:trPr><w:cantSplit/></w:trPr>' +
+      `<w:tc><w:tcPr><w:tcW w:w="9360" w:type="dxa"/></w:tcPr>${rowParas}</w:tc></w:tr>` +
+      '</w:tbl>';
+    const body =
+      '<w:p><w:r><w:t>Lead paragraph</w:t></w:r></w:p>' +
+      '<w:p><w:r><w:t>Reference here</w:t><w:footnoteReference w:id="1"/></w:r></w:p>' +
+      tableXml +
+      Array.from({ length: 6 }, (_, i) => `<w:p><w:r><w:t>Tail ${i}</w:t></w:r></w:p>`).join('');
+    const layout = layoutOf(packageXml(body, singleRunFootnote(1, 9000)), 'fn-cantsplit');
+
+    // The row landed whole: one table fragment, taller than any reserve-shrunk band.
+    const tableFragments = layout.pages.flatMap((page) =>
+      page.fragments.filter((fragment) => fragment.kind === 'table')
+    );
+    expect(tableFragments.length).toBe(1);
+    expect(tableFragments[0]!.box.height).toBeGreaterThan(400);
+
+    // Footnote areas never overlap body content on any page.
+    for (const page of layout.pages) {
+      if (!page.footnotes) continue;
+      let bodyBottom = 0;
+      for (const fragment of page.fragments) {
+        bodyBottom = Math.max(bodyBottom, fragment.box.y + fragment.box.height);
+      }
+      expect(page.footnotes.box.y).toBeGreaterThanOrEqual(page.contentBox.y + bodyBottom - 0.5);
+    }
+
+    const noteLines = Math.ceil(9000 / CHARS_PER_LINE);
+    const expected = Math.ceil(
+      ((8 + 40 + noteLines) * LINE_H) / layout.pages[0]!.contentBox.height
+    );
+    expect(Math.abs(layout.pages.length - expected)).toBeLessThanOrEqual(1);
+    expectFullyDrained(layout, noteLines);
+  });
+
+  test('a page hosting several references sizes each note to its own reference line', () => {
+    // 12 references over the first 48 paragraphs, all on page 0 of a body-only layout.
+    // Sizing the page's reserve against the LOWEST reference line strangles every note to
+    // the sliver under it — stably, because the resulting layout reproduces the same floor.
+    // Per-reference floors let the first notes push body (and later references) forward.
+    const refs = new Map(Array.from({ length: 12 }, (_, i) => [(i + 1) * 4, i + 1] as const));
+    const notesXml = Array.from(
+      { length: 12 },
+      (_, i) =>
+        `<w:footnote w:id="${i + 1}"><w:p><w:r><w:t>${'n'.repeat(800)}</w:t></w:r></w:p></w:footnote>`
+    ).join('');
+    const layout = layoutOf(packageXml(bodyParas(60, refs), notesXml), 'fn-multi-ref');
+
+    // Page 0 keeps only the body above the accumulated note stack — not 48 lines with a
+    // strangled 1-line note region.
+    expect(bodyLineCount(layout.pages[0]!)).toBeLessThanOrEqual(30);
+    expect(placedNoteHeight(layout.pages[0]!)).toBeGreaterThan(300);
+
+    const noteLines = 12 * Math.ceil(800 / CHARS_PER_LINE);
+    const expected = Math.ceil(((60 + noteLines) * LINE_H) / layout.pages[0]!.contentBox.height);
+    expect(Math.abs(layout.pages.length - expected)).toBeLessThanOrEqual(1);
+    expectFullyDrained(layout, noteLines);
+    expectNoStarvedPages(layout);
+  });
+
+  test('many mid-size footnotes adopt recomputed reserves instead of accumulating stale ones', () => {
+    // 24 notes of ~18 lines across ~13 pages: every reserve pass shifts references forward,
+    // so a monotonic union of pass maps keeps reserves at every slot any pass ever wanted —
+    // runs of one-line pages whose reservation nothing fills (the real-document shape behind
+    // issue #608). Adoption stays within a page of the hand-computed packing cold, and the
+    // session-seeded passes continue the iteration to the interleaved fixed point.
+    const refs = new Map(Array.from({ length: 24 }, (_, i) => [(i + 1) * 8, i + 1] as const));
+    const notesXml = Array.from(
+      { length: 24 },
+      (_, i) =>
+        `<w:footnote w:id="${i + 1}"><w:p><w:r><w:t>${'n'.repeat(1500)}</w:t></w:r></w:p></w:footnote>`
+    ).join('');
+    const bytes = packageXml(bodyParas(200, refs), notesXml);
+
+    const noteLines = 24 * Math.ceil(1500 / CHARS_PER_LINE);
+    const cold = layoutOf(bytes, 'fn-adoption');
+    const expected = Math.ceil(((200 + noteLines) * LINE_H) / cold.pages[0]!.contentBox.height);
+    expect(Math.abs(cold.pages.length - expected)).toBeLessThanOrEqual(1);
+    expectFullyDrained(cold, noteLines);
+    expectNoStarvedPages(cold);
+
+    // Session-seeded passes continue the reserve iteration where the cold pass stopped;
+    // by the third the packing is interleaved everywhere and a further pass changes nothing.
+    const session = createLayoutSession();
+    let settled = layoutOf(bytes, 'fn-adoption', session);
+    for (let pass = 0; pass < 3; pass += 1) {
+      settled = layoutOf(bytes, 'fn-adoption', session, 2 + pass);
+    }
+    const again = layoutOf(bytes, 'fn-adoption', session, 5);
+    expect(shapeOf(again)).toBe(shapeOf(settled));
+    expect(settled.pages.length).toBe(cold.pages.length);
+    expectFullyDrained(settled, noteLines);
+    expectNoStarvedPages(settled);
+    // Fully settled, every note interleaves beside its reference — no drain sheets remain.
+    expect(settled.pages.every((page) => page.noteStream === undefined)).toBe(true);
+  });
+
   test('warm session converges to the cold layout after an edit near the reference', () => {
     const footnotes = singleRunFootnote(1, 9000);
     const session = createLayoutSession();

--- a/packages/core/src/layout/__tests__/footnote-page-overflow.test.ts
+++ b/packages/core/src/layout/__tests__/footnote-page-overflow.test.ts
@@ -1,0 +1,273 @@
+// Footnotes taller than the remaining page: the first fragment stays on the reference
+// page, the remainder drains forward, and drained reservations release (issue #608).
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { readOoxmlPackage } from '../../store/package/ooxml-package.ts';
+import { resolveNotesPart } from '../../store/package/note-references.ts';
+import {
+  resolveEndnoteProperties,
+  resolveFootnoteProperties,
+} from '../../store/package/note-properties.ts';
+import { createFixedMeasurer } from '../fixed-measurer.ts';
+import { createLayoutSession } from '../layout-session.ts';
+import { layoutSemanticDocument } from '../semantic-layout.ts';
+import type { NotesLayoutInput } from '../note-pagination.ts';
+import type { PageRecord, SemanticLayout } from '../semantic-records.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+
+// Letter page, 1-inch margins, createFixedMeasurer(6, 14): the default run size is 10pt,
+// so a line is 14 * 10/11 pt tall, a character 6 * 10/11 pt wide, and the 468pt content
+// column breaks at floor(468 / (60/11)) = 85 characters.
+const LINE_H = 14 * (10 / 11);
+const CHARS_PER_LINE = 85;
+
+function packageXml(documentBody: string, footnotes: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '<Override PartName="/word/footnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rIdFn" Type="${R}/footnotes" Target="footnotes.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}" xmlns:r="${R}"><w:body>` +
+        documentBody +
+        '<w:sectPr><w:pgSz w:w="12240" w:h="15840"/>' +
+        '<w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440"/>' +
+        '</w:sectPr>' +
+        '</w:body></w:document>'
+    ),
+    'word/footnotes.xml': strToU8(
+      `<w:footnotes xmlns:w="${W}">` +
+        '<w:footnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:footnote>' +
+        '<w:footnote w:type="continuationSeparator" w:id="0"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:footnote>' +
+        footnotes +
+        '</w:footnotes>'
+    ),
+  });
+}
+
+/** 60 one-line body paragraphs; `refs` maps paragraph index → footnote id. */
+function bodyParas(count: number, refs: ReadonlyMap<number, number>, edited = false): string {
+  return Array.from({ length: count }, (_, i) => {
+    const label = edited && i === 0 ? `Body para ${i} EDITED` : `Body para ${i}`;
+    const id = refs.get(i);
+    return id !== undefined
+      ? `<w:p><w:r><w:t>${label} ref</w:t><w:footnoteReference w:id="${id}"/></w:r></w:p>`
+      : `<w:p><w:r><w:t>${label}</w:t></w:r></w:p>`;
+  }).join('');
+}
+
+function singleRunFootnote(id: number, chars: number): string {
+  return `<w:footnote w:id="${id}"><w:p><w:r><w:t>${'f'.repeat(chars)}</w:t></w:r></w:p></w:footnote>`;
+}
+
+function layoutOf(
+  bytes: Uint8Array,
+  producer: string,
+  session?: ReturnType<typeof createLayoutSession>,
+  revision = 1
+): SemanticLayout {
+  const loaded = readOoxmlPackage(bytes);
+  expect(loaded.ok).toBe(true);
+  if (!loaded.ok) throw new Error(loaded.reason);
+  const part = loaded.package.parts.get(loaded.package.mainDocumentPart)!;
+  const documentFootnoteProps = resolveFootnoteProperties(undefined, undefined);
+  const documentEndnoteProps = resolveEndnoteProperties(undefined, undefined);
+  const notes: NotesLayoutInput = {
+    footnotesPart: resolveNotesPart(loaded.package, 'footnote'),
+    endnotesPart: null,
+    footnotePropsBySection: [documentFootnoteProps],
+    endnotePropsBySection: [documentEndnoteProps],
+    documentFootnoteProps,
+    documentEndnoteProps,
+    measurer: createFixedMeasurer(6, 14),
+    producer,
+  };
+  return layoutSemanticDocument(part, revision, {
+    measurer: notes.measurer,
+    notes,
+    ...(session ? { session } : {}),
+    producer,
+  });
+}
+
+function bodyLineCount(page: PageRecord): number {
+  let lines = 0;
+  for (const fragment of page.fragments) {
+    if (fragment.kind === 'paragraph') lines += fragment.lines.length;
+  }
+  return lines;
+}
+
+function placedNoteHeight(page: PageRecord): number {
+  return (page.footnotes?.notes ?? []).reduce((sum, note) => sum + note.box.height, 0);
+}
+
+/**
+ * Every non-drain page that keeps at most one body line must be a genuine full-page
+ * footnote continuation. A near-empty body page with little or no footnote content is
+ * exactly the starved shape of issue #608: a reservation outliving the content it was
+ * measured for. The final page is exempt — trailing body can legitimately end there.
+ */
+function expectNoStarvedPages(layout: SemanticLayout): void {
+  for (const page of layout.pages) {
+    if (page.noteStream !== undefined) continue;
+    if (page.index === layout.pages.length - 1) continue;
+    if (bodyLineCount(page) > 1) continue;
+    expect(placedNoteHeight(page)).toBeGreaterThanOrEqual(page.contentBox.height - 4 * LINE_H);
+  }
+}
+
+function expectFullyDrained(layout: SemanticLayout, expectedNoteLines: number): void {
+  let placed = 0;
+  for (const page of layout.pages) placed += placedNoteHeight(page);
+  expect(placed).toBeCloseTo(expectedNoteLines * LINE_H, 1);
+}
+
+describe('oversized footnote starts on its reference page (issue #608)', () => {
+  // The issue's repro table: one long footnote referenced from paragraph 2 of 60.
+  test.each([[6000], [9000], [14000]])('fn=%i chars', (chars) => {
+    const layout = layoutOf(
+      packageXml(bodyParas(60, new Map([[1, 1]])), singleRunFootnote(1, chars)),
+      `fn-overflow-${chars}`
+    );
+
+    // The reference page (page 0 — the citation sits on paragraph 2) hosts the note's
+    // FIRST fragment, not a continuation, with real height.
+    const refPage = layout.pages[0]!;
+    expect(refPage.footnotes).toBeTruthy();
+    const head = refPage.footnotes!.notes.find((n) => n.noteId === 1);
+    expect(head).toBeTruthy();
+    expect(head!.continuation).not.toBe(true);
+    expect(head!.box.height).toBeGreaterThan(LINE_H);
+    // Body keeps the referencing line — the page is not evacuated to a drain sheet.
+    expect(bodyLineCount(refPage)).toBeGreaterThanOrEqual(2);
+
+    // Hand-computed packing: body lines + note lines at one line height per line, ignoring
+    // the two separators — the result must land within one page of it.
+    const noteLines = Math.ceil(chars / CHARS_PER_LINE);
+    const expected = Math.ceil(((60 + noteLines) * LINE_H) / refPage.contentBox.height);
+    expect(Math.abs(layout.pages.length - expected)).toBeLessThanOrEqual(1);
+
+    expectFullyDrained(layout, noteLines);
+    expectNoStarvedPages(layout);
+  });
+
+  test('two adjacent footnotes totalling more than one page drain without starving pages', () => {
+    const refs = new Map([
+      [1, 1],
+      [2, 2],
+    ]);
+    const layout = layoutOf(
+      packageXml(bodyParas(60, refs), singleRunFootnote(1, 6000) + singleRunFootnote(2, 6000)),
+      'fn-adjacent'
+    );
+
+    const refPage = layout.pages[0]!;
+    const head = refPage.footnotes?.notes.find((n) => n.noteId === 1);
+    expect(head).toBeTruthy();
+    expect(head!.continuation).not.toBe(true);
+    expect(head!.box.height).toBeGreaterThan(LINE_H);
+
+    const noteLines = 2 * Math.ceil(6000 / CHARS_PER_LINE);
+    const expected = Math.ceil(((60 + noteLines) * LINE_H) / refPage.contentBox.height);
+    expect(Math.abs(layout.pages.length - expected)).toBeLessThanOrEqual(1);
+
+    expectFullyDrained(layout, noteLines);
+    expectNoStarvedPages(layout);
+  });
+
+  test('a footnote taller than an entire page caps and drains without unbounded pages', () => {
+    const noteParaTexts = Array.from(
+      { length: 250 },
+      (_, i) => `Giant note para ${i} ${'x'.repeat(70)}`
+    );
+    const noteParas = noteParaTexts
+      .map((text) => `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`)
+      .join('');
+    const layout = layoutOf(
+      packageXml(bodyParas(6, new Map([[1, 1]])), `<w:footnote w:id="1">${noteParas}</w:footnote>`),
+      'fn-giant'
+    );
+
+    const refPage = layout.pages[0]!;
+    const head = refPage.footnotes?.notes.find((n) => n.noteId === 1);
+    expect(head).toBeTruthy();
+    expect(head!.continuation).not.toBe(true);
+    expect(bodyLineCount(refPage)).toBeGreaterThanOrEqual(2);
+
+    let noteLines = 0;
+    for (const text of noteParaTexts) noteLines += Math.ceil(text.length / CHARS_PER_LINE);
+    const expected = Math.ceil(((6 + noteLines) * LINE_H) / refPage.contentBox.height);
+    expect(Math.abs(layout.pages.length - expected)).toBeLessThanOrEqual(1);
+
+    // Drain sheets exist, each carries note content, and the drain terminates.
+    const drain = layout.pages.filter((page) => page.noteStream === 'footnote-drain');
+    expect(drain.length).toBeGreaterThan(0);
+    for (const page of drain) {
+      expect((page.footnotes?.notes.length ?? 0) > 0).toBe(true);
+    }
+    expectFullyDrained(layout, noteLines);
+    expectNoStarvedPages(layout);
+  });
+
+  test('warm session converges to the cold layout after an edit near the reference', () => {
+    const footnotes = singleRunFootnote(1, 9000);
+    const session = createLayoutSession();
+    const loadedCold = layoutOf(
+      packageXml(bodyParas(60, new Map([[1, 1]])), footnotes),
+      'fn-warm-converge'
+    );
+    // Cold pass carries the session forward.
+    const withSession = layoutOf(
+      packageXml(bodyParas(60, new Map([[1, 1]])), footnotes),
+      'fn-warm-converge',
+      session
+    );
+    expect(shapeOf(withSession)).toBe(shapeOf(loadedCold));
+
+    // Edit paragraph 0, one paragraph above the reference; the warm pass must publish
+    // exactly what a clean pass over the edited document publishes.
+    const editedBytes = packageXml(bodyParas(60, new Map([[1, 1]]), true), footnotes);
+    const warm = layoutOf(editedBytes, 'fn-warm-converge', session, 2);
+    const clean = layoutOf(editedBytes, 'fn-warm-converge', undefined, 2);
+    expect(shapeOf(warm)).toBe(shapeOf(clean));
+    expectNoStarvedPages(warm);
+  });
+});
+
+const shapeOf = (layout: SemanticLayout): string =>
+  JSON.stringify(
+    layout.pages.map((page) => ({
+      index: page.index,
+      contentBox: page.contentBox,
+      noteStream: page.noteStream ?? null,
+      bodyLines: bodyLineCount(page),
+      fragments: page.fragments.map((f) => ({
+        kind: f.kind,
+        id: f.id,
+        box: f.box,
+      })),
+      footnoteHeight: page.footnotes?.box.height ?? 0,
+      footnoteNotes: (page.footnotes?.notes ?? []).map((n) => ({
+        id: n.noteId,
+        continuation: n.continuation ?? false,
+        height: n.box.height,
+      })),
+    }))
+  );

--- a/packages/core/src/layout/__tests__/footnote-reserves.test.ts
+++ b/packages/core/src/layout/__tests__/footnote-reserves.test.ts
@@ -143,6 +143,9 @@ function paraFrag(
   paragraphId: string,
   opts: { atomEnd: number; y: number; height: number; width?: number }
 ): ParagraphFragmentRecord {
+  // One line at the fragment top covering the whole atom range — real layout always
+  // publishes lines, and the reserve pass reads the referencing LINE's bottom from them.
+  const lineHeight = Math.min(14, opts.height);
   return {
     kind: 'paragraph',
     id: `${paragraphId}-frag`,
@@ -153,7 +156,17 @@ function paraFrag(
     props: [],
     spacing: { before: 0, after: 0, line: null, lineRule: 'auto' },
     indent: { start: 0, end: 0, firstLine: 0, hanging: 0 },
-    lines: [],
+    lines: [
+      {
+        id: `${paragraphId}-line-0`,
+        range: { paragraphId, start: 0, end: opts.atomEnd },
+        spans: [],
+        box: { x: 0, y: opts.y, width: opts.width ?? 400, height: lineHeight },
+        contentX: 0,
+        baseline: lineHeight * 0.8,
+        leading: 0,
+      },
+    ],
   };
 }
 

--- a/packages/core/src/layout/__tests__/note-overflow-page-insets.test.ts
+++ b/packages/core/src/layout/__tests__/note-overflow-page-insets.test.ts
@@ -312,11 +312,13 @@ describe('note overflow sheets under even/odd headers', () => {
    * the variant — and with it the content box — of the wrong page number.
    */
   /**
-   * `footnoteLines` is tuned to drain exactly ONE sheet. An odd drain count is what makes the
-   * bug visible: an even one shifts every endnote sheet by an even number of pages, and
-   * even/odd parity survives that unchanged.
+   * `footnoteLines` is tuned to drain an ODD number of sheets, which is what makes the bug
+   * visible: an even count shifts every endnote sheet by an even number of pages, and
+   * even/odd parity survives that unchanged. The count depends on how much of the note the
+   * reference page itself hosts (its reserve keeps the referencing line), so retune here
+   * when reserve sizing changes.
    */
-  function parityDoc(footnoteLines = 10): Uint8Array {
+  function parityDoc(footnoteLines = 20): Uint8Array {
     const footnoteParas = Array.from(
       { length: footnoteLines },
       (_, i) => `<w:p><w:r><w:t>Footnote ${i} ${'x'.repeat(60)}</w:t></w:r></w:p>`

--- a/packages/core/src/layout/note-fragment-geometry.ts
+++ b/packages/core/src/layout/note-fragment-geometry.ts
@@ -80,37 +80,41 @@ export function fragmentFlowBottom(fragments: readonly BlockFragmentRecord[]): n
 }
 
 /**
- * Bottom (content-relative pt) of the lowest body line on `page` that carries one of
- * `refs` — the band body text must KEEP when a footnote reserve is measured for the page.
+ * Bottom (content-relative pt) of the body line on `page` that carries `ref` — the band
+ * body text must KEEP for this reference when its footnote reserve is measured.
  *
  * Word's rule: a footnote STARTS on the page that references it. A reserve capped only by
  * the minimum body band (`MIN_FOOTNOTE_BODY_BAND_PT`) can exceed the room below the
- * referencing line, which
- * evicts that line — and with it the reference — to the next page. The next reserve pass
- * then follows the reference forward, the reflow loop oscillates between the two placements,
- * and the fingerprint lock freezes whichever phase it happens to be in: the referencing page
- * ends with body only, and a later page keeps a reservation nothing fills. Flooring the
- * reserve at this line keeps the reference together with the note's first fragment and gives
- * the loop a fixed point.
+ * referencing line, which evicts that line — and with it the reference — to the next page.
+ * The next reserve pass then follows the reference forward, the reflow loop oscillates
+ * between the two placements, and the fingerprint lock freezes whichever phase it happens
+ * to be in: the referencing page ends with body only, and a later page keeps a reservation
+ * nothing fills. Flooring the reserve at this line keeps the reference together with the
+ * note's first fragment and gives the loop a fixed point.
  *
- * A ref inside a table floors at the TABLE fragment's bottom: nested line geometry is not in
- * page-content coordinates, and keeping the whole block band is the conservative reading of
- * the same rule. A ref no fragment on this page owns contributes nothing.
+ * PER REFERENCE, never the page's lowest reference: notes accumulate top-down, and each
+ * note may push body down to ITS OWN reference line. On a page carrying many references, a
+ * single floor at the lowest one strangles every note above it to the sliver under that
+ * line — and that state is a fixed point, so the reflow loop keeps it. The caller sizes
+ * note `i`'s room against reference `i`'s floor; references whose room reaches zero simply
+ * carry forward, and the next pass finds them on the page body pushed them to.
+ *
+ * A ref inside a table floors at the TABLE fragment's bottom: nested line geometry is not
+ * in page-content coordinates, and keeping the whole block band is the conservative reading
+ * of the same rule. A ref no fragment on this page owns floors at zero.
  */
 export function noteReferenceFloorPt(
   page: PageRecord,
-  refs: readonly { readonly paragraphId: string; readonly atomOffset: number }[]
+  ref: { readonly paragraphId: string; readonly atomOffset: number }
 ): number {
   let floor = 0;
   for (const block of page.fragments) {
     if (block.kind === 'paragraph') {
-      for (const ref of refs) {
-        if (!fragmentOwnsPosition(block, ref.paragraphId, ref.atomOffset)) continue;
-        floor = Math.max(floor, referenceLineBottom(block, ref) ?? block.box.y + block.box.height);
-      }
+      if (!fragmentOwnsPosition(block, ref.paragraphId, ref.atomOffset)) continue;
+      floor = Math.max(floor, referenceLineBottom(block, ref) ?? block.box.y + block.box.height);
       continue;
     }
-    if (tableOwnsAnyRef(block, refs)) {
+    if (tableOwnsAnyRef(block, [ref])) {
       floor = Math.max(floor, block.box.y + block.box.height);
     }
   }

--- a/packages/core/src/layout/note-fragment-geometry.ts
+++ b/packages/core/src/layout/note-fragment-geometry.ts
@@ -1,0 +1,163 @@
+// Fragment geometry for note pagination: story-relative shifts, flow bottoms, and the
+// body band a page must keep so its footnote references stay with their first fragment.
+
+import { fragmentOwnsPosition, lineSegments } from './line-segments.ts';
+import type {
+  BlockFragmentRecord,
+  PageRecord,
+  ParagraphFragmentRecord,
+} from './semantic-records.ts';
+
+/** Translate one paragraph fragment (and every box inside it) by `dy`. */
+export function shiftParagraphFragment(
+  fragment: ParagraphFragmentRecord,
+  dy: number
+): ParagraphFragmentRecord {
+  if (dy === 0) return fragment;
+  return {
+    ...fragment,
+    box: { ...fragment.box, y: fragment.box.y + dy },
+    ...(fragment.shadingBox
+      ? { shadingBox: { ...fragment.shadingBox, y: fragment.shadingBox.y + dy } }
+      : {}),
+    ...(fragment.bottomBorder
+      ? {
+          bottomBorder: {
+            ...fragment.bottomBorder,
+            box: { ...fragment.bottomBorder.box, y: fragment.bottomBorder.box.y + dy },
+          },
+        }
+      : {}),
+    ...(fragment.borders
+      ? {
+          borders: fragment.borders.map((stroke) => ({
+            ...stroke,
+            box: { ...stroke.box, y: stroke.box.y + dy },
+          })),
+        }
+      : {}),
+    ...(fragment.marker
+      ? {
+          marker: {
+            ...fragment.marker,
+            box: { ...fragment.marker.box, y: fragment.marker.box.y + dy },
+          },
+        }
+      : {}),
+    lines: fragment.lines.map((line) => ({
+      ...line,
+      box: { ...line.box, y: line.box.y + dy },
+      spans: line.spans.map((span) => ({
+        ...span,
+        box: { ...span.box, y: span.box.y + dy },
+      })),
+    })),
+  };
+}
+
+/** Translate a block list by `dy` (paragraphs deep, other blocks by their outer box). */
+export function shiftFragments(
+  fragments: readonly BlockFragmentRecord[],
+  dy: number
+): BlockFragmentRecord[] {
+  if (dy === 0) return [...fragments];
+  return fragments.map((fragment) => {
+    if (fragment.kind === 'paragraph') return shiftParagraphFragment(fragment, dy);
+    return {
+      ...fragment,
+      box: { ...fragment.box, y: fragment.box.y + dy },
+    };
+  });
+}
+
+/** Bottom-most fragment edge of a story-relative block list. */
+export function fragmentFlowBottom(fragments: readonly BlockFragmentRecord[]): number {
+  let bottom = 0;
+  for (const fragment of fragments) {
+    bottom = Math.max(bottom, fragment.box.y + fragment.box.height);
+  }
+  return bottom;
+}
+
+/**
+ * Bottom (content-relative pt) of the lowest body line on `page` that carries one of
+ * `refs` — the band body text must KEEP when a footnote reserve is measured for the page.
+ *
+ * Word's rule: a footnote STARTS on the page that references it. A reserve capped only by
+ * the minimum body band (`MIN_FOOTNOTE_BODY_BAND_PT`) can exceed the room below the
+ * referencing line, which
+ * evicts that line — and with it the reference — to the next page. The next reserve pass
+ * then follows the reference forward, the reflow loop oscillates between the two placements,
+ * and the fingerprint lock freezes whichever phase it happens to be in: the referencing page
+ * ends with body only, and a later page keeps a reservation nothing fills. Flooring the
+ * reserve at this line keeps the reference together with the note's first fragment and gives
+ * the loop a fixed point.
+ *
+ * A ref inside a table floors at the TABLE fragment's bottom: nested line geometry is not in
+ * page-content coordinates, and keeping the whole block band is the conservative reading of
+ * the same rule. A ref no fragment on this page owns contributes nothing.
+ */
+export function noteReferenceFloorPt(
+  page: PageRecord,
+  refs: readonly { readonly paragraphId: string; readonly atomOffset: number }[]
+): number {
+  let floor = 0;
+  for (const block of page.fragments) {
+    if (block.kind === 'paragraph') {
+      for (const ref of refs) {
+        if (!fragmentOwnsPosition(block, ref.paragraphId, ref.atomOffset)) continue;
+        floor = Math.max(floor, referenceLineBottom(block, ref) ?? block.box.y + block.box.height);
+      }
+      continue;
+    }
+    if (tableOwnsAnyRef(block, refs)) {
+      floor = Math.max(floor, block.box.y + block.box.height);
+    }
+  }
+  return Math.min(Math.max(0, floor), page.contentBox.height);
+}
+
+/** The owning line's bottom inside a fragment already known to own the ref, or null. */
+function referenceLineBottom(
+  fragment: ParagraphFragmentRecord,
+  ref: { readonly paragraphId: string; readonly atomOffset: number }
+): number | null {
+  for (const line of fragment.lines) {
+    for (const segment of lineSegments(line)) {
+      if (segment.paragraphId !== ref.paragraphId) continue;
+      if (ref.atomOffset < segment.start || ref.atomOffset >= segment.end) continue;
+      return line.box.y + line.box.height;
+    }
+  }
+  return null;
+}
+
+function tableOwnsAnyRef(
+  table: Extract<BlockFragmentRecord, { kind: 'table' }>,
+  refs: readonly { readonly paragraphId: string; readonly atomOffset: number }[]
+): boolean {
+  const visit = (blocks: readonly BlockFragmentRecord[]): boolean => {
+    for (const block of blocks) {
+      if (block.kind === 'paragraph') {
+        for (const ref of refs) {
+          if (fragmentOwnsPosition(block, ref.paragraphId, ref.atomOffset)) return true;
+        }
+        continue;
+      }
+      for (const row of block.rows) {
+        if (row.isHeaderRepeat) continue;
+        for (const cell of row.cells) {
+          if (visit(cell.blocks)) return true;
+        }
+      }
+    }
+    return false;
+  };
+  for (const row of table.rows) {
+    if (row.isHeaderRepeat) continue;
+    for (const cell of row.cells) {
+      if (visit(cell.blocks)) return true;
+    }
+  }
+  return false;
+}

--- a/packages/core/src/layout/note-pagination.ts
+++ b/packages/core/src/layout/note-pagination.ts
@@ -45,6 +45,11 @@ import {
   type LayoutNoteStoryOptions,
 } from './note-layout.ts';
 import { noteMarkKey, type NoteMarkContext } from './note-projection.ts';
+import {
+  fragmentFlowBottom,
+  noteReferenceFloorPt,
+  shiftFragments,
+} from './note-fragment-geometry.ts';
 import { reindexAndRestackPages } from './page-restacking.ts';
 import type {
   BlockFragmentRecord,
@@ -549,66 +554,6 @@ function layoutOpts(input: NotesLayoutInput, noteMarks?: NoteMarkContext): Layou
   };
 }
 
-function shiftParagraphFragment(
-  fragment: ParagraphFragmentRecord,
-  dy: number
-): ParagraphFragmentRecord {
-  if (dy === 0) return fragment;
-  return {
-    ...fragment,
-    box: { ...fragment.box, y: fragment.box.y + dy },
-    ...(fragment.shadingBox
-      ? { shadingBox: { ...fragment.shadingBox, y: fragment.shadingBox.y + dy } }
-      : {}),
-    ...(fragment.bottomBorder
-      ? {
-          bottomBorder: {
-            ...fragment.bottomBorder,
-            box: { ...fragment.bottomBorder.box, y: fragment.bottomBorder.box.y + dy },
-          },
-        }
-      : {}),
-    ...(fragment.borders
-      ? {
-          borders: fragment.borders.map((stroke) => ({
-            ...stroke,
-            box: { ...stroke.box, y: stroke.box.y + dy },
-          })),
-        }
-      : {}),
-    ...(fragment.marker
-      ? {
-          marker: {
-            ...fragment.marker,
-            box: { ...fragment.marker.box, y: fragment.marker.box.y + dy },
-          },
-        }
-      : {}),
-    lines: fragment.lines.map((line) => ({
-      ...line,
-      box: { ...line.box, y: line.box.y + dy },
-      spans: line.spans.map((span) => ({
-        ...span,
-        box: { ...span.box, y: span.box.y + dy },
-      })),
-    })),
-  };
-}
-
-function shiftFragments(
-  fragments: readonly BlockFragmentRecord[],
-  dy: number
-): BlockFragmentRecord[] {
-  if (dy === 0) return [...fragments];
-  return fragments.map((fragment) => {
-    if (fragment.kind === 'paragraph') return shiftParagraphFragment(fragment, dy);
-    return {
-      ...fragment,
-      box: { ...fragment.box, y: fragment.box.y + dy },
-    };
-  });
-}
-
 /**
  * Split one paragraph fragment at a line boundary so the head fits under `availableBottom`
  * (story-relative). Empty head means no line fits — caller must defer the fragment.
@@ -701,14 +646,6 @@ function splitParagraphFragmentByBottom(
       : {}),
   };
   return { head, tail };
-}
-
-function fragmentFlowBottom(fragments: readonly BlockFragmentRecord[]): number {
-  let bottom = 0;
-  for (const fragment of fragments) {
-    bottom = Math.max(bottom, fragment.box.y + fragment.box.height);
-  }
-  return bottom;
 }
 
 /**
@@ -1129,6 +1066,15 @@ function buildFootnoteArea(
      * reserve measurement so height is not clipped before body reflow.
      */
     readonly reserveColumnBudget?: boolean;
+    /**
+     * Body band (content-relative pt) the reserve budget must additionally keep — the
+     * bottom of the page's lowest referencing line ({@link noteReferenceFloorPt}). Keeps a
+     * note's first fragment on its reference page: a budget that ignores where the
+     * reference sits evicts the referencing line itself, and the reflow loop then chases
+     * the reference across pages instead of converging. Only read with
+     * {@link reserveColumnBudget}; attach passes size from real body slack instead.
+     */
+    readonly reserveBodyFloorPt?: number;
     readonly separatorCache?: NoteSeparatorCache;
   }
 ): { area: NoteAreaRecord | undefined; nextCarry: NoteCarryMap } {
@@ -1173,7 +1119,9 @@ function buildFootnoteArea(
   );
   const columnBudget = Math.max(
     0,
-    page.contentBox.height - MIN_FOOTNOTE_BODY_BAND_PT - separator.flowHeight
+    page.contentBox.height -
+      Math.max(MIN_FOOTNOTE_BODY_BAND_PT, options?.reserveBodyFloorPt ?? 0) -
+      separator.flowHeight
   );
   const availableForNotes = options?.reserveColumnBudget ? columnBudget : slackBudget;
   const fullNoteColumn = Math.max(0, page.contentBox.height - separator.flowHeight);
@@ -2158,8 +2106,17 @@ export function computeFootnoteReserves(
     }
 
     // Column budget for the note stack (separator is added inside buildFootnoteArea).
-    // Cap so body retains MIN_FOOTNOTE_BODY_BAND_PT for a referencing line to land.
-    const maxArea = Math.max(0, bodyPage.contentBox.height - MIN_FOOTNOTE_BODY_BAND_PT);
+    // The body keeps everything down to the LOWEST referencing line (Word starts a footnote
+    // on the page that references it), never less than MIN_FOOTNOTE_BODY_BAND_PT. A reserve
+    // that ignores the reference evicts its own line to the next page, and the reflow loop
+    // then oscillates between the two placements until the fingerprint lock freezes one —
+    // the shape behind reference pages with zero note height and later pages holding a
+    // reservation nothing fills.
+    const referenceFloor = fnRefs.length > 0 ? noteReferenceFloorPt(bodyPage, fnRefs) : 0;
+    const maxArea = Math.max(
+      0,
+      bodyPage.contentBox.height - Math.max(MIN_FOOTNOTE_BODY_BAND_PT, referenceFloor)
+    );
 
     const carryWasEmpty = carry.size === 0;
     const reasonsBefore = reasons.length;
@@ -2171,7 +2128,7 @@ export function computeFootnoteReserves(
       props.pos,
       carry,
       reasons,
-      { reserveColumnBudget: true, separatorCache }
+      { reserveColumnBudget: true, reserveBodyFloorPt: referenceFloor, separatorCache }
     );
     carry = nextCarry;
     const needed = Math.min(area?.box.height ?? 0, maxArea);

--- a/packages/core/src/layout/note-pagination.ts
+++ b/packages/core/src/layout/note-pagination.ts
@@ -46,6 +46,14 @@ import {
 } from './note-layout.ts';
 import { noteMarkKey, type NoteMarkContext } from './note-projection.ts';
 import {
+  compactFootnoteReserves,
+  footnoteReservesEqual,
+  footnoteReservesFingerprint,
+  growFootnoteReserves,
+  notesReserveContextKey,
+} from './note-reserves.ts';
+export { notesReserveContextKey };
+import {
   fragmentFlowBottom,
   noteReferenceFloorPt,
   shiftFragments,
@@ -74,6 +82,19 @@ import { DEFAULT_REVISION_DISPLAY_MODE, type RevisionDisplayMode } from './revis
 
 /** Bound on reflow attempts per document layout pass. */
 export const MAX_NOTE_REFLOW_ATTEMPTS = 8;
+
+/**
+ * Total reserve-map adoptions allowed per BODY-PART identity, across passes.
+ *
+ * One pass is capped at {@link MAX_NOTE_REFLOW_ATTEMPTS}; session-seeded passes continue
+ * the same iteration, so a reference-dense document converges across a few passes instead
+ * of restarting. Some documents have no fixed point at all — the map's own body shifts move
+ * references across page boundaries and the iteration orbits a short cycle — so the search
+ * must also END: once this budget is spent, the memo records the answer and every later
+ * pass over the same part reproduces it, instead of flapping an unchanged document between
+ * the orbit's page counts forever. An edit replaces the part and restarts the search.
+ */
+const MAX_NOTE_REFLOW_ADOPTIONS_PER_STATE = 3 * MAX_NOTE_REFLOW_ATTEMPTS;
 
 /** Cap on total note story fragments attached across the document. */
 export const MAX_NOTE_AREA_FRAGMENTS = 4_096;
@@ -200,6 +221,23 @@ interface NotesPassMemo {
   readonly allHits: readonly PageRefHit[];
   readonly provisionalMarks: NoteMarkContext;
   finalMarks: { readonly sitesFingerprint: string; readonly marks: NoteMarkContext } | null;
+  /**
+   * The reserve answer the reflow settled on for one body-part identity.
+   *
+   * Recorded when a pass converges, when it ends without adopting a new map, or when the
+   * cross-pass adoption budget ({@link MAX_NOTE_REFLOW_ADOPTIONS_PER_STATE}) is spent. A
+   * later pass over the SAME part seeded with this exact map skips the reflow loop and
+   * republishes — the loop exists to find reserves for a new document state, and re-running
+   * it on an unchanged one can only flap a fixed-point-free document between the page
+   * counts of its orbit. An edit replaces the part, which invalidates this by identity.
+   */
+  settledReserves: {
+    readonly part: OoxmlPart;
+    readonly fingerprint: string;
+    readonly reasons: readonly NotePaginationFallbackReason[];
+  } | null;
+  /** Reserve-map adoptions spent on the current body-part identity (budget above). */
+  reflowSpent: { readonly part: OoxmlPart; adopted: number } | null;
   readonly pageAttach: WeakMap<PageRecord, NotesPageAttachEntry>;
   readonly pageReserve: WeakMap<
     PageRecord,
@@ -298,6 +336,8 @@ function notesMemoFor(
     allHits,
     provisionalMarks: provisionalNoteMarks(allHits, input),
     finalMarks: null,
+    settledReserves: null,
+    reflowSpent: null,
     pageAttach: new WeakMap(),
     pageReserve: new WeakMap(),
   };
@@ -1067,14 +1107,17 @@ function buildFootnoteArea(
      */
     readonly reserveColumnBudget?: boolean;
     /**
-     * Body band (content-relative pt) the reserve budget must additionally keep — the
-     * bottom of the page's lowest referencing line ({@link noteReferenceFloorPt}). Keeps a
-     * note's first fragment on its reference page: a budget that ignores where the
-     * reference sits evicts the referencing line itself, and the reflow loop then chases
-     * the reference across pages instead of converging. Only read with
-     * {@link reserveColumnBudget}; attach passes size from real body slack instead.
+     * Body band (content-relative pt) each REFERENCE keeps — the bottom of its own line
+     * ({@link noteReferenceFloorPt}). Keeps a note's first fragment on its reference page:
+     * a budget that ignores where the reference sits evicts the referencing line itself,
+     * and the reflow loop then chases the reference across pages instead of converging.
+     * Per reference, because the stack tightens as it grows: note `i` may fill down to
+     * reference `i`'s line, so an earlier note keeps its full room while a later one whose
+     * line sits under the accumulated stack gets nothing and carries — one shared floor at
+     * the page's lowest reference strangles them all to the sliver under it, stably. Only
+     * read with {@link reserveColumnBudget}; attach passes size from real body slack.
      */
-    readonly reserveBodyFloorPt?: number;
+    readonly reserveFloorOf?: (ref: PageRefHit) => number;
     readonly separatorCache?: NoteSeparatorCache;
   }
 ): { area: NoteAreaRecord | undefined; nextCarry: NoteCarryMap } {
@@ -1119,9 +1162,7 @@ function buildFootnoteArea(
   );
   const columnBudget = Math.max(
     0,
-    page.contentBox.height -
-      Math.max(MIN_FOOTNOTE_BODY_BAND_PT, options?.reserveBodyFloorPt ?? 0) -
-      separator.flowHeight
+    page.contentBox.height - MIN_FOOTNOTE_BODY_BAND_PT - separator.flowHeight
   );
   const availableForNotes = options?.reserveColumnBudget ? columnBudget : slackBudget;
   const fullNoteColumn = Math.max(0, page.contentBox.height - separator.flowHeight);
@@ -1203,7 +1244,22 @@ function buildFootnoteArea(
       continue;
     }
     const mark = noteMarks.marks.get(noteMarkKey('footnote', ref.noteId)) ?? null;
-    const room = Math.max(0, availableForNotes - stackHeight);
+    // Reserve mode tightens each note's budget to ITS reference's floor; the stack may not
+    // rise above any line that cites into it. Later references sit lower, so their budgets
+    // only shrink — a note whose room hits zero carries whole, and the reflow loop finds
+    // its reference on the page the shrunken body pushes it to.
+    const refBudget = options?.reserveFloorOf
+      ? Math.min(
+          availableForNotes,
+          Math.max(
+            0,
+            page.contentBox.height -
+              Math.max(MIN_FOOTNOTE_BODY_BAND_PT, options.reserveFloorOf(ref)) -
+              separator.flowHeight
+          )
+        )
+      : availableForNotes;
+    const room = Math.max(0, refBudget - stackHeight);
     fragmentBudget -= laid.fragments.length;
     if (fragmentBudget < 0) {
       reasons.push('note-area-fragment-limit');
@@ -2106,17 +2162,13 @@ export function computeFootnoteReserves(
     }
 
     // Column budget for the note stack (separator is added inside buildFootnoteArea).
-    // The body keeps everything down to the LOWEST referencing line (Word starts a footnote
-    // on the page that references it), never less than MIN_FOOTNOTE_BODY_BAND_PT. A reserve
-    // that ignores the reference evicts its own line to the next page, and the reflow loop
-    // then oscillates between the two placements until the fingerprint lock freezes one —
-    // the shape behind reference pages with zero note height and later pages holding a
-    // reservation nothing fills.
-    const referenceFloor = fnRefs.length > 0 ? noteReferenceFloorPt(bodyPage, fnRefs) : 0;
-    const maxArea = Math.max(
-      0,
-      bodyPage.contentBox.height - Math.max(MIN_FOOTNOTE_BODY_BAND_PT, referenceFloor)
-    );
+    // Each reference keeps the body band down to ITS OWN line (Word starts a footnote on
+    // the page that references it): a reserve that ignores the reference evicts its own
+    // line to the next page, and the reflow loop then oscillates between the two
+    // placements — reference pages with zero note height, later pages holding a
+    // reservation nothing fills. Per reference and never the page's lowest one, whose
+    // floor would stably strangle every note above it on a multi-reference page.
+    const maxArea = Math.max(0, bodyPage.contentBox.height - MIN_FOOTNOTE_BODY_BAND_PT);
 
     const carryWasEmpty = carry.size === 0;
     const reasonsBefore = reasons.length;
@@ -2128,7 +2180,11 @@ export function computeFootnoteReserves(
       props.pos,
       carry,
       reasons,
-      { reserveColumnBudget: true, reserveBodyFloorPt: referenceFloor, separatorCache }
+      {
+        reserveColumnBudget: true,
+        reserveFloorOf: (ref) => noteReferenceFloorPt(bodyPage, ref),
+        separatorCache,
+      }
     );
     carry = nextCarry;
     const needed = Math.min(area?.box.height ?? 0, maxArea);
@@ -2535,98 +2591,21 @@ function tableParagraphIdsOf(table: OoxmlNode): readonly string[] {
   return ids;
 }
 
-/**
- * The note-reserve slice of one section's layout context key.
- *
- * The reserve map is keyed by DOCUMENT page index ({@link computeFootnoteReserves}), while a
- * section's pass reads it at `pageIndexStart + localSlot` as it opens pages. The key folds
- * exactly the entries that pass can read — document slots in
- * `[pageIndexStart, pageIndexStart + pageBound)` — so a reserve on another section's pages
- * cannot invalidate this one. `pageBound` is EXCLUSIVE and section-LOCAL: the highest local
- * page slot the pass can read, plus one.
- *
- * Entries are emitted at their LOCAL slot (`documentSlot - pageIndexStart`), not the document
- * one. The document page index is deliberately absent from a section's context key (an Enter
- * that adds a page above must not re-lay every section below), and the local slot is what the
- * pass's reads actually depend on: two passes whose readable windows carry the same heights
- * at the same local offsets read identically wherever the section sits, so a section whose
- * reserves shift down a sheet with it reconverges to its stored key once the reflow loop has
- * recomputed the map, while a reserve that stays at a fixed document page as the section
- * moves lands on a different local slot and invalidates.
- *
- * Entries are sorted by slot so two content-equal maps render one canonical key regardless
- * of insertion order. `Infinity` folds every entry from `pageIndexStart` on (a pass with no
- * prior page count cannot bound its reads). A window with no entries keys like no map at
- * all: both mean every read returns zero, and two encodings of that would invalidate every
- * untouched section when a document's last note disappears.
- */
-export function notesReserveContextKey(
-  reserves: ReadonlyMap<number, number> | undefined,
-  pageIndexStart: number,
-  pageBound: number
-): string {
-  if (!reserves) return '';
-  const entries: [number, number][] = [];
-  for (const [pageSlot, height] of reserves) {
-    const localSlot = pageSlot - pageIndexStart;
-    if (localSlot >= 0 && localSlot < pageBound) entries.push([localSlot, height]);
-  }
-  if (entries.length === 0) return '';
-  entries.sort((a, b) => a[0] - b[0]);
-  return `|nr:${entries.map(([localSlot, height]) => `${localSlot}=${height}`).join(',')}`;
-}
-
-/** Drop non-positive heights so missing and zero compare equal. */
-function compactFootnoteReserves(reserves: ReadonlyMap<number, number>): Map<number, number> {
-  const next = new Map<number, number>();
-  for (const [pageIndex, height] of reserves) {
-    if (height > 0) next.set(pageIndex, height);
-  }
-  return next;
-}
-
-/** True when both maps list the same page → height pairs (zeros ignored). */
-function footnoteReservesEqual(
-  a: ReadonlyMap<number, number>,
-  b: ReadonlyMap<number, number>
-): boolean {
-  const left = compactFootnoteReserves(a);
-  const right = compactFootnoteReserves(b);
-  if (left.size !== right.size) return false;
-  for (const [pageIndex, height] of left) {
-    if ((right.get(pageIndex) ?? 0) !== height) return false;
-  }
-  return true;
-}
-
-/** Monotonic union: each page keeps the larger of the two heights. */
-function growFootnoteReserves(
-  base: ReadonlyMap<number, number>,
-  computed: ReadonlyMap<number, number>
-): Map<number, number> {
-  const next = compactFootnoteReserves(base);
-  for (const [pageIndex, height] of computed) {
-    if (height <= 0) continue;
-    next.set(pageIndex, Math.max(next.get(pageIndex) ?? 0, height));
-  }
-  return next;
-}
-
-function footnoteReservesFingerprint(reserves: ReadonlyMap<number, number>): string {
-  return [...compactFootnoteReserves(reserves)]
-    .map(([pageIndex, height]) => `${pageIndex}=${height}`)
-    .sort()
-    .join(',');
-}
+// Reserve-map algebra (context key, compact/equal/grow/fingerprint) lives in
+// note-reserves.ts; the context key re-exports below so existing import sites hold.
 
 /**
  * Notes path: provisional marks → body layout → reserve → bounded reflow → attach.
  * `runBody` is the coordinator's body layout pass (single- or multi-section).
  *
  * Convergence requires the body to have been laid out with exactly the reserves still
- * needed. Monotonic growth covers the unstable path; a stable-but-mismatched compute
- * (citation moved off a reserved page) drops stale entries and re-runs. Revisited
- * reserve fingerprints fail closed via the grow envelope so the loop cannot oscillate.
+ * needed. Every pass adopts the freshly computed map (stale entries drop with it); a
+ * revisited reserve fingerprint means a true placement cycle and fails closed via a
+ * one-shot grow envelope so the loop cannot oscillate. The attempt cap can end a
+ * reference-dense document short of the fixed point; the session seeds the next pass
+ * with the last adopted map, so iteration continues across passes instead of restarting,
+ * bounded by {@link MAX_NOTE_REFLOW_ADOPTIONS_PER_STATE} per body-part identity — after
+ * which the memo's settled answer republishes and an unchanged document stops moving.
  *
  * Reserves seed from {@link LayoutSession.notePageBottomReserves} so a warm session's
  * first body pass already carries the prior published reserve set (and its context key).
@@ -2688,48 +2667,103 @@ export function layoutSemanticDocumentWithNotes<
     noteMarks,
     pageBottomReserves: usedReserves,
   });
-  const appliedFingerprints = new Set<string>([footnoteReservesFingerprint(usedReserves)]);
+  const seedFingerprint = footnoteReservesFingerprint(usedReserves);
+  // An unchanged document seeded with the answer it settled on republishes it: the loop
+  // below exists to find reserves for a NEW document state, and re-running it on the same
+  // one can only flap a fixed-point-free document between the page counts of its orbit.
+  const settled =
+    notesMemoState.reused &&
+    notesMemo?.settledReserves &&
+    notesMemo.settledReserves.part === part &&
+    notesMemo.settledReserves.fingerprint === seedFingerprint
+      ? notesMemo.settledReserves
+      : null;
+  if (settled) {
+    fallbackReasons = [...settled.reasons];
+  } else {
+    const appliedFingerprints = new Set<string>([seedFingerprint]);
+    // Adoption budget for this body-part identity, carried across session passes so the
+    // iteration continues where the previous pass stopped instead of restarting.
+    const spent =
+      notesMemo && notesMemo.reflowSpent && notesMemo.reflowSpent.part === part
+        ? notesMemo.reflowSpent
+        : { part, adopted: 0 };
+    if (notesMemo) notesMemo.reflowSpent = spent;
+    let adoptedThisPass = 0;
 
-  for (let attempt = 0; attempt < MAX_NOTE_REFLOW_ATTEMPTS; attempt += 1) {
-    const computed = computeFootnoteReserves(bodyLayout, allHits, notesInput, noteMarks, notesMemo);
-    fallbackReasons = [...computed.reasons];
-    // Published pages must reflect the reserves used to produce them — not a later map.
-    if (computed.stable && footnoteReservesEqual(computed.reserves, usedReserves)) {
-      break;
-    }
-
-    // Unstable: grow only. Stable mismatch: adopt exact computed (drop stale pages).
-    let next = computed.stable
-      ? compactFootnoteReserves(computed.reserves)
-      : growFootnoteReserves(usedReserves, computed.reserves);
-
-    if (footnoteReservesEqual(next, usedReserves)) {
-      fallbackReasons.push('note-reflow-exhausted');
-      break;
-    }
-
-    const nextFp = footnoteReservesFingerprint(next);
-    if (appliedFingerprints.has(nextFp)) {
-      // Shrink↔grow cycle — lock to the monotonic envelope; stop if that is not new.
-      next = growFootnoteReserves(usedReserves, computed.reserves);
-      const envelopeFp = footnoteReservesFingerprint(next);
-      if (footnoteReservesEqual(next, usedReserves) || appliedFingerprints.has(envelopeFp)) {
+    for (let attempt = 0; attempt < MAX_NOTE_REFLOW_ATTEMPTS; attempt += 1) {
+      const computed = computeFootnoteReserves(
+        bodyLayout,
+        allHits,
+        notesInput,
+        noteMarks,
+        notesMemo
+      );
+      fallbackReasons = [...computed.reasons];
+      // Published pages must reflect the reserves used to produce them — not a later map.
+      if (computed.stable && footnoteReservesEqual(computed.reserves, usedReserves)) {
+        break;
+      }
+      if (spent.adopted >= MAX_NOTE_REFLOW_ADOPTIONS_PER_STATE) {
         fallbackReasons.push('note-reflow-exhausted');
         break;
       }
+
+      // Adopt the computed map EVERY round — never union it with the previous one.
+      // Reserves shift references forward, so consecutive rounds put the same note's
+      // reserve at different page slots; a monotonic union keeps every slot any round
+      // ever wanted, and on reference-dense documents the map only grows until the
+      // attempt cap freezes a layout reserved at several times the notes' true height —
+      // runs of near-empty pages whose reservation nothing fills. Plain adoption is a
+      // fixed-point iteration whose settled prefix extends forward each round; an
+      // unconverged tail under-fills a page or two near the frontier, which the next
+      // (seeded) pass continues to repair, instead of over-reserving everywhere.
+      let next = compactFootnoteReserves(computed.reserves);
+
+      if (footnoteReservesEqual(next, usedReserves)) {
+        fallbackReasons.push('note-reflow-exhausted');
+        break;
+      }
+
+      const nextFp = footnoteReservesFingerprint(next);
+      if (appliedFingerprints.has(nextFp)) {
+        // Shrink↔grow cycle — lock to the monotonic envelope; stop if that is not new.
+        next = growFootnoteReserves(usedReserves, computed.reserves);
+        const envelopeFp = footnoteReservesFingerprint(next);
+        if (footnoteReservesEqual(next, usedReserves) || appliedFingerprints.has(envelopeFp)) {
+          fallbackReasons.push('note-reflow-exhausted');
+          break;
+        }
+      }
+
+      usedReserves = next;
+      appliedFingerprints.add(footnoteReservesFingerprint(usedReserves));
+      spent.adopted += 1;
+      adoptedThisPass += 1;
+      // Keep the caller's session: reserve changes alter the layout context key, so
+      // checkpoints from a different reserve set are not resumed — they are replaced.
+      bodyLayout = runBody({
+        ...optionsWithLists,
+        noteMarks,
+        pageBottomReserves: usedReserves,
+      });
+      if (attempt === MAX_NOTE_REFLOW_ATTEMPTS - 1) {
+        fallbackReasons.push('note-reflow-exhausted');
+      }
     }
 
-    usedReserves = next;
-    appliedFingerprints.add(footnoteReservesFingerprint(usedReserves));
-    // Keep the caller's session: reserve changes alter the layout context key, so
-    // checkpoints from a different reserve set are not resumed — they are replaced.
-    bodyLayout = runBody({
-      ...optionsWithLists,
-      noteMarks,
-      pageBottomReserves: usedReserves,
-    });
-    if (attempt === MAX_NOTE_REFLOW_ATTEMPTS - 1) {
-      fallbackReasons.push('note-reflow-exhausted');
+    // A pass that adopted nothing changed nothing — converged, computed==used, or an
+    // immediate cycle — and a spent budget means the search is over either way. Record
+    // the answer so later passes over this part republish instead of re-searching.
+    if (
+      notesMemo &&
+      (adoptedThisPass === 0 || spent.adopted >= MAX_NOTE_REFLOW_ADOPTIONS_PER_STATE)
+    ) {
+      notesMemo.settledReserves = {
+        part,
+        fingerprint: footnoteReservesFingerprint(usedReserves),
+        reasons: [...fallbackReasons],
+      };
     }
   }
 

--- a/packages/core/src/layout/note-reserves.ts
+++ b/packages/core/src/layout/note-reserves.ts
@@ -1,0 +1,90 @@
+// Footnote reserve maps: page-slot → bottom reserve height (points). The compute lives in
+// note-pagination.ts (computeFootnoteReserves); this module holds the pure map algebra the
+// reflow loop and the section context keys share.
+
+/**
+ * The note-reserve slice of one section's layout context key.
+ *
+ * The reserve map is keyed by DOCUMENT page index (`computeFootnoteReserves`), while a
+ * section's pass reads it at `pageIndexStart + localSlot` as it opens pages. The key folds
+ * exactly the entries that pass can read — document slots in
+ * `[pageIndexStart, pageIndexStart + pageBound)` — so a reserve on another section's pages
+ * cannot invalidate this one. `pageBound` is EXCLUSIVE and section-LOCAL: the highest local
+ * page slot the pass can read, plus one.
+ *
+ * Entries are emitted at their LOCAL slot (`documentSlot - pageIndexStart`), not the document
+ * one. The document page index is deliberately absent from a section's context key (an Enter
+ * that adds a page above must not re-lay every section below), and the local slot is what the
+ * pass's reads actually depend on: two passes whose readable windows carry the same heights
+ * at the same local offsets read identically wherever the section sits, so a section whose
+ * reserves shift down a sheet with it reconverges to its stored key once the reflow loop has
+ * recomputed the map, while a reserve that stays at a fixed document page as the section
+ * moves lands on a different local slot and invalidates.
+ *
+ * Entries are sorted by slot so two content-equal maps render one canonical key regardless
+ * of insertion order. `Infinity` folds every entry from `pageIndexStart` on (a pass with no
+ * prior page count cannot bound its reads). A window with no entries keys like no map at
+ * all: both mean every read returns zero, and two encodings of that would invalidate every
+ * untouched section when a document's last note disappears.
+ */
+export function notesReserveContextKey(
+  reserves: ReadonlyMap<number, number> | undefined,
+  pageIndexStart: number,
+  pageBound: number
+): string {
+  if (!reserves) return '';
+  const entries: [number, number][] = [];
+  for (const [pageSlot, height] of reserves) {
+    const localSlot = pageSlot - pageIndexStart;
+    if (localSlot >= 0 && localSlot < pageBound) entries.push([localSlot, height]);
+  }
+  if (entries.length === 0) return '';
+  entries.sort((a, b) => a[0] - b[0]);
+  return `|nr:${entries.map(([localSlot, height]) => `${localSlot}=${height}`).join(',')}`;
+}
+
+/** Drop non-positive heights so missing and zero compare equal. */
+export function compactFootnoteReserves(
+  reserves: ReadonlyMap<number, number>
+): Map<number, number> {
+  const next = new Map<number, number>();
+  for (const [pageIndex, height] of reserves) {
+    if (height > 0) next.set(pageIndex, height);
+  }
+  return next;
+}
+
+/** True when both maps list the same page → height pairs (zeros ignored). */
+export function footnoteReservesEqual(
+  a: ReadonlyMap<number, number>,
+  b: ReadonlyMap<number, number>
+): boolean {
+  const left = compactFootnoteReserves(a);
+  const right = compactFootnoteReserves(b);
+  if (left.size !== right.size) return false;
+  for (const [pageIndex, height] of left) {
+    if ((right.get(pageIndex) ?? 0) !== height) return false;
+  }
+  return true;
+}
+
+/** Monotonic union: each page keeps the larger of the two heights. */
+export function growFootnoteReserves(
+  base: ReadonlyMap<number, number>,
+  computed: ReadonlyMap<number, number>
+): Map<number, number> {
+  const next = compactFootnoteReserves(base);
+  for (const [pageIndex, height] of computed) {
+    if (height <= 0) continue;
+    next.set(pageIndex, Math.max(next.get(pageIndex) ?? 0, height));
+  }
+  return next;
+}
+
+/** Canonical content fingerprint, for cycle detection over adopted maps. */
+export function footnoteReservesFingerprint(reserves: ReadonlyMap<number, number>): string {
+  return [...compactFootnoteReserves(reserves)]
+    .map(([pageIndex, height]) => `${pageIndex}=${height}`)
+    .sort()
+    .join(',');
+}

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -1028,19 +1028,20 @@ function layoutBlocksPass(
    * full-height overflow page, so a block taller than the limit still terminates, and the
    * search reads "produced a second page" as "does not fit".
    */
-  const contentHeight = (): number => {
-    // Reserves are keyed by DOCUMENT page index (computeFootnoteReserves); this pass fills
-    // the document page at `pageIndexStart + pages.length`. A continuous section's local
-    // page 0 IS the previous section's last sheet: both passes read the same document slot,
-    // so every flow sharing the sheet stops above the same note area.
-    const base = Math.max(
-      1,
-      insetsFor(pages.length).height - (pageBottomReserves?.get(pageIndexStart + pages.length) ?? 0)
-    );
+  const contentHeightOf = (reservedPt: number): number => {
+    const base = Math.max(1, insetsFor(pages.length).height - reservedPt);
     return columnRegionBottom !== undefined && pages.length === 0
       ? Math.max(1, Math.min(base, columnRegionBottom))
       : base;
   };
+  const contentHeight = (): number =>
+    // Reserves are keyed by DOCUMENT page index (computeFootnoteReserves); this pass fills
+    // the document page at `pageIndexStart + pages.length`. A continuous section's local
+    // page 0 IS the previous section's last sheet: both passes read the same document slot,
+    // so every flow sharing the sheet stops above the same note area.
+    contentHeightOf(pageBottomReserves?.get(pageIndexStart + pages.length) ?? 0);
+  /** The same band with the footnote reserve ignored — the table paginator's recovery. */
+  const unreservedContentHeight = (): number => contentHeightOf(0);
 
   // Prepass: everything needed to KEY a paragraph, before any of them is placed. Resuming
   // means knowing where the first change is, and that cannot be discovered while walking.
@@ -1923,6 +1924,7 @@ function layoutBlocksPass(
       columnWidth,
       columnLeft,
       contentHeight,
+      unreservedContentHeight,
       advanceColumn: () => {
         cursorY = flow.cursorY;
         advanceColumn();

--- a/packages/core/src/layout/table-flow-pagination.ts
+++ b/packages/core/src/layout/table-flow-pagination.ts
@@ -47,6 +47,14 @@ export interface TableFlowCursor {
   readonly columnLeft: () => number;
   /** Height available on the page being filled — note reserves already subtracted. */
   readonly contentHeight: () => number;
+  /**
+   * The same band with any footnote reserve IGNORED. Recovery seam for keep-together rows:
+   * a `w:cantSplit` / `hRule=exact` row that exceeds the reserved band on a fresh page takes
+   * the full band instead of aborting the layout. The reserve is advisory at this point —
+   * the notes pass sizes its area from the body actually placed — so the overlap only
+   * pushes that page's footnotes forward. Absent means the two bands are the same.
+   */
+  readonly unreservedContentHeight?: () => number;
   /** Move to the next column, or the next page when this was the last one. */
   readonly advanceColumn: () => void;
   /** Frames a `w:tblpPr` table positions against. */
@@ -352,6 +360,35 @@ export function paginateTableInFlow(table: OoxmlElement, flow: TableFlowCursor):
           // page it just moved to, which is the whole point of deciding where a row lands.
           admitSpans(bodyRowIndex);
           continue;
+        }
+        // A fresh page whose band is shrunk by a footnote reserve still owns the full
+        // column underneath it. A keep-together row that fits THAT takes it rather than
+        // aborting: the reserve is advisory here (the notes pass sizes its area from the
+        // body actually placed, so this only pushes the page's footnotes forward), while
+        // the throw below rejects the entire document for one row+reserve collision.
+        const fullBand = flow.unreservedContentHeight?.() ?? contentHeight();
+        if (
+          fullBand > contentHeight() + 0.001 &&
+          naturalHeight <= fullBand - flow.cursorY + 0.001
+        ) {
+          const placed = layoutRowFragment(
+            row,
+            structure.columnWidthsPt,
+            tableLeft,
+            flow.cursorY,
+            false,
+            0,
+            tableDeps,
+            structure.cellSpacingPt,
+            vMerge,
+            fullBand
+          );
+          if (placed.bottom <= fullBand + 0.001 && placed.remainder === null) {
+            rows.push(placed.record);
+            sourceRows.push(row);
+            flow.cursorY = placed.bottom;
+            break;
+          }
         }
         throw new TablePaginationError(
           'table-row-overheight',


### PR DESCRIPTION
Footnote-heavy documents paginated at up to half density: a footnote taller than the space left on its reference page never started there, and long runs of pages held one body line with no footnote content. A charter-style document with 94 footnotes produced 123 pages headless where references produce about 49.

Three causes, one per commit region:

- The reserve pass sized a page's footnote reserve without knowing where the referencing line sits, so an oversized reserve evicted the referencing paragraph itself, and the reflow loop froze the wrong phase of the resulting oscillation. Reserves now cap at each note's own reference line, so the reference page always hosts the note's first fragment.
- `growFootnoteReserves` unioned every pass's reserves; because each pass shifts references forward, stale slots accumulated across pages and starved them after the notes were exhausted. The loop now adopts each recomputed map as a plain fixed-point iteration, with a bounded adoption budget and a settled answer per body part for documents whose reserves orbit a short cycle.
- A `w:cantSplit` table row taller than the reserve-shrunk band aborted layout with `table-row-overheight`. A keep-together row that fits the unreserved band now takes the full page and the notes drain forward.

Verified against representative documents: the charter lands at 54 pages headless and 48 in the browser (reference 49), an investors-rights document at 48 (reference 44, previously 73), and no page holds a single body line with an empty footnote region.

Fixes #608

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/610"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790595874&installation_model_id=422592&pr_number=610&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F610&signature=f882c3a8c0466c21d1a7f0b86a0f2fcae924c3a1be70ca35c7d1a7c546a43387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->