### PR TITLE
feat: support the REF \t switch and NOTEREF fields

### DIFF
--- a/.changeset/ref-t-switch-noteref.md
+++ b/.changeset/ref-t-switch-noteref.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Resolve the REF `\t` switch and NOTEREF fields live from the document's numbering, so those references track edits instead of painting stale cached results. Fixes #612.

--- a/packages/core/src/layout/__tests__/field-noteref.test.ts
+++ b/packages/core/src/layout/__tests__/field-noteref.test.ts
@@ -1,0 +1,395 @@
+// NOTEREF fields: the number of the note whose reference mark sits inside the bookmark,
+// derived through the painter's own numbering path (`deriveNoteDisplayMarksResolved` over
+// per-section resolved properties) and gated by the same per-field calibration the REF
+// grammar uses. Everything unsupported — `\p` / `\f`, a missing bookmark, a bookmark with no
+// note mark inside, `eachPage` restart, a custom-marked citation — keeps the cached result.
+
+import { describe, expect, test } from 'bun:test';
+import { strToU8, zipSync } from 'fflate';
+import {
+  readOoxmlPackage,
+  readOoxmlPart,
+  type OoxmlElement,
+  type OoxmlNode,
+  type OoxmlPart,
+} from '@docx-editor.dev/core/store';
+import { isFldSimple } from '@docx-editor.dev/core/store';
+import {
+  DEFAULT_ENDNOTE_PROPERTIES,
+  DEFAULT_FOOTNOTE_PROPERTIES,
+} from '../../store/package/note-properties.ts';
+import { resolveNotesPart } from '../../store/package/note-references.ts';
+import { locateFieldResults } from '../../store/store/tree-op-field-results.ts';
+import { createFixedMeasurer } from '../fixed-measurer.ts';
+import type { NoteRefNumberingInput } from '../field-noteref.ts';
+import { parseRefInstruction, resolveStoryRefFieldsWithNoteNumbers } from '../field-ref.ts';
+import { planRefFieldResultRefresh } from '../field-ref-refresh.ts';
+import { isFldChar } from '../field-instruction.ts';
+import { createLayoutSession } from '../layout-session.ts';
+import { createParagraphLayoutCache } from '../layout-cache.ts';
+import type { NotesLayoutInput } from '../note-pagination.ts';
+import { layoutSemanticDocument } from '../semantic-layout.ts';
+import type { SemanticLayout } from '../index.ts';
+import { paragraphFragmentsOf } from '../index.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+
+function document(body: string): OoxmlPart {
+  const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'application/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+function blocksOf(part: OoxmlPart): OoxmlElement[] {
+  const body = part.root.children.find(
+    (child): child is OoxmlElement => child.kind !== 'textValue' && child.localName === 'body'
+  )!;
+  return body.children.filter(
+    (child): child is OoxmlElement => child.kind === 'paragraph' || child.kind === 'table'
+  );
+}
+
+/** Field anchor ids (begin `w:fldChar` / `w:fldSimple`) in document order, for lookups. */
+function refAnchorIds(part: OoxmlPart): string[] {
+  const ids: string[] = [];
+  const visit = (node: OoxmlNode): void => {
+    if (node.kind === 'textValue') return;
+    if (isFldChar(node, 'begin') || isFldSimple(node)) ids.push(node.id);
+    for (const child of node.children) visit(child);
+  };
+  visit(part.root);
+  return ids;
+}
+
+const refField = (instr: string, cached = '') =>
+  '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+  `<w:r><w:instrText>${instr}</w:instrText></w:r>` +
+  '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+  (cached ? `<w:r><w:t>${cached}</w:t></w:r>` : '') +
+  '<w:r><w:fldChar w:fldCharType="end"/></w:r>';
+const cite = (id: number, extra = '') => `<w:r><w:footnoteReference w:id="${id}"${extra}/></w:r>`;
+const bookmarkedCite = (name: string, inner: string) =>
+  `<w:bookmarkStart w:id="7" w:name="${name}"/>${inner}<w:bookmarkEnd w:id="7"/>`;
+
+/** Numbering input over one implicit section, with overridable footnote properties. */
+function numberingInput(overrides?: Partial<NoteRefNumberingInput>): NoteRefNumberingInput {
+  return {
+    sections: [],
+    footnotePropsBySection: [],
+    endnotePropsBySection: [],
+    documentFootnoteProps: DEFAULT_FOOTNOTE_PROPERTIES,
+    documentEndnoteProps: DEFAULT_ENDNOTE_PROPERTIES,
+    ...overrides,
+  };
+}
+
+function liveAt(
+  part: OoxmlPart,
+  input: NoteRefNumberingInput | undefined,
+  ordinal: number,
+  instruction: string
+): string | null {
+  const context = resolveStoryRefFieldsWithNoteNumbers(blocksOf(part), undefined, undefined, input);
+  if (context === null) throw new Error('no context');
+  const anchorId = refAnchorIds(part)[ordinal];
+  if (anchorId === undefined) throw new Error('no such field');
+  const spec = parseRefInstruction(instruction);
+  if (spec === null) throw new Error('instruction must parse');
+  return context.liveValueOf(anchorId, spec);
+}
+
+describe('NOTEREF resolution against the body story', () => {
+  test('paints the display number of the note referenced inside the bookmark', () => {
+    const part = document(
+      `<w:p>${cite(11)}</w:p>` +
+        `<w:p><w:r><w:t>lead </w:t></w:r>${bookmarkedCite('nb', cite(12))}</w:p>` +
+        `<w:p>${refField(' NOTEREF nb \\h ')}</w:p>`
+    );
+    // Second citation in document order under the default decimal footnote numbering.
+    expect(liveAt(part, numberingInput(), 0, ' NOTEREF nb \\h ')).toBe('2');
+  });
+
+  test('a w:numFmt-styled sequence resolves through the same format mapping', () => {
+    const part = document(
+      `<w:p>${cite(11)}</w:p>` +
+        `<w:p>${bookmarkedCite('nb', cite(12))}</w:p>` +
+        `<w:p>${refField(' NOTEREF nb ')}</w:p>`
+    );
+    const input = numberingInput({
+      footnotePropsBySection: [{ ...DEFAULT_FOOTNOTE_PROPERTIES, numFmt: 'lowerRoman' }],
+    });
+    expect(liveAt(part, input, 0, ' NOTEREF nb ')).toBe('ii');
+  });
+
+  test('an endnote reference numbers under the endnote properties (lowerRoman default)', () => {
+    const part = document(
+      `<w:p>${bookmarkedCite('nb', `<w:r><w:endnoteReference w:id="3"/></w:r>`)}</w:p>` +
+        `<w:p>${refField(' NOTEREF nb ')}</w:p>`
+    );
+    expect(liveAt(part, numberingInput(), 0, ' NOTEREF nb ')).toBe('i');
+  });
+
+  test('eachSect restart counts per section, through the section bounds', () => {
+    const part = document(
+      `<w:p>${cite(11)}</w:p>` +
+        `<w:p>${bookmarkedCite('nb', cite(12))}</w:p>` +
+        `<w:p>${refField(' NOTEREF nb ')}</w:p>`
+    );
+    const props = { ...DEFAULT_FOOTNOTE_PROPERTIES, numRestart: 'eachSect' as const };
+    const input = numberingInput({
+      sections: [
+        { blockStart: 0, blockEndExclusive: 1 },
+        { blockStart: 1, blockEndExclusive: 3 },
+      ],
+      footnotePropsBySection: [props, props],
+    });
+    // The bookmarked citation opens section 1, so its number restarts at 1.
+    expect(liveAt(part, input, 0, ' NOTEREF nb ')).toBe('1');
+  });
+
+  test('unsupported shapes keep the cache: eachPage, custom mark, no mark, no bookmark', () => {
+    const eachPage = numberingInput({
+      footnotePropsBySection: [{ ...DEFAULT_FOOTNOTE_PROPERTIES, numRestart: 'eachPage' }],
+    });
+    const paged = document(
+      `<w:p>${bookmarkedCite('nb', cite(11))}</w:p>` + `<w:p>${refField(' NOTEREF nb ')}</w:p>`
+    );
+    // Page assignment does not exist pre-pagination; the kind is refused whole.
+    expect(liveAt(paged, eachPage, 0, ' NOTEREF nb ')).toBeNull();
+
+    const custom = document(
+      `<w:p>${bookmarkedCite('nb', cite(11, ' w:customMarkFollows="1"'))}</w:p>` +
+        `<w:p>${refField(' NOTEREF nb ')}</w:p>`
+    );
+    expect(liveAt(custom, numberingInput(), 0, ' NOTEREF nb ')).toBeNull();
+
+    const markless = document(
+      `<w:p>${bookmarkedCite('nb', '<w:r><w:t>text only</w:t></w:r>')}${cite(11)}</w:p>` +
+        `<w:p>${refField(' NOTEREF nb ')}</w:p>`
+    );
+    expect(liveAt(markless, numberingInput(), 0, ' NOTEREF nb ')).toBeNull();
+
+    const unbookmarked = document(
+      `<w:p>${cite(11)}</w:p>` + `<w:p>${refField(' NOTEREF absent ')}</w:p>`
+    );
+    expect(liveAt(unbookmarked, numberingInput(), 0, ' NOTEREF absent ')).toBeNull();
+
+    // No numbering input at all (a story laid out without notes) keeps the cache too.
+    const plain = document(
+      `<w:p>${bookmarkedCite('nb', cite(11))}</w:p>` + `<w:p>${refField(' NOTEREF nb ')}</w:p>`
+    );
+    expect(liveAt(plain, undefined, 0, ' NOTEREF nb ')).toBeNull();
+  });
+
+  test('calibration: a cache the computed number cannot reproduce wins permanently', () => {
+    const body =
+      `<w:p>${bookmarkedCite('nb', cite(11))}</w:p>` +
+      `<w:p>${refField(' NOTEREF nb ', '9')}</w:p>` +
+      `<w:p>${refField(' NOTEREF nb \\h ', '1')}</w:p>`;
+    const part = document(body);
+    expect(liveAt(part, numberingInput(), 0, ' NOTEREF nb ')).toBeNull();
+    expect(liveAt(part, numberingInput(), 1, ' NOTEREF nb \\h ')).toBe('1');
+  });
+});
+
+// ------------------------------------------------------------------------------------------
+// Full layout: painted values, painter parity and the session repaint path.
+// ------------------------------------------------------------------------------------------
+
+function notesDoc(body: string): Uint8Array {
+  const footnotes =
+    `<w:footnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:footnote>` +
+    `<w:footnote w:id="1"><w:p><w:r><w:t>first note</w:t></w:r></w:p></w:footnote>` +
+    `<w:footnote w:id="2"><w:p><w:r><w:t>second note</w:t></w:r></w:p></w:footnote>`;
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '<Override PartName="/word/footnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rIdFn" Type="${R}/footnotes" Target="footnotes.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}" xmlns:r="${R}"><w:body>${body}<w:sectPr/></w:body></w:document>`
+    ),
+    'word/footnotes.xml': strToU8(`<w:footnotes xmlns:w="${W}">${footnotes}</w:footnotes>`),
+  });
+}
+
+function openNotesDoc(
+  bytes: Uint8Array,
+  footnoteNumFmt = 'decimal'
+): { part: OoxmlPart; notes: NotesLayoutInput } {
+  const loaded = readOoxmlPackage(bytes);
+  if (!loaded.ok) throw new Error(loaded.reason);
+  const part = loaded.package.parts.get(loaded.package.mainDocumentPart)!;
+  const documentFootnoteProps = { ...DEFAULT_FOOTNOTE_PROPERTIES, numFmt: footnoteNumFmt };
+  const notes: NotesLayoutInput = {
+    footnotesPart: resolveNotesPart(loaded.package, 'footnote'),
+    endnotesPart: null,
+    footnotePropsBySection: [documentFootnoteProps],
+    endnotePropsBySection: [DEFAULT_ENDNOTE_PROPERTIES],
+    documentFootnoteProps,
+    documentEndnoteProps: DEFAULT_ENDNOTE_PROPERTIES,
+    measurer: createFixedMeasurer(6, 14),
+    producer: 'noteref',
+  };
+  return { part, notes };
+}
+function packageOf(bytes: Uint8Array) {
+  const loaded = readOoxmlPackage(bytes);
+  if (!loaded.ok) throw new Error(loaded.reason);
+  return loaded.package;
+}
+
+const textsOf = (layout: SemanticLayout): string[] =>
+  layout.pages.flatMap((page) =>
+    paragraphFragmentsOf(page).map((fragment) =>
+      fragment.lines
+        .flatMap((line) => line.spans.map((span) => span.text))
+        .join('')
+        .trim()
+    )
+  );
+
+/** Structural-sharing body edit: every surviving node kept BY IDENTITY, like a store commit. */
+function withBlocks(
+  part: OoxmlPart,
+  edit: (blocks: readonly OoxmlElement[]) => readonly OoxmlElement[]
+): OoxmlPart {
+  const body = part.root.children.find(
+    (child): child is OoxmlElement => child.kind !== 'textValue' && child.localName === 'body'
+  )!;
+  const blocks = body.children.filter(
+    (child): child is OoxmlElement => child.kind === 'paragraph' || child.kind === 'table'
+  );
+  const edited = edit(blocks);
+  const nextChildren = [
+    ...edited,
+    ...body.children.filter(
+      (child) =>
+        child.kind === 'textValue' || (child.kind !== 'paragraph' && child.kind !== 'table')
+    ),
+  ];
+  const nextBody = { ...body, children: nextChildren } as OoxmlElement;
+  const nextRoot = {
+    ...part.root,
+    children: part.root.children.map((child) => (child === body ? nextBody : child)),
+  } as OoxmlElement;
+  return { ...part, root: nextRoot };
+}
+
+const CITING_BODY =
+  `<w:p><w:r><w:t>gone soon</w:t></w:r>${cite(1)}</w:p>` +
+  `<w:p><w:r><w:t>keeps</w:t></w:r>${bookmarkedCite('noteBm', cite(2))}</w:p>`;
+
+describe('NOTEREF through full layout', () => {
+  test('paints the number the note area shows, per-section numFmt included', () => {
+    const { part, notes } = openNotesDoc(
+      notesDoc(
+        CITING_BODY + `<w:p><w:r><w:t>see </w:t></w:r>${refField(' NOTEREF noteBm \\h ')}</w:p>`
+      ),
+      'lowerRoman'
+    );
+    const layout = layoutSemanticDocument(part, 1, {
+      measurer: notes.measurer,
+      notes,
+      producer: 'noteref',
+    });
+    const texts = textsOf(layout);
+    // The citation itself paints `ii`, and the NOTEREF paints the same rendering.
+    expect(texts).toContain('see ii');
+    expect(texts.join('|')).toContain('keepsii');
+  });
+
+  test('`\\p`, a missing bookmark and a mismatched cache keep their cached results', () => {
+    const { part, notes } = openNotesDoc(
+      notesDoc(
+        CITING_BODY +
+          `<w:p><w:r><w:t>a </w:t></w:r>${refField(' NOTEREF noteBm \\p ', 'above')}</w:p>` +
+          `<w:p><w:r><w:t>b </w:t></w:r>${refField(' NOTEREF gone ', 'kept')}</w:p>` +
+          `<w:p><w:r><w:t>c </w:t></w:r>${refField(' NOTEREF noteBm ', 'IX')}</w:p>`
+      )
+    );
+    const layout = layoutSemanticDocument(part, 1, {
+      measurer: notes.measurer,
+      notes,
+      producer: 'noteref',
+    });
+    const texts = textsOf(layout);
+    expect(texts).toContain('a above');
+    expect(texts).toContain('b kept');
+    expect(texts).toContain('c IX');
+  });
+
+  test('a renumbering edit repaints a live NOTEREF on a warm session; a cached one stays put', () => {
+    const { part, notes } = openNotesDoc(
+      notesDoc(
+        CITING_BODY +
+          // Empty cache: always calibration-eligible, paints live.
+          `<w:p><w:r><w:t>see </w:t></w:r>${refField(' NOTEREF noteBm \\h ')}</w:p>` +
+          // A cache the computed value never reproduces: pinned to `X` before and after.
+          `<w:p><w:r><w:t>pin </w:t></w:r>${refField(' NOTEREF noteBm ', 'X')}</w:p>`
+      )
+    );
+    const options = {
+      measurer: notes.measurer,
+      notes,
+      producer: 'noteref',
+      session: createLayoutSession(),
+      cache: createParagraphLayoutCache(),
+    };
+    const first = layoutSemanticDocument(part, 1, options);
+    expect(textsOf(first)).toContain('see 2');
+    expect(textsOf(first)).toContain('pin X');
+
+    // Remove the paragraph citing note 1: note 2 renumbers to 1. The NOTEREF paragraph
+    // survives BY IDENTITY, so only the resolved-value tokens can repaint it.
+    const after = withBlocks(part, (blocks) => blocks.filter((_, index) => index !== 0));
+    const warm = layoutSemanticDocument(after, 2, options);
+    const texts = textsOf(warm);
+    expect(texts).toContain('see 1');
+    expect(texts.join('|')).not.toContain('see 2');
+    expect(texts).toContain('pin X');
+  });
+});
+
+describe('NOTEREF results ride the save refresh plan', () => {
+  test('a calibrated body NOTEREF whose raw run differs from the live value is planned', () => {
+    // The cache normalizes to the computed `2` (NBSP = space), so the field calibrates
+    // live; the raw run still carries the NBSP, so the plan rewrites it to the painted text.
+    const bytes = notesDoc(
+      CITING_BODY + `<w:p><w:r><w:t>see </w:t></w:r>${refField(' NOTEREF noteBm \\h ', ' 2')}</w:p>`
+    );
+    const pkg = packageOf(bytes);
+    const part = pkg.parts.get(pkg.mainDocumentPart)!;
+    const op = planRefFieldResultRefresh(part, { package: pkg });
+    expect(op).not.toBeNull();
+    expect(op!.updates).toHaveLength(1);
+    expect(op!.updates[0]!.text).toBe('2');
+  });
+
+  test('a fresh document with an exact NOTEREF cache plans nothing', () => {
+    const bytes = notesDoc(
+      CITING_BODY + `<w:p><w:r><w:t>see </w:t></w:r>${refField(' NOTEREF noteBm \\h ', '2')}</w:p>`
+    );
+    const pkg = packageOf(bytes);
+    const part = pkg.parts.get(pkg.mainDocumentPart)!;
+    expect(planRefFieldResultRefresh(part, { package: pkg })).toBeNull();
+    // Sanity: the locator sees the field this asserts about.
+    const located = blocksOf(part).flatMap((block) => locateFieldResults(block));
+    expect(located.some((field) => field.instruction.includes('NOTEREF'))).toBe(true);
+  });
+});

--- a/packages/core/src/layout/__tests__/field-ref.test.ts
+++ b/packages/core/src/layout/__tests__/field-ref.test.ts
@@ -51,10 +51,45 @@ describe('parseRefInstruction', () => {
     expect(parseRefInstruction('REF x \\w \\r')?.numberSwitch).toBe('r');
   });
 
+  test('the `\\t` switch parses, stacked or alone, without changing the public members', () => {
+    // The suppress flag rides the modifier side channel, so the spec object stays this shape.
+    expect(parseRefInstruction('REF target \\t')).toEqual({
+      bookmark: 'target',
+      numberSwitch: null,
+      hyperlink: false,
+    });
+    // The certificate-template stack: number switches, hyperlink, `\t`, MERGEFORMAT.
+    expect(parseRefInstruction(' REF _Ref1 \\w \\n \\h \\t \\* MERGEFORMAT ')).toEqual({
+      bookmark: '_Ref1',
+      numberSwitch: 'n',
+      hyperlink: true,
+    });
+  });
+
+  test('NOTEREF parses its bookmark, `\\h` and MERGEFORMAT — nothing else', () => {
+    expect(parseRefInstruction(' NOTEREF _Ref9 ')).toEqual({
+      bookmark: '_Ref9',
+      numberSwitch: null,
+      hyperlink: false,
+    });
+    expect(parseRefInstruction('noteref _Ref9 \\h \\* MERGEFORMAT')).toEqual({
+      bookmark: '_Ref9',
+      numberSwitch: null,
+      hyperlink: true,
+    });
+    // `\p` (above/below text) and `\f` (note-style formatting) are out of scope on purpose:
+    // their presence keeps the whole field on its cached result.
+    expect(parseRefInstruction('NOTEREF _Ref9 \\p')).toBeNull();
+    expect(parseRefInstruction('NOTEREF _Ref9 \\f')).toBeNull();
+    expect(parseRefInstruction('NOTEREF _Ref9 \\h \\p')).toBeNull();
+    // Number switches belong to REF, not NOTEREF.
+    expect(parseRefInstruction('NOTEREF _Ref1 \\r')).toBeNull();
+    expect(parseRefInstruction('NOTEREF')).toBeNull();
+    expect(parseRefInstruction(`NOTEREF ${'x'.repeat(257)}`)).toBeNull();
+  });
+
   test('anything outside the supported grammar stays inert (null)', () => {
-    // Unknown switches fall back to the cached result — never a guess. `\t` in particular is
-    // common in real documents and stays unsupported on purpose.
-    expect(parseRefInstruction('REF target \\t')).toBeNull();
+    // Unknown switches fall back to the cached result — never a guess.
     expect(parseRefInstruction('REF target \\p')).toBeNull();
     expect(parseRefInstruction('REF target \\f')).toBeNull();
     expect(parseRefInstruction('REF target \\d "-"')).toBeNull();
@@ -66,7 +101,6 @@ describe('parseRefInstruction', () => {
     expect(parseRefInstruction(`REF ${'x'.repeat(257)}`)).toBeNull();
     expect(parseRefInstruction('REF "unterminated')).toBeNull();
     // Other keywords are not this field.
-    expect(parseRefInstruction('NOTEREF _Ref1 \\r')).toBeNull();
     expect(parseRefInstruction('PAGEREF _Ref1 \\h')).toBeNull();
     // Over the shared instruction cap fails closed.
     expect(parseRefInstruction(`REF ${'y'.repeat(MAX_FIELD_INSTRUCTION_CHARS)}`)).toBeNull();
@@ -376,6 +410,15 @@ describe('calibration: the authored cache is the oracle', () => {
     expect(context.tokenForParagraph(refParagraphs[1]!.id)).toContain('b.3');
   });
 
+  test('a `\\t` value that cannot reproduce the authored cache keeps that cache', () => {
+    // The filter yields `1`, the cache says `Section 1` — the field stays cached forever.
+    const part = document(
+      numbered(0, bookmarked('t', 'A')) + refField(' REF t \\r \\t ', 'Section 1')
+    );
+    const context = contextUnder(TWO_LEVEL_NUMBERING, part);
+    expect(liveAt(part, context, 0, parseRefInstruction(' REF t \\r \\t ')!)).toBeNull();
+  });
+
   test('normalization: NBSP and whitespace runs do not fail an otherwise exact match', () => {
     const part = document(
       numbered(0, bookmarked('t', 'A')) +
@@ -384,5 +427,58 @@ describe('calibration: the authored cache is the oracle', () => {
     );
     const context = contextUnder(TWO_LEVEL_NUMBERING, part);
     expect(liveAt(part, context, 0, spec('t', 'r'))).toBe('1');
+  });
+});
+
+/** Level texts with literal words — what the `\t` switch exists to suppress. */
+const WORDY_NUMBERING = `
+  <w:abstractNum w:abstractNumId="0">
+    <w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/>
+      <w:lvlText w:val="Section %1."/><w:lvlJc w:val="left"/></w:lvl>
+    <w:lvl w:ilvl="1"><w:start w:val="1"/><w:numFmt w:val="decimal"/>
+      <w:lvlText w:val="Section %1.%2"/><w:lvlJc w:val="left"/></w:lvl>
+    <w:lvl w:ilvl="2"><w:start w:val="1"/><w:numFmt w:val="lowerLetter"/>
+      <w:lvlText w:val="(%3)"/><w:lvlJc w:val="left"/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="5"><w:abstractNumId w:val="0"/></w:num>
+`;
+
+describe('the \\t switch suppresses non-delimiter text in the referenced number', () => {
+  // Counters at the targets: `Section 1.2` (ilvl 1, second item) and `(c)` (ilvl 2, third).
+  const body =
+    numbered(0, '<w:r><w:t>Section one</w:t></w:r>') +
+    numbered(1, '<w:r><w:t>1.1</w:t></w:r>') +
+    numbered(1, bookmarked('sec', 'Section 1.2')) +
+    numbered(2, '<w:r><w:t>(a)</w:t></w:r>') +
+    numbered(2, '<w:r><w:t>(b)</w:t></w:r>') +
+    numbered(2, bookmarked('clause', 'Clause (c)')) +
+    refField(' REF sec \\w \\t ') +
+    refField(' REF sec \\w ') +
+    refField(' REF clause \\n \\t ') +
+    refField(' REF clause \\w \\n \\h \\t \\* MERGEFORMAT ') +
+    refField(' REF clause \\w \\t ') +
+    refField(' REF sec \\t ');
+  const part = document(body);
+  const context = contextUnder(WORDY_NUMBERING, part);
+
+  test('`Section %1.%2` yields `1.2`; without `\\t` the words stay', () => {
+    expect(liveAt(part, context, 0, parseRefInstruction(' REF sec \\w \\t ')!)).toBe('1.2');
+    expect(liveAt(part, context, 1, spec('sec', 'w'))).toBe('Section 1.2');
+  });
+
+  test('a letter level `(%3)` keeps `(c)` — parentheses are delimiters, wherever they sit', () => {
+    expect(liveAt(part, context, 2, parseRefInstruction(' REF clause \\n \\t ')!)).toBe('(c)');
+    // The full stacked shape: `\n` outranks `\w`; `\h` and MERGEFORMAT stay inert.
+    expect(
+      liveAt(part, context, 3, parseRefInstruction(' REF clause \\w \\n \\h \\t \\* MERGEFORMAT ')!)
+    ).toBe('(c)');
+  });
+
+  test('`\\w \\t` filters every kept level of the full context', () => {
+    expect(liveAt(part, context, 4, parseRefInstruction(' REF clause \\w \\t ')!)).toBe('1.2(c)');
+  });
+
+  test('`\\t` on a plain REF has no counter template to filter — cached fallback', () => {
+    expect(liveAt(part, context, 5, parseRefInstruction(' REF sec \\t ')!)).toBeNull();
   });
 });

--- a/packages/core/src/layout/field-noteref.ts
+++ b/packages/core/src/layout/field-noteref.ts
@@ -1,0 +1,386 @@
+// NOTEREF fields (§17.16.5.48): the number of the footnote/endnote whose reference mark sits
+// inside the bookmarked range. The display number derives through the SAME numbering path the
+// painter uses — `deriveNoteDisplayMarksResolved` over per-section resolved note properties —
+// so the field and the note area cannot disagree on what a note is called. The parser arm
+// lives with the REF grammar in `field-ref.ts`; this module owns resolution only.
+//
+// CONSTRAINTS, each falling back to the field's cached result (never a guess):
+//   - Sites are collected pre-pagination, in document order over the body story blocks. A
+//     kind whose numbering restarts `eachPage` is refused outright: page assignment does not
+//     exist yet, and a guessed page paints exactly the wrong number the cache avoids.
+//   - The scan reads the canonical tree, not a revision display mode's projection. A document
+//     where hidden tracked deletions renumber notes keeps its NOTEREF caches through the
+//     per-field calibration gate instead of painting a diverged value.
+//   - `w:customMarkFollows` sites consume no automatic number and paint an authored glyph
+//     this module never sees; a NOTEREF aimed at one stays cached.
+//   - The note reference must sit inside the target paragraph's stretch of the bookmark —
+//     the same in-paragraph deviation plain-REF extraction takes, and the same bound that
+//     keeps a hostile range from widening any scan.
+//
+// Everything here is bounded: per-paragraph site scans ride the segment model and memoize on
+// the immutable paragraph node, the story aggregate is capped, and the bookmark walk shares
+// the field-scan budget and depth cap.
+
+import {
+  WML_NAMESPACE_URI,
+  type OoxmlElement,
+  type OoxmlNode,
+  type OoxmlParagraphNode,
+  type OoxmlPart,
+} from '@docx-editor.dev/core/store';
+import type { OoxmlPackage } from '../store/package/ooxml-package.ts';
+import { noteIdOf, noteReferenceKindOf, type NoteKind } from '../store/package/note-nodes.ts';
+import {
+  authoredDocumentEndnoteProperties,
+  authoredDocumentFootnoteProperties,
+  authoredEndnotePropertiesFromSectPr,
+  authoredFootnotePropertiesFromSectPr,
+  resolveEndnoteProperties,
+  resolveFootnoteProperties,
+  settingsPartOf,
+  type ResolvedEndnoteProperties,
+  type ResolvedFootnoteProperties,
+} from '../store/package/note-properties.ts';
+import { segmentsOf } from '../store/store/tree-op-segments.ts';
+import {
+  consumeScanNode,
+  createScanBudget,
+  MAX_STORY_FIELD_SCAN_DEPTH,
+} from './field-instruction.ts';
+import { walkStoryParagraphs } from './list-resolve.ts';
+import { deriveNoteDisplayMarksResolved, type NoteReferenceSite } from './note-numbering.ts';
+import { enumerateDocumentSectionsFromBlocks, paragraphSectionNode } from './section-properties.ts';
+
+/** Ceiling on note reference sites one story contributes; sites past it resolve to cache. */
+const MAX_NOTEREF_SITES = 4096;
+
+/** One section's block range, the minimum a site needs to pick its resolved properties. */
+export interface NoteRefSectionRange {
+  readonly blockStart: number;
+  readonly blockEndExclusive: number;
+}
+
+/**
+ * What NOTEREF resolution numbers against: the section bounds of the SAME walk that resolves
+ * the fields, paired with the per-section note properties the notes pass numbers with —
+ * the exact pairing `attachNotesToLayout` uses, so field and note area agree by construction.
+ */
+export interface NoteRefNumberingInput {
+  readonly sections: readonly NoteRefSectionRange[];
+  readonly footnotePropsBySection: readonly ResolvedFootnoteProperties[];
+  readonly endnotePropsBySection: readonly ResolvedEndnoteProperties[];
+  readonly documentFootnoteProps: ResolvedFootnoteProperties;
+  readonly documentEndnoteProps: ResolvedEndnoteProperties;
+}
+
+/** The note-properties slice of a `NotesLayoutInput`, structural so no import cycle forms. */
+export interface NoteRefNumberingSource {
+  readonly footnotePropsBySection: readonly ResolvedFootnoteProperties[];
+  readonly endnotePropsBySection: readonly ResolvedEndnoteProperties[];
+  readonly documentFootnoteProps: ResolvedFootnoteProperties;
+  readonly documentEndnoteProps: ResolvedEndnoteProperties;
+}
+
+/**
+ * Memoized per source object: the notes input is session-stable and the section enumeration
+ * is cached per blocks array, so an unchanged pass reuses the wrapper BY IDENTITY — which is
+ * what keeps the REF context memo (validated on this identity) serving its no-change hit.
+ */
+const numberingInputMemos = new WeakMap<
+  NoteRefNumberingSource,
+  { sections: readonly NoteRefSectionRange[]; input: NoteRefNumberingInput }
+>();
+
+/** The layout pass's numbering input, from its notes input and its own section bounds. */
+export function noteRefNumberingFromNotes(
+  notes: NoteRefNumberingSource,
+  sections: readonly NoteRefSectionRange[]
+): NoteRefNumberingInput {
+  const memo = numberingInputMemos.get(notes);
+  if (memo && memo.sections === sections) return memo.input;
+  const input: NoteRefNumberingInput = {
+    sections,
+    footnotePropsBySection: notes.footnotePropsBySection,
+    endnotePropsBySection: notes.endnotePropsBySection,
+    documentFootnoteProps: notes.documentFootnoteProps,
+    documentEndnoteProps: notes.documentEndnoteProps,
+  };
+  numberingInputMemos.set(notes, { sections, input });
+  return input;
+}
+
+/**
+ * The save-refresh path's numbering input, rebuilt from the package the way the surface
+ * builds its notes input (settings-level `w:footnotePr`/`w:endnotePr`, then each section's
+ * paragraph-level `w:sectPr` override), so a refreshed NOTEREF result carries the value the
+ * pages paint. The final section's body-level `w:sectPr` resolves to the document defaults
+ * here exactly as it does there.
+ */
+export function noteRefNumberingForPart(
+  pkg: OoxmlPackage,
+  part: OoxmlPart,
+  blocks: readonly OoxmlElement[]
+): NoteRefNumberingInput {
+  const settings = settingsPartOf(pkg);
+  const docFnAuthored = authoredDocumentFootnoteProperties(settings);
+  const docEnAuthored = authoredDocumentEndnoteProperties(settings);
+  const documentFootnoteProps = resolveFootnoteProperties(undefined, docFnAuthored);
+  const documentEndnoteProps = resolveEndnoteProperties(undefined, docEnAuthored);
+  const sections = enumerateDocumentSectionsFromBlocks(part, blocks).sections;
+  const sectPrOf = (section: NoteRefSectionRange): OoxmlElement | undefined => {
+    if (section.blockStart === section.blockEndExclusive) return undefined;
+    const block = blocks[section.blockEndExclusive - 1];
+    return block?.kind === 'paragraph' ? paragraphSectionNode(block) : undefined;
+  };
+  return {
+    sections,
+    footnotePropsBySection: sections.map((section) =>
+      resolveFootnoteProperties(
+        authoredFootnotePropertiesFromSectPr(sectPrOf(section)),
+        docFnAuthored
+      )
+    ),
+    endnotePropsBySection: sections.map((section) =>
+      resolveEndnoteProperties(
+        authoredEndnotePropertiesFromSectPr(sectPrOf(section)),
+        docEnAuthored
+      )
+    ),
+    documentFootnoteProps,
+    documentEndnoteProps,
+  };
+}
+
+/** One note reference mark inside a paragraph, before its section is known. */
+interface ParagraphNoteSite {
+  readonly nodeId: string;
+  readonly noteKind: NoteKind;
+  readonly noteId: number;
+  readonly customMarkFollows: boolean;
+}
+const EMPTY_SITES: readonly ParagraphNoteSite[] = Object.freeze([]);
+
+function customMarkFollowsOf(node: OoxmlElement): boolean {
+  for (const attribute of node.attributes) {
+    if (attribute.localName !== 'customMarkFollows') continue;
+    if (attribute.namespaceUri !== WML_NAMESPACE_URI && attribute.namespaceUri !== '') continue;
+    const value = attribute.value;
+    return !(value === '0' || value === 'false' || value === 'off');
+  }
+  return false;
+}
+
+/**
+ * Memoized per immutable paragraph node. Segment-aligned, like the lifecycle's own reference
+ * scan: only typed `noteReference` nodes count, so generic/demoted wrappers never invent a
+ * numbered site the painter would not number.
+ */
+const paragraphNoteSites = new WeakMap<OoxmlElement, readonly ParagraphNoteSite[]>();
+
+function noteSitesOfParagraph(paragraph: OoxmlElement): readonly ParagraphNoteSite[] {
+  const memo = paragraphNoteSites.get(paragraph);
+  if (memo) return memo;
+  let sites: ParagraphNoteSite[] | null = null;
+  for (const segment of segmentsOf(paragraph as OoxmlParagraphNode)) {
+    const node = segment.node;
+    if (node.kind !== 'noteReference') continue;
+    const noteKind = noteReferenceKindOf(node);
+    const noteId = noteIdOf(node);
+    if (noteKind === null || noteId === null) continue;
+    (sites ??= []).push({
+      nodeId: node.id,
+      noteKind,
+      noteId,
+      customMarkFollows: customMarkFollowsOf(node),
+    });
+  }
+  const result = sites === null ? EMPTY_SITES : Object.freeze(sites);
+  paragraphNoteSites.set(paragraph, result);
+  return result;
+}
+
+/** The painter's per-section fallback chain, verbatim: section entry, section 0, document. */
+function footnotePropsAt(
+  input: NoteRefNumberingInput,
+  sectionIndex: number
+): ResolvedFootnoteProperties {
+  return (
+    input.footnotePropsBySection[sectionIndex] ??
+    input.footnotePropsBySection[0] ??
+    input.documentFootnoteProps
+  );
+}
+function endnotePropsAt(
+  input: NoteRefNumberingInput,
+  sectionIndex: number
+): ResolvedEndnoteProperties {
+  return (
+    input.endnotePropsBySection[sectionIndex] ??
+    input.endnotePropsBySection[0] ??
+    input.documentEndnoteProps
+  );
+}
+
+const EMPTY_MARK_INDEX: ReadonlyMap<string, string> = new Map();
+
+/** Memo per blocks array, validated on the numbering input's identity (see the wrapper memo). */
+const markIndexMemos = new WeakMap<
+  readonly OoxmlElement[],
+  { input: NoteRefNumberingInput; index: ReadonlyMap<string, string> }
+>();
+
+/**
+ * Reference-mark node id → the display number the painter gives that citation, over the body
+ * story blocks in document order. Built lazily (only a story that holds a NOTEREF pays for
+ * it) and memoized on the blocks array, so a repeated resolve is a pointer lookup.
+ */
+export function noteRefMarkIndex(
+  blocks: readonly OoxmlElement[],
+  input: NoteRefNumberingInput
+): ReadonlyMap<string, string> {
+  const memo = markIndexMemos.get(blocks);
+  if (memo && memo.input === input) return memo.index;
+
+  const footnoteSites: NoteReferenceSite[] = [];
+  const footnoteNodeIds: string[] = [];
+  const endnoteSites: NoteReferenceSite[] = [];
+  const endnoteNodeIds: string[] = [];
+  let total = 0;
+  let sectionCursor = 0;
+  for (
+    let blockIndex = 0;
+    blockIndex < blocks.length && total < MAX_NOTEREF_SITES;
+    blockIndex += 1
+  ) {
+    while (
+      sectionCursor < input.sections.length - 1 &&
+      blockIndex >= input.sections[sectionCursor]!.blockEndExclusive
+    ) {
+      sectionCursor += 1;
+    }
+    const sectionIndex = input.sections.length > 0 ? sectionCursor : 0;
+    for (const paragraph of walkStoryParagraphs([blocks[blockIndex]!])) {
+      for (const site of noteSitesOfParagraph(paragraph)) {
+        // Sites past the cap resolve to the cached result; the prefix keeps painter order,
+        // so every number BELOW the cap is still the number the note area shows.
+        if (total >= MAX_NOTEREF_SITES) break;
+        total += 1;
+        const reference: NoteReferenceSite = {
+          noteId: site.noteId,
+          sectionIndex,
+          customMarkFollows: site.customMarkFollows,
+        };
+        if (site.noteKind === 'footnote') {
+          footnoteSites.push(reference);
+          footnoteNodeIds.push(site.nodeId);
+        } else {
+          endnoteSites.push(reference);
+          endnoteNodeIds.push(site.nodeId);
+        }
+      }
+    }
+  }
+
+  let index: Map<string, string> | null = null;
+  const addKind = (
+    kind: NoteKind,
+    sites: readonly NoteReferenceSite[],
+    nodeIds: readonly string[],
+    propsAt: (sectionIndex: number) => ResolvedFootnoteProperties | ResolvedEndnoteProperties
+  ): void => {
+    if (sites.length === 0) return;
+    // `eachPage` restart needs the page each site lands on, which only pagination knows.
+    // Check the same list the fallback chain can consult, and refuse the kind whole.
+    const consulted =
+      kind === 'footnote'
+        ? input.footnotePropsBySection.length > 0
+          ? input.footnotePropsBySection
+          : [input.documentFootnoteProps]
+        : input.endnotePropsBySection.length > 0
+          ? input.endnotePropsBySection
+          : [input.documentEndnoteProps];
+    if (consulted.some((props) => props.numRestart === 'eachPage')) return;
+    const marks = deriveNoteDisplayMarksResolved(kind, sites, propsAt);
+    for (let i = 0; i < marks.length; i += 1) {
+      const mark = marks[i]!.mark;
+      const nodeId = nodeIds[i];
+      // A suppressed mark (customMarkFollows) never joins: its citation paints an authored
+      // glyph, and a NOTEREF at it keeps the cache.
+      if (mark !== null && mark.length > 0 && nodeId !== undefined) {
+        (index ??= new Map()).set(nodeId, mark);
+      }
+    }
+  };
+  addKind('footnote', footnoteSites, footnoteNodeIds, (si) => footnotePropsAt(input, si));
+  addKind('endnote', endnoteSites, endnoteNodeIds, (si) => endnotePropsAt(input, si));
+
+  const result: ReadonlyMap<string, string> = index ?? EMPTY_MARK_INDEX;
+  markIndexMemos.set(blocks, { input, index: result });
+  return result;
+}
+
+function wmlAttribute(node: OoxmlElement, localName: string): string | undefined {
+  for (const attribute of node.attributes) {
+    if (attribute.namespaceUri === WML_NAMESPACE_URI && attribute.localName === localName) {
+      return attribute.value;
+    }
+  }
+  return undefined;
+}
+
+/** First note-reference id per (target paragraph, name), memoized on the immutable node. */
+const bookmarkNoteRefMemos = new WeakMap<OoxmlElement, Map<string, string | null>>();
+
+/**
+ * The FIRST typed note reference between the named `w:bookmarkStart` and its matching
+ * `w:bookmarkEnd` (same `w:id`), or to the paragraph's end when the range runs past it —
+ * the plain-REF extraction bound. Null when the range holds none.
+ */
+export function firstNoteReferenceIdInBookmark(
+  paragraph: OoxmlElement,
+  name: string
+): string | null {
+  let memo = bookmarkNoteRefMemos.get(paragraph);
+  const cached = memo?.get(name);
+  if (cached !== undefined) return cached;
+
+  let collecting = false;
+  let done = false;
+  let endId: string | undefined;
+  let found: string | null = null;
+  const budget = createScanBudget();
+
+  const visit = (node: OoxmlNode, depth: number): void => {
+    if (done || node.kind === 'textValue') return;
+    if (budget.exhausted || depth > MAX_STORY_FIELD_SCAN_DEPTH) return;
+    if (node.kind === 'bookmarkStart') {
+      if (!collecting && wmlAttribute(node, 'name') === name) {
+        collecting = true;
+        endId = wmlAttribute(node, 'id');
+      }
+      return;
+    }
+    if (node.kind === 'bookmarkEnd') {
+      if (collecting && endId !== undefined && wmlAttribute(node, 'id') === endId) done = true;
+      return;
+    }
+    if (collecting && node.kind === 'noteReference') {
+      found = node.id;
+      done = true;
+      return;
+    }
+    if (!consumeScanNode(budget)) return;
+    for (const child of node.children) visit(child, depth + 1);
+  };
+  for (const child of paragraph.children) {
+    if (done || !consumeScanNode(budget)) break;
+    visit(child, 1);
+  }
+
+  if (!memo) {
+    memo = new Map();
+    bookmarkNoteRefMemos.set(paragraph, memo);
+  }
+  memo.set(name, found);
+  return found;
+}

--- a/packages/core/src/layout/field-ref-refresh.ts
+++ b/packages/core/src/layout/field-ref-refresh.ts
@@ -27,7 +27,12 @@ import {
   MAX_FIELD_RESULT_UPDATES,
   type RefreshFieldResultsOp,
 } from '../store/store/tree-op-field-results.ts';
-import { parseRefInstruction, resolveStoryRefFields, type RefNoteParts } from './field-ref.ts';
+import { noteRefNumberingForPart } from './field-noteref.ts';
+import {
+  parseRefInstruction,
+  resolveStoryRefFieldsWithNoteNumbers,
+  type RefNoteParts,
+} from './field-ref.ts';
 import { walkStoryParagraphs, withResolvedListItems } from './list-resolve.ts';
 import type { NumberingIndex } from './numbering-index.ts';
 import { DEFAULT_REVISION_DISPLAY_MODE } from './revision-projection.ts';
@@ -72,7 +77,14 @@ export function planRefFieldResultRefresh(
         endnotesPart: resolveNotesPart(options.package, 'endnote'),
       }
     : undefined;
-  const context = resolveStoryRefFields(blocks, listItems, notes);
+  // NOTEREF results ride the same plan: the numbering input rebuilds from the package the
+  // way the surface builds its notes input, so a refreshed result carries the painted value.
+  const context = resolveStoryRefFieldsWithNoteNumbers(
+    blocks,
+    listItems,
+    notes,
+    options.package ? noteRefNumberingForPart(options.package, part, blocks) : undefined
+  );
   if (context === null) return null;
 
   const updates: { paragraphId: string; fieldNodeId: string; text: string }[] = [];

--- a/packages/core/src/layout/field-ref.ts
+++ b/packages/core/src/layout/field-ref.ts
@@ -5,7 +5,12 @@
 // quote-aware tokenize pass over a length-capped string; anything outside the supported
 // grammar — an unknown switch (`\p`, `\f`, `\d`, `\#`, …), a missing bookmark argument, an
 // over-long name — resolves to null and the field keeps painting its cached result exactly as
-// before. `\* MERGEFORMAT` is inert; `\h` only parses (navigation is not wired here).
+// before. `\* MERGEFORMAT` is inert; `\h` only parses (navigation is not wired here). `\t`
+// suppresses the number's literal text (the template filter in `list-counters.ts` states the
+// delimiter rule). The same tokenizer also recognizes `NOTEREF <bookmark> [\h]` — the number
+// of the note whose reference mark sits inside the bookmark, resolved by `field-noteref.ts`
+// through the painter's own numbering; its `\p` / `\f` switches stay out of the grammar on
+// purpose, so such fields keep their cache.
 //
 // Resolution reads three story-derived inputs, all bounded:
 //   - bookmark name → target paragraph, indexed ONLY for referenced names (the index can never
@@ -69,6 +74,11 @@ import {
   onFldCharEnd,
   onFldCharSeparate,
 } from './field-instruction.ts';
+import {
+  firstNoteReferenceIdInBookmark,
+  noteRefMarkIndex,
+  type NoteRefNumberingInput,
+} from './field-noteref.ts';
 import { composeFullContextNumber } from './list-counters.ts';
 import {
   listItemNumberSource,
@@ -94,6 +104,38 @@ export interface RefFieldSpec {
   readonly numberSwitch: 'r' | 'w' | 'n' | null;
   /** `\h` parsed and inert — the reference paints; navigation is a follow-up. */
   readonly hyperlink: boolean;
+}
+
+/**
+ * The modifiers a parse attaches beyond the public members: `\t` (suppress the number's
+ * literal text) and the NOTEREF field kind. A side channel rather than members — the same
+ * idiom `ListCounterAdvance` uses, for the same reason: `RefFieldSpec` is public API, and a
+ * hand-built spec without an entry must mean "no modifiers", which the default below encodes.
+ * Values are the frozen singletons, so agreement between two independent parses of the same
+ * instruction is an identity comparison.
+ */
+interface RefSpecModifiers {
+  /** `\t`: drop non-delimiter literal text from the referenced number. */
+  readonly suppressNonDelimiterText: boolean;
+  /** The instruction was `NOTEREF`: paint the bookmarked note reference's display number. */
+  readonly noteRef: boolean;
+}
+const REF_MODS_NONE: RefSpecModifiers = Object.freeze({
+  suppressNonDelimiterText: false,
+  noteRef: false,
+});
+const REF_MODS_SUPPRESS: RefSpecModifiers = Object.freeze({
+  suppressNonDelimiterText: true,
+  noteRef: false,
+});
+const REF_MODS_NOTEREF: RefSpecModifiers = Object.freeze({
+  suppressNonDelimiterText: false,
+  noteRef: true,
+});
+const refSpecModifiers = new WeakMap<RefFieldSpec, RefSpecModifiers>();
+
+function refSpecModifiersOf(spec: RefFieldSpec): RefSpecModifiers {
+  return refSpecModifiers.get(spec) ?? REF_MODS_NONE;
 }
 
 /**
@@ -127,12 +169,14 @@ function tokenizeInstruction(collapsed: string): string[] | null {
 }
 
 /**
- * Recognize `REF <bookmark> [\r|\w|\n] [\h] [\* MERGEFORMAT]`, or null for anything else.
+ * Recognize `REF <bookmark> [\r|\w|\n] [\t] [\h] [\* MERGEFORMAT]` or
+ * `NOTEREF <bookmark> [\h] [\* MERGEFORMAT]`, or null for anything else.
  *
  * The keyword matches case-insensitively; the bookmark name keeps its authored case (it is a
  * lookup key into a Map, never an object property, so hostile names like `__proto__` are just
  * names that resolve to nothing). Any unrecognized switch fails the parse so the field falls
- * back to its cached result — never the raw instruction, never a guess.
+ * back to its cached result — never the raw instruction, never a guess. NOTEREF's `\p`
+ * (above/below position text) and `\f` (note-style formatting) are unrecognized on purpose.
  */
 export function parseRefInstruction(raw: string): RefFieldSpec | null {
   if (raw.length > MAX_FIELD_INSTRUCTION_CHARS) return null;
@@ -140,7 +184,8 @@ export function parseRefInstruction(raw: string): RefFieldSpec | null {
   if (collapsed.length > MAX_FIELD_INSTRUCTION_CHARS) return null;
   const tokens = tokenizeInstruction(collapsed);
   if (tokens === null || tokens.length < 2) return null;
-  if (tokens[0]!.toUpperCase() !== 'REF') return null;
+  const keyword = tokens[0]!.toUpperCase();
+  if (keyword !== 'REF' && keyword !== 'NOTEREF') return null;
   const bookmark = tokens[1]!;
   if (
     bookmark.length === 0 ||
@@ -149,15 +194,18 @@ export function parseRefInstruction(raw: string): RefFieldSpec | null {
   ) {
     return null;
   }
+  if (keyword === 'NOTEREF') return parseNoteRefSwitches(tokens, bookmark);
   let sawN = false;
   let sawR = false;
   let sawW = false;
+  let sawT = false;
   let hyperlink = false;
   for (let index = 2; index < tokens.length; index += 1) {
     const token = tokens[index]!.toUpperCase();
     if (token === '\\R') sawR = true;
     else if (token === '\\W') sawW = true;
     else if (token === '\\N') sawN = true;
+    else if (token === '\\T') sawT = true;
     else if (token === '\\H') hyperlink = true;
     else if (token === '\\*' && tokens[index + 1]?.toUpperCase() === 'MERGEFORMAT') index += 1;
     else if (token === '\\*MERGEFORMAT') continue;
@@ -166,7 +214,24 @@ export function parseRefInstruction(raw: string): RefFieldSpec | null {
   // Several number switches in one instruction: `\n` outranks `\r` outranks `\w`. Real
   // documents write `\w \n \h` and cache the `\n`-shaped value; calibration guards the rest.
   const numberSwitch: RefFieldSpec['numberSwitch'] = sawN ? 'n' : sawR ? 'r' : sawW ? 'w' : null;
-  return { bookmark, numberSwitch, hyperlink };
+  const spec: RefFieldSpec = { bookmark, numberSwitch, hyperlink };
+  if (sawT) refSpecModifiers.set(spec, REF_MODS_SUPPRESS);
+  return spec;
+}
+
+/** The NOTEREF switch arm: `\h` inert, `\* MERGEFORMAT` inert, anything else fails closed. */
+function parseNoteRefSwitches(tokens: readonly string[], bookmark: string): RefFieldSpec | null {
+  let hyperlink = false;
+  for (let index = 2; index < tokens.length; index += 1) {
+    const token = tokens[index]!.toUpperCase();
+    if (token === '\\H') hyperlink = true;
+    else if (token === '\\*' && tokens[index + 1]?.toUpperCase() === 'MERGEFORMAT') index += 1;
+    else if (token === '\\*MERGEFORMAT') continue;
+    else return null;
+  }
+  const spec: RefFieldSpec = { bookmark, numberSwitch: null, hyperlink };
+  refSpecModifiers.set(spec, REF_MODS_NOTEREF);
+  return spec;
 }
 
 /**
@@ -562,6 +627,7 @@ interface RefContextMemoEntry {
   readonly listItems: ReadonlyMap<string, ResolvedListItem> | undefined;
   readonly footnotesPart: OoxmlPart | null;
   readonly endnotesPart: OoxmlPart | null;
+  readonly noteNumbering: NoteRefNumberingInput | undefined;
   readonly context: RefFieldContext | null;
 }
 /**
@@ -575,7 +641,8 @@ const refContextMemos = new WeakMap<readonly OoxmlElement[], RefContextMemoEntry
 function buildRefFieldContext(
   blocks: readonly OoxmlElement[],
   listItems: ReadonlyMap<string, ResolvedListItem> | undefined,
-  notes: RefNoteParts | undefined
+  notes: RefNoteParts | undefined,
+  noteNumbering: NoteRefNumberingInput | undefined
 ): RefFieldContext | null {
   const fieldsByParagraph = new Map<string, readonly ScannedRefField[]>();
   const blockScans: BlockRefScan[] = [];
@@ -616,8 +683,18 @@ function buildRefFieldContext(
   }
 
   const resolve = (spec: RefFieldSpec): string | null => {
+    const mods = refSpecModifiersOf(spec);
     const target = targets.get(spec.bookmark);
     if (!target) return null;
+    if (mods.noteRef) {
+      // NOTEREF: the display number of the note whose reference mark sits inside the
+      // bookmark. The index derives through the painter's own numbering path; a pass with
+      // no numbering input (a story laid out without notes) keeps the cache.
+      if (noteNumbering === undefined) return null;
+      const referenceNodeId = firstNoteReferenceIdInBookmark(target, spec.bookmark);
+      if (referenceNodeId === null) return null;
+      return noteRefMarkIndex(blocks, noteNumbering).get(referenceNodeId) ?? null;
+    }
     if (spec.numberSwitch !== null) {
       const item = listItems?.get(target.id);
       if (!item) return null;
@@ -625,26 +702,43 @@ function buildRefFieldContext(
       // and painting bare `(c)` for a `1.2(c)` target is worse than the stale cache. `\n`:
       // the target's own level only, per Word's cached values for that switch. Items built
       // outside `resolveStoryListItems` carry no counter source; their marker is the bounded
-      // fallback.
+      // fallback — except under `\t`, whose filter runs on the level TEMPLATES and cannot
+      // strip an already-expanded marker, so that pairing keeps the cache.
       const source = listItemNumberSource(item);
       const composed =
-        source !== undefined ? composeFullContextNumber(source, spec.numberSwitch === 'n') : null;
+        source !== undefined
+          ? composeFullContextNumber(
+              source,
+              spec.numberSwitch === 'n',
+              mods.suppressNonDelimiterText
+            )
+          : null;
       // A bullet has a marker but no number a reader can cite — cached fallback, not a glyph.
       const fallback =
-        item.numFmt !== 'bullet' && item.numFmt !== 'none' && item.markerText.length > 0
+        !mods.suppressNonDelimiterText &&
+        item.numFmt !== 'bullet' &&
+        item.numFmt !== 'none' &&
+        item.markerText.length > 0
           ? item.markerText
           : null;
       const value = composed ?? fallback;
       if (value === null) return null;
       return trimTrailingPeriod(value);
     }
+    // `\t` on a plain REF would filter the bookmarked TEXT, which has no counter template to
+    // filter against — cached fallback, the pre-existing degradation for that shape.
+    if (mods.suppressNonDelimiterText) return null;
     const text = bookmarkRangeText(target, spec.bookmark);
     return text.length > 0 ? text : null;
   };
 
   const computedValues = new Map<string, string | null>();
   const computedOf = (spec: RefFieldSpec): string | null => {
-    const key = `${spec.numberSwitch ?? 't'}\u0000${spec.bookmark}`;
+    // The modifier singletons join the key, so `REF x \w`, `REF x \w \t` and `NOTEREF x`
+    // never share a computed value.
+    const mods = refSpecModifiersOf(spec);
+    const modKey = mods === REF_MODS_SUPPRESS ? 't' : mods === REF_MODS_NOTEREF ? 'x' : '';
+    const key = `${spec.numberSwitch ?? '-'}${modKey}\u0000${spec.bookmark}`;
     if (computedValues.has(key)) return computedValues.get(key) ?? null;
     const value = resolve(spec);
     computedValues.set(key, value);
@@ -694,8 +788,13 @@ function buildRefFieldContext(
       const entry = liveByAnchor.get(anchorId);
       if (!entry || entry.live === null) return null;
       // The projection parsed the same instruction this scan did; a disagreement means the
-      // anchor id names some other field now — fail to the cache.
-      if (entry.spec.bookmark !== spec.bookmark || entry.spec.numberSwitch !== spec.numberSwitch) {
+      // anchor id names some other field now — fail to the cache. Modifiers are frozen
+      // singletons, so identity compares them.
+      if (
+        entry.spec.bookmark !== spec.bookmark ||
+        entry.spec.numberSwitch !== spec.numberSwitch ||
+        refSpecModifiersOf(entry.spec) !== refSpecModifiersOf(spec)
+      ) {
         return null;
       }
       return entry.live;
@@ -716,6 +815,22 @@ export function resolveStoryRefFields(
   listItems: ReadonlyMap<string, ResolvedListItem> | undefined,
   notes?: RefNoteParts
 ): RefFieldContext | null {
+  return resolveStoryRefFieldsWithNoteNumbers(blocks, listItems, notes, undefined);
+}
+
+/**
+ * {@link resolveStoryRefFields} plus the numbering input NOTEREF resolution needs. A separate
+ * entry (not re-exported from the layout index) so the public signature stays put; callers
+ * that cannot supply the input keep every NOTEREF field on its cached result. The input is
+ * memoized by its producers (`noteRefNumberingFromNotes`), so the identity check below still
+ * serves the no-change pass.
+ */
+export function resolveStoryRefFieldsWithNoteNumbers(
+  blocks: readonly OoxmlElement[],
+  listItems: ReadonlyMap<string, ResolvedListItem> | undefined,
+  notes: RefNoteParts | undefined,
+  noteNumbering: NoteRefNumberingInput | undefined
+): RefFieldContext | null {
   const footnotesPart = notes?.footnotesPart ?? null;
   const endnotesPart = notes?.endnotesPart ?? null;
   const memo = refContextMemos.get(blocks);
@@ -723,12 +838,13 @@ export function resolveStoryRefFields(
     memo &&
     memo.listItems === listItems &&
     memo.footnotesPart === footnotesPart &&
-    memo.endnotesPart === endnotesPart
+    memo.endnotesPart === endnotesPart &&
+    memo.noteNumbering === noteNumbering
   ) {
     return memo.context;
   }
-  const context = buildRefFieldContext(blocks, listItems, notes);
-  refContextMemos.set(blocks, { listItems, footnotesPart, endnotesPart, context });
+  const context = buildRefFieldContext(blocks, listItems, notes, noteNumbering);
+  refContextMemos.set(blocks, { listItems, footnotesPart, endnotesPart, noteNumbering, context });
   return context;
 }
 

--- a/packages/core/src/layout/list-counters.ts
+++ b/packages/core/src/layout/list-counters.ts
@@ -206,6 +206,40 @@ export function expandCountersOf(advance: ListCounterAdvance): readonly number[]
   return expandCountersByAdvance.get(advance) ?? advance.counters;
 }
 
+/** Matches what the `\t` filter drops from a `w:lvlText`: literal letters and whitespace. */
+const SUPPRESSED_LVL_TEXT_CHAR = /[\p{L}\s]/u;
+
+/**
+ * The `REF \t` filter over one level's `w:lvlText`: keep the counter placeholders and the
+ * delimiter characters, drop the literal words.
+ *
+ * DESIGN DECISION — what counts as a delimiter: every non-letter, non-whitespace character
+ * (`.`, `(`, `)`, `-`, `/`, `:`, literal digits) is KEPT wherever it sits, including the
+ * leading and trailing parentheses of `(%3)` — Word's cached `\t` values for such levels
+ * read `(c)`, not `c`. Literal LETTERS drop (they are the text the switch suppresses), and
+ * whitespace drops with them: it exists to set the dropped words off, and Word's cached
+ * values show compact joins (`Section 4.2` caches as `4.2`). The filter runs on the
+ * TEMPLATE, never the expanded string, because expanded a letter or roman COUNTER (`(c)`,
+ * `(ii)`) is indistinguishable from a literal word. One linear pass over a length-capped
+ * string; the per-field calibration gate in `field-ref.ts` keeps any document whose cached
+ * values disagree on its cache.
+ */
+function suppressNonDelimiterLvlText(lvlText: string): string {
+  let out = '';
+  for (let index = 0; index < lvlText.length; index += 1) {
+    const char = lvlText[index]!;
+    const next = lvlText[index + 1];
+    if (char === '%' && next !== undefined && next >= '1' && next <= '9') {
+      out += char + next;
+      index += 1;
+      continue;
+    }
+    if (SUPPRESSED_LVL_TEXT_CHAR.test(char)) continue;
+    out += char;
+  }
+  return out;
+}
+
 /**
  * What composing a paragraph's FULL-CONTEXT number needs: the linked index its levels resolve
  * through and the substitution-ready counters captured when the paragraph was counted.
@@ -229,11 +263,15 @@ export interface FullContextNumberSource {
  * falls back). Bounded: at most nine levels, each expansion under the marker-length caps.
  *
  * `ownLevelOnly` keeps just the target level's expansion — what a `REF \n` paints (`(c)`,
- * `(ii)`), per Word's own cached values for that switch.
+ * `(ii)`), per Word's own cached values for that switch. `suppressNonDelimiterText` applies
+ * the `REF \t` template filter (see {@link suppressNonDelimiterLvlText}) to every kept level
+ * before it expands. The keep/drop decisions above it read the ORIGINAL texts — the filter
+ * preserves placeholders, so both views agree on which levels contribute.
  */
 export function composeFullContextNumber(
   source: FullContextNumberSource,
-  ownLevelOnly = false
+  ownLevelOnly = false,
+  suppressNonDelimiterText = false
 ): string | null {
   const { index, numId, ilvl, expandCounters } = source;
   if (ilvl < 0 || ilvl > 8) return null;
@@ -269,11 +307,10 @@ export function composeFullContextNumber(
   let out = '';
   for (const lvl of kept) {
     const level = levels[lvl]!;
-    out += expandLvlText(
-      level.lvlText,
-      expandCounters,
-      legalEffectiveFormats(formats, level.isLgl)
-    );
+    const template = suppressNonDelimiterText
+      ? suppressNonDelimiterLvlText(level.lvlText)
+      : level.lvlText;
+    out += expandLvlText(template, expandCounters, legalEffectiveFormats(formats, level.isLgl));
   }
   return out.length > 0 ? out : null;
 }

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -171,7 +171,12 @@ import {
   withResolvedListItemsForSession,
   type ResolvedListItem,
 } from './list-resolve.ts';
-import { refTokenForTableBlock, resolveStoryRefFields, type RefFieldContext } from './field-ref.ts';
+import { noteRefNumberingFromNotes } from './field-noteref.ts';
+import {
+  refTokenForTableBlock,
+  resolveStoryRefFieldsWithNoteNumbers,
+  type RefFieldContext,
+} from './field-ref.ts';
 import { publishListMarker } from './list-marker.ts';
 import {
   NO_DEFERRED_DRAWINGS,
@@ -614,12 +619,16 @@ export function layoutSemanticDocument(
   // so the context is built here — the one place that sees both — and rides the options
   // spreads into every section pass. Note stories join the context (their REF fields cite
   // body targets), so paint agrees across stories. Null for the common REF-free document.
-  const refFields = resolveStoryRefFields(
+  // NOTEREF fields number against THIS walk's section bounds paired with the notes input's
+  // per-section properties — the pairing `attachNotesToLayout` numbers the note areas with,
+  // so field and area agree by construction.
+  const refFields = resolveStoryRefFieldsWithNoteNumbers(
     blocks,
     optionsWithLists.listItems,
     options.notes
       ? { footnotesPart: options.notes.footnotesPart, endnotesPart: options.notes.endnotesPart }
-      : undefined
+      : undefined,
+    options.notes ? noteRefNumberingFromNotes(options.notes, sections) : undefined
   );
   const optionsForBody = refFields === null ? optionsWithLists : { ...optionsWithLists, refFields };
 


### PR DESCRIPTION
Two coverage widenings for cross-reference fields, both guarded by the existing per-field calibration gate, so no document can render worse than its saved cache.

The `\t` switch suppresses non-delimiter text in a referenced number (`Section 4.2` reads `4.2`). The filter runs on the level template, not the expanded string, so letter and roman counters like `(c)` and `(ii)` survive: literal letters and whitespace drop, every other character is a delimiter and stays.

`NOTEREF` fields resolve the bookmarked footnote or endnote reference to its display number through the same numbering path the painter uses, including per-section formats and `eachSect` restarts. `\h` parses and stays inert; `\p`, `\f`, `eachPage` restarts, and custom marks keep the cached result. Resolved values fold into the same cache tokens as `REF`, so a note renumbering repaints dependent fields, and body-story results ride the save-time refresh.

Fixes #612

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790601615&installation_model_id=422592&pr_number=616&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F616&signature=a4a4da00ab595462b8d2e53ae6f81e044f710ad99c39f037cbef155952e2cbea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->