### PR TITLE
fix(core): gate the font-substitution notice on rendered families

### DIFF
--- a/.changeset/font-notice-rendered-families.md
+++ b/.changeset/font-notice-rendered-families.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': minor
+---
+
+The font-substitution notice now reports only families that rendered text resolves to through the style cascade, so declarations in unused styles no longer trigger it. Adds `renderedFontFamilies()` to the tree session.

--- a/docs/api/docx-editor-core/binding.api.md
+++ b/docs/api/docx-editor-core/binding.api.md
@@ -174,6 +174,7 @@ export interface TreeDocxSessionView {
         readonly target: string;
     } | null;
     removeCustomNode(controlNodeId: string, scope?: StoryScope): CustomNodeWriteResult;
+    renderedFontFamilies(): readonly string[];
     rendersText(): boolean;
     replaceImage(scope: StoryScope, drawingNodeId: string, bytes: Uint8Array, mime: SupportedImageMime, decodePort: ImageDecodePort, options: ReplaceImageOptions): Promise<ImageIntentResult>;
     replyToComment(parentCommentId: string | null, anchor: {

--- a/docs/api/docx-editor-core/editor.api.md
+++ b/docs/api/docx-editor-core/editor.api.md
@@ -2341,6 +2341,7 @@ export interface TreeDocxSessionView {
         readonly target: string;
     } | null;
     removeCustomNode(controlNodeId: string, scope?: StoryScope): CustomNodeWriteResult;
+    renderedFontFamilies(): readonly string[];
     rendersText(): boolean;
     replaceImage(scope: StoryScope, drawingNodeId: string, bytes: Uint8Array, mime: SupportedImageMime, decodePort: ImageDecodePort, options: ReplaceImageOptions): Promise<ImageIntentResult>;
     replyToComment(parentCommentId: string | null, anchor: {

--- a/packages/core/src/binding/__tests__/document-rendered-fonts.test.ts
+++ b/packages/core/src/binding/__tests__/document-rendered-fonts.test.ts
@@ -1,0 +1,319 @@
+// What `renderedFontFamilies()` — the substitution notice's input — reports.
+//
+// The contract under test: a family joins the answer only when RENDERED text resolves to
+// it through the style cascade. A declaration in a style no paragraph references (Word's
+// latent Balloon Text naming Segoe UI, a table style carrying a face name) contributes to
+// `documentFonts()` for the picker, and never here. The cascade half: used `w:pStyle` /
+// `w:rStyle` / `w:tblStyle` chains resolve through `basedOn` with the nearest family
+// winning, absent references fall to the `w:default="1"` style of the type, and
+// `w:docDefaults` counts once any text renders.
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { readOoxmlPart } from '../../store/package/ooxml-tree.ts';
+import { collectRenderedFontFamilies } from '../document-rendered-fonts.ts';
+import { openTreeSession, type TreeDocxSession } from '../tree-session.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT_NS = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL_NS = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OFFICE_DOC =
+  'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+const STYLES_REL = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles';
+const HEADER_REL = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/header';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+
+function docx(options: { body: string; styles?: string; header?: string }): Uint8Array {
+  const { body, styles, header } = options;
+  const files: Record<string, Uint8Array> = {
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT_NS}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        (styles
+          ? '<Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>'
+          : '') +
+        (header
+          ? '<Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>'
+          : '') +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL_NS}">` +
+        `<Relationship Id="rId1" Type="${OFFICE_DOC}" Target="word/document.xml"/>` +
+        '</Relationships>'
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
+    ),
+  };
+  const documentRels: string[] = [];
+  if (styles) {
+    files['word/styles.xml'] = strToU8(styles);
+    documentRels.push(`<Relationship Id="rId10" Type="${STYLES_REL}" Target="styles.xml"/>`);
+  }
+  if (header) {
+    files['word/header1.xml'] = strToU8(header);
+    documentRels.push(`<Relationship Id="rId11" Type="${HEADER_REL}" Target="header1.xml"/>`);
+  }
+  if (documentRels.length > 0) {
+    files['word/_rels/document.xml.rels'] = strToU8(
+      `<Relationships xmlns="${REL_NS}">${documentRels.join('')}</Relationships>`
+    );
+  }
+  return zipSync(files);
+}
+
+function open(bytes: Uint8Array): TreeDocxSession {
+  const result = openTreeSession(bytes);
+  if (!result.ok) throw new Error(`${result.reason}: ${result.detail ?? ''}`);
+  return result.session;
+}
+
+const run = (font: string, text: string) =>
+  `<w:r><w:rPr><w:rFonts w:ascii="${font}" w:hAnsi="${font}"/></w:rPr><w:t>${text}</w:t></w:r>`;
+
+const styles = (body: string) => `<w:styles xmlns:w="${W}">${body}</w:styles>`;
+
+const styleWithFont = (type: string, id: string, font: string) =>
+  `<w:style w:type="${type}" w:styleId="${id}">` +
+  `<w:rPr><w:rFonts w:ascii="${font}" w:hAnsi="${font}"/></w:rPr></w:style>`;
+
+describe('collectRenderedFontFamilies', () => {
+  test('a declaration in an unused style is not rendered', () => {
+    // The false-positive shape from real Word files: latent Balloon Text names Segoe UI,
+    // an unused table style carries a face name as a family; no paragraph uses either.
+    const session = open(
+      docx({
+        body: `<w:p>${run('Garamond', 'body text')}</w:p>`,
+        styles: styles(
+          styleWithFont('paragraph', 'BalloonText', 'Segoe UI') +
+            styleWithFont('table', 'TableGrid1', 'Times New Roman Bold')
+        ),
+      })
+    );
+    expect(session.renderedFontFamilies()).toEqual(['Garamond']);
+    // The picker still sees every declaration — the two answers ask different questions.
+    expect(session.documentFonts()).toEqual(['Garamond', 'Segoe UI', 'Times New Roman Bold']);
+  });
+
+  test('a run without text contributes nothing; an empty document answers []', () => {
+    const empty = open(docx({ body: '<w:p/>' }));
+    expect(empty.renderedFontFamilies()).toEqual([]);
+
+    const declared = open(
+      docx({ body: '<w:p><w:r><w:rPr><w:rFonts w:ascii="Impact"/></w:rPr></w:r></w:p>' })
+    );
+    expect(declared.renderedFontFamilies()).toEqual([]);
+  });
+
+  test('a used paragraph style resolves through basedOn, nearest family wins', () => {
+    const session = open(
+      docx({
+        body:
+          `<w:p><w:pPr><w:pStyle w:val="Body"/></w:pPr><w:r><w:t>text</w:t></w:r></w:p>` +
+          `<w:p><w:pPr><w:pStyle w:val="Quote"/></w:pPr><w:r><w:t>quoted</w:t></w:r></w:p>`,
+        styles: styles(
+          // Body inherits its face from Base — the chain must be walked.
+          `<w:style w:type="paragraph" w:styleId="Body"><w:basedOn w:val="Base"/></w:style>` +
+            styleWithFont('paragraph', 'Base', 'Georgia') +
+            // Quote SHADOWS Base's face: only the nearest family renders.
+            `<w:style w:type="paragraph" w:styleId="Quote"><w:basedOn w:val="Base"/>` +
+            '<w:rPr><w:rFonts w:ascii="Palatino" w:hAnsi="Palatino"/></w:rPr></w:style>' +
+            // Declared and unused: excluded.
+            styleWithFont('paragraph', 'Unused', 'Segoe UI')
+        ),
+      })
+    );
+    expect(session.renderedFontFamilies()).toEqual(['Georgia', 'Palatino']);
+  });
+
+  test('a used character style counts; docDefaults count once text renders', () => {
+    const session = open(
+      docx({
+        body:
+          '<w:p><w:r><w:rPr><w:rStyle w:val="Strong"/></w:rPr><w:t>bold-ish</w:t></w:r>' +
+          '<w:r><w:t>plain</w:t></w:r></w:p>',
+        styles: styles(
+          '<w:docDefaults><w:rPrDefault><w:rPr><w:rFonts w:ascii="Cambria" w:hAnsi="Cambria"/></w:rPr></w:rPrDefault></w:docDefaults>' +
+            styleWithFont('character', 'Strong', 'Georgia')
+        ),
+      })
+    );
+    expect(session.renderedFontFamilies()).toEqual(['Cambria', 'Georgia']);
+  });
+
+  test('absent style references fall to the w:default="1" style of the type', () => {
+    const session = open(
+      docx({
+        body: '<w:p><w:r><w:t>bare</w:t></w:r></w:p>',
+        styles: styles(
+          `<w:style w:type="paragraph" w:default="1" w:styleId="Normal">` +
+            '<w:rPr><w:rFonts w:ascii="Aptos" w:hAnsi="Aptos"/></w:rPr></w:style>' +
+            // The default CHARACTER style stands in for absent rStyle too.
+            `<w:style w:type="character" w:default="1" w:styleId="DPF">` +
+            '<w:rPr><w:rFonts w:ascii="Consolas"/></w:rPr></w:style>'
+        ),
+      })
+    );
+    expect(session.renderedFontFamilies()).toEqual(['Aptos', 'Consolas']);
+  });
+
+  test('a text-bearing table brings its tblStyle chain and conditional formats', () => {
+    const table = (styleRef: string) =>
+      `<w:tbl>${styleRef}<w:tr><w:tc><w:p><w:r><w:t>cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl>`;
+    const session = open(
+      docx({
+        body: table('<w:tblPr><w:tblStyle w:val="Grid"/></w:tblPr>'),
+        styles: styles(
+          `<w:style w:type="table" w:styleId="Grid">` +
+            '<w:rPr><w:rFonts w:ascii="Verdana" w:hAnsi="Verdana"/></w:rPr>' +
+            '<w:tblStylePr w:type="firstRow"><w:rPr><w:rFonts w:ascii="Impact"/></w:rPr></w:tblStylePr>' +
+            '</w:style>' +
+            styleWithFont('table', 'UnusedGrid', 'Segoe UI')
+        ),
+      })
+    );
+    expect(session.renderedFontFamilies()).toEqual(['Impact', 'Verdana']);
+  });
+
+  test('theme slot references resolve to the theme faces', () => {
+    const result = readOoxmlPart(
+      `<w:document xmlns:w="${W}"><w:body><w:p><w:r><w:rPr>` +
+        '<w:rFonts w:asciiTheme="minorHAnsi" w:hAnsiTheme="minorHAnsi"/>' +
+        '</w:rPr><w:t>themed</w:t></w:r></w:p></w:body></w:document>',
+      { name: '/word/document.xml', contentType: 'app/xml' }
+    );
+    if (!result.ok) throw new Error(result.reason);
+    expect(
+      collectRenderedFontFamilies([result.part.root], null, {
+        major: 'Aptos Display',
+        minor: 'Aptos',
+      })
+    ).toEqual(['Aptos']);
+    // Without theme faces the reference contributes nothing.
+    expect(
+      collectRenderedFontFamilies([result.part.root], null, { major: null, minor: null })
+    ).toEqual([]);
+  });
+
+  test('text in a referenced header counts', () => {
+    const session = open(
+      docx({
+        body: `<w:p/><w:sectPr><w:headerReference xmlns:r="${R}" w:type="default" r:id="rId11"/></w:sectPr>`,
+        header: `<w:hdr xmlns:w="${W}"><w:p>${run('Impact', 'head')}</w:p></w:hdr>`,
+      })
+    );
+    expect(session.renderedFontFamilies()).toEqual(['Impact']);
+  });
+
+  test('memoized per revision; the first typed character moves the answer', () => {
+    const session = open(
+      docx({
+        body: '<w:p/>',
+        styles: styles(
+          '<w:docDefaults><w:rPrDefault><w:rPr><w:rFonts w:ascii="Calibri" w:hAnsi="Calibri"/></w:rPr></w:rPrDefault></w:docDefaults>'
+        ),
+      })
+    );
+    const first = session.renderedFontFamilies();
+    expect(first).toEqual([]);
+    expect(session.renderedFontFamilies()).toBe(first);
+    const [paragraphId] = session.paragraphIds();
+    const applied = session.applyTreeOps([
+      { op: 'insertText', paragraphId: paragraphId!, offset: 0, text: 'Z' },
+    ]);
+    expect(applied.committed).toBe(true);
+    expect(session.renderedFontFamilies()).toEqual(['Calibri']);
+  });
+
+  test('hostile names are dropped at the derivation boundary', () => {
+    const long = 'A'.repeat(500);
+    const session = open(
+      docx({
+        body: `<w:p>${run(long, 'a')}${run('Bad&#x09;Name', 'b')}${run('Calibri', 'c')}</w:p>`,
+      })
+    );
+    expect(session.renderedFontFamilies()).toEqual(['Calibri']);
+  });
+
+  test('a glyph mark without w:t still counts its run: note marks render in a face', () => {
+    // A footnote reference mark's run carries rFonts (or an rStyle chain) and no w:t.
+    // The mark visibly renders, so its families must not vanish from the notice.
+    const session = open(
+      docx({
+        body:
+          '<w:p><w:r><w:rPr><w:rFonts w:ascii="Marker Face" w:hAnsi="Marker Face"/>' +
+          '<w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteRef/></w:r></w:p>',
+        styles: styles(styleWithFont('character', 'FootnoteReference', 'Georgia')),
+      })
+    );
+    expect(session.renderedFontFamilies()).toEqual(['Georgia', 'Marker Face']);
+  });
+
+  test('a duplicated styleId resolves to the LAST definition, matching layout', () => {
+    const session = open(
+      docx({
+        body: `<w:p><w:pPr><w:pStyle w:val="Body"/></w:pPr><w:r><w:t>text</w:t></w:r></w:p>`,
+        styles: styles(
+          styleWithFont('paragraph', 'Body', 'FontA') + styleWithFont('paragraph', 'Body', 'FontB')
+        ),
+      })
+    );
+    // Layout's `buildStyleCascadeTable` paints from the last duplicate; the notice must
+    // check the same definition.
+    expect(session.renderedFontFamilies()).toEqual(['FontB']);
+  });
+
+  test('a later duplicate without w:default clears the default claim', () => {
+    const session = open(
+      docx({
+        body: '<w:p><w:r><w:t>bare</w:t></w:r></w:p>',
+        styles: styles(
+          `<w:style w:type="paragraph" w:default="1" w:styleId="Normal">` +
+            '<w:rPr><w:rFonts w:ascii="FontA"/></w:rPr></w:style>' +
+            styleWithFont('paragraph', 'Normal', 'FontB')
+        ),
+      })
+    );
+    // No default paragraph style remains, so the bare paragraph resolves to docDefaults
+    // alone (which name nothing here) — the same answer layout gives.
+    expect(session.renderedFontFamilies()).toEqual([]);
+  });
+
+  test('a bare w:t outside any run never counts, whatever the child count', () => {
+    // Invalid-but-parseable shape: a paragraph holding a stray w:t not wrapped in a run.
+    // Layout paints runs, so neither the narrow nor the wide (compose-path) paragraph may
+    // count it — the two walk paths must give one answer.
+    const stray = '<w:pPr><w:pStyle w:val="X"/></w:pPr><w:t>stray</w:t>';
+    const padding = '<w:bookmarkStart w:id="1" w:name="b"/>'.repeat(20);
+    const narrow = open(
+      docx({
+        body: `<w:p>${stray}</w:p><w:p>${run('Garamond', 'real')}</w:p>`,
+        styles: styles(styleWithFont('paragraph', 'X', 'Segoe UI')),
+      })
+    );
+    const wide = open(
+      docx({
+        body: `<w:p>${stray}${padding}</w:p><w:p>${run('Garamond', 'real')}</w:p>`,
+        styles: styles(styleWithFont('paragraph', 'X', 'Segoe UI')),
+      })
+    );
+    expect(narrow.renderedFontFamilies()).toEqual(['Garamond']);
+    expect(wide.renderedFontFamilies()).toEqual(narrow.renderedFontFamilies());
+  });
+
+  test('a basedOn cycle terminates and still answers', () => {
+    const session = open(
+      docx({
+        body: `<w:p><w:pPr><w:pStyle w:val="A"/></w:pPr><w:r><w:t>text</w:t></w:r></w:p>`,
+        styles: styles(
+          `<w:style w:type="paragraph" w:styleId="A"><w:basedOn w:val="B"/></w:style>` +
+            `<w:style w:type="paragraph" w:styleId="B"><w:basedOn w:val="A"/>` +
+            '<w:rPr><w:rFonts w:ascii="Georgia"/></w:rPr></w:style>'
+        ),
+      })
+    );
+    expect(session.renderedFontFamilies()).toEqual(['Georgia']);
+  });
+});

--- a/packages/core/src/binding/document-rendered-fonts.ts
+++ b/packages/core/src/binding/document-rendered-fonts.ts
@@ -1,0 +1,438 @@
+// Which font families the document's RENDERED text resolves to.
+//
+// `collectDocumentFonts` answers what the document DECLARES — every `w:rFonts` anywhere,
+// including styles no paragraph references. That is what a font picker wants and exactly
+// what a substitution notice must not use: Word writes latent styles (`BalloonText` names
+// Segoe UI in nearly every file) into documents that never render a character in them, and
+// a notice built on declarations warns about faces with no glyph behind them.
+//
+// This derivation mirrors what layout will actually ask the measurer for. A run renders in
+// ONE Latin family (`run-style.ts`: theme slot ?? `w:ascii` ?? `w:hAnsi`), resolved through
+// the cascade layout applies: direct run `w:rFonts`, the `w:rStyle` chain, the `w:pStyle`
+// chain, the enclosing table's `w:tblStyle` chain, then `w:docDefaults` — with the
+// `w:default="1"` style of each type standing in where the reference is absent
+// (`style-cascade.ts` resolves absent `pStyle`/`rStyle`/`tblStyle` the same way).
+//
+// Deliberate bounds, all on the over-reporting side, never hiding a rendered face:
+// - The chains of every USED style contribute even when a nearer level overrides them, and
+//   `docDefaults` contributes whenever any text renders. Tracking per-run fall-through
+//   would re-run the full cascade here; a shadowed family is at worst a spurious notice
+//   entry, and in practice `docDefaults` names a covered Word default.
+// - A used table style contributes its `w:tblStylePr` conditional-format families without
+//   evaluating `w:tblLook` — a first-row face usually does render.
+// - Only paragraphs, runs and tables that contain a GLYPH-BEARING run count — literal
+//   `w:t`/`w:delText` text or a mark element the run's face paints (`w:footnoteRef`,
+//   `w:sym`, `w:tab`, …). An empty paragraph's mark metrics do move layout, but the
+//   notice's contract is "text renders in the wrong face".
+
+import type { OoxmlElement, OoxmlNode } from '../store/package/ooxml-tree.ts';
+import { WML_NAMESPACE_URI } from '../store/package/ooxml-shared.ts';
+import type { DocumentThemeFonts } from './document-theme.ts';
+import { familyFromRFonts, validStyleId } from './document-run-defaults.ts';
+
+/** `basedOn` walk cap, matching `document-run-defaults`. */
+const CHAIN_CAP = 16;
+/**
+ * Containers at least this wide compose from their children's memos instead of walking —
+ * the same shape as `collectDocumentFonts`, so a keystroke re-derives only the edited path.
+ */
+const COMPOSE_CHILD_THRESHOLD = 16;
+/** Compose recursion stops here; deeper subtrees take the iterative terminal walk. */
+const MAX_COMPOSE_DEPTH = 32;
+/**
+ * Direct `w:style` children cap — the same bound as `MAX_STYLE_DEFINITIONS` in
+ * `layout/style-cascade.ts` (kept by value: `binding` does not import the layout lane).
+ */
+const MAX_STYLE_DEFINITIONS = 4096;
+
+function isElement(node: OoxmlNode): node is OoxmlElement {
+  return node.kind !== 'textValue';
+}
+
+function childElement(parent: OoxmlElement, localName: string): OoxmlElement | undefined {
+  for (const child of parent.children as readonly OoxmlNode[]) {
+    if (isElement(child) && child.localName === localName) return child;
+  }
+  return undefined;
+}
+
+function attributeValue(node: OoxmlElement, localName: string): string | undefined {
+  return node.attributes.find((attribute) => attribute.localName === localName)?.value;
+}
+
+/** `w:style/@w:default` — `ST_OnOff`, so `on` is legal alongside `1` and `true`. */
+function isDefaultFlag(value: string | undefined): boolean {
+  return value === '1' || value === 'true' || value === 'on';
+}
+
+/** What one subtree's rendered text uses. Composes by union across sibling subtrees. */
+interface RenderedFontsSummary {
+  /** Case-fold → first-seen spelling, from the direct `w:rFonts` of text-bearing runs. */
+  readonly families: ReadonlyMap<string, string>;
+  /**
+   * Style ids referenced where text renders: `w:rStyle` of text runs, `w:pStyle` of text
+   * paragraphs, `w:tblStyle` of tables containing text.
+   */
+  readonly styleIds: ReadonlySet<string>;
+  /** Any glyph-bearing run in the subtree ({@link runRendersGlyphs}). */
+  readonly anyText: boolean;
+  /** A text paragraph without `w:pStyle` — the default paragraph style stands in. */
+  readonly bareParagraph: boolean;
+  /** A text run without `w:rStyle` — the default character style stands in. */
+  readonly bareRun: boolean;
+  /** A text-bearing table without `w:tblStyle` — the default table style stands in. */
+  readonly bareTable: boolean;
+}
+
+interface MutableSummary {
+  families: Map<string, string>;
+  styleIds: Set<string>;
+  anyText: boolean;
+  bareParagraph: boolean;
+  bareRun: boolean;
+  bareTable: boolean;
+}
+
+function createSummary(): MutableSummary {
+  return {
+    families: new Map(),
+    styleIds: new Set(),
+    anyText: false,
+    bareParagraph: false,
+    bareRun: false,
+    bareTable: false,
+  };
+}
+
+function mergeSummary(into: MutableSummary, from: RenderedFontsSummary): void {
+  for (const [fold, family] of from.families) {
+    if (!into.families.has(fold)) into.families.set(fold, family);
+  }
+  for (const id of from.styleIds) into.styleIds.add(id);
+  into.anyText ||= from.anyText;
+  into.bareParagraph ||= from.bareParagraph;
+  into.bareRun ||= from.bareRun;
+  into.bareTable ||= from.bareTable;
+}
+
+function addFamily(families: Map<string, string>, family: string | null): void {
+  // `familyFromRFonts` (and the style index built on it) already validated the name.
+  if (family === null) return;
+  const fold = family.toLowerCase();
+  if (!families.has(fold)) families.set(fold, family);
+}
+
+/**
+ * Run children that paint a glyph in the RUN's face without carrying text: note reference
+ * marks, symbol runs (their `w:font` face is a pre-existing `collectDocumentFonts` gap,
+ * but the run's own `w:rFonts`/`w:rStyle` still resolve the surrounding face), tabs
+ * (leader dots measure in the run face) and hyphens. `w:br` paints nothing;
+ * `w:instrText` is never painted — the field RESULT runs are.
+ */
+const GLYPH_MARKS: ReadonlySet<string> = new Set([
+  'sym',
+  'tab',
+  'noBreakHyphen',
+  'softHyphen',
+  'footnoteRef',
+  'endnoteRef',
+  'footnoteReference',
+  'endnoteReference',
+]);
+
+/**
+ * Whether a `w:r` puts a glyph on the page: a non-empty `w:t`, a `w:delText` (tracked
+ * deletions render in markup view — over-reporting in final view, never hiding), or a
+ * glyph mark element.
+ */
+function runRendersGlyphs(run: OoxmlElement): boolean {
+  for (const child of run.children as readonly OoxmlNode[]) {
+    if (!isElement(child) || child.namespaceUri !== WML_NAMESPACE_URI) continue;
+    if (GLYPH_MARKS.has(child.localName)) return true;
+    if (child.localName !== 't' && child.localName !== 'delText') continue;
+    for (const grand of child.children as readonly OoxmlNode[]) {
+      if (!isElement(grand) && grand.value.length > 0) return true;
+    }
+  }
+  return false;
+}
+
+/** Whether any descendant `w:r` renders glyphs — the terminal-path block answer. */
+function subtreeHasGlyphRun(subtree: OoxmlElement): boolean {
+  const stack: OoxmlNode[] = [subtree];
+  while (stack.length > 0) {
+    const node = stack.pop()!;
+    if (!isElement(node)) continue;
+    if (node.localName === 'r' && node.namespaceUri === WML_NAMESPACE_URI) {
+      if (runRendersGlyphs(node)) return true;
+      continue;
+    }
+    for (const child of node.children as readonly OoxmlNode[]) stack.push(child);
+  }
+  return false;
+}
+
+function applyRun(
+  run: OoxmlElement,
+  summary: MutableSummary,
+  themeFonts: DocumentThemeFonts
+): void {
+  if (!runRendersGlyphs(run)) return;
+  summary.anyText = true;
+  const rPr = childElement(run, 'rPr');
+  const rFonts = rPr ? childElement(rPr, 'rFonts') : undefined;
+  if (rFonts) addFamily(summary.families, familyFromRFonts(rFonts, themeFonts));
+  const rStyle = rPr ? childElement(rPr, 'rStyle') : undefined;
+  const styleId = validStyleId(rStyle ? attributeValue(rStyle, 'val') : undefined);
+  if (styleId !== null) summary.styleIds.add(styleId);
+  else summary.bareRun = true;
+}
+
+/**
+ * Record a text-bearing paragraph's or table's style reference. `containsText` is the
+ * subtree answer — merged child summaries on the compose path, a bounded early-exit scan
+ * on the terminal path.
+ */
+function applyBlock(block: OoxmlElement, summary: MutableSummary, containsText: boolean): void {
+  if (!containsText) return;
+  const isTable = block.localName === 'tbl';
+  const properties = childElement(block, isTable ? 'tblPr' : 'pPr');
+  const reference = properties
+    ? childElement(properties, isTable ? 'tblStyle' : 'pStyle')
+    : undefined;
+  const styleId = validStyleId(reference ? attributeValue(reference, 'val') : undefined);
+  if (styleId !== null) summary.styleIds.add(styleId);
+  else if (isTable) summary.bareTable = true;
+  else summary.bareParagraph = true;
+}
+
+function isStyledBlock(node: OoxmlElement): boolean {
+  return (
+    (node.localName === 'p' || node.localName === 'tbl') && node.namespaceUri === WML_NAMESPACE_URI
+  );
+}
+
+function applyNode(
+  node: OoxmlElement,
+  summary: MutableSummary,
+  themeFonts: DocumentThemeFonts,
+  containsText: boolean
+): void {
+  if (node.namespaceUri !== WML_NAMESPACE_URI) return;
+  if (node.localName === 'r') applyRun(node, summary, themeFonts);
+  else if (isStyledBlock(node)) applyBlock(node, summary, containsText);
+}
+
+interface SummaryMemo {
+  readonly major: string | null;
+  readonly minor: string | null;
+  readonly summary: RenderedFontsSummary;
+}
+const summaryMemos = new WeakMap<OoxmlElement, SummaryMemo>();
+
+function summaryOf(
+  subtree: OoxmlElement,
+  themeFonts: DocumentThemeFonts,
+  depth: number
+): RenderedFontsSummary {
+  const cached = summaryMemos.get(subtree);
+  if (cached && cached.major === themeFonts.major && cached.minor === themeFonts.minor) {
+    return cached.summary;
+  }
+  const summary = createSummary();
+  if (subtree.children.length >= COMPOSE_CHILD_THRESHOLD && depth < MAX_COMPOSE_DEPTH) {
+    for (const child of subtree.children as readonly OoxmlNode[]) {
+      if (!isElement(child)) continue;
+      mergeSummary(summary, summaryOf(child, themeFonts, depth + 1));
+    }
+    applyNode(subtree, summary, themeFonts, summary.anyText);
+  } else {
+    // Iterative: the parse bounds tree depth, but this derivation must not be the one
+    // place a deep generic subtree can overflow the call stack. Children push in reverse
+    // so first-seen casing means the first occurrence a reader would see.
+    const stack: OoxmlNode[] = [subtree];
+    while (stack.length > 0) {
+      const node = stack.pop()!;
+      if (!isElement(node)) continue;
+      // Only the paragraph/table handler needs the subtree answer. The scan exits at the
+      // first glyph-bearing run, so the common case reads one run — and it asks the SAME
+      // question `applyRun` answers on the compose path, so a block's contribution never
+      // depends on which path its child count selects.
+      const containsText = isStyledBlock(node) && subtreeHasGlyphRun(node);
+      applyNode(node, summary, themeFonts, containsText);
+      for (let i = node.children.length - 1; i >= 0; i -= 1) stack.push(node.children[i]!);
+    }
+  }
+  summaryMemos.set(subtree, { major: themeFonts.major, minor: themeFonts.minor, summary });
+  return summary;
+}
+
+// ── Styles part index ────────────────────────────────────────────────────────────────────
+
+interface StyleIndexEntry {
+  readonly basedOn: string | null;
+  readonly family: string | null;
+  /** Families named by `w:tblStylePr` conditional-format `w:rPr/w:rFonts`. */
+  readonly conditionalFamilies: readonly string[];
+}
+
+interface StyleIndex {
+  readonly docDefaultFamily: string | null;
+  readonly defaultParagraph: string | null;
+  readonly defaultCharacter: string | null;
+  readonly defaultTable: string | null;
+  /**
+   * The families a style reference can render: the nearest `basedOn`-chain family (deeper
+   * ones are shadowed for the Latin slot) plus every conditional-format family along the
+   * chain. Cycle-safe, capped at {@link CHAIN_CAP}.
+   */
+  chainFamilies(styleId: string | null): readonly string[];
+}
+
+const EMPTY_STYLE_INDEX: StyleIndex = {
+  docDefaultFamily: null,
+  defaultParagraph: null,
+  defaultCharacter: null,
+  defaultTable: null,
+  chainFamilies: () => [],
+};
+
+interface StyleIndexMemo {
+  readonly major: string | null;
+  readonly minor: string | null;
+  readonly index: StyleIndex;
+}
+const styleIndexMemos = new WeakMap<OoxmlElement, StyleIndexMemo>();
+
+function rPrFamily(container: OoxmlElement, themeFonts: DocumentThemeFonts): string | null {
+  const rPr = childElement(container, 'rPr');
+  const rFonts = rPr ? childElement(rPr, 'rFonts') : undefined;
+  return rFonts ? familyFromRFonts(rFonts, themeFonts) : null;
+}
+
+function buildStyleIndex(stylesRoot: OoxmlElement, themeFonts: DocumentThemeFonts): StyleIndex {
+  const entries = new Map<string, StyleIndexEntry>();
+  let docDefaultFamily: string | null = null;
+  let defaultParagraph: string | null = null;
+  let defaultCharacter: string | null = null;
+  let defaultTable: string | null = null;
+
+  const docDefaults = childElement(stylesRoot, 'docDefaults');
+  const rPrDefault = docDefaults ? childElement(docDefaults, 'rPrDefault') : undefined;
+  if (rPrDefault) docDefaultFamily = rPrFamily(rPrDefault, themeFonts);
+
+  let counted = 0;
+  for (const child of stylesRoot.children as readonly OoxmlNode[]) {
+    if (!isElement(child) || child.localName !== 'style') continue;
+    if (counted >= MAX_STYLE_DEFINITIONS) break;
+    counted += 1;
+    const styleId = validStyleId(attributeValue(child, 'styleId'));
+    if (styleId === null) continue;
+    const basedOnElement = childElement(child, 'basedOn');
+    const conditionalFamilies: string[] = [];
+    for (const condition of child.children as readonly OoxmlNode[]) {
+      if (!isElement(condition) || condition.localName !== 'tblStylePr') continue;
+      const family = rPrFamily(condition, themeFonts);
+      if (family !== null) conditionalFamilies.push(family);
+    }
+    // Last duplicate wins, and a later duplicate that is not the default CLEARS a default
+    // the earlier one claimed — both matching `buildStyleCascadeTable` in
+    // `layout/style-cascade.ts`, so the notice checks the definition layout paints from.
+    entries.set(styleId, {
+      basedOn: validStyleId(basedOnElement ? attributeValue(basedOnElement, 'val') : undefined),
+      family: rPrFamily(child, themeFonts),
+      conditionalFamilies,
+    });
+    const isDefault = isDefaultFlag(attributeValue(child, 'default'));
+    const type = attributeValue(child, 'type');
+    if (type === 'paragraph') {
+      if (isDefault) defaultParagraph = styleId;
+      else if (defaultParagraph === styleId) defaultParagraph = null;
+    } else if (type === 'character') {
+      if (isDefault) defaultCharacter = styleId;
+      else if (defaultCharacter === styleId) defaultCharacter = null;
+    } else if (type === 'table') {
+      if (isDefault) defaultTable = styleId;
+      else if (defaultTable === styleId) defaultTable = null;
+    }
+  }
+
+  const chainMemo = new Map<string, readonly string[]>();
+  const chainFamilies = (styleId: string | null): readonly string[] => {
+    if (styleId === null) return [];
+    const cached = chainMemo.get(styleId);
+    if (cached) return cached;
+    const families: string[] = [];
+    let nearest: string | null = null;
+    const seen = new Set<string>();
+    let at: string | null = styleId;
+    for (let hop = 0; at !== null && hop < CHAIN_CAP && !seen.has(at); hop += 1) {
+      seen.add(at);
+      const entry = entries.get(at);
+      if (!entry) break;
+      nearest ??= entry.family;
+      families.push(...entry.conditionalFamilies);
+      at = entry.basedOn;
+    }
+    if (nearest !== null) families.unshift(nearest);
+    chainMemo.set(styleId, families);
+    return families;
+  };
+
+  return { docDefaultFamily, defaultParagraph, defaultCharacter, defaultTable, chainFamilies };
+}
+
+function styleIndexOf(stylesRoot: OoxmlElement | null, themeFonts: DocumentThemeFonts): StyleIndex {
+  if (!stylesRoot) return EMPTY_STYLE_INDEX;
+  const cached = styleIndexMemos.get(stylesRoot);
+  if (cached && cached.major === themeFonts.major && cached.minor === themeFonts.minor) {
+    return cached.index;
+  }
+  const index = buildStyleIndex(stylesRoot, themeFonts);
+  styleIndexMemos.set(stylesRoot, { major: themeFonts.major, minor: themeFonts.minor, index });
+  return index;
+}
+
+// ── Entry point ──────────────────────────────────────────────────────────────────────────
+
+/**
+ * The font families the document's rendered text resolves to, over the STORY roots (body,
+ * headers/footers, notes — never the styles part itself): validated, deduplicated
+ * case-insensitively (first-seen casing wins), sorted by code point. A document that
+ * renders no character answers `[]`, whatever it declares.
+ */
+export function collectRenderedFontFamilies(
+  storyRoots: readonly OoxmlElement[],
+  stylesRoot: OoxmlElement | null,
+  themeFonts: DocumentThemeFonts
+): readonly string[] {
+  const summary = createSummary();
+  for (const root of storyRoots) {
+    // The root element is never a run or a styled block; its children carry the memo.
+    for (const child of root.children as readonly OoxmlNode[]) {
+      if (!isElement(child)) continue;
+      mergeSummary(summary, summaryOf(child, themeFonts, 0));
+    }
+  }
+
+  const index = styleIndexOf(stylesRoot, themeFonts);
+  const byFold = new Map<string, string>();
+  for (const family of summary.families.values()) addFamily(byFold, family);
+  for (const styleId of summary.styleIds) {
+    for (const family of index.chainFamilies(styleId)) addFamily(byFold, family);
+  }
+  if (summary.bareParagraph) {
+    for (const family of index.chainFamilies(index.defaultParagraph)) addFamily(byFold, family);
+  }
+  if (summary.bareRun) {
+    for (const family of index.chainFamilies(index.defaultCharacter)) addFamily(byFold, family);
+  }
+  if (summary.bareTable) {
+    for (const family of index.chainFamilies(index.defaultTable)) addFamily(byFold, family);
+  }
+  if (summary.anyText) addFamily(byFold, index.docDefaultFamily);
+
+  const families = [...byFold.values()];
+  families.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  return families;
+}

--- a/packages/core/src/binding/document-run-defaults.ts
+++ b/packages/core/src/binding/document-run-defaults.ts
@@ -53,7 +53,7 @@ function attributeValue(node: OoxmlElement, localName: string): string | undefin
   return node.attributes.find((attribute) => attribute.localName === localName)?.value;
 }
 
-function validStyleId(raw: string | undefined): string | null {
+export function validStyleId(raw: string | undefined): string | null {
   if (raw === undefined || raw.length === 0 || raw.length > STYLE_ID_MAX) return null;
   if (CONTROL_CHARS.test(raw)) return null;
   return raw;
@@ -79,7 +79,10 @@ function themeFamilyOf(value: string | undefined, themeFonts: DocumentThemeFonts
  * use. Reading it in preference would make this answer a different font from the one the
  * document is painted in, which is what the font box would then display.
  */
-function familyFromRFonts(rFonts: OoxmlElement, themeFonts: DocumentThemeFonts): string | null {
+export function familyFromRFonts(
+  rFonts: OoxmlElement,
+  themeFonts: DocumentThemeFonts
+): string | null {
   const themed =
     themeFamilyOf(attributeValue(rFonts, 'asciiTheme'), themeFonts) ??
     themeFamilyOf(attributeValue(rFonts, 'hAnsiTheme'), themeFonts);

--- a/packages/core/src/binding/tree-session-contract.ts
+++ b/packages/core/src/binding/tree-session-contract.ts
@@ -169,6 +169,17 @@ export interface TreeDocxSessionView {
    */
   documentFonts(): readonly string[];
   /**
+   * Font families the document's RENDERED text resolves to, over the story roots only:
+   * direct run `w:rFonts` of text-bearing runs plus the style chains those runs,
+   * paragraphs and tables actually reference — never a declaration in an unused style.
+   * Memoized per package revision.
+   *
+   * The font-substitution notice reads this one: `documentFonts` reports what the
+   * document DECLARES, and Word writes latent styles (Balloon Text naming Segoe UI)
+   * into documents that never render a character in them.
+   */
+  renderedFontFamilies(): readonly string[];
+  /**
    * Whether the document puts any literal character on a page, over the same roots
    * {@link TreeDocxSessionView.documentFonts} reads. Memoized per package revision.
    *

--- a/packages/core/src/binding/tree-session.ts
+++ b/packages/core/src/binding/tree-session.ts
@@ -78,6 +78,7 @@ import {
   paragraphStyleId,
   type DocumentOutlineEntry,
 } from './document-outline.ts';
+import { collectRenderedFontFamilies } from './document-rendered-fonts.ts';
 import { collectTextMatches, type DocumentSearchResult } from './document-search.ts';
 import {
   collectDocumentThemeColors,
@@ -426,24 +427,34 @@ export function openTreeSession(
   };
 
   let fontsCache: { readonly revision: number; readonly fonts: readonly string[] } | null = null;
+  let renderedFontsCache: {
+    readonly revision: number;
+    readonly styles: OoxmlElement | null;
+    readonly families: readonly string[];
+  } | null = null;
   let rendersTextCache: { readonly revision: number; readonly rendersText: boolean } | null = null;
   let stylesCache: readonly DocumentStyleEntry[] | null = null;
   let themeColorsCache: readonly DocumentThemeColorEntry[] | null = null;
   let themeFontsCache: DocumentThemeFonts | null = null;
   /**
-   * Live body, styles, headers, footers, and notes used by both document-wide catalogs.
-   * Including notes ensures their fonts load. Callers memoize each answer by package revision.
+   * Live body, headers, footers, and notes — the roots whose content RENDERS. Including
+   * notes ensures their fonts load. Callers memoize each answer by package revision.
    */
-  const catalogRoots = (): OoxmlElement[] => {
+  const storyCatalogRoots = (): OoxmlElement[] => {
     const roots: OoxmlElement[] = [bodyStore().part.root];
-    const styles = resolveStylesRoot();
-    if (styles) roots.push(styles);
     const seen = new Set<OoxmlPart>();
     for (const part of furnitureAndNoteParts()) {
       if (seen.has(part)) continue;
       seen.add(part);
       roots.push(part.root);
     }
+    return roots;
+  };
+  const catalogRoots = (): OoxmlElement[] => {
+    const roots = storyCatalogRoots();
+    const styles = resolveStylesRoot();
+    // Body first, then styles, then furniture — first-seen casing follows reading order.
+    if (styles) roots.splice(1, 0, styles);
     return roots;
   };
 
@@ -747,6 +758,30 @@ export function openTreeSession(
           ),
         };
         return fontsCache.fonts;
+      },
+
+      renderedFontFamilies() {
+        // Keyed on the package revision AND the styles root: `resolveStylesRoot` swaps the
+        // root by identity when the styles part is repaired or replaced, and the style
+        // chains this derivation walks live there.
+        const styles = resolveStylesRoot();
+        if (
+          renderedFontsCache &&
+          renderedFontsCache.revision === packageStore.packageRevision &&
+          renderedFontsCache.styles === styles
+        ) {
+          return renderedFontsCache.families;
+        }
+        renderedFontsCache = {
+          revision: packageStore.packageRevision,
+          styles,
+          families: collectRenderedFontFamilies(
+            storyCatalogRoots(),
+            styles,
+            collectDocumentThemeFonts(resolveThemeRoot())
+          ),
+        };
+        return renderedFontsCache.families;
       },
 
       rendersText() {

--- a/packages/core/src/editor/__tests__/font-substitution-notice.test.ts
+++ b/packages/core/src/editor/__tests__/font-substitution-notice.test.ts
@@ -20,6 +20,7 @@ import { GlobalRegistrator } from '@happy-dom/global-registrator';
 if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
 import { readFileSync } from 'node:fs';
 import { sha256FontBytes } from '../../layout/index.ts';
 import { blankDocumentBytes } from '../blank-document.ts';
@@ -75,6 +76,31 @@ afterAll(() => {
 const runIn = (family: string, text: string) =>
   `<w:p><w:r><w:rPr><w:rFonts w:ascii="${family}" w:hAnsi="${family}"/></w:rPr><w:t>${text}</w:t></w:r></w:p>`;
 
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT_NS = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL_NS = 'http://schemas.openxmlformats.org/package/2006/relationships';
+
+/** Like `docx(body)`, with a styles part carrying the given `w:style` elements. */
+function docxWithStyles(body: string, styleElements: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT_NS}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '<Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/></Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL_NS}"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL_NS}"><Relationship Id="rId10" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
+    ),
+    'word/styles.xml': strToU8(`<w:styles xmlns:w="${W}">${styleElements}</w:styles>`),
+  });
+}
+
 describe('font substitution notice', () => {
   test('a brand-new blank document reports no substitution', () => {
     installed = [];
@@ -101,6 +127,27 @@ describe('font substitution notice', () => {
     editor.destroy();
   });
 
+  test('a family declared only by an unused style is not reported', () => {
+    // Word writes latent styles into real files — Balloon Text names Segoe UI in nearly
+    // every document — and no rendered character resolves to them. The notice reads the
+    // RENDERED families, so the declaration stays in the picker and out of the warning.
+    installed = [];
+    const editor = createDocxEditor({
+      container: document.createElement('div'),
+      document: docxWithStyles(
+        runIn('Garamond', 'body text'),
+        '<w:style w:type="paragraph" w:styleId="BalloonText">' +
+          '<w:rPr><w:rFonts w:ascii="Segoe UI" w:hAnsi="Segoe UI"/></w:rPr></w:style>' +
+          '<w:style w:type="table" w:styleId="TableGrid1">' +
+          '<w:rPr><w:rFonts w:ascii="Times New Roman Bold"/></w:rPr></w:style>'
+      ),
+    });
+    // Both are still DECLARED — the picker reports them — but neither renders.
+    expect(editor.getDocumentFonts()).toContain('Segoe UI');
+    expect(editor.snapshot().fontSubstitutions ?? []).toEqual(['Garamond']);
+    editor.destroy();
+  });
+
   test('a document whose text renders in an unavailable face reports it', () => {
     installed = [];
     const editor = createDocxEditor({
@@ -108,6 +155,21 @@ describe('font substitution notice', () => {
       document: docx(runIn('Garamond', 'body text')),
     });
     expect(editor.snapshot().fontSubstitutions ?? []).toContain('Garamond');
+    editor.destroy();
+  });
+
+  test('a document whose only glyphs are marks still reports their face', () => {
+    // No w:t anywhere: the only rendered glyph is a note-reference-style mark whose run
+    // names a face. A literal-text pre-gate would hide it; the derivation must not.
+    installed = [];
+    const editor = createDocxEditor({
+      container: document.createElement('div'),
+      document: docx(
+        '<w:p><w:r><w:rPr><w:rFonts w:ascii="Marker Face" w:hAnsi="Marker Face"/></w:rPr>' +
+          '<w:noBreakHyphen/></w:r></w:p>'
+      ),
+    });
+    expect(editor.snapshot().fontSubstitutions ?? []).toEqual(['Marker Face']);
     editor.destroy();
   });
 

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -401,14 +401,11 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
    * at resolution, so a file whose own fonts are arriving must not flash a notice first.
    *
    * The notice reads `renderedFontFamilies()`, never `documentFonts()`: a family joins it
-   * only when a rendered glyph resolves to it through the style cascade. A declaration
-   * alone renders nothing — Word's `w:docDefaults` declares Calibri over a brand-new
-   * empty document, and its latent Balloon Text style names Segoe UI in files that never
-   * render a character in either — so a declaration-based notice warned about text that
-   * does not exist. A brand-new blank document answers `[]` for the same reason, and the
-   * first typed character moves the answer. No `rendersText()` gate on top: it counts
-   * only literal `w:t`, and a stricter pre-gate would hide a document whose only glyphs
-   * are marks (note references, tab leaders) rendering in a substitute face.
+   * only when a rendered glyph resolves to it through the style cascade, so a declaration
+   * with no glyph behind it (a blank document's `w:docDefaults` Calibri, a latent Balloon
+   * Text style) answers `[]` and the first typed character moves the answer. No
+   * `rendersText()` gate on top: it counts only literal `w:t` and would hide a document
+   * whose only glyphs are marks (note references, tab leaders) in a substitute face.
    */
   const deriveFontSubstitutions = (): readonly string[] => {
     if (!surface || fontsResolving) return EMPTY_FONT_SUBSTITUTIONS;

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -400,18 +400,20 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
    * While font work is still in flight the answer would flicker: embedded faces register
    * at resolution, so a file whose own fonts are arriving must not flash a notice first.
    *
-   * A document that renders no character has nothing a substitute face could get wrong.
-   * That is not a special case for the blank template but the notice's own definition:
-   * `documentFonts()` reports DECLARED families, and Word's `w:docDefaults` declares
-   * Calibri over a document with no runs at all — so the first thing a user saw on a page
-   * they had just created was a warning about text that does not exist. The gate lifts on
-   * the first typed character, when the claim becomes true.
+   * The notice reads `renderedFontFamilies()`, never `documentFonts()`: a family joins it
+   * only when a rendered glyph resolves to it through the style cascade. A declaration
+   * alone renders nothing — Word's `w:docDefaults` declares Calibri over a brand-new
+   * empty document, and its latent Balloon Text style names Segoe UI in files that never
+   * render a character in either — so a declaration-based notice warned about text that
+   * does not exist. A brand-new blank document answers `[]` for the same reason, and the
+   * first typed character moves the answer. No `rendersText()` gate on top: it counts
+   * only literal `w:t`, and a stricter pre-gate would hide a document whose only glyphs
+   * are marks (note references, tab leaders) rendering in a substitute face.
    */
   const deriveFontSubstitutions = (): readonly string[] => {
     if (!surface || fontsResolving) return EMPTY_FONT_SUBSTITUTIONS;
-    if (!surface.session.rendersText()) return EMPTY_FONT_SUBSTITUTIONS;
     return detectFontSubstitutions(
-      surface.session.documentFonts(),
+      surface.session.renderedFontFamilies(),
       fontFamilyCovered,
       probeLocalFont
     );


### PR DESCRIPTION
The notice reported every declared `w:rFonts` family. Word writes latent styles into most files — Balloon Text names Segoe UI — so documents showed a substitution warning for faces no character renders in.

The notice now reads `renderedFontFamilies()`, a new session derivation that resolves rendered glyphs through the style cascade: direct run `w:rFonts`, the `w:rStyle`, `w:pStyle`, and `w:tblStyle` chains with their `w:default="1"` stand-ins, then `w:docDefaults`. Declarations in unused styles stay in the font picker and out of the notice. Duplicate style ids resolve last-wins, matching the layout cascade, and the derivation memoizes per subtree so typing cost is unchanged.

`documentFonts()` keeps its declared-family answer for the picker and the on-demand resolver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790599904&installation_model_id=422592&pr_number=613&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F613&signature=5aa9f5b279555b44db1056f53d94e1736860b192d9b990e3c904fb6d9baad1f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->