### PR TITLE
fix: keep paragraph after-spacing out of the page-fit decision

### DIFF
--- a/.changeset/after-spacing-page-fit.md
+++ b/.changeset/after-spacing-page-fit.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Paragraph spacing-after no longer counts toward the page-fit decision: a line that fits stays on its page and trailing space clips at the boundary, so an oversized `w:after` (the signature-block idiom) no longer mints blank trailing pages. Fixes #615.

--- a/packages/core/src/layout/__tests__/paragraph-spacing-borders.test.ts
+++ b/packages/core/src/layout/__tests__/paragraph-spacing-borders.test.ts
@@ -439,3 +439,49 @@ describe('linesOf still walks every line when spacing and borders are present', 
     expect(lines[0]!.range).toMatchObject({ start: 0, end: 5 });
   });
 });
+
+// Spacing-after never decides its own line's fit (§17.3.1.33, issue #615): Word fits the
+// LINE box, and trailing space that crosses the page boundary clips at the break. The
+// signature-block idiom (`w:after="10867"` on an empty paragraph) otherwise mints a blank
+// trailing page Word does not produce.
+describe('after-spacing stays out of the page-fit decision', () => {
+  // SMALL content height is 80pt; each fixed-measurer line is 14pt.
+
+  test('an empty final paragraph with oversized after does not mint a trailing page', () => {
+    const body =
+      Array.from({ length: 4 }, (_, index) => paragraph(`line ${index}`)).join('') +
+      paragraph('', '<w:spacing w:after="10867"/>');
+    const layout = lay(load(body), SMALL);
+    // Lines sit at 0/14/28/42; the empty mark's line fits at 56..70 of 80.
+    expect(layout.pages).toHaveLength(1);
+    const withoutTrailing = lay(
+      load(Array.from({ length: 4 }, (_, index) => paragraph(`line ${index}`)).join('')),
+      SMALL
+    );
+    expect(layout.pages.length).toBe(withoutTrailing.pages.length);
+  });
+
+  test('a line that fits stays on its page even when line + after overflows', () => {
+    const body =
+      Array.from({ length: 4 }, (_, index) => paragraph(`line ${index}`)).join('') +
+      paragraph('fits', '<w:spacing w:after="800"/>') +
+      paragraph('next');
+    const layout = lay(load(body), SMALL);
+    expect(layout.pages).toHaveLength(2);
+    const fits = layout.pages[0]!.fragments.filter((f) => f.kind === 'paragraph').at(-1)!;
+    if (fits.kind !== 'paragraph') throw new Error('expected paragraph');
+    expect(fits.lines[0]!.spans.map((span) => span.text).join('')).toBe('fits');
+    expect(fits.lines[0]!.box.y).toBe(56);
+    // The clipped after-spacing leaves no residual: the next paragraph opens page 2 at 0.
+    const next = layout.pages[1]!.fragments.find((f) => f.kind === 'paragraph')!;
+    if (next.kind !== 'paragraph') throw new Error('expected paragraph');
+    expect(next.lines[0]!.spans.map((span) => span.text).join('')).toBe('next');
+    expect(next.spacing.before).toBe(0);
+    expect(next.lines[0]!.box.y).toBe(0);
+  });
+
+  test('a lone paragraph whose after exceeds the page keeps to one page', () => {
+    const layout = lay(load(paragraph('only', '<w:spacing w:after="10867"/>')), SMALL);
+    expect(layout.pages).toHaveLength(1);
+  });
+});

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -2197,7 +2197,11 @@ function layoutBlocksPass(
         markRunProperties.length === 0
           ? DEFAULT_RUN_STYLE
           : resolveRunStyle(markRunProperties, styleCascade?.themeFonts);
-      const firstTail = lines.length <= 1 ? borderExtent + spacing.after : 0;
+      // Spacing-after never decides its own line's fit (§17.3.1.33): Word fits the LINE box,
+      // and trailing space that crosses the page boundary clips at the break. Only the closing
+      // border rule is real painted content below the last line, so only it joins the budget.
+      // An oversized `w:after` — the signature-block idiom — otherwise mints blank pages.
+      const firstTail = lines.length <= 1 ? borderExtent : 0;
       const prospectiveFirstTop = cursorY + lead + topExtent;
       const firstZones = placementZonesForLine(
         entry,
@@ -2577,7 +2581,10 @@ function layoutBlocksPass(
     for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
       const pendingLine = lines[lineIndex]!;
       const isLastLine = lineIndex === lines.length - 1;
-      const tail = isLastLine ? borderExtent + spacing.after : 0;
+      // Spacing-after stays out of the fit budget (see the firstTail note above): it moves
+      // where the NEXT paragraph starts, never whether this line fits, and it clips at the
+      // page boundary rather than carrying over.
+      const tail = isLastLine ? borderExtent : 0;
       if (lineIndex === fragmentFirstLine) {
         fragmentParagraphStartY = cursorY;
         if (paragraphHasAnchors && paragraphAnchorOrigin === null && fragmentIndex === 0) {


### PR DESCRIPTION
Page-fit for a paragraph line now consumes spacing-before and the line box only. Spacing-after moves where the next paragraph starts and clips at the page boundary, so an oversized `w:after` on a trailing paragraph no longer mints a blank page, and a line that fits stays on its page. The closing border rule still joins the fit budget because paint draws it below the last line.

Fixes #615.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/619"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790614293&installation_model_id=422592&pr_number=619&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F619&signature=f06b0463b935e15a8a46c512b313771633e92a9140da4ba9cbdc21c80fcbb945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->