### PR TITLE
feat: refresh REF results inside footnotes and endnotes on save

### DIFF
--- a/.changeset/note-ref-save-refresh.md
+++ b/.changeset/note-ref-save-refresh.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Saving now refreshes stale REF field results inside footnotes and endnotes, so the exported note parts carry the values the pages paint. Fixes #611

--- a/.changeset/note-ref-save-refresh.md
+++ b/.changeset/note-ref-save-refresh.md
@@ -1,5 +1,5 @@
 ---
-'@docx-editor.dev/core': patch
+'@docx-editor.dev/core': minor
 ---
 
-Saving now refreshes stale REF field results inside footnotes and endnotes, so the exported note parts carry the values the pages paint. Fixes #611
+Saving now refreshes stale REF field results inside footnotes and endnotes as one undoable transaction with the body, so the exported note parts carry the values the pages paint; a field inside a locked or data-bound content control keeps its cached result without blocking the others, and collaborative sessions keep exporting cached results. Fixes #611

--- a/docs/api/docx-editor-core/binding.api.md
+++ b/docs/api/docx-editor-core/binding.api.md
@@ -119,6 +119,10 @@ export interface TreeDocxSessionView {
     applyFragmentPaste(scope: StoryScope, input: FragmentPasteInput): FragmentPasteResult;
     applyImageProperties(scope: StoryScope, input: ApplyImagePropertiesInput): ImageIntentResult;
     applyTreeOps(ops: readonly TreeDocOp[], selectionBefore?: SelectionMark | null, selectionAfter?: SelectionMark | null, scope?: StoryScope, options?: TreeApplyOptions): TreeApplyResult;
+    applyTreeOpsAtomic(groups: readonly {
+        readonly ops: readonly TreeDocOp[];
+        readonly scope: StoryScope;
+    }[], options?: TreeApplyOptions): TreeApplyResult;
     // (undocumented)
     beginComposition(scope?: StoryScope): void;
     bodyText(): string;

--- a/docs/api/docx-editor-core/editor.api.md
+++ b/docs/api/docx-editor-core/editor.api.md
@@ -2287,6 +2287,10 @@ export interface TreeDocxSessionView {
     applyFragmentPaste(scope: StoryScope, input: FragmentPasteInput): FragmentPasteResult;
     applyImageProperties(scope: StoryScope, input: ApplyImagePropertiesInput): ImageIntentResult;
     applyTreeOps(ops: readonly TreeDocOp[], selectionBefore?: SelectionMark | null, selectionAfter?: SelectionMark | null, scope?: StoryScope, options?: TreeApplyOptions): TreeApplyResult;
+    applyTreeOpsAtomic(groups: readonly {
+        readonly ops: readonly TreeDocOp[];
+        readonly scope: StoryScope;
+    }[], options?: TreeApplyOptions): TreeApplyResult;
     // (undocumented)
     beginComposition(scope?: StoryScope): void;
     bodyText(): string;

--- a/packages/core/src/__tests__/part-for-call-sites.test.ts
+++ b/packages/core/src/__tests__/part-for-call-sites.test.ts
@@ -28,7 +28,10 @@ const PINNED_CALL_SITES: Readonly<Record<string, number>> = {
   'core/src/automation/server-host.ts': 2,
   'core/src/binding/tree-session.ts': 5, // the facade definition moved to tree-session-contract.ts
   'core/src/binding/tree-session-contract.ts': 1, // the session view's partFor declaration
-  'core/src/binding/tree-session-apply.ts': 1,
+  // Two writes: the collaboration part-name resolution, and the atomic multi-story commit
+  // resolving each extra group's part BEFORE its transaction writes it — the slot is spent
+  // by the write either way.
+  'core/src/binding/tree-session-apply.ts': 2,
   'core/src/editor/doc-target-resolution.ts': 2,
   'core/src/editor/docx-editor-derive.ts': 1,
   'core/src/editor/docx-editor-images.ts': 1,

--- a/packages/core/src/binding/tree-session-apply.ts
+++ b/packages/core/src/binding/tree-session-apply.ts
@@ -15,6 +15,59 @@ function refused(opCount: number, reason?: string): TreeApplyResult {
     : { committed: false, rejected: true, opCount, reason };
 }
 
+/** One story's ops for {@link commitSessionTreeOpsAtomic}. */
+export interface StoryOpsGroup {
+  readonly scope: StoryScope;
+  readonly ops: readonly TreeDocOp[];
+}
+
+/**
+ * Commit several stories' ops as ONE transaction and ONE undo unit.
+ *
+ * The transaction opens on the first group's scope; every other group applies through the
+ * context's cross-part channel (`ctx.applyTo`), the same shape a comment write uses for its
+ * story markers plus `comments.xml`. Any refusal — validation, protection, an unknown part —
+ * rolls the WHOLE working set back, so a caller can never observe some groups committed and
+ * others not, and a single undo restores every part. Lifecycle ops do not belong here: they
+ * run their own coordinator lane.
+ */
+export function commitSessionTreeOpsAtomic(
+  packageStore: TreePackageStore,
+  groups: readonly StoryOpsGroup[],
+  options: TreeApplyOptions = {}
+): TreeApplyResult {
+  const nonEmpty = groups.filter((group) => group.ops.length > 0);
+  const opCount = nonEmpty.reduce((sum, group) => sum + group.ops.length, 0);
+  if (opCount === 0) return EMPTY_APPLY;
+  if (nonEmpty.some((group) => group.ops.some(isHeaderFooterLifecycleOp))) {
+    return refused(opCount, 'invalidArgs');
+  }
+  if (nonEmpty.some((group) => group.ops.some(isNoteLifecycleOp))) {
+    return refused(opCount, 'invalidArgs');
+  }
+  const [primary, ...rest] = nonEmpty;
+  // Every part is resolved BEFORE the transaction opens: a missing part refuses the whole
+  // commit up front instead of half-applying and rolling back.
+  const restParts: { readonly partName: string; readonly ops: readonly TreeDocOp[] }[] = [];
+  for (const group of rest) {
+    const part = packageStore.partFor(group.scope);
+    if (!part) return refused(opCount, 'unknown-part');
+    restParts.push({ partName: part.name, ops: group.ops });
+  }
+  const result = packageStore.transact(
+    primary!.scope,
+    (ctx) => {
+      for (const op of primary!.ops) ctx.apply(op);
+      for (const group of restParts) {
+        for (const op of group.ops) ctx.applyTo(group.partName, op);
+      }
+    },
+    options
+  );
+  if (!result.ok) return refused(opCount, result.reason);
+  return { committed: true, rejected: false, opCount };
+}
+
 export function commitSessionTreeOps(
   packageStore: TreePackageStore,
   ops: readonly TreeDocOp[],

--- a/packages/core/src/binding/tree-session-contract.ts
+++ b/packages/core/src/binding/tree-session-contract.ts
@@ -105,6 +105,18 @@ export interface TreeDocxSessionView {
     options?: TreeApplyOptions
   ): TreeApplyResult;
   /**
+   * Commit several stories' ops as ONE transaction and ONE undo unit.
+   *
+   * `applyTreeOps` addresses one story; a write that must land in the body AND note parts
+   * together — the save-time field-result refresh — needs all-or-nothing semantics, or a
+   * mid-sequence refusal exports a file mixing refreshed and stale values and a single undo
+   * restores only the last part. Any refusal rolls every group back. Lifecycle ops refuse.
+   */
+  applyTreeOpsAtomic(
+    groups: readonly { readonly scope: StoryScope; readonly ops: readonly TreeDocOp[] }[],
+    options?: TreeApplyOptions
+  ): TreeApplyResult;
+  /**
    * Every part that holds a story, body first, then headers, footers and note parts.
    *
    * A READ: parts come from the package, so this opens no story store and spends none of the

--- a/packages/core/src/binding/tree-session.ts
+++ b/packages/core/src/binding/tree-session.ts
@@ -105,7 +105,7 @@ import {
   type DocumentProperties,
 } from '../store/package/document-properties.ts';
 import { createCollaborationDocumentPort } from '../collaboration/replication.ts';
-import { commitSessionTreeOps } from './tree-session-apply.ts';
+import { commitSessionTreeOps, commitSessionTreeOpsAtomic } from './tree-session-apply.ts';
 
 // The session view contract (TreeApplyResult + TreeDocxSessionView) lives in
 // tree-session-contract.ts; re-exported so every existing import through this module stays
@@ -666,6 +666,10 @@ export function openTreeSession(
           scope,
           options
         );
+      },
+
+      applyTreeOpsAtomic(groups, options = {}) {
+        return commitSessionTreeOpsAtomic(packageStore, groups, options);
       },
 
       projectDoc: () => treeToDoc(bodyStore().part),

--- a/packages/core/src/editor/__tests__/ref-field-note-save-refresh.test.ts
+++ b/packages/core/src/editor/__tests__/ref-field-note-save-refresh.test.ts
@@ -17,6 +17,8 @@ import { strFromU8, strToU8, unzipSync, zipSync } from 'fflate';
 import { readOoxmlPackage } from '../../store/package/ooxml-package.ts';
 import { semanticDigest } from '../../store/package/ooxml-digest.ts';
 import { createDocxEditor, type DocxEditorInstance } from '../docx-editor.ts';
+import { mountPaginatedSurface } from '../paginated-surface.ts';
+import { stubCollaborationSession } from './collaboration-test-module.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
@@ -255,5 +257,82 @@ describe('save() refreshes stale REF results inside note parts', () => {
     };
     expect(digestOf(secondSave)).toEqual(digestOf(firstSave));
     reopened.destroy();
+  });
+
+  test('a locked content control keeps its cache without starving the other stale fields', async () => {
+    // Validation rejects a WHOLE refreshFieldResults op for a bound or content-locked
+    // paragraph, so the planner must exclude the locked field — otherwise one locked
+    // outlier silently keeps every other stale field in the part unrefreshed.
+    const lockedCitation =
+      '<w:sdt><w:sdtPr><w:lock w:val="sdtContentLocked"/></w:sdtPr><w:sdtContent>' +
+      `<w:p>${refField(' REF term \\h ', '<w:r><w:t>Closing Date</w:t></w:r>')}</w:p>` +
+      '</w:sdtContent></w:sdt>';
+    const plainCitation = `<w:p>${refField(
+      ' REF term \\h ',
+      '<w:r><w:t>Closing Date</w:t></w:r>'
+    )}</w:p>`;
+    const editor = mount(
+      docx(`<w:p>${bookmarked('term', 'Closing Date')}</w:p>` + lockedCitation + plainCitation, {})
+    );
+    editTarget(editor);
+    const xml = await savedPartXml(editor, 'word/document.xml');
+    // The plain field refreshed; the locked one saved exactly as loaded.
+    expect(xml).toContain('<w:t>Closing Dates</w:t>');
+    const lockedRegion = xml.slice(xml.indexOf('<w:sdt>'), xml.indexOf('</w:sdt>'));
+    expect(lockedRegion).toContain('<w:t>Closing Date</w:t>');
+    expect(lockedRegion).not.toContain('Closing Dates');
+    editor.destroy();
+  });
+
+  test('one undo after save restores the pre-save document across body and note parts', async () => {
+    const body =
+      `<w:p>${bookmarked('term', 'Closing Date')}</w:p>` +
+      `<w:p>${refField(' REF term \\h ', '<w:r><w:t>Closing Date</w:t></w:r>')}</w:p>` +
+      `<w:p><w:r><w:t>cites</w:t><w:footnoteReference w:id="1"/></w:r></w:p>`;
+    const editor = mount(docx(body, { footnote: freshNoteContent() }));
+    editTarget(editor);
+    const session = editor.surface!.session;
+    const beforeSave = new Uint8Array(session.save());
+    const saved = new Uint8Array(await editor.save());
+    // Both parts refreshed in the save...
+    expect(strFromU8(unzipSync(saved)['word/document.xml']!)).toContain('Closing Dates</w:t>');
+    expect(strFromU8(unzipSync(saved)['word/footnotes.xml']!)).toContain('Closing Dates');
+    // ...as ONE undo unit: a single undo restores the exact pre-save document. (`undo()`
+    // returns the restored SELECTION, which a field rewrite legitimately lacks — the byte
+    // comparison below is the oracle, `canUndo` only proves an entry existed.)
+    expect(session.canUndo()).toBe(true);
+    session.undo();
+    expect(new Uint8Array(session.save())).toEqual(beforeSave);
+    editor.destroy();
+  });
+
+  test('a collaborative session skips the refresh instead of claiming freshness', () => {
+    // The collaboration gate admits only body insert/delete text ops, so the rewrite cannot
+    // journal to peers. The refresh must skip CLEANLY — no transaction, no revision bump —
+    // and return false so the caller knows the save exports cached results.
+    const body =
+      `<w:p>${bookmarked('term', 'Closing Date')}</w:p>` +
+      `<w:p>${refField(' REF term \\h ', '<w:r><w:t>Closing Date</w:t></w:r>')}</w:p>`;
+    const container = document.createElement('div');
+    const mounted = mountPaginatedSurface(container, docx(body, {}), {
+      scale: 1,
+      collaborationModel: { session: stubCollaborationSession() },
+    });
+    if (!mounted.ok) throw new Error(mounted.reason);
+    const surface = mounted.surface;
+    const edited = surface.session.applyTreeOps([
+      {
+        op: 'insertText',
+        paragraphId: surface.session.part().root.id.replace(/#.*$/, '#0.0.0'),
+        offset: 'Closing Date'.length,
+        text: 's',
+      },
+    ]);
+    expect(edited.committed).toBe(true);
+    const revisionAfterEdit = surface.session.packageRevision();
+    expect(surface.refreshRefFieldResults()).toBe(false);
+    expect(surface.session.packageRevision()).toBe(revisionAfterEdit);
+    surface.destroy();
+    container.remove();
   });
 });

--- a/packages/core/src/editor/__tests__/ref-field-note-save-refresh.test.ts
+++ b/packages/core/src/editor/__tests__/ref-field-note-save-refresh.test.ts
@@ -1,0 +1,259 @@
+// The save path refreshes stale REF field results inside footnote and endnote PARTS.
+//
+// Note stories already paint live values through the shared body context; these tests pin
+// the other half: after a body edit, `editor.save()` exports the live value inside
+// `word/footnotes.xml` / `word/endnotes.xml` (instruction untouched, run properties kept);
+// a document whose note results are already fresh saves byte-identically with no revision
+// bump and no undo entry; a note field that failed calibration keeps its cache; a
+// revision-marked note result is skipped; and refresh+save+reopen digests identically
+// across a second save. Fixtures mount FRESH — the calibration gate requires a field's
+// computed value to reproduce its cache once before it goes live.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { strFromU8, strToU8, unzipSync, zipSync } from 'fflate';
+import { readOoxmlPackage } from '../../store/package/ooxml-package.ts';
+import { semanticDigest } from '../../store/package/ooxml-digest.ts';
+import { createDocxEditor, type DocxEditorInstance } from '../docx-editor.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+
+type NoteKind = 'footnote' | 'endnote';
+
+/** One notes part: a separator note plus one normal note holding `content` in a paragraph. */
+const notesXml = (kind: NoteKind, content: string) =>
+  `<w:${kind}s xmlns:w="${W}">` +
+  `<w:${kind} w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:${kind}>` +
+  `<w:${kind} w:id="1"><w:p>${content}</w:p></w:${kind}>` +
+  `</w:${kind}s>`;
+
+function docx(body: string, notes: Partial<Record<NoteKind, string>>): Uint8Array {
+  const overrides = (Object.keys(notes) as NoteKind[])
+    .map(
+      (kind) =>
+        `<Override PartName="/word/${kind}s.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.${kind}s+xml"/>`
+    )
+    .join('');
+  const noteRels = (Object.keys(notes) as NoteKind[])
+    .map((kind) => `<Relationship Id="rId${kind}" Type="${R}/${kind}s" Target="${kind}s.xml"/>`)
+    .join('');
+  const files: Record<string, Uint8Array> = {
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        `<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>` +
+        overrides +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}">${noteRels}</Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}<w:sectPr/></w:body></w:document>`
+    ),
+  };
+  for (const kind of Object.keys(notes) as NoteKind[]) {
+    files[`word/${kind}s.xml`] = strToU8(notesXml(kind, notes[kind]!));
+  }
+  return zipSync(files);
+}
+
+const bookmarked = (name: string, text: string) =>
+  `<w:bookmarkStart w:id="1" w:name="${name}"/><w:r><w:t>${text}</w:t></w:r>` +
+  `<w:bookmarkEnd w:id="1"/>`;
+const refField = (instr: string, result: string) =>
+  '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+  `<w:r><w:instrText xml:space="preserve">${instr}</w:instrText></w:r>` +
+  '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+  result +
+  '<w:r><w:fldChar w:fldCharType="end"/></w:r>';
+
+/** Target FIRST (the edit below addresses it), one citing paragraph per note kind after. */
+const bodyWithReferences = (kinds: readonly NoteKind[]) =>
+  `<w:p>${bookmarked('term', 'Closing Date')}</w:p>` +
+  kinds
+    .map((kind) => `<w:p><w:r><w:t>cites</w:t><w:${kind}Reference w:id="1"/></w:r></w:p>`)
+    .join('');
+
+/** FRESH on load: the cache reproduces the bookmarked text, so calibration goes live. */
+const freshNoteContent = (rPr = '') =>
+  `<w:r><w:t xml:space="preserve">see </w:t></w:r>` +
+  refField(' REF term \\h ', `<w:r>${rPr}<w:t>Closing Date</w:t></w:r>`);
+
+function mount(bytes: Uint8Array): DocxEditorInstance {
+  const container = document.createElement('div');
+  const editor = createDocxEditor({ container, document: bytes });
+  if (!editor.surface) throw new Error('surface failed to mount');
+  return editor;
+}
+
+function firstParagraphId(editor: DocxEditorInstance): string {
+  const part = editor.surface!.session.part();
+  let found: string | undefined;
+  const walk = (node: (typeof part)['root']): void => {
+    if (found) return;
+    if (node.kind === 'paragraph') {
+      found = node.id;
+      return;
+    }
+    for (const child of node.children) {
+      if (child.kind !== 'textValue') walk(child);
+    }
+  };
+  walk(part.root);
+  if (!found) throw new Error('missing paragraph');
+  return found;
+}
+
+/** Append one character to the bookmarked target text, so the note REF cache goes stale. */
+function editTarget(editor: DocxEditorInstance): void {
+  const result = editor.surface!.session.applyTreeOps([
+    {
+      op: 'insertText',
+      paragraphId: firstParagraphId(editor),
+      offset: 'Closing Date'.length,
+      text: 's',
+    },
+  ]);
+  expect(result.committed).toBe(true);
+}
+
+async function savedPartXml(editor: DocxEditorInstance, partName: string): Promise<string> {
+  const bytes = new Uint8Array(await editor.save());
+  return strFromU8(unzipSync(bytes)[partName]!);
+}
+
+describe('save() refreshes stale REF results inside note parts', () => {
+  test('a stale footnote REF exports the live value; instruction and rPr survive', async () => {
+    const editor = mount(
+      docx(bodyWithReferences(['footnote']), {
+        footnote: freshNoteContent('<w:rPr><w:i/></w:rPr>'),
+      })
+    );
+    editTarget(editor);
+    const xml = await savedPartXml(editor, 'word/footnotes.xml');
+    expect(xml).toContain(' REF term \\h ');
+    // The result run keeps its own properties and carries the live value.
+    expect(xml).toContain(
+      '<w:fldChar w:fldCharType="separate"/></w:r>' +
+        '<w:r><w:rPr><w:i/></w:rPr><w:t>Closing Dates</w:t></w:r>'
+    );
+    expect(xml).not.toContain('<w:t>Closing Date</w:t>');
+    editor.destroy();
+  });
+
+  test('a stale endnote REF exports the live value likewise', async () => {
+    const editor = mount(docx(bodyWithReferences(['endnote']), { endnote: freshNoteContent() }));
+    editTarget(editor);
+    const xml = await savedPartXml(editor, 'word/endnotes.xml');
+    expect(xml).toContain(' REF term \\h ');
+    expect(xml).toContain(
+      '<w:fldChar w:fldCharType="separate"/></w:r><w:r><w:t>Closing Dates</w:t></w:r>'
+    );
+    editor.destroy();
+  });
+
+  test('a note REF that failed calibration is never rewritten', async () => {
+    // 'Outdated' does not reproduce the bookmarked text, so the field never goes live —
+    // and the refresh must not export the very value calibration suppressed.
+    const editor = mount(
+      docx(bodyWithReferences(['footnote']), {
+        footnote:
+          `<w:r><w:t xml:space="preserve">see </w:t></w:r>` +
+          refField(' REF term \\h ', '<w:r><w:t>Outdated</w:t></w:r>'),
+      })
+    );
+    editTarget(editor);
+    const revisionAfterEdit = editor.getDocumentHandle().revision;
+    const xml = await savedPartXml(editor, 'word/footnotes.xml');
+    expect(xml).toContain('<w:t>Outdated</w:t>');
+    expect(xml).not.toContain('Closing Dates');
+    // No refresh transaction ran: nothing else in this document is refreshable.
+    expect(editor.getDocumentHandle().revision).toBe(revisionAfterEdit);
+    editor.destroy();
+  });
+
+  test('fresh note results save byte-identically, with no revision bump and no undo entry', async () => {
+    const editor = mount(
+      docx(bodyWithReferences(['footnote', 'endnote']), {
+        footnote: freshNoteContent(),
+        endnote: freshNoteContent(),
+      })
+    );
+    const surface = editor.surface!;
+    const revisionBefore = editor.getDocumentHandle().revision;
+    // The oracle: a serialize with NO refresh in front of it.
+    const withoutRefresh = surface.session.save();
+    const withRefresh = new Uint8Array(await editor.save());
+    expect(withRefresh).toEqual(withoutRefresh);
+    expect(editor.getDocumentHandle().revision).toBe(revisionBefore);
+    expect(surface.session.canUndo()).toBe(false);
+    editor.destroy();
+  });
+
+  test('a stale note refresh is an ordinary transaction: revision bumps and it is undoable', async () => {
+    const editor = mount(docx(bodyWithReferences(['footnote']), { footnote: freshNoteContent() }));
+    editTarget(editor);
+    const revisionAfterEdit = editor.getDocumentHandle().revision;
+    await editor.save();
+    expect(editor.getDocumentHandle().revision).toBeGreaterThan(revisionAfterEdit);
+    expect(editor.surface!.session.canUndo()).toBe(true);
+    editor.destroy();
+  });
+
+  test('a note result wrapped in revision markup is skipped and saved exactly as loaded', async () => {
+    const editor = mount(
+      docx(bodyWithReferences(['footnote']), {
+        footnote:
+          `<w:r><w:t xml:space="preserve">see </w:t></w:r>` +
+          refField(
+            ' REF term \\h ',
+            '<w:ins w:id="9" w:author="QA" w:date="2020-01-01T00:00:00Z">' +
+              '<w:r><w:t>Closing Date</w:t></w:r></w:ins>'
+          ),
+      })
+    );
+    editTarget(editor);
+    const revisionAfterEdit = editor.getDocumentHandle().revision;
+    const xml = await savedPartXml(editor, 'word/footnotes.xml');
+    expect(xml).toContain('<w:ins');
+    expect(xml).toContain('<w:t>Closing Date</w:t>');
+    expect(xml).not.toContain('Closing Dates');
+    expect(editor.getDocumentHandle().revision).toBe(revisionAfterEdit);
+    editor.destroy();
+  });
+
+  test('refresh + save + reopen digests identically across a second save', async () => {
+    const editor = mount(
+      docx(bodyWithReferences(['footnote', 'endnote']), {
+        footnote: freshNoteContent(),
+        endnote: freshNoteContent(),
+      })
+    );
+    editTarget(editor);
+    const firstSave = new Uint8Array(await editor.save());
+    expect(strFromU8(unzipSync(firstSave)['word/footnotes.xml']!)).toContain('Closing Dates');
+    expect(strFromU8(unzipSync(firstSave)['word/endnotes.xml']!)).toContain('Closing Dates');
+    editor.destroy();
+
+    const reopened = mount(firstSave);
+    const secondSave = new Uint8Array(await reopened.save());
+    // The rewrite is a fixed point: nothing was stale on reopen, so the second save is the
+    // byte-identical serialization, and the semantic digests agree.
+    expect(secondSave).toEqual(firstSave);
+    const digestOf = (bytes: Uint8Array) => {
+      const loaded = readOoxmlPackage(bytes);
+      if (!loaded.ok) throw new Error(loaded.reason);
+      return semanticDigest(loaded.package.parts.values());
+    };
+    expect(digestOf(secondSave)).toEqual(digestOf(firstSave));
+    reopened.destroy();
+  });
+});

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -1837,7 +1837,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
       if (!surface) return Promise.reject(editorError('notFound', 'no document is loaded'));
       // Ctrl+S can race a typing burst: queued keystrokes belong in the bytes.
       surface.flushPendingInput();
-      // Stale REF results rewrite first (bytes carry the paint); fresh commits nothing.
+      // Stale REF results rewrite first; false (collab skip) exports cached results anyway.
       surface.refreshRefFieldResults();
       // A fresh copy, so the returned ArrayBuffer is exactly the document — not a window
       // into a larger allocation.

--- a/packages/core/src/editor/paginated-surface-contract.ts
+++ b/packages/core/src/editor/paginated-surface-contract.ts
@@ -715,9 +715,12 @@ export interface PaginatedSurface {
   /** Refresh cached TOC entries and/or page numbers through the two-pass layout pipeline. */
   refreshToc(tocId?: string, mode?: 'entire' | 'pageNumbers'): boolean;
   /**
-   * Rewrite stale REF field results in the body story so a save exports what the pages
-   * paint. Fresh results commit nothing (no transaction, no revision bump, no undo entry);
-   * a rewrite is one ordinary journaled transaction. Viewing writes nothing.
+   * Rewrite stale REF field results in the body, footnote and endnote stories so a save
+   * exports what the pages paint. Fresh results commit nothing (no transaction, no revision
+   * bump, no undo entry); a rewrite is ONE transaction and ONE undo unit across every stale
+   * part. Viewing, a non-editable session, and a collaborative session write nothing — the
+   * collaboration gate cannot journal the rewrite, so those saves export cached results and
+   * the call returns false.
    */
   refreshRefFieldResults(): boolean;
   /** Whether a body paragraph belongs to a detected TOC boundary or cached result. */

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -4490,33 +4490,36 @@ export function mountPaginatedSurface(
    * the pages paint. Planning is read-only — the note parts are read from the package,
    * never through `partFor`, which would durably open a notes store — so a document whose
    * results are already fresh commits no transaction, bumps no revision and adds no undo
-   * entry. Each stale story commits one ordinary journaled transaction against its own
-   * scope — undoable, like a TOC refresh. Viewing writes nothing.
+   * entry. Every stale story commits together as ONE transaction and ONE undo unit
+   * (`applyTreeOpsAtomic`): a refusal anywhere rolls the whole refresh back, so the saved
+   * file can never mix refreshed and stale values, and a single undo restores the exact
+   * pre-save document. Viewing and a non-editable session write nothing.
+   *
+   * COLLABORATIVE SESSIONS SKIP THE REFRESH: the collaboration gate admits only body
+   * insert/delete text ops, so the rewrite cannot journal to peers. The save then exports
+   * the cached results (the pre-refresh behavior; Word refreshes fields on open), and the
+   * `false` return says so rather than claiming freshness.
    */
   function refreshRefFieldResults(): boolean {
-    if (editingMode === 'view') return true;
+    if (editingMode === 'view' || !session.editable) return true;
+    if (collaborationSession) return false;
     const refreshOptions = {
       package: session.currentPackage(),
       styleCascade: styleCascade(),
       numberingIndex: numberingIndex(),
       displayMode: revisionDisplayMode(),
     };
-    // Both plans read before either write lands, and they share one memoized resolution
+    // Both plans read before the write lands, and they share one memoized resolution
     // context — the note values are the ones the pages painted, per calibration verdict.
     const bodyOp = planRefFieldResultRefresh(session.part(), refreshOptions);
     const notePlans = planNoteRefFieldResultRefreshes(session.part(), refreshOptions);
-    let committed = true;
-    if (bodyOp) {
-      committed = applyJournaledOps([bodyOp], undefined, undefined, BODY_STORY).committed;
-    }
+    if (!bodyOp && notePlans.length === 0) return true;
+    const groups: { scope: StoryScope; ops: readonly TreeDocOp[] }[] = [];
+    if (bodyOp) groups.push({ scope: BODY_STORY, ops: [bodyOp] });
     for (const plan of notePlans) {
-      const applied = applyJournaledOps([plan.op], undefined, undefined, {
-        kind: 'notesPart',
-        noteKind: plan.noteKind,
-      });
-      committed = applied.committed && committed;
+      groups.push({ scope: { kind: 'notesPart', noteKind: plan.noteKind }, ops: [plan.op] });
     }
-    return committed;
+    return session.applyTreeOpsAtomic(groups).committed;
   }
 
   // Which range a destructive or replacing gesture acts on, and where content replacing it

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -72,6 +72,7 @@ import {
   type SemanticSelection,
 } from '@docx-editor.dev/core/layout';
 import { attachListResolveChangeEvidence } from '../layout/list-resolve.ts';
+import { planNoteRefFieldResultRefreshes } from '../layout/field-ref-refresh.ts';
 import {
   DEFAULT_REVISION_DISPLAY_MODE,
   type RevisionDisplayMode,
@@ -4485,22 +4486,37 @@ export function mountPaginatedSurface(
   }
 
   /**
-   * Rewrite stale REF field results in the body story, so a save exports what the pages
-   * paint. Planning is read-only: a document whose results are already fresh commits no
-   * transaction, bumps no revision and adds no undo entry. A refresh that does rewrite is
-   * one ordinary journaled transaction — undoable, like a TOC refresh. Viewing writes
-   * nothing; note-part results still save cached (see `field-ref-refresh.ts`).
+   * Rewrite stale REF field results in the body and note stories, so a save exports what
+   * the pages paint. Planning is read-only — the note parts are read from the package,
+   * never through `partFor`, which would durably open a notes store — so a document whose
+   * results are already fresh commits no transaction, bumps no revision and adds no undo
+   * entry. Each stale story commits one ordinary journaled transaction against its own
+   * scope — undoable, like a TOC refresh. Viewing writes nothing.
    */
   function refreshRefFieldResults(): boolean {
     if (editingMode === 'view') return true;
-    const op = planRefFieldResultRefresh(session.part(), {
+    const refreshOptions = {
       package: session.currentPackage(),
       styleCascade: styleCascade(),
       numberingIndex: numberingIndex(),
       displayMode: revisionDisplayMode(),
-    });
-    if (!op) return true;
-    return applyJournaledOps([op], undefined, undefined, BODY_STORY).committed;
+    };
+    // Both plans read before either write lands, and they share one memoized resolution
+    // context — the note values are the ones the pages painted, per calibration verdict.
+    const bodyOp = planRefFieldResultRefresh(session.part(), refreshOptions);
+    const notePlans = planNoteRefFieldResultRefreshes(session.part(), refreshOptions);
+    let committed = true;
+    if (bodyOp) {
+      committed = applyJournaledOps([bodyOp], undefined, undefined, BODY_STORY).committed;
+    }
+    for (const plan of notePlans) {
+      const applied = applyJournaledOps([plan.op], undefined, undefined, {
+        kind: 'notesPart',
+        noteKind: plan.noteKind,
+      });
+      committed = applied.committed && committed;
+    }
+    return committed;
   }
 
   // Which range a destructive or replacing gesture acts on, and where content replacing it

--- a/packages/core/src/layout/field-ref-refresh.ts
+++ b/packages/core/src/layout/field-ref-refresh.ts
@@ -24,6 +24,7 @@ import { resolveNotesPart } from '../store/package/note-references.ts';
 import type { NoteKind } from '../store/package/note-nodes.ts';
 import type { OoxmlPackage } from '../store/package/ooxml-package.ts';
 import {
+  fieldResultUpdateRefusal,
   locateFieldResults,
   MAX_FIELD_RESULT_TEXT_CHARS,
   MAX_FIELD_RESULT_UPDATES,
@@ -109,6 +110,7 @@ function resolveRefreshContext(
  * cached runs exactly as loaded.
  */
 function collectStaleResultUpdates(
+  owningPart: OoxmlPart,
   paragraphs: Iterable<OoxmlElement>,
   context: RefFieldContext,
   updates: { paragraphId: string; fieldNodeId: string; text: string }[]
@@ -118,6 +120,10 @@ function collectStaleResultUpdates(
     // The context already scanned every paragraph; only the ones holding recognized REF
     // specs are worth the locate walk.
     if (context.tokenForParagraph(paragraph.id) === '') continue;
+    // Validation rejects the WHOLE op for a bound or content-locked paragraph, so the plan
+    // must exclude it here — one locked field must not starve every other stale field in
+    // the part. The same predicate validation applies, asked against the owning RAW part.
+    if (fieldResultUpdateRefusal(owningPart, paragraph.id) !== null) continue;
     for (const located of locateFieldResults(paragraph)) {
       if (updates.length >= MAX_FIELD_RESULT_UPDATES) return;
       if (!located.rewritable) continue;
@@ -148,7 +154,7 @@ export function planRefFieldResultRefresh(
   const { blocks, context } = resolveRefreshContext(part, options);
   if (context === null) return null;
   const updates: { paragraphId: string; fieldNodeId: string; text: string }[] = [];
-  collectStaleResultUpdates(walkStoryParagraphs(blocks), context, updates);
+  collectStaleResultUpdates(part, walkStoryParagraphs(blocks), context, updates);
   if (updates.length === 0) return null;
   return { op: 'refreshFieldResults', updates };
 }
@@ -179,7 +185,7 @@ export function planNoteRefFieldResultRefreshes(
     const updates: { paragraphId: string; fieldNodeId: string; text: string }[] = [];
     for (const story of noteStoriesOfPart(notesPart)) {
       if (updates.length >= MAX_FIELD_RESULT_UPDATES) break;
-      collectStaleResultUpdates(walkStoryParagraphs(story), context, updates);
+      collectStaleResultUpdates(notesPart, walkStoryParagraphs(story), context, updates);
     }
     if (updates.length > 0) plans.push({ noteKind, op: { op: 'refreshFieldResults', updates } });
   }

--- a/packages/core/src/layout/field-ref-refresh.ts
+++ b/packages/core/src/layout/field-ref-refresh.ts
@@ -1,25 +1,27 @@
-// Save-time REF result refresh: plan the one `refreshFieldResults` op that makes the saved
+// Save-time REF result refresh: plan the `refreshFieldResults` ops that make the saved
 // bytes carry what the pages paint.
 //
 // Painted REF values are a layout projection; the file keeps Word's cached result runs, so
-// an export after a renumbering edit is stale until Word refreshes fields. The plan reuses
+// an export after a renumbering edit is stale until Word refreshes fields. The plans reuse
 // the layout's own resolution (`resolveStoryRefFields` — grammar, bookmark index, number
 // composition AND the per-field calibration verdict, all shared, so save and paint cannot
-// drift) and pairs it with the store's result locator, then keeps only the fields whose
+// drift) and pair it with the store's result locator, then keep only the fields whose
 // plain-run cached text differs from the LIVE value. `liveValueOf` answers null for a field
 // that failed calibration, so a field painting its cache keeps that cache on save too —
 // rewriting it would export the very value the calibration gate exists to suppress. A fresh
-// document plans NOTHING: the caller sees null, runs no transaction, bumps no revision, and
-// the save is byte-identical to one without the refresh.
+// document plans NOTHING: the caller sees null (body) or no plans (notes), runs no
+// transaction, bumps no revision, and the save is byte-identical to one without the refresh.
 //
-// Scope: the BODY story. Note-story results still paint live through the shared context but
-// keep their cached runs on save — rewriting them needs per-note-part transactions, tracked
-// with the notes half of the follow-up. The field INSTRUCTION is never modified, and any
-// result the locator calls non-rewritable (revision markup, nested fields, locks, anything
-// but plain runs) keeps its cache untouched.
+// Scope: the BODY story plus the footnote/endnote stories. Note plans carry the note kind
+// so the caller can commit each one against its own notes-part scope — the store keeps one
+// transaction lane per part, and a plan is pure reading (never `partFor`, which durably
+// opens a notes store). The field INSTRUCTION is never modified, and any result the locator
+// calls non-rewritable (revision markup, nested fields, locks, anything but plain runs)
+// keeps its cache untouched.
 
-import type { OoxmlPart } from '@docx-editor.dev/core/store';
+import type { OoxmlElement, OoxmlPart } from '@docx-editor.dev/core/store';
 import { resolveNotesPart } from '../store/package/note-references.ts';
+import type { NoteKind } from '../store/package/note-nodes.ts';
 import type { OoxmlPackage } from '../store/package/ooxml-package.ts';
 import {
   locateFieldResults,
@@ -29,8 +31,10 @@ import {
 } from '../store/store/tree-op-field-results.ts';
 import { noteRefNumberingForPart } from './field-noteref.ts';
 import {
+  noteStoriesOfPart,
   parseRefInstruction,
   resolveStoryRefFieldsWithNoteNumbers,
+  type RefFieldContext,
   type RefNoteParts,
 } from './field-ref.ts';
 import { walkStoryParagraphs, withResolvedListItems } from './list-resolve.ts';
@@ -53,19 +57,28 @@ export interface RefFieldRefreshOptions {
   readonly displayMode?: RevisionDisplayMode;
 }
 
+/** One notes part's refresh, tagged with the story scope its transaction must target. */
+export interface NoteRefFieldRefreshPlan {
+  readonly noteKind: NoteKind;
+  readonly op: RefreshFieldResultsOp;
+}
+
+interface RefRefreshResolution {
+  readonly blocks: readonly OoxmlElement[];
+  readonly notes: RefNoteParts | undefined;
+  readonly context: RefFieldContext | null;
+}
+
 /**
- * Plan the refresh for one body part, or null when every supported REF result is already
- * fresh (the no-op save path — no transaction, no revision bump, no undo entry).
- *
- * Every skip is conservative and per-field: an unrecognized instruction or switch, a
- * missing bookmark, an unnumbered target under a number switch, a non-plain result, a
- * locked field and a field whose calibration verdict is "keeps the cache" all keep their
- * cached runs exactly as loaded.
+ * The shared resolution both planners read: body blocks, the note parts joined to the scan,
+ * and ONE context. Every input is the memoized identity paint resolves through
+ * (`storyBlocks`, `withResolvedListItems`, `resolveStoryRefFields`), so the body and note
+ * plans of one save read the same context object and the same calibration verdicts.
  */
-export function planRefFieldResultRefresh(
+function resolveRefreshContext(
   part: OoxmlPart,
   options: RefFieldRefreshOptions
-): RefreshFieldResultsOp | null {
+): RefRefreshResolution {
   const blocks = storyBlocks(part, options.displayMode ?? DEFAULT_REVISION_DISPLAY_MODE);
   const listItems = withResolvedListItems(
     { numberingIndex: options.numberingIndex, styleCascade: options.styleCascade },
@@ -85,16 +98,28 @@ export function planRefFieldResultRefresh(
     notes,
     options.package ? noteRefNumberingForPart(options.package, part, blocks) : undefined
   );
-  if (context === null) return null;
+  return { blocks, notes, context };
+}
 
-  const updates: { paragraphId: string; fieldNodeId: string; text: string }[] = [];
-  for (const paragraph of walkStoryParagraphs(blocks)) {
-    if (updates.length >= MAX_FIELD_RESULT_UPDATES) break;
+/**
+ * Collect the stale-but-calibrated fields of one story walk into `updates`, up to the op's
+ * cap. Every skip is conservative and per-field: an unrecognized instruction or switch, a
+ * missing bookmark, an unnumbered target under a number switch, a non-plain result, a
+ * locked field and a field whose calibration verdict is "keeps the cache" all keep their
+ * cached runs exactly as loaded.
+ */
+function collectStaleResultUpdates(
+  paragraphs: Iterable<OoxmlElement>,
+  context: RefFieldContext,
+  updates: { paragraphId: string; fieldNodeId: string; text: string }[]
+): void {
+  for (const paragraph of paragraphs) {
+    if (updates.length >= MAX_FIELD_RESULT_UPDATES) return;
     // The context already scanned every paragraph; only the ones holding recognized REF
     // specs are worth the locate walk.
     if (context.tokenForParagraph(paragraph.id) === '') continue;
     for (const located of locateFieldResults(paragraph)) {
-      if (updates.length >= MAX_FIELD_RESULT_UPDATES) break;
+      if (updates.length >= MAX_FIELD_RESULT_UPDATES) return;
       if (!located.rewritable) continue;
       const spec = parseRefInstruction(located.instruction);
       if (spec === null) continue;
@@ -110,6 +135,53 @@ export function planRefFieldResultRefresh(
       updates.push({ paragraphId: paragraph.id, fieldNodeId: located.fieldNodeId, text: value });
     }
   }
+}
+
+/**
+ * Plan the refresh for one body part, or null when every supported REF result is already
+ * fresh (the no-op save path — no transaction, no revision bump, no undo entry).
+ */
+export function planRefFieldResultRefresh(
+  part: OoxmlPart,
+  options: RefFieldRefreshOptions
+): RefreshFieldResultsOp | null {
+  const { blocks, context } = resolveRefreshContext(part, options);
+  if (context === null) return null;
+  const updates: { paragraphId: string; fieldNodeId: string; text: string }[] = [];
+  collectStaleResultUpdates(walkStoryParagraphs(blocks), context, updates);
   if (updates.length === 0) return null;
   return { op: 'refreshFieldResults', updates };
+}
+
+/**
+ * Plan the refresh for the footnote and endnote parts, empty when every note result is
+ * fresh — the same no-op contract as the body plan, per part: a part with no stale field
+ * gets no plan, so its store is never opened and its bytes save exactly as loaded.
+ *
+ * `part` is the BODY part: the context resolves against body bookmarks and numbering, the
+ * targets a citing note overwhelmingly names. The note stories walked here are the SAME
+ * arrays the context scanned (`noteStoriesOfPart`), so a located field's anchor id reads
+ * its own calibration verdict.
+ */
+export function planNoteRefFieldResultRefreshes(
+  part: OoxmlPart,
+  options: RefFieldRefreshOptions
+): readonly NoteRefFieldRefreshPlan[] {
+  const { notes, context } = resolveRefreshContext(part, options);
+  if (context === null || notes === undefined) return [];
+  const plans: NoteRefFieldRefreshPlan[] = [];
+  const noteParts: readonly { noteKind: NoteKind; notesPart: OoxmlPart | null }[] = [
+    { noteKind: 'footnote', notesPart: notes.footnotesPart },
+    { noteKind: 'endnote', notesPart: notes.endnotesPart },
+  ];
+  for (const { noteKind, notesPart } of noteParts) {
+    if (!notesPart) continue;
+    const updates: { paragraphId: string; fieldNodeId: string; text: string }[] = [];
+    for (const story of noteStoriesOfPart(notesPart)) {
+      if (updates.length >= MAX_FIELD_RESULT_UPDATES) break;
+      collectStaleResultUpdates(walkStoryParagraphs(story), context, updates);
+    }
+    if (updates.length > 0) plans.push({ noteKind, op: { op: 'refreshFieldResults', updates } });
+  }
+  return plans;
 }

--- a/packages/core/src/layout/field-ref.ts
+++ b/packages/core/src/layout/field-ref.ts
@@ -608,7 +608,12 @@ export interface RefNoteParts {
 /** Normal-note story block arrays of one notes part, memoized on the immutable part. */
 const notePartStories = new WeakMap<OoxmlPart, readonly (readonly OoxmlElement[])[]>();
 
-function noteStoriesOfPart(part: OoxmlPart | null): readonly (readonly OoxmlElement[])[] {
+/**
+ * Normal-note stories of one notes part, in part order. Exported for the save-time refresh
+ * planner: walking the SAME story arrays this context scanned keeps its anchor ids and the
+ * planner's located fields aligned by construction.
+ */
+export function noteStoriesOfPart(part: OoxmlPart | null): readonly (readonly OoxmlElement[])[] {
   if (!part) return [];
   const cached = notePartStories.get(part);
   if (cached) return cached;

--- a/packages/core/src/store/store/tree-op-field-results.ts
+++ b/packages/core/src/store/store/tree-op-field-results.ts
@@ -301,6 +301,23 @@ export function locateFieldResults(paragraph: OoxmlElement): readonly LocatedFie
   return out;
 }
 
+/**
+ * Why a paragraph's field results may not be rewritten, or null when they may.
+ *
+ * ONE statement of the content-control rules, shared by validation below and by the
+ * save-time PLANNER: validation rejects the WHOLE op (all-or-nothing is the transaction
+ * contract), so the planner must exclude these paragraphs up front or one locked field
+ * would silently starve every other stale field in the part.
+ */
+export function fieldResultUpdateRefusal(
+  part: OoxmlPart,
+  paragraphId: string
+): 'bound' | 'locked' | null {
+  if (isBoundAt(part, paragraphId)) return 'bound';
+  if (effectiveContentLockAt(part, paragraphId).content) return 'locked';
+  return null;
+}
+
 export function validateRefreshFieldResults(
   part: OoxmlPart,
   op: RefreshFieldResultsOp
@@ -326,8 +343,8 @@ export function validateRefreshFieldResults(
     }
     const paragraph = findNode(part, update.paragraphId);
     if (!paragraph || paragraph.kind !== 'paragraph') return 'unknown-paragraph';
-    if (isBoundAt(part, update.paragraphId)) return 'bound';
-    if (effectiveContentLockAt(part, update.paragraphId).content) return 'locked';
+    const refusal = fieldResultUpdateRefusal(part, update.paragraphId);
+    if (refusal) return refusal;
   }
   return null;
 }

--- a/packages/core/src/store/store/tree-package-store.ts
+++ b/packages/core/src/store/store/tree-package-store.ts
@@ -429,6 +429,15 @@ export class TreePackageStore {
           // `applyPackage` are how a transaction writes the comment or numbering part in the
           // same unit as the story, and rebuilding the object dropped them.
           ...ctx,
+          // A write to ANOTHER part lives only in the store's working package; the story
+          // sync after the commit carries the story part alone, so without shell promotion
+          // the foreign write would silently evaporate. Promotion adopts the whole working
+          // package and makes the undo pointer one package unit spanning every written part.
+          applyTo: (partName, op) => {
+            const appliedOk = ctx.applyTo(partName, op);
+            if (appliedOk && partName !== story.partName) packageShellTouched = true;
+            return appliedOk;
+          },
           applyPackage: (edit) =>
             ctx.applyPackage((current) => {
               const next = edit(current);

--- a/scripts/check-eslint-max-lines-globs.mjs
+++ b/scripts/check-eslint-max-lines-globs.mjs
@@ -42,7 +42,7 @@ const SLACK_EXEMPT = new Map([
  * diff where a reviewer sees it, instead of the file quietly gaining a thousand lines.
  */
 const BLANKET_DISABLES = new Map([
-  ['packages/core/src/editor/paginated-surface.ts', 6223],
+  ['packages/core/src/editor/paginated-surface.ts', 6239],
   ['packages/core/src/store/store/tree-op-apply.ts', 3495],
   ['packages/core/src/output/semantic-paint.ts', 3005],
   ['packages/core/src/layout/note-pagination.ts', 2852],

--- a/scripts/check-eslint-max-lines-globs.mjs
+++ b/scripts/check-eslint-max-lines-globs.mjs
@@ -42,7 +42,7 @@ const SLACK_EXEMPT = new Map([
  * diff where a reviewer sees it, instead of the file quietly gaining a thousand lines.
  */
 const BLANKET_DISABLES = new Map([
-  ['packages/core/src/editor/paginated-surface.ts', 6239],
+  ['packages/core/src/editor/paginated-surface.ts', 6242],
   ['packages/core/src/store/store/tree-op-apply.ts', 3495],
   ['packages/core/src/output/semantic-paint.ts', 3005],
   ['packages/core/src/layout/note-pagination.ts', 2852],


### PR DESCRIPTION
Note stories paint live `REF` values, but the save-time refresh covered the body story only, so exported footnotes and endnotes kept stale cached results.

The refresh now plans updates for note paragraphs through the same memoized resolution context the painter uses, so the calibration verdicts match what the pages show. Each stale note part commits one journaled transaction against its own `notesPart` scope; a document whose note results are fresh saves byte-identical with no transaction, no revision bump, and no undo entry. Planning reads the parts from the package directly, never through the store-opening accessor.

Fixes #611

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/614"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790600914&installation_model_id=422592&pr_number=614&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F614&signature=32045adf21755cac82b8f13ddaf2789065c30867fb699f94fee436f0aff69444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->