### PR TITLE
feat: compute PAGEREF results from the target's page at pagination time

### DIFF
--- a/.changeset/pageref-fields-compute.md
+++ b/.changeset/pageref-fields-compute.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Body `PAGEREF` fields now compute the page number of their bookmark target at pagination time and refresh on save, so table-of-contents page numbers stay correct after edits and in exported files. Each field is calibrated against its authored cache; unsupported switches or a missing bookmark keep the cached result. Fixes #617.

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -724,6 +724,7 @@ export interface FieldAtomMarker {
         readonly kind: AllowlistedPageField;
         readonly picture?: string;
     };
+    readonly pageRef?: PageRefFieldProjection;
 }
 
 // @public
@@ -1823,7 +1824,21 @@ export interface PageRecord {
 }
 
 // @public
+export type PageRefCalibrationCell = Readonly<Record<never, never>>;
+
+// @public
+export interface PageRefFieldProjection {
+    readonly cached: string;
+    // (undocumented)
+    readonly calibration: PageRefCalibrationCell;
+    readonly targetParagraphId: string;
+}
+
+// @public
 export type PageRefIndex = ReadonlyMap<string, readonly PageRefHit[]>;
+
+// @public
+export function pageRefPageNumbersFromLayout(layout: SemanticLayout): (targetParagraphId: string) => string | null;
 
 // @public
 export function pagesToMaterialize(input: MaterializationInput): Set<number>;
@@ -2147,6 +2162,7 @@ displayMode?: RevisionDisplayMode): SemanticTableStructure | null;
 export interface RefFieldContext {
     autonumValueOf?(anchorId: string): string | null;
     liveValueOf(anchorId: string, spec: RefFieldSpec): string | null;
+    pageRefProjectionOf?(anchorId: string, spec: RefFieldSpec): PageRefFieldProjection | null;
     tokenForParagraph(paragraphId: string): string;
     readonly valuesToken: string;
 }
@@ -2157,6 +2173,7 @@ export interface RefFieldRefreshOptions {
     // (undocumented)
     readonly numberingIndex?: NumberingIndex;
     readonly package?: OoxmlPackage;
+    readonly pageRefPageNumberOf?: (targetParagraphId: string) => string | null;
     // (undocumented)
     readonly styleCascade?: StyleCascadeTable;
 }

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -54,6 +54,7 @@ import {
   contentControlRecordsInPart,
   contentControlsInLayout,
   layoutSemanticDocument,
+  pageRefPageNumbersFromLayout,
   planRefFieldResultRefresh,
   resolveNumberingLevel,
   positionPastDeletion,
@@ -4509,6 +4510,11 @@ export function mountPaginatedSurface(
       styleCascade: styleCascade(),
       numberingIndex: numberingIndex(),
       displayMode: revisionDisplayMode(),
+      // PAGEREF results refresh from the CURRENT finalized pages, through the same index
+      // finalize substitution reads, so the saved numbers are the painted ones. Body plan
+      // only — the note planner ignores it, since note-story PAGEREF fields paint their
+      // cache.
+      pageRefPageNumberOf: pageRefPageNumbersFromLayout(surface.layout()),
     };
     // Both plans read before the write lands, and they share one memoized resolution
     // context — the note values are the ones the pages painted, per calibration verdict.

--- a/packages/core/src/layout/__tests__/field-pageref-layout.test.ts
+++ b/packages/core/src/layout/__tests__/field-pageref-layout.test.ts
@@ -241,7 +241,10 @@ describe('a bookmark edit re-resolves the target in a warm session', () => {
 describe('save-time PAGEREF result refresh', () => {
   test('a fresh result plans nothing; a moved target plans the painted value', () => {
     const part = load(TWO_PAGE_BODY('2'));
-    // Computed equals the cache: the field calibrates live and nothing needs rewriting.
+    // Paint first: the layout finalize is what latches the calibration (a save-time check
+    // alone never latches — its NaN revision could not be revoked by the note pass).
+    layoutSemanticDocument(part, 1, { measurer, geometry: SMALL });
+    // Computed equals the cache: the field is live and nothing needs rewriting.
     expect(planRefFieldResultRefresh(part, { pageRefPageNumberOf: () => '2' })).toBeNull();
     // Same document object, so the sticky live verdict carries; the target now reports
     // page 3 and the plan rewrites the result to what the pages paint.

--- a/packages/core/src/layout/__tests__/field-pageref-layout.test.ts
+++ b/packages/core/src/layout/__tests__/field-pageref-layout.test.ts
@@ -13,6 +13,7 @@ import { createLayoutSession } from '../layout-session.ts';
 import { createParagraphLayoutCache } from '../layout-cache.ts';
 import { paragraphFragmentsOf, type PageGeometry, type SemanticLayout } from '../index.ts';
 import { planRefFieldResultRefresh } from '../field-ref-refresh.ts';
+import { pageRefCalibrationVerdict } from '../field-page-furniture.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const measurer = createFixedMeasurer(6, 14);
@@ -168,6 +169,70 @@ describe('a repagination repaints dependent PAGEREF fields in a warm session', (
     ]);
     const warm = layoutSemanticDocument(after, 2, options);
     expect(warm.pages).toHaveLength(3);
+    expect(textsOf(warm)).toContain('page 3');
+    expect(textsOf(warm).join('|')).not.toContain('page 2');
+  });
+});
+
+describe('the calibration latch is provisional within a revision, sticky across them', () => {
+  test('a same-revision re-finalize that moved the target revokes the latch', () => {
+    // The body finalize matches the cache; the note pass then re-finalizes the SAME revision
+    // with the target shifted by an inserted overflow sheet. The pass's last word is that the
+    // cache is not reproduced, so the field must stay cached.
+    const cell = {};
+    expect(pageRefCalibrationVerdict(cell, '5', '5', 7)).toBe(true);
+    expect(pageRefCalibrationVerdict(cell, '5', '6', 7)).toBe(false);
+    expect(pageRefCalibrationVerdict(cell, '5', '6', 7)).toBe(false);
+  });
+
+  test('a later revision cannot revoke: an edit diverges the live value by design', () => {
+    const cell = {};
+    expect(pageRefCalibrationVerdict(cell, '5', '5', 7)).toBe(true);
+    expect(pageRefCalibrationVerdict(cell, '5', '6', 8)).toBe(true);
+    expect(pageRefCalibrationVerdict(cell, '5', '9', 9)).toBe(true);
+  });
+
+  test('an empty cache is always live and never revoked', () => {
+    const cell = {};
+    expect(pageRefCalibrationVerdict(cell, '', '5', 7)).toBe(true);
+    expect(pageRefCalibrationVerdict(cell, '', '6', 7)).toBe(true);
+  });
+
+  test('a failed first compare re-checks and can go live on the post-note numbering', () => {
+    const cell = {};
+    expect(pageRefCalibrationVerdict(cell, '6', '5', 7)).toBe(false);
+    expect(pageRefCalibrationVerdict(cell, '6', '6', 7)).toBe(true);
+    expect(pageRefCalibrationVerdict(cell, '6', '9', 8)).toBe(true);
+  });
+});
+
+describe('a bookmark edit re-resolves the target in a warm session', () => {
+  test('removing the winning declaration moves the field to the next one', () => {
+    // Two paragraphs declare the same name; first declaration wins, so the field paints the
+    // page of the FIRST. Removing that paragraph re-resolves the name to the survivor on the
+    // next page — while the field's own paragraph survives the edit by identity, so only the
+    // target id folded into its ref token can invalidate its cached fragment.
+    const before = load(
+      pageRefParagraph(' PAGEREF target \\h ') +
+        filler(5) +
+        heading('target', 'First winner') +
+        filler(6, 'gap') +
+        `<w:p><w:bookmarkStart w:id="2" w:name="target"/><w:r><w:t>Second</w:t></w:r>` +
+        `<w:bookmarkEnd w:id="2"/></w:p>`
+    );
+    const options = {
+      measurer,
+      geometry: SMALL,
+      session: createLayoutSession(),
+      cache: createParagraphLayoutCache(),
+    };
+    const first = layoutSemanticDocument(before, 1, options);
+    expect(textsOf(first)).toContain('page 2');
+
+    const after = withBlocks(before, (blocks) => blocks.filter((block) => block !== blocks[6]));
+    const warm = layoutSemanticDocument(after, 2, options);
+    const oracle = layoutSemanticDocument(after, 1, { measurer, geometry: SMALL });
+    expect(textsOf(oracle)).toContain('page 3');
     expect(textsOf(warm)).toContain('page 3');
     expect(textsOf(warm).join('|')).not.toContain('page 2');
   });

--- a/packages/core/src/layout/__tests__/field-pageref-layout.test.ts
+++ b/packages/core/src/layout/__tests__/field-pageref-layout.test.ts
@@ -1,0 +1,198 @@
+// PAGEREF fields through full layout: the page number of the bookmark target's page.
+//
+// The value is a property of pagination, so the paragraph walk paints the cached result (or
+// the placeholder digit) and marks the span; `finalizePageFieldProjection` substitutes the
+// number of the page hosting the target's first fragment. The document's own cache is the
+// calibration oracle, exactly as it is for REF: a cache the computed number cannot reproduce
+// keeps painting verbatim, and the verdict is sticky in the live direction only.
+
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, type OoxmlElement, type OoxmlPart } from '@docx-editor.dev/core/store';
+import { createFixedMeasurer, layoutSemanticDocument } from '../semantic-layout.ts';
+import { createLayoutSession } from '../layout-session.ts';
+import { createParagraphLayoutCache } from '../layout-cache.ts';
+import { paragraphFragmentsOf, type PageGeometry, type SemanticLayout } from '../index.ts';
+import { planRefFieldResultRefresh } from '../field-ref-refresh.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const measurer = createFixedMeasurer(6, 14);
+
+// Content height 80pt at 14pt per fixed-measurer line: five lines per page.
+const SMALL: PageGeometry = {
+  width: 200,
+  height: 100,
+  margin: { top: 10, right: 10, bottom: 10, left: 10 },
+};
+
+function load(body: string): OoxmlPart {
+  const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'application/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+const filler = (count: number, prefix = 'filler') =>
+  Array.from({ length: count }, (_, i) => `<w:p><w:r><w:t>${prefix} ${i}</w:t></w:r></w:p>`).join(
+    ''
+  );
+
+const heading = (name: string, text: string) =>
+  `<w:p><w:bookmarkStart w:id="1" w:name="${name}"/><w:r><w:t>${text}</w:t></w:r>` +
+  `<w:bookmarkEnd w:id="1"/></w:p>`;
+
+const pageRefField = (instr: string, cached = '') =>
+  '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+  `<w:r><w:instrText>${instr}</w:instrText></w:r>` +
+  '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+  (cached ? `<w:r><w:t>${cached}</w:t></w:r>` : '') +
+  '<w:r><w:fldChar w:fldCharType="end"/></w:r>';
+
+const pageRefParagraph = (instr: string, cached = '') =>
+  `<w:p><w:r><w:t>page </w:t></w:r>${pageRefField(instr, cached)}</w:p>`;
+
+const textsOf = (layout: SemanticLayout): string[] =>
+  layout.pages.flatMap((page) =>
+    paragraphFragmentsOf(page).map((fragment) =>
+      fragment.lines
+        .flatMap((line) => line.spans.map((span) => span.text))
+        .join('')
+        .trim()
+    )
+  );
+
+function layoutOf(body: string): SemanticLayout {
+  return layoutSemanticDocument(load(body), 1, { measurer, geometry: SMALL });
+}
+
+// Six 14pt lines fit the 80pt content box (a boundary line's trailing spacing may cross the
+// bottom text margin). The PAGEREF paragraph opens the document; five filler lines fill
+// page 1; the bookmarked heading opens page 2.
+const TWO_PAGE_BODY = (cached = '', instr = ' PAGEREF target \\h ') =>
+  pageRefParagraph(instr, cached) + filler(5) + heading('target', 'The heading');
+
+describe('body PAGEREF fields compute the target page at finalize', () => {
+  test('an empty cache paints the computed page number', () => {
+    const layout = layoutOf(TWO_PAGE_BODY());
+    expect(layout.pages).toHaveLength(2);
+    expect(textsOf(layout)).toContain('page 2');
+  });
+
+  test('a cache the computed number reproduces goes live', () => {
+    const layout = layoutOf(TWO_PAGE_BODY('2'));
+    expect(textsOf(layout)).toContain('page 2');
+  });
+
+  test('a cache the computed number cannot reproduce paints verbatim', () => {
+    const layout = layoutOf(TWO_PAGE_BODY('9'));
+    expect(textsOf(layout)).toContain('page 9');
+    expect(textsOf(layout).join('|')).not.toContain('page 2');
+  });
+
+  test('an unsupported switch keeps the cached result', () => {
+    // `\p` (relative "above/below") is out of the grammar on purpose.
+    const layout = layoutOf(TWO_PAGE_BODY('9', ' PAGEREF target \\p '));
+    expect(textsOf(layout)).toContain('page 9');
+  });
+
+  test('a missing bookmark keeps the cached result', () => {
+    const layout = layoutOf(TWO_PAGE_BODY('9', ' PAGEREF nowhere \\h '));
+    expect(textsOf(layout)).toContain('page 9');
+  });
+
+  test('a simple PAGEREF resolves the same way', () => {
+    const body =
+      `<w:p><w:r><w:t>page </w:t></w:r><w:fldSimple w:instr=" PAGEREF target \\h "/></w:p>` +
+      filler(5) +
+      heading('target', 'The heading');
+    const layout = layoutOf(body);
+    expect(textsOf(layout)).toContain('page 2');
+  });
+});
+
+/**
+ * Replace the body's block list while keeping every surviving node BY IDENTITY — the shape a
+ * `TreeDocumentStore` commit publishes (the same helper `field-ref-layout.test.ts` uses).
+ */
+function withBlocks(
+  part: OoxmlPart,
+  edit: (blocks: readonly OoxmlElement[]) => readonly OoxmlElement[]
+): OoxmlPart {
+  const body = part.root.children.find(
+    (child): child is OoxmlElement => child.kind !== 'textValue' && child.localName === 'body'
+  )!;
+  const blocks = body.children.filter(
+    (child): child is OoxmlElement => child.kind === 'paragraph' || child.kind === 'table'
+  );
+  const edited = edit(blocks);
+  const nextChildren = [
+    ...edited,
+    ...body.children.filter(
+      (child) =>
+        child.kind === 'textValue' || (child.kind !== 'paragraph' && child.kind !== 'table')
+    ),
+  ];
+  const nextBody = { ...body, children: nextChildren } as OoxmlElement;
+  const nextRoot = {
+    ...part.root,
+    children: part.root.children.map((child) => (child === body ? nextBody : child)),
+  } as OoxmlElement;
+  return { ...part, root: nextRoot };
+}
+
+describe('a repagination repaints dependent PAGEREF fields in a warm session', () => {
+  test('the target moving a page updates the painted number, live past its cache', () => {
+    // The cache says 2 and the target IS on page 2, so the field calibrates live. The edit
+    // pushes the heading to page 3 while the PAGEREF paragraph survives by identity — only
+    // the finalize substitution can repaint it, and the sticky live verdict must hold even
+    // though the computed value now diverges from the cache.
+    const before = load(TWO_PAGE_BODY('2'));
+    const options = {
+      measurer,
+      geometry: SMALL,
+      session: createLayoutSession(),
+      cache: createParagraphLayoutCache(),
+    };
+    const first = layoutSemanticDocument(before, 1, options);
+    expect(textsOf(first)).toContain('page 2');
+
+    const inserted = load(filler(6, 'insert'));
+    const insertedBlocks = inserted.root.children
+      .flatMap((child) => (child.kind === 'textValue' ? [] : child.children))
+      .filter((child): child is OoxmlElement => child.kind === 'paragraph');
+    const after = withBlocks(before, (blocks) => [
+      blocks[0]!,
+      ...insertedBlocks,
+      ...blocks.slice(1),
+    ]);
+    const warm = layoutSemanticDocument(after, 2, options);
+    expect(warm.pages).toHaveLength(3);
+    expect(textsOf(warm)).toContain('page 3');
+    expect(textsOf(warm).join('|')).not.toContain('page 2');
+  });
+});
+
+describe('save-time PAGEREF result refresh', () => {
+  test('a fresh result plans nothing; a moved target plans the painted value', () => {
+    const part = load(TWO_PAGE_BODY('2'));
+    // Computed equals the cache: the field calibrates live and nothing needs rewriting.
+    expect(planRefFieldResultRefresh(part, { pageRefPageNumberOf: () => '2' })).toBeNull();
+    // Same document object, so the sticky live verdict carries; the target now reports
+    // page 3 and the plan rewrites the result to what the pages paint.
+    const op = planRefFieldResultRefresh(part, { pageRefPageNumberOf: () => '3' });
+    expect(op).not.toBeNull();
+    expect(op!.updates).toHaveLength(1);
+    expect(op!.updates[0]!.text).toBe('3');
+  });
+
+  test('a field that failed calibration keeps its cached result on save', () => {
+    const part = load(TWO_PAGE_BODY('9'));
+    expect(planRefFieldResultRefresh(part, { pageRefPageNumberOf: () => '2' })).toBeNull();
+  });
+
+  test('a plan without a page-number source keeps every PAGEREF result as loaded', () => {
+    const part = load(TWO_PAGE_BODY('9'));
+    expect(planRefFieldResultRefresh(part, {})).toBeNull();
+  });
+});

--- a/packages/core/src/layout/__tests__/field-ref.test.ts
+++ b/packages/core/src/layout/__tests__/field-ref.test.ts
@@ -101,7 +101,11 @@ describe('parseRefInstruction', () => {
     expect(parseRefInstruction(`REF ${'x'.repeat(257)}`)).toBeNull();
     expect(parseRefInstruction('REF "unterminated')).toBeNull();
     // Other keywords are not this field.
-    expect(parseRefInstruction('PAGEREF _Ref1 \\h')).toBeNull();
+    expect(parseRefInstruction('SEQ figure')).toBeNull();
+    // PAGEREF parses (its value defers to pagination finalize), but only `\h` and the inert
+    // `\* MERGEFORMAT` are in its grammar — `\p` keeps the cache.
+    expect(parseRefInstruction('PAGEREF _Ref1 \\h')?.bookmark).toBe('_Ref1');
+    expect(parseRefInstruction('PAGEREF _Ref1 \\p')).toBeNull();
     // Over the shared instruction cap fails closed.
     expect(parseRefInstruction(`REF ${'y'.repeat(MAX_FIELD_INSTRUCTION_CHARS)}`)).toBeNull();
   });

--- a/packages/core/src/layout/field-page-furniture.ts
+++ b/packages/core/src/layout/field-page-furniture.ts
@@ -305,28 +305,43 @@ export interface PageRefHostRecord {
 }
 
 /**
- * Sticky PAGEREF calibration verdicts, keyed weakly on each field's calibration cell.
+ * Sticky PAGEREF calibration latches, keyed weakly on each field's calibration cell.
  *
- * The cell (minted and carried across passes by `field-ref.ts`) is the identity; the verdict
+ * The cell (minted and carried across passes by `field-ref.ts`) is the identity; the latch
  * lives here so writing it never mutates a span marker that fragment signatures serialize.
- * Sticky in the LIVE direction only: once a field's computed number reproduced its cache it
- * stays live — after an edit the two diverge by design, and re-comparing would flip every
- * fresh TOC number back to stale. A FAILED compare is re-taken on later finalizes instead,
- * because pagination is not final when the first finalize runs: the note pass can insert
- * overflow sheets and re-finalize, and a verdict frozen against the pre-note numbering would
- * keep a correct field on its cache forever.
+ * The latch records the REVISION it was taken at because one document revision can finalize
+ * more than once — the body pass first, then the note pass after overflow sheets shifted
+ * body pages — and only the pass's LAST word is the pagination the calibration rule speaks
+ * about. So the latch is provisional within its own revision (a same-revision re-finalize
+ * whose computed number no longer reproduces the cache revokes it) and sticky across
+ * revisions (after an edit the live value diverges from the cache by design, and re-comparing
+ * would flip every fresh TOC number back to stale). A compare that FAILS re-checks on later
+ * finalizes, so a field whose cache matches only the post-note numbering still goes live.
  */
-const pageRefLiveVerdicts = new WeakSet<object>();
+const pageRefLiveLatches = new WeakMap<object, { revision: number }>();
 
 /**
- * Whether one PAGEREF field paints its computed number, taking the calibration once against
- * a non-empty cache. Shared with the save-time result refresh so the exported bytes and the
- * painted pages read the same verdict.
+ * Whether one PAGEREF field paints its computed number, taking the calibration against a
+ * non-empty cache under the rules above. Shared with the save-time result refresh so the
+ * exported bytes and the painted pages read the same verdict; the refresh passes `NaN` as
+ * its revision, which can neither latch-collide with nor revoke a layout pass's latch.
  */
-export function pageRefCalibrationVerdict(cell: object, cached: string, computed: string): boolean {
-  if (pageRefLiveVerdicts.has(cell)) return true;
+export function pageRefCalibrationVerdict(
+  cell: object,
+  cached: string,
+  computed: string,
+  revision: number
+): boolean {
+  const latch = pageRefLiveLatches.get(cell);
+  if (latch) {
+    if (cached.length > 0 && computed !== cached && latch.revision === revision) {
+      pageRefLiveLatches.delete(cell);
+      return false;
+    }
+    return true;
+  }
   const live = cached.length === 0 || cached === computed;
-  if (live) pageRefLiveVerdicts.add(cell);
+  if (live) pageRefLiveLatches.set(cell, { revision });
   return live;
 }
 
@@ -383,7 +398,21 @@ interface PageRefTargetIndex {
  * but runs only when a marker exists. The token folds every assignment, so a finalize memo
  * keyed on it re-substitutes exactly when repagination moved a target.
  */
+/**
+ * Memo per page-list identity: finalize and the multi-section restore gate both index the
+ * same array in one pass, and the walk should run once, not once per asker.
+ */
+const pageRefIndexMemos = new WeakMap<readonly PageRecord[], PageRefTargetIndex | null>();
+
 export function buildPageRefTargetIndex(pages: readonly PageRecord[]): PageRefTargetIndex | null {
+  const memo = pageRefIndexMemos.get(pages);
+  if (memo !== undefined) return memo;
+  const built = buildPageRefTargetIndexUncached(pages);
+  pageRefIndexMemos.set(pages, built);
+  return built;
+}
+
+function buildPageRefTargetIndexUncached(pages: readonly PageRecord[]): PageRefTargetIndex | null {
   let wanted: Set<string> | null = null;
   for (const page of pages) {
     if (page.hasBodyPageFields === false) continue;
@@ -432,7 +461,7 @@ export function pageRefAssignmentToken(pages: readonly PageRecord[]): string {
 function substituteBodyPageFieldLine(
   line: LineRecord,
   context: FieldPageContext,
-  pageRefHosts?: ReadonlyMap<string, PageRefHostRecord>
+  pageRefs?: PageRefSubstitution
 ): LineRecord {
   let spans: StyleSpanRecord[] | null = null;
   for (let index = 0; index < line.spans.length; index += 1) {
@@ -440,14 +469,24 @@ function substituteBodyPageFieldLine(
     const pageRef = span.fieldAtom?.pageRef;
     if (pageRef) {
       // The target never placed (deleted target, or a bookmark in furniture): keep the cache.
-      const hostPage = pageRefHosts?.get(pageRef.targetParagraphId);
+      const hostPage = pageRefs?.hosts.get(pageRef.targetParagraphId);
       if (!hostPage) continue;
       const computed = formatPageNumber(hostPage.pageNumber, hostPage.format);
       if (computed.length === 0) continue;
-      if (!pageRefCalibrationVerdict(pageRef.calibration, pageRef.cached, computed)) continue;
-      if (computed === span.text) continue;
+      const live = pageRefCalibrationVerdict(
+        pageRef.calibration,
+        pageRef.cached,
+        computed,
+        pageRefs!.revision
+      );
+      // A revoked latch must also UNDO: the note pass re-finalizes pages an earlier finalize
+      // of the same revision already substituted, and leaving the span alone would keep the
+      // pre-note number — neither the cache nor the truth. A never-live field already paints
+      // its cache, so the restore is an identity no-op there.
+      const text = live ? computed : pageRef.cached;
+      if (text.length === 0 || text === span.text) continue;
       if (!spans) spans = line.spans.slice();
-      spans[index] = { ...span, text: computed };
+      spans[index] = { ...span, text };
       continue;
     }
     const marker = span.fieldAtom?.pageField;
@@ -469,10 +508,17 @@ function substituteBodyPageFieldLine(
  * mirroring {@link finalizePageFieldProjection}'s identity discipline so incremental layout keeps
  * reusing untouched pages.
  */
+/** The PAGEREF inputs one finalize substitutes under: the host index and its revision. */
+export interface PageRefSubstitution {
+  readonly hosts: ReadonlyMap<string, PageRefHostRecord>;
+  /** The finalizing layout's revision — the calibration latch's provisional-revoke scope. */
+  readonly revision: number;
+}
+
 export function substituteBodyPageFields(
   blocks: readonly BlockFragmentRecord[],
   context: FieldPageContext,
-  pageRefHosts?: ReadonlyMap<string, PageRefHostRecord>
+  pageRefs?: PageRefSubstitution
 ): readonly BlockFragmentRecord[] {
   let next: BlockFragmentRecord[] | null = null;
   for (let index = 0; index < blocks.length; index += 1) {
@@ -482,7 +528,7 @@ export function substituteBodyPageFields(
       let mutatedLines: LineRecord[] | null = null;
       for (let lineIndex = 0; lineIndex < block.lines.length; lineIndex += 1) {
         const line = block.lines[lineIndex]!;
-        const nextLine = substituteBodyPageFieldLine(line, context, pageRefHosts);
+        const nextLine = substituteBodyPageFieldLine(line, context, pageRefs);
         if (nextLine === line) continue;
         if (!mutatedLines) mutatedLines = block.lines.slice();
         mutatedLines[lineIndex] = nextLine;
@@ -495,7 +541,7 @@ export function substituteBodyPageFields(
         let mutatedCells: (typeof row.cells)[number][] | null = null;
         for (let cellIndex = 0; cellIndex < row.cells.length; cellIndex += 1) {
           const cell = row.cells[cellIndex]!;
-          const cellBlocks = substituteBodyPageFields(cell.blocks, context, pageRefHosts);
+          const cellBlocks = substituteBodyPageFields(cell.blocks, context, pageRefs);
           if (cellBlocks === cell.blocks) continue;
           if (!mutatedCells) mutatedCells = row.cells.slice();
           mutatedCells[cellIndex] = { ...cell, blocks: cellBlocks };
@@ -676,7 +722,11 @@ export function finalizePageFieldProjection(layout: SemanticLayout): SemanticLay
     const fragments =
       page.hasBodyPageFields === false
         ? page.fragments
-        : substituteBodyPageFields(page.fragments, context, pageRefIndex?.hosts);
+        : substituteBodyPageFields(
+            page.fragments,
+            context,
+            pageRefIndex ? { hosts: pageRefIndex.hosts, revision: layout.revision } : undefined
+          );
     // Reachable only for pages with NO live projector and NO body substitution: `project`
     // always mints a fresh record for a projector-bearing story (the rest-spread above), so
     // this identity entry can never publish — or memoize as final — a record that still

--- a/packages/core/src/layout/field-page-furniture.ts
+++ b/packages/core/src/layout/field-page-furniture.ts
@@ -238,10 +238,10 @@ export function withPageFieldSources(
   return changed ? next : (pages as PageRecord[]);
 }
 
-/** True when any span on this line carries a body page-field marker. */
+/** True when any span on this line carries a body page-field or PAGEREF marker. */
 function lineHasBodyPageField(line: LineRecord): boolean {
   for (const span of line.spans) {
-    if (span.fieldAtom?.pageField) return true;
+    if (span.fieldAtom?.pageField || span.fieldAtom?.pageRef) return true;
   }
   return false;
 }
@@ -296,17 +296,160 @@ export function summarizeFlushedPage(
 }
 
 /**
+ * Where a PAGEREF target's first fragment landed: the displayed PAGE value of that sheet and
+ * the section's authored number format, read off the page's {@link PageFieldSource}.
+ */
+export interface PageRefHostRecord {
+  readonly pageNumber: number;
+  readonly format?: string;
+}
+
+/**
+ * Sticky PAGEREF calibration verdicts, keyed weakly on each field's calibration cell.
+ *
+ * The cell (minted and carried across passes by `field-ref.ts`) is the identity; the verdict
+ * lives here so writing it never mutates a span marker that fragment signatures serialize.
+ * Sticky in the LIVE direction only: once a field's computed number reproduced its cache it
+ * stays live — after an edit the two diverge by design, and re-comparing would flip every
+ * fresh TOC number back to stale. A FAILED compare is re-taken on later finalizes instead,
+ * because pagination is not final when the first finalize runs: the note pass can insert
+ * overflow sheets and re-finalize, and a verdict frozen against the pre-note numbering would
+ * keep a correct field on its cache forever.
+ */
+const pageRefLiveVerdicts = new WeakSet<object>();
+
+/**
+ * Whether one PAGEREF field paints its computed number, taking the calibration once against
+ * a non-empty cache. Shared with the save-time result refresh so the exported bytes and the
+ * painted pages read the same verdict.
+ */
+export function pageRefCalibrationVerdict(cell: object, cached: string, computed: string): boolean {
+  if (pageRefLiveVerdicts.has(cell)) return true;
+  const live = cached.length === 0 || cached === computed;
+  if (live) pageRefLiveVerdicts.add(cell);
+  return live;
+}
+
+/** Collect the PAGEREF target ids one block's markers name, into `into`. */
+function collectPageRefTargets(block: BlockFragmentRecord, into: Set<string>): void {
+  if (block.kind === 'paragraph') {
+    for (const line of block.lines) {
+      for (const span of line.spans) {
+        const target = span.fieldAtom?.pageRef?.targetParagraphId;
+        if (target !== undefined) into.add(target);
+      }
+    }
+    return;
+  }
+  for (const row of block.rows) {
+    for (const cell of row.cells) {
+      for (const inner of cell.blocks) collectPageRefTargets(inner, into);
+    }
+  }
+}
+
+/** Record the first page hosting each wanted paragraph, walking nested table cells too. */
+function recordPageRefHosts(
+  block: BlockFragmentRecord,
+  wanted: ReadonlySet<string>,
+  host: PageRefHostRecord,
+  hosts: Map<string, PageRefHostRecord>
+): void {
+  if (block.kind === 'paragraph') {
+    if (wanted.has(block.paragraphId) && !hosts.has(block.paragraphId)) {
+      hosts.set(block.paragraphId, host);
+    }
+    return;
+  }
+  for (const row of block.rows) {
+    for (const cell of row.cells) {
+      for (const inner of cell.blocks) recordPageRefHosts(inner, wanted, host, hosts);
+    }
+  }
+}
+
+/** The resolved PAGEREF target → host-page map for one finalize, plus its reuse token. */
+interface PageRefTargetIndex {
+  readonly hosts: ReadonlyMap<string, PageRefHostRecord>;
+  readonly token: string;
+}
+
+/**
+ * Build the PAGEREF target index for one page list, or null when no page carries a marker.
+ *
+ * Marker collection honours the `hasBodyPageFields` fast-out (a PAGEREF marker stamps the
+ * flag exactly like a PAGE marker), so the common no-TOC document pays one flag read per
+ * page. The HOST walk covers every page — targets are headings anywhere in the document —
+ * but runs only when a marker exists. The token folds every assignment, so a finalize memo
+ * keyed on it re-substitutes exactly when repagination moved a target.
+ */
+export function buildPageRefTargetIndex(pages: readonly PageRecord[]): PageRefTargetIndex | null {
+  let wanted: Set<string> | null = null;
+  for (const page of pages) {
+    if (page.hasBodyPageFields === false) continue;
+    for (const fragment of page.fragments) {
+      collectPageRefTargets(fragment, (wanted ??= new Set()));
+    }
+  }
+  if (!wanted || wanted.size === 0) return null;
+  const hosts = new Map<string, PageRefHostRecord>();
+  for (const page of pages) {
+    if (hosts.size >= wanted.size) break;
+    const source = page.pageFieldSource;
+    const host: PageRefHostRecord = {
+      pageNumber: source?.pageNumber ?? page.index + 1,
+      ...(source?.format ? { format: source.format } : {}),
+    };
+    for (const fragment of page.fragments) {
+      recordPageRefHosts(fragment, wanted, host, hosts);
+    }
+  }
+  let token = '';
+  for (const [paragraphId, host] of hosts) {
+    token += `${paragraphId}@${host.pageNumber}/${host.format ?? ''};`;
+  }
+  return { hosts, token };
+}
+
+/**
+ * The PAGEREF reuse token of a finalized or raw page list — what the multi-section restore
+ * compares before handing back previously finalized sheets, since a target can change pages
+ * while the restored sheet's own record is identity-unchanged.
+ */
+export function pageRefAssignmentToken(pages: readonly PageRecord[]): string {
+  return buildPageRefTargetIndex(pages)?.token ?? '';
+}
+
+/**
  * Substitute a body page-field placeholder line, or return it by identity.
  *
- * Only a span carrying a {@link FieldAtomMarker.pageField} marker is touched, and only when the
- * value the atom lands on differs from what the span already paints. The span's model `range`
- * stays its reserved one-unit width whatever the substituted text length is — paint and the
- * offset accounting clamp to that width, so a multi-digit page number never lengthens the model.
+ * Only a span carrying a {@link FieldAtomMarker.pageField} / {@link FieldAtomMarker.pageRef}
+ * marker is touched, and only when the value the atom lands on differs from what the span
+ * already paints. The span's model `range` stays its reserved one-unit width whatever the
+ * substituted text length is — paint and the offset accounting clamp to that width, so a
+ * multi-digit page number never lengthens the model.
  */
-function substituteBodyPageFieldLine(line: LineRecord, context: FieldPageContext): LineRecord {
+function substituteBodyPageFieldLine(
+  line: LineRecord,
+  context: FieldPageContext,
+  pageRefHosts?: ReadonlyMap<string, PageRefHostRecord>
+): LineRecord {
   let spans: StyleSpanRecord[] | null = null;
   for (let index = 0; index < line.spans.length; index += 1) {
     const span = line.spans[index]!;
+    const pageRef = span.fieldAtom?.pageRef;
+    if (pageRef) {
+      // The target never placed (deleted target, or a bookmark in furniture): keep the cache.
+      const hostPage = pageRefHosts?.get(pageRef.targetParagraphId);
+      if (!hostPage) continue;
+      const computed = formatPageNumber(hostPage.pageNumber, hostPage.format);
+      if (computed.length === 0) continue;
+      if (!pageRefCalibrationVerdict(pageRef.calibration, pageRef.cached, computed)) continue;
+      if (computed === span.text) continue;
+      if (!spans) spans = line.spans.slice();
+      spans[index] = { ...span, text: computed };
+      continue;
+    }
     const marker = span.fieldAtom?.pageField;
     if (!marker) continue;
     const text = projectPageFieldValue(marker.kind, context, marker.picture);
@@ -328,7 +471,8 @@ function substituteBodyPageFieldLine(line: LineRecord, context: FieldPageContext
  */
 export function substituteBodyPageFields(
   blocks: readonly BlockFragmentRecord[],
-  context: FieldPageContext
+  context: FieldPageContext,
+  pageRefHosts?: ReadonlyMap<string, PageRefHostRecord>
 ): readonly BlockFragmentRecord[] {
   let next: BlockFragmentRecord[] | null = null;
   for (let index = 0; index < blocks.length; index += 1) {
@@ -338,7 +482,7 @@ export function substituteBodyPageFields(
       let mutatedLines: LineRecord[] | null = null;
       for (let lineIndex = 0; lineIndex < block.lines.length; lineIndex += 1) {
         const line = block.lines[lineIndex]!;
-        const nextLine = substituteBodyPageFieldLine(line, context);
+        const nextLine = substituteBodyPageFieldLine(line, context, pageRefHosts);
         if (nextLine === line) continue;
         if (!mutatedLines) mutatedLines = block.lines.slice();
         mutatedLines[lineIndex] = nextLine;
@@ -351,7 +495,7 @@ export function substituteBodyPageFields(
         let mutatedCells: (typeof row.cells)[number][] | null = null;
         for (let cellIndex = 0; cellIndex < row.cells.length; cellIndex += 1) {
           const cell = row.cells[cellIndex]!;
-          const cellBlocks = substituteBodyPageFields(cell.blocks, context);
+          const cellBlocks = substituteBodyPageFields(cell.blocks, context, pageRefHosts);
           if (cellBlocks === cell.blocks) continue;
           if (!mutatedCells) mutatedCells = row.cells.slice();
           mutatedCells[cellIndex] = { ...cell, blocks: cellBlocks };
@@ -456,7 +600,10 @@ export function carryStrippedPageFieldProjection(
  * field — and then threw 555 of those fresh records away when the previous finalized
  * identities were restored. Same idiom as `publishedPageMemos` in `multi-section-layout.ts`.
  */
-const finalizedPageMemos = new WeakMap<PageRecord, { pageCount: number; result: PageRecord }>();
+const finalizedPageMemos = new WeakMap<
+  PageRecord,
+  { pageCount: number; pageRefToken: string; result: PageRecord }
+>();
 
 /**
  * Project allowlisted PAGE/NUMPAGES/SECTIONPAGES once the document page count is known.
@@ -471,10 +618,16 @@ export function finalizePageFieldProjection(layout: SemanticLayout): SemanticLay
   const pageCount = layout.pages.length;
   if (pageCount === 0) return layout;
 
+  // PAGEREF values are a function of the WHOLE pagination, not of the page they paint on, so
+  // the assignment token joins the per-page memo key: a page reused by identity while its
+  // target moved sheets must re-substitute, and one reused while nothing moved must not.
+  const pageRefIndex = buildPageRefTargetIndex(layout.pages);
+  const pageRefToken = pageRefIndex?.token ?? '';
+
   let changed = false;
   const pages = layout.pages.map((page) => {
     const memo = finalizedPageMemos.get(page);
-    if (memo && memo.pageCount === pageCount) {
+    if (memo && memo.pageCount === pageCount && memo.pageRefToken === pageRefToken) {
       if (memo.result !== page) changed = true;
       return memo.result;
     }
@@ -523,14 +676,14 @@ export function finalizePageFieldProjection(layout: SemanticLayout): SemanticLay
     const fragments =
       page.hasBodyPageFields === false
         ? page.fragments
-        : substituteBodyPageFields(page.fragments, context);
+        : substituteBodyPageFields(page.fragments, context, pageRefIndex?.hosts);
     // Reachable only for pages with NO live projector and NO body substitution: `project`
     // always mints a fresh record for a projector-bearing story (the rest-spread above), so
     // this identity entry can never publish — or memoize as final — a record that still
     // carries a `pageFieldProjector`. A story kept by identity because its RETAINED
     // projection context still holds is already published text under this exact context.
     if (header === page.header && footer === page.footer && fragments === page.fragments) {
-      finalizedPageMemos.set(page, { pageCount, result: page });
+      finalizedPageMemos.set(page, { pageCount, pageRefToken, result: page });
       return page;
     }
     if (fragments !== page.fragments) changed = true;
@@ -540,7 +693,7 @@ export function finalizePageFieldProjection(layout: SemanticLayout): SemanticLay
       ...(footer !== undefined ? { footer } : {}),
       ...(fragments !== page.fragments ? { fragments } : {}),
     };
-    finalizedPageMemos.set(page, { pageCount, result });
+    finalizedPageMemos.set(page, { pageCount, pageRefToken, result });
     return result;
   });
 

--- a/packages/core/src/layout/field-page-furniture.ts
+++ b/packages/core/src/layout/field-page-furniture.ts
@@ -341,7 +341,9 @@ export function pageRefCalibrationVerdict(
     return true;
   }
   const live = cached.length === 0 || cached === computed;
-  if (live) pageRefLiveLatches.set(cell, { revision });
+  // Only a real layout revision may latch: a save-time (NaN) latch could never be revoked
+  // by the note pass, so it must stay a one-shot answer.
+  if (live && Number.isFinite(revision)) pageRefLiveLatches.set(cell, { revision });
   return live;
 }
 

--- a/packages/core/src/layout/field-pieces.ts
+++ b/packages/core/src/layout/field-pieces.ts
@@ -18,7 +18,7 @@ import type { FormFieldKind } from './field-form.ts';
 import type { AllowlistedPageField } from './field-instruction.ts';
 import type { AutonumFieldSpec } from './field-autonum.ts';
 import type { HyperlinkFieldSpec } from './field-link.ts';
-import type { RefFieldSpec } from './field-ref.ts';
+import type { PageRefFieldProjection, RefFieldSpec } from './field-ref.ts';
 import type { SymbolFieldSpec } from './field-symbol.ts';
 import type { RevisionAttribution } from './revision-projection.ts';
 import type { ResolvedRunStyle } from './run-style.ts';
@@ -68,6 +68,15 @@ export interface FieldAtomMarker {
     /** The field's `\#` numeric picture, applied when finalize substitutes the value. */
     readonly picture?: string;
   };
+  /**
+   * A BODY `PAGEREF` atom whose value is the page number its bookmark target lands on.
+   *
+   * Deferred exactly like {@link pageField}: the paragraph walk paints the field's cached
+   * result (or the placeholder digit when the file cached none) and records the resolved
+   * target here; document finalize substitutes the number of the page hosting the target's
+   * first fragment, gated per field on the calibration verdict.
+   */
+  readonly pageRef?: PageRefFieldProjection;
 }
 
 /**

--- a/packages/core/src/layout/field-projection.ts
+++ b/packages/core/src/layout/field-projection.ts
@@ -351,13 +351,19 @@ export function piecesOfParagraph(
     });
     if (synthesis) {
       const extras = carried();
-      // A body page-field placeholder rides the same field-atom marker its finalize pass reads.
-      const withPageField = synthesis.pageField
-        ? {
-            ...extras,
-            fieldAtom: { formField: pending.formField, pageField: synthesis.pageField },
-          }
-        : extras;
+      // A body page-field / PAGEREF placeholder rides the same field-atom marker its finalize
+      // pass reads.
+      const withPageField =
+        synthesis.pageField || synthesis.pageRefField
+          ? {
+              ...extras,
+              fieldAtom: {
+                formField: pending.formField,
+                ...(synthesis.pageField ? { pageField: synthesis.pageField } : {}),
+                ...(synthesis.pageRefField ? { pageRef: synthesis.pageRefField } : {}),
+              },
+            }
+          : extras;
       push(synthesis.text, synthesis.props, synthesis.style, true, start, end, withPageField);
     }
     pending = null;
@@ -906,6 +912,7 @@ export function piecesOfParagraph(
       fieldAtom: {
         formField: false,
         ...(projected.pageField ? { pageField: projected.pageField } : {}),
+        ...(projected.pageRef ? { pageRef: projected.pageRef } : {}),
       },
       ...(projected.link ? { linkOverride: projected.link } : {}),
     });

--- a/packages/core/src/layout/field-ref-parse.ts
+++ b/packages/core/src/layout/field-ref-parse.ts
@@ -1,0 +1,182 @@
+// The REF-family grammar: `REF` / `NOTEREF` / `PAGEREF` instruction recognition and the
+// modifier side channel their parses attach. Split from `field-ref.ts`, which owns the story
+// scan and the resolution context, so that module stays under its line budget.
+//
+// The instruction is attacker-controlled and NEVER executes. Recognition is one bounded,
+// quote-aware tokenize pass over a length-capped string; anything outside the supported
+// grammar resolves to null and the field keeps painting its cached result.
+
+import { MAX_FIELD_INSTRUCTION_CHARS } from './field-instruction.ts';
+
+/** Word's own bookmark-name limit is 40; this is the fail-closed bound, not a fidelity claim. */
+export const MAX_REF_BOOKMARK_NAME_CHARS = 256;
+
+/** One recognized REF instruction: the target name and the supported switches, nothing else. */
+export interface RefFieldSpec {
+  readonly bookmark: string;
+  /** `r` / `w` paint the target's number; `n` the same without context; null the range text. */
+  readonly numberSwitch: 'r' | 'w' | 'n' | null;
+  /** `\h` parsed and inert — the reference paints; navigation is a follow-up. */
+  readonly hyperlink: boolean;
+}
+
+/**
+ * The modifiers a parse attaches beyond the public members: `\t` (suppress the number's
+ * literal text) and the NOTEREF field kind. A side channel rather than members — the same
+ * idiom `ListCounterAdvance` uses, for the same reason: `RefFieldSpec` is public API, and a
+ * hand-built spec without an entry must mean "no modifiers", which the default below encodes.
+ * Values are the frozen singletons, so agreement between two independent parses of the same
+ * instruction is an identity comparison.
+ */
+export interface RefSpecModifiers {
+  /** `\t`: drop non-delimiter literal text from the referenced number. */
+  readonly suppressNonDelimiterText: boolean;
+  /** The instruction was `NOTEREF`: paint the bookmarked note reference's display number. */
+  readonly noteRef: boolean;
+  /** The instruction was `PAGEREF`: paint the page number of the bookmark target's page. */
+  readonly pageRef: boolean;
+}
+const REF_MODS_NONE: RefSpecModifiers = Object.freeze({
+  suppressNonDelimiterText: false,
+  noteRef: false,
+  pageRef: false,
+});
+const REF_MODS_SUPPRESS: RefSpecModifiers = Object.freeze({
+  suppressNonDelimiterText: true,
+  noteRef: false,
+  pageRef: false,
+});
+const REF_MODS_NOTEREF: RefSpecModifiers = Object.freeze({
+  suppressNonDelimiterText: false,
+  noteRef: true,
+  pageRef: false,
+});
+const REF_MODS_PAGEREF: RefSpecModifiers = Object.freeze({
+  suppressNonDelimiterText: false,
+  noteRef: false,
+  pageRef: true,
+});
+const refSpecModifiers = new WeakMap<RefFieldSpec, RefSpecModifiers>();
+
+export function refSpecModifiersOf(spec: RefFieldSpec): RefSpecModifiers {
+  return refSpecModifiers.get(spec) ?? REF_MODS_NONE;
+}
+
+/**
+ * Split a whitespace-collapsed instruction into space- or quote-delimited tokens.
+ *
+ * One linear pass, no regex over file-derived text. An unterminated quote fails the whole
+ * parse (null) rather than guessing where the argument ends.
+ */
+function tokenizeInstruction(collapsed: string): string[] | null {
+  const tokens: string[] = [];
+  let index = 0;
+  while (index < collapsed.length) {
+    const char = collapsed[index]!;
+    if (char === ' ') {
+      index += 1;
+      continue;
+    }
+    if (char === '"') {
+      const close = collapsed.indexOf('"', index + 1);
+      if (close === -1) return null;
+      tokens.push(collapsed.slice(index + 1, close));
+      index = close + 1;
+      continue;
+    }
+    let end = index;
+    while (end < collapsed.length && collapsed[end] !== ' ') end += 1;
+    tokens.push(collapsed.slice(index, end));
+    index = end;
+  }
+  return tokens;
+}
+
+/**
+ * Recognize `REF <bookmark> [\r|\w|\n] [\t] [\h] [\* MERGEFORMAT]` or
+ * `NOTEREF <bookmark> [\h] [\* MERGEFORMAT]`, or null for anything else.
+ *
+ * The keyword matches case-insensitively; the bookmark name keeps its authored case (it is a
+ * lookup key into a Map, never an object property, so hostile names like `__proto__` are just
+ * names that resolve to nothing). Any unrecognized switch fails the parse so the field falls
+ * back to its cached result — never the raw instruction, never a guess. NOTEREF's `\p`
+ * (above/below position text) and `\f` (note-style formatting) are unrecognized on purpose.
+ */
+export function parseRefInstruction(raw: string): RefFieldSpec | null {
+  if (raw.length > MAX_FIELD_INSTRUCTION_CHARS) return null;
+  const collapsed = raw.replace(/\s+/g, ' ').trim();
+  if (collapsed.length > MAX_FIELD_INSTRUCTION_CHARS) return null;
+  const tokens = tokenizeInstruction(collapsed);
+  if (tokens === null || tokens.length < 2) return null;
+  const keyword = tokens[0]!.toUpperCase();
+  if (keyword !== 'REF' && keyword !== 'NOTEREF' && keyword !== 'PAGEREF') return null;
+  const bookmark = tokens[1]!;
+  if (
+    bookmark.length === 0 ||
+    bookmark.length > MAX_REF_BOOKMARK_NAME_CHARS ||
+    bookmark.startsWith('\\')
+  ) {
+    return null;
+  }
+  if (keyword === 'NOTEREF') return parseNoteRefSwitches(tokens, bookmark);
+  if (keyword === 'PAGEREF') return parsePageRefSwitches(tokens, bookmark);
+  let sawN = false;
+  let sawR = false;
+  let sawW = false;
+  let sawT = false;
+  let hyperlink = false;
+  for (let index = 2; index < tokens.length; index += 1) {
+    const token = tokens[index]!.toUpperCase();
+    if (token === '\\R') sawR = true;
+    else if (token === '\\W') sawW = true;
+    else if (token === '\\N') sawN = true;
+    else if (token === '\\T') sawT = true;
+    else if (token === '\\H') hyperlink = true;
+    else if (token === '\\*' && tokens[index + 1]?.toUpperCase() === 'MERGEFORMAT') index += 1;
+    else if (token === '\\*MERGEFORMAT') continue;
+    else return null;
+  }
+  // Several number switches in one instruction: `\n` outranks `\r` outranks `\w`. Real
+  // documents write `\w \n \h` and cache the `\n`-shaped value; calibration guards the rest.
+  const numberSwitch: RefFieldSpec['numberSwitch'] = sawN ? 'n' : sawR ? 'r' : sawW ? 'w' : null;
+  const spec: RefFieldSpec = { bookmark, numberSwitch, hyperlink };
+  if (sawT) refSpecModifiers.set(spec, REF_MODS_SUPPRESS);
+  return spec;
+}
+
+/** The NOTEREF switch arm: `\h` inert, `\* MERGEFORMAT` inert, anything else fails closed. */
+function parseNoteRefSwitches(tokens: readonly string[], bookmark: string): RefFieldSpec | null {
+  let hyperlink = false;
+  for (let index = 2; index < tokens.length; index += 1) {
+    const token = tokens[index]!.toUpperCase();
+    if (token === '\\H') hyperlink = true;
+    else if (token === '\\*' && tokens[index + 1]?.toUpperCase() === 'MERGEFORMAT') index += 1;
+    else if (token === '\\*MERGEFORMAT') continue;
+    else return null;
+  }
+  const spec: RefFieldSpec = { bookmark, numberSwitch: null, hyperlink };
+  refSpecModifiers.set(spec, REF_MODS_NOTEREF);
+  return spec;
+}
+
+/**
+ * The PAGEREF switch arm: `\h` inert, `\* MERGEFORMAT` inert, anything else fails closed.
+ *
+ * `\p` (the "above/below" relative form) is unrecognized ON PURPOSE — such a field keeps its
+ * cached result, never a guessed position word. The value itself is a property of pagination,
+ * so the projection paints the cache and marks the span for the document finalize pass
+ * (`finalizePageFieldProjection`) to substitute the target's page number.
+ */
+function parsePageRefSwitches(tokens: readonly string[], bookmark: string): RefFieldSpec | null {
+  let hyperlink = false;
+  for (let index = 2; index < tokens.length; index += 1) {
+    const token = tokens[index]!.toUpperCase();
+    if (token === '\\H') hyperlink = true;
+    else if (token === '\\*' && tokens[index + 1]?.toUpperCase() === 'MERGEFORMAT') index += 1;
+    else if (token === '\\*MERGEFORMAT') continue;
+    else return null;
+  }
+  const spec: RefFieldSpec = { bookmark, numberSwitch: null, hyperlink };
+  refSpecModifiers.set(spec, REF_MODS_PAGEREF);
+  return spec;
+}

--- a/packages/core/src/layout/field-ref-refresh.ts
+++ b/packages/core/src/layout/field-ref-refresh.ts
@@ -32,6 +32,13 @@ import {
 } from '../store/store/tree-op-field-results.ts';
 import { noteRefNumberingForPart } from './field-noteref.ts';
 import {
+  buildPageRefTargetIndex,
+  formatPageNumber,
+  pageRefCalibrationVerdict,
+  type PageRefHostRecord,
+} from './field-page-furniture.ts';
+import type { SemanticLayout } from './semantic-records.ts';
+import {
   noteStoriesOfPart,
   parseRefInstruction,
   resolveStoryRefFieldsWithNoteNumbers,
@@ -56,6 +63,30 @@ export interface RefFieldRefreshOptions {
   readonly numberingIndex?: NumberingIndex;
   /** The mode the surface painted under, so the saved values match the painted ones. */
   readonly displayMode?: RevisionDisplayMode;
+  /**
+   * The DISPLAYED page number of one paragraph in the current finalized layout, or null when
+   * it is not placed. PAGEREF results ride the plan through this: the value is pagination's,
+   * so only a caller holding the laid-out pages can answer, and a plan without it keeps every
+   * PAGEREF result as loaded. The same calibration verdict paint took gates each rewrite.
+   */
+  readonly pageRefPageNumberOf?: (targetParagraphId: string) => string | null;
+}
+
+/**
+ * A {@link RefFieldRefreshOptions.pageRefPageNumberOf} source over one finalized layout.
+ *
+ * Builds the target → host-page index once, on first demand, and answers every field from
+ * it — the same walk finalize substitution takes, so the saved number is the painted one.
+ */
+export function pageRefPageNumbersFromLayout(
+  layout: SemanticLayout
+): (targetParagraphId: string) => string | null {
+  let hosts: ReadonlyMap<string, PageRefHostRecord> | null | undefined;
+  return (targetParagraphId) => {
+    if (hosts === undefined) hosts = buildPageRefTargetIndex(layout.pages)?.hosts ?? null;
+    const host = hosts?.get(targetParagraphId);
+    return host ? formatPageNumber(host.pageNumber, host.format) : null;
+  };
 }
 
 /** One notes part's refresh, tagged with the story scope its transaction must target. */
@@ -114,7 +145,8 @@ function collectStaleResultUpdates(
   owningPart: OoxmlPart,
   paragraphs: Iterable<OoxmlElement>,
   context: RefFieldContext,
-  updates: { paragraphId: string; fieldNodeId: string; text: string }[]
+  updates: { paragraphId: string; fieldNodeId: string; text: string }[],
+  pageRefPageNumberOf?: (targetParagraphId: string) => string | null
 ): void {
   for (const paragraph of paragraphs) {
     if (updates.length >= MAX_FIELD_RESULT_UPDATES) return;
@@ -132,8 +164,23 @@ function collectStaleResultUpdates(
       if (spec === null) continue;
       // The locator's field id IS the calibration anchor (begin fldChar / fldSimple node),
       // so this read returns exactly what the pages paint — or null for a field painting
-      // its cache, which then saves as loaded.
-      const value = context.liveValueOf(located.fieldNodeId, spec);
+      // its cache, which then saves as loaded. A PAGEREF answers through the deferred
+      // projection instead: the caller supplies the target's displayed page number, and the
+      // same sticky verdict paint's finalize took gates the rewrite.
+      let value = context.liveValueOf(located.fieldNodeId, spec);
+      if (value === null && pageRefPageNumberOf && context.pageRefProjectionOf) {
+        const pageRef = context.pageRefProjectionOf(located.fieldNodeId, spec);
+        if (pageRef) {
+          const computed = pageRefPageNumberOf(pageRef.targetParagraphId);
+          if (
+            computed !== null &&
+            computed.length > 0 &&
+            pageRefCalibrationVerdict(pageRef.calibration, pageRef.cached, computed)
+          ) {
+            value = computed;
+          }
+        }
+      }
       if (value === null || value === located.cachedText) continue;
       // The op's own bounds, applied per field so one outlier cannot refuse the whole plan:
       // length-capped, and no line breaks (a rewrite expresses tabs, never `w:br`).
@@ -155,7 +202,15 @@ export function planRefFieldResultRefresh(
   const { blocks, context } = resolveRefreshContext(part, options);
   if (context === null) return null;
   const updates: { paragraphId: string; fieldNodeId: string; text: string }[] = [];
-  collectStaleResultUpdates(part, walkStoryParagraphs(blocks), context, updates);
+  // PAGEREF refresh is BODY-only on purpose: note-story PAGEREF fields paint their cache
+  // (notes have no substitute pass), and a save must carry what the pages paint.
+  collectStaleResultUpdates(
+    part,
+    walkStoryParagraphs(blocks),
+    context,
+    updates,
+    options.pageRefPageNumberOf
+  );
   if (updates.length === 0) return null;
   return { op: 'refreshFieldResults', updates };
 }

--- a/packages/core/src/layout/field-ref-refresh.ts
+++ b/packages/core/src/layout/field-ref-refresh.ts
@@ -175,7 +175,9 @@ function collectStaleResultUpdates(
           if (
             computed !== null &&
             computed.length > 0 &&
-            pageRefCalibrationVerdict(pageRef.calibration, pageRef.cached, computed)
+            // NaN revision: a save-time check can neither collide with nor revoke a layout
+            // pass's provisional latch (NaN never equals any revision).
+            pageRefCalibrationVerdict(pageRef.calibration, pageRef.cached, computed, Number.NaN)
           ) {
             value = computed;
           }

--- a/packages/core/src/layout/field-ref.ts
+++ b/packages/core/src/layout/field-ref.ts
@@ -882,8 +882,12 @@ function buildRefFieldContext(
       }
       // A PAGEREF defers: the scan resolves the TARGET and finalize computes the number, so
       // its verdict is finalize's to take (against the pagination, not against this walk).
-      // The token folds the cache, which is what this pass paints — the substituted number
-      // rides the finalize memo keys, not the block keys, exactly like a body PAGE field.
+      // The token folds the cache — what this pass paints; the substituted number rides the
+      // finalize memo keys, not the block keys, exactly like a body PAGE field — AND the
+      // resolved target id. The target is what the marker carries, and a bookmark edit can
+      // re-resolve the name while the field's own paragraph stays byte-identical: without
+      // the id in the token, the cached fragment keeps its old marker and finalize
+      // substitutes the OLD target's page forever.
       if (refSpecModifiersOf(field.spec).pageRef) {
         const target = targets.get(field.spec.bookmark);
         if (target) {
@@ -899,7 +903,7 @@ function buildRefFieldContext(
             });
           }
         }
-        pieces.push(`c\u0002${field.cached}`);
+        pieces.push(`c\u0002${field.cached}\u0002${target?.id ?? ''}`);
         continue;
       }
       const computed = computedOf(field.spec);

--- a/packages/core/src/layout/field-ref.ts
+++ b/packages/core/src/layout/field-ref.ts
@@ -64,6 +64,15 @@ import {
   MAX_REF_TEXT_CHARS,
   wmlAttribute,
 } from './field-ref-text.ts';
+import {
+  MAX_REF_BOOKMARK_NAME_CHARS,
+  parseRefInstruction,
+  refSpecModifiersOf,
+  type RefFieldSpec,
+} from './field-ref-parse.ts';
+
+// Re-exported so every existing importer keeps its one `field-ref.ts` import site.
+export { parseRefInstruction, type RefFieldSpec } from './field-ref-parse.ts';
 import { isNormalNote, notesOf, MAX_NOTES_PER_PART } from '../store/package/note-nodes.ts';
 import { noteStoryBlocks } from './story-roots.ts';
 import {
@@ -74,7 +83,6 @@ import {
   ingestInstrTextBounded,
   isFldChar,
   isInstrText,
-  MAX_FIELD_INSTRUCTION_CHARS,
   MAX_STORY_FIELD_SCAN_DEPTH,
   onFldCharBegin,
   onFldCharEnd,
@@ -108,184 +116,12 @@ import {
   type ResolvedListItem,
 } from './list-resolve.ts';
 
-/** Word's own bookmark-name limit is 40; this is the fail-closed bound, not a fidelity claim. */
-const MAX_REF_BOOKMARK_NAME_CHARS = 256;
 /** Ceiling on live-resolved REF fields per story; fields past it keep their cached results. */
 const MAX_REF_FIELDS_PER_STORY = 512;
 /** Ceiling on bookmark names remembered per top-level block (hostile declaration spam). */
 const MAX_REF_BOOKMARKS_PER_BLOCK = 2048;
 /** Ceiling on sticky calibration verdicts carried for one story across a session. */
 const MAX_REF_VERDICTS = 4096;
-
-/** One recognized REF instruction: the target name and the supported switches, nothing else. */
-export interface RefFieldSpec {
-  readonly bookmark: string;
-  /** `r` / `w` paint the target's number; `n` the same without context; null the range text. */
-  readonly numberSwitch: 'r' | 'w' | 'n' | null;
-  /** `\h` parsed and inert — the reference paints; navigation is a follow-up. */
-  readonly hyperlink: boolean;
-}
-
-/**
- * The modifiers a parse attaches beyond the public members: `\t` (suppress the number's
- * literal text) and the NOTEREF field kind. A side channel rather than members — the same
- * idiom `ListCounterAdvance` uses, for the same reason: `RefFieldSpec` is public API, and a
- * hand-built spec without an entry must mean "no modifiers", which the default below encodes.
- * Values are the frozen singletons, so agreement between two independent parses of the same
- * instruction is an identity comparison.
- */
-interface RefSpecModifiers {
-  /** `\t`: drop non-delimiter literal text from the referenced number. */
-  readonly suppressNonDelimiterText: boolean;
-  /** The instruction was `NOTEREF`: paint the bookmarked note reference's display number. */
-  readonly noteRef: boolean;
-  /** The instruction was `PAGEREF`: paint the page number of the bookmark target's page. */
-  readonly pageRef: boolean;
-}
-const REF_MODS_NONE: RefSpecModifiers = Object.freeze({
-  suppressNonDelimiterText: false,
-  noteRef: false,
-  pageRef: false,
-});
-const REF_MODS_SUPPRESS: RefSpecModifiers = Object.freeze({
-  suppressNonDelimiterText: true,
-  noteRef: false,
-  pageRef: false,
-});
-const REF_MODS_NOTEREF: RefSpecModifiers = Object.freeze({
-  suppressNonDelimiterText: false,
-  noteRef: true,
-  pageRef: false,
-});
-const REF_MODS_PAGEREF: RefSpecModifiers = Object.freeze({
-  suppressNonDelimiterText: false,
-  noteRef: false,
-  pageRef: true,
-});
-const refSpecModifiers = new WeakMap<RefFieldSpec, RefSpecModifiers>();
-
-function refSpecModifiersOf(spec: RefFieldSpec): RefSpecModifiers {
-  return refSpecModifiers.get(spec) ?? REF_MODS_NONE;
-}
-
-/**
- * Split a whitespace-collapsed instruction into space- or quote-delimited tokens.
- *
- * One linear pass, no regex over file-derived text. An unterminated quote fails the whole
- * parse (null) rather than guessing where the argument ends.
- */
-function tokenizeInstruction(collapsed: string): string[] | null {
-  const tokens: string[] = [];
-  let index = 0;
-  while (index < collapsed.length) {
-    const char = collapsed[index]!;
-    if (char === ' ') {
-      index += 1;
-      continue;
-    }
-    if (char === '"') {
-      const close = collapsed.indexOf('"', index + 1);
-      if (close === -1) return null;
-      tokens.push(collapsed.slice(index + 1, close));
-      index = close + 1;
-      continue;
-    }
-    let end = index;
-    while (end < collapsed.length && collapsed[end] !== ' ') end += 1;
-    tokens.push(collapsed.slice(index, end));
-    index = end;
-  }
-  return tokens;
-}
-
-/**
- * Recognize `REF <bookmark> [\r|\w|\n] [\t] [\h] [\* MERGEFORMAT]` or
- * `NOTEREF <bookmark> [\h] [\* MERGEFORMAT]`, or null for anything else.
- *
- * The keyword matches case-insensitively; the bookmark name keeps its authored case (it is a
- * lookup key into a Map, never an object property, so hostile names like `__proto__` are just
- * names that resolve to nothing). Any unrecognized switch fails the parse so the field falls
- * back to its cached result — never the raw instruction, never a guess. NOTEREF's `\p`
- * (above/below position text) and `\f` (note-style formatting) are unrecognized on purpose.
- */
-export function parseRefInstruction(raw: string): RefFieldSpec | null {
-  if (raw.length > MAX_FIELD_INSTRUCTION_CHARS) return null;
-  const collapsed = raw.replace(/\s+/g, ' ').trim();
-  if (collapsed.length > MAX_FIELD_INSTRUCTION_CHARS) return null;
-  const tokens = tokenizeInstruction(collapsed);
-  if (tokens === null || tokens.length < 2) return null;
-  const keyword = tokens[0]!.toUpperCase();
-  if (keyword !== 'REF' && keyword !== 'NOTEREF' && keyword !== 'PAGEREF') return null;
-  const bookmark = tokens[1]!;
-  if (
-    bookmark.length === 0 ||
-    bookmark.length > MAX_REF_BOOKMARK_NAME_CHARS ||
-    bookmark.startsWith('\\')
-  ) {
-    return null;
-  }
-  if (keyword === 'NOTEREF') return parseNoteRefSwitches(tokens, bookmark);
-  if (keyword === 'PAGEREF') return parsePageRefSwitches(tokens, bookmark);
-  let sawN = false;
-  let sawR = false;
-  let sawW = false;
-  let sawT = false;
-  let hyperlink = false;
-  for (let index = 2; index < tokens.length; index += 1) {
-    const token = tokens[index]!.toUpperCase();
-    if (token === '\\R') sawR = true;
-    else if (token === '\\W') sawW = true;
-    else if (token === '\\N') sawN = true;
-    else if (token === '\\T') sawT = true;
-    else if (token === '\\H') hyperlink = true;
-    else if (token === '\\*' && tokens[index + 1]?.toUpperCase() === 'MERGEFORMAT') index += 1;
-    else if (token === '\\*MERGEFORMAT') continue;
-    else return null;
-  }
-  // Several number switches in one instruction: `\n` outranks `\r` outranks `\w`. Real
-  // documents write `\w \n \h` and cache the `\n`-shaped value; calibration guards the rest.
-  const numberSwitch: RefFieldSpec['numberSwitch'] = sawN ? 'n' : sawR ? 'r' : sawW ? 'w' : null;
-  const spec: RefFieldSpec = { bookmark, numberSwitch, hyperlink };
-  if (sawT) refSpecModifiers.set(spec, REF_MODS_SUPPRESS);
-  return spec;
-}
-
-/** The NOTEREF switch arm: `\h` inert, `\* MERGEFORMAT` inert, anything else fails closed. */
-function parseNoteRefSwitches(tokens: readonly string[], bookmark: string): RefFieldSpec | null {
-  let hyperlink = false;
-  for (let index = 2; index < tokens.length; index += 1) {
-    const token = tokens[index]!.toUpperCase();
-    if (token === '\\H') hyperlink = true;
-    else if (token === '\\*' && tokens[index + 1]?.toUpperCase() === 'MERGEFORMAT') index += 1;
-    else if (token === '\\*MERGEFORMAT') continue;
-    else return null;
-  }
-  const spec: RefFieldSpec = { bookmark, numberSwitch: null, hyperlink };
-  refSpecModifiers.set(spec, REF_MODS_NOTEREF);
-  return spec;
-}
-
-/**
- * The PAGEREF switch arm: `\h` inert, `\* MERGEFORMAT` inert, anything else fails closed.
- *
- * `\p` (the "above/below" relative form) is unrecognized ON PURPOSE — such a field keeps its
- * cached result, never a guessed position word. The value itself is a property of pagination,
- * so the projection paints the cache and marks the span for the document finalize pass
- * (`finalizePageFieldProjection`) to substitute the target's page number.
- */
-function parsePageRefSwitches(tokens: readonly string[], bookmark: string): RefFieldSpec | null {
-  let hyperlink = false;
-  for (let index = 2; index < tokens.length; index += 1) {
-    const token = tokens[index]!.toUpperCase();
-    if (token === '\\H') hyperlink = true;
-    else if (token === '\\*' && tokens[index + 1]?.toUpperCase() === 'MERGEFORMAT') index += 1;
-    else if (token === '\\*MERGEFORMAT') continue;
-    else return null;
-  }
-  const spec: RefFieldSpec = { bookmark, numberSwitch: null, hyperlink };
-  refSpecModifiers.set(spec, REF_MODS_PAGEREF);
-  return spec;
-}
 
 /**
  * The story's resolved REF inputs for one layout pass.
@@ -844,7 +680,7 @@ function buildRefFieldContext(
     // The modifier singletons join the key, so `REF x \w`, `REF x \w \t` and `NOTEREF x`
     // never share a computed value.
     const mods = refSpecModifiersOf(spec);
-    const modKey = mods === REF_MODS_SUPPRESS ? 't' : mods === REF_MODS_NOTEREF ? 'x' : '';
+    const modKey = `${mods.suppressNonDelimiterText ? 't' : ''}${mods.noteRef ? 'x' : ''}`;
     const key = `${spec.numberSwitch ?? '-'}${modKey}\u0000${spec.bookmark}`;
     if (computedValues.has(key)) return computedValues.get(key) ?? null;
     const value = resolve(spec);

--- a/packages/core/src/layout/field-ref.ts
+++ b/packages/core/src/layout/field-ref.ts
@@ -139,18 +139,28 @@ interface RefSpecModifiers {
   readonly suppressNonDelimiterText: boolean;
   /** The instruction was `NOTEREF`: paint the bookmarked note reference's display number. */
   readonly noteRef: boolean;
+  /** The instruction was `PAGEREF`: paint the page number of the bookmark target's page. */
+  readonly pageRef: boolean;
 }
 const REF_MODS_NONE: RefSpecModifiers = Object.freeze({
   suppressNonDelimiterText: false,
   noteRef: false,
+  pageRef: false,
 });
 const REF_MODS_SUPPRESS: RefSpecModifiers = Object.freeze({
   suppressNonDelimiterText: true,
   noteRef: false,
+  pageRef: false,
 });
 const REF_MODS_NOTEREF: RefSpecModifiers = Object.freeze({
   suppressNonDelimiterText: false,
   noteRef: true,
+  pageRef: false,
+});
+const REF_MODS_PAGEREF: RefSpecModifiers = Object.freeze({
+  suppressNonDelimiterText: false,
+  noteRef: false,
+  pageRef: true,
 });
 const refSpecModifiers = new WeakMap<RefFieldSpec, RefSpecModifiers>();
 
@@ -205,7 +215,7 @@ export function parseRefInstruction(raw: string): RefFieldSpec | null {
   const tokens = tokenizeInstruction(collapsed);
   if (tokens === null || tokens.length < 2) return null;
   const keyword = tokens[0]!.toUpperCase();
-  if (keyword !== 'REF' && keyword !== 'NOTEREF') return null;
+  if (keyword !== 'REF' && keyword !== 'NOTEREF' && keyword !== 'PAGEREF') return null;
   const bookmark = tokens[1]!;
   if (
     bookmark.length === 0 ||
@@ -215,6 +225,7 @@ export function parseRefInstruction(raw: string): RefFieldSpec | null {
     return null;
   }
   if (keyword === 'NOTEREF') return parseNoteRefSwitches(tokens, bookmark);
+  if (keyword === 'PAGEREF') return parsePageRefSwitches(tokens, bookmark);
   let sawN = false;
   let sawR = false;
   let sawW = false;
@@ -255,6 +266,28 @@ function parseNoteRefSwitches(tokens: readonly string[], bookmark: string): RefF
 }
 
 /**
+ * The PAGEREF switch arm: `\h` inert, `\* MERGEFORMAT` inert, anything else fails closed.
+ *
+ * `\p` (the "above/below" relative form) is unrecognized ON PURPOSE — such a field keeps its
+ * cached result, never a guessed position word. The value itself is a property of pagination,
+ * so the projection paints the cache and marks the span for the document finalize pass
+ * (`finalizePageFieldProjection`) to substitute the target's page number.
+ */
+function parsePageRefSwitches(tokens: readonly string[], bookmark: string): RefFieldSpec | null {
+  let hyperlink = false;
+  for (let index = 2; index < tokens.length; index += 1) {
+    const token = tokens[index]!.toUpperCase();
+    if (token === '\\H') hyperlink = true;
+    else if (token === '\\*' && tokens[index + 1]?.toUpperCase() === 'MERGEFORMAT') index += 1;
+    else if (token === '\\*MERGEFORMAT') continue;
+    else return null;
+  }
+  const spec: RefFieldSpec = { bookmark, numberSwitch: null, hyperlink };
+  refSpecModifiers.set(spec, REF_MODS_PAGEREF);
+  return spec;
+}
+
+/**
  * The story's resolved REF inputs for one layout pass.
  *
  * Threaded as a runtime rider on the layout options (see `layoutSemanticDocument`) rather
@@ -289,6 +322,39 @@ export interface RefFieldContext {
    * Optional so hand-built contexts predating it stay valid.
    */
   autonumValueOf?(anchorId: string): string | null;
+  /**
+   * The deferred projection of ONE `PAGEREF` field, or null to keep the cached result
+   * (missing bookmark, unsupported switches, or an anchor this scan never saw).
+   *
+   * A `PAGEREF` value is a property of pagination, so the scan cannot compute it — it hands
+   * the projection the resolved TARGET and the calibration inputs instead, and document
+   * finalize (`finalizePageFieldProjection`) substitutes the page number the target's first
+   * fragment lands on. Optional so hand-built contexts predating it stay valid.
+   */
+  pageRefProjectionOf?(anchorId: string, spec: RefFieldSpec): PageRefFieldProjection | null;
+}
+
+/**
+ * Sticky calibration identity for one `PAGEREF` field.
+ *
+ * An opaque frozen object rather than a mutable verdict holder because span markers are
+ * serialized into fragment signatures — a verdict written into the marker would move a
+ * signature that no painted output moved. The verdict itself lives beside the finalize pass
+ * (`field-page-furniture.ts`), keyed weakly on this object; the registry below carries the
+ * object across passes the same way REF verdicts are carried.
+ */
+export type PageRefCalibrationCell = Readonly<Record<never, never>>;
+
+/**
+ * What a `PAGEREF` span carries to document finalize: the resolved target, the normalized
+ * authored cache (the calibration oracle), and the sticky calibration identity.
+ */
+export interface PageRefFieldProjection {
+  /** Canonical id of the paragraph the bookmark names — first declaration wins. */
+  readonly targetParagraphId: string;
+  /** The authored cached result, whitespace-collapsed — what the computed number must reproduce. */
+  readonly cached: string;
+  readonly calibration: PageRefCalibrationCell;
 }
 
 /** One scanned REF or AUTONUM-family field: instruction, anchor node id, NORMALIZED cache. */
@@ -569,6 +635,27 @@ function carriedVerdicts(blocks: readonly OoxmlElement[]): Map<string, boolean> 
   return carried;
 }
 
+/**
+ * PAGEREF calibration cells for one story, keyed by field anchor id — the same carry idiom
+ * as {@link refVerdictsByAnchorBlock}, and bounded the same way. The cell must survive the
+ * pass, not the verdict: finalize compares the computed page number against the cache the
+ * first time it meets a cell, and keying that verdict on a per-pass object would re-calibrate
+ * after every keystroke — flipping every live TOC number back to its stale cache.
+ */
+const pageRefCellsByAnchorBlock = new WeakMap<OoxmlElement, Map<string, PageRefCalibrationCell>>();
+
+function carriedPageRefCells(blocks: readonly OoxmlElement[]): Map<string, PageRefCalibrationCell> {
+  const first = blocks[0];
+  const last = blocks[blocks.length - 1];
+  const carried =
+    (first ? pageRefCellsByAnchorBlock.get(first) : undefined) ??
+    (last ? pageRefCellsByAnchorBlock.get(last) : undefined) ??
+    new Map<string, PageRefCalibrationCell>();
+  if (first) pageRefCellsByAnchorBlock.set(first, carried);
+  if (last) pageRefCellsByAnchorBlock.set(last, carried);
+  return carried;
+}
+
 /** Word trims one trailing period off a referenced number: `1.` → `1`, `1.2` stays `1.2`. */
 function trimTrailingPeriod(marker: string): string {
   return marker.length > 1 && marker.endsWith('.') ? marker.slice(0, -1) : marker;
@@ -695,6 +782,8 @@ function buildRefFieldContext(
 
   const resolve = (spec: RefFieldSpec): string | null => {
     const mods = refSpecModifiersOf(spec);
+    // A PAGEREF value is pagination's to compute — it must never resolve as bookmark text.
+    if (mods.pageRef) return null;
     const target = targets.get(spec.bookmark);
     if (!target) return null;
     if (mods.noteRef) {
@@ -769,9 +858,14 @@ function buildRefFieldContext(
   // would flip it back to stale. The token folds the PAINTED output — the live value when
   // calibrated, the session-constant cache otherwise — so it moves exactly when paint moves.
   const verdicts = carriedVerdicts(blocks);
+  const pageRefCells = carriedPageRefCells(blocks);
   const liveByAnchor = new Map<
     string,
     { readonly spec: RefFieldSpec; readonly live: string | null }
+  >();
+  const pageRefByAnchor = new Map<
+    string,
+    { readonly spec: RefFieldSpec; readonly projection: PageRefFieldProjection }
   >();
   const tokens = new Map<string, string>();
   const storyParts: string[] = [];
@@ -784,6 +878,28 @@ function buildRefFieldContext(
       if (field.spec === null) {
         const value = field.autonum ? (autonumByAnchor.get(field.anchorId) ?? null) : null;
         pieces.push(value !== null ? `a\u0001${value}` : `c\u0002${field.cached}`);
+        continue;
+      }
+      // A PAGEREF defers: the scan resolves the TARGET and finalize computes the number, so
+      // its verdict is finalize's to take (against the pagination, not against this walk).
+      // The token folds the cache, which is what this pass paints — the substituted number
+      // rides the finalize memo keys, not the block keys, exactly like a body PAGE field.
+      if (refSpecModifiersOf(field.spec).pageRef) {
+        const target = targets.get(field.spec.bookmark);
+        if (target) {
+          let cell = pageRefCells.get(field.anchorId);
+          if (cell === undefined && pageRefCells.size < MAX_REF_VERDICTS) {
+            cell = Object.freeze({});
+            pageRefCells.set(field.anchorId, cell);
+          }
+          if (cell !== undefined) {
+            pageRefByAnchor.set(field.anchorId, {
+              spec: field.spec,
+              projection: { targetParagraphId: target.id, cached: field.cached, calibration: cell },
+            });
+          }
+        }
+        pieces.push(`c\u0002${field.cached}`);
         continue;
       }
       const computed = computedOf(field.spec);
@@ -826,6 +942,18 @@ function buildRefFieldContext(
       return entry.live;
     },
     autonumValueOf: (anchorId) => autonumByAnchor.get(anchorId) ?? null,
+    pageRefProjectionOf: (anchorId, spec) => {
+      const entry = pageRefByAnchor.get(anchorId);
+      if (!entry) return null;
+      // Same agreement rule as liveValueOf: the anchor must still name this instruction.
+      if (
+        entry.spec.bookmark !== spec.bookmark ||
+        refSpecModifiersOf(entry.spec) !== refSpecModifiersOf(spec)
+      ) {
+        return null;
+      }
+      return entry.projection;
+    },
   };
 }
 

--- a/packages/core/src/layout/field-simple-result.ts
+++ b/packages/core/src/layout/field-simple-result.ts
@@ -20,7 +20,11 @@ import { docPropertyValue, parseDocPropertyInstruction } from './field-doc-prope
 import { parseHyperlinkInstruction } from './field-link.ts';
 import type { FieldLinkProjector } from './field-pieces.ts';
 import { parseAutonumInstruction } from './field-autonum.ts';
-import { parseRefInstruction, type RefFieldContext } from './field-ref.ts';
+import {
+  parseRefInstruction,
+  type PageRefFieldProjection,
+  type RefFieldContext,
+} from './field-ref.ts';
 import {
   modelTextOfRunChild,
   runPropertiesOf,
@@ -46,6 +50,7 @@ import {
 import { createNestedPageTracker } from './field-nested-page.ts';
 import {
   numericPictureApplies,
+  PAGE_FIELD_PLACEHOLDER,
   pageFieldPlaceholder,
   projectPageFieldValue,
   type BodyPageFieldContext,
@@ -265,6 +270,11 @@ export interface SimpleFieldProjection {
     /** The field's `\#` numeric picture, carried to the substitute pass. */
     readonly picture?: string;
   };
+  /**
+   * Present when this is a BODY `PAGEREF`: the cached display paints now and document
+   * finalize substitutes the number of the page the resolved target lands on.
+   */
+  readonly pageRef?: PageRefFieldProjection;
 }
 
 /**
@@ -368,6 +378,20 @@ export function projectSimpleFieldResult(args: {
         const style = display.resultStyle ?? resolveRunStyle(inheritedRunProperties, themeFonts);
         if (style.hidden) return null;
         return { text: value, props, style };
+      }
+      // A BODY simple PAGEREF defers exactly like the complex shape: paint the cached display
+      // (or the placeholder digit when the file cached none and hid nothing), mark the span,
+      // and let document finalize substitute the target's page number.
+      if (args.bodyPageFields && args.refFields.pageRefProjectionOf) {
+        const pageRef = args.refFields.pageRefProjectionOf(simple.id, refSpec);
+        if (pageRef) {
+          const style = display.resultStyle ?? resolveRunStyle(inheritedRunProperties, themeFonts);
+          if (style.hidden) return null;
+          if (display.text.length > 0) return { text: display.text, props, style, pageRef };
+          if (!display.sawResultContent) {
+            return { text: PAGE_FIELD_PLACEHOLDER, props, style, pageRef };
+          }
+        }
       }
     } else if (args.refFields.autonumValueOf && parseAutonumInstruction(instr)) {
       // A simple AUTONUM-family field synthesizes exactly like the complex shape: the

--- a/packages/core/src/layout/field-synthesis.ts
+++ b/packages/core/src/layout/field-synthesis.ts
@@ -23,13 +23,14 @@ import { formFieldResult } from './field-form.ts';
 import {
   numericPictureApplies,
   pageFieldPlaceholder,
+  PAGE_FIELD_PLACEHOLDER,
   projectPageFieldValue,
   type BodyPageFieldContext,
   type FieldPageContext,
 } from './field-page-furniture.ts';
 import type { AllowlistedPageField } from './field-instruction.ts';
 import type { PendingFieldProjection } from './field-pieces.ts';
-import type { RefFieldContext } from './field-ref.ts';
+import type { PageRefFieldProjection, RefFieldContext } from './field-ref.ts';
 import { symbolFieldGlyph } from './field-symbol.ts';
 import type { ResolvedRunStyle, ThemeFonts } from './run-style.ts';
 
@@ -48,6 +49,12 @@ export interface AtomicFieldSynthesis {
     /** The field's `\#` numeric picture, carried to the substitute pass. */
     readonly picture?: string;
   };
+  /**
+   * Present when this is a BODY `PAGEREF`: {@link text} is the cached result (or the
+   * placeholder digit for an empty cache) and document finalize substitutes the number of
+   * the page the resolved target lands on. The caller carries this onto the span marker.
+   */
+  readonly pageRefField?: PageRefFieldProjection;
 }
 
 /** Document-global inputs the synthesis reads, none of them per-run. */
@@ -104,6 +111,34 @@ export function synthesizeAtomicField(
   if (pending.refSpec && ctx.refFields) {
     const value = ctx.refFields.liveValueOf(pending.beginId, pending.refSpec);
     if (value !== null) return { text: value, props: pending.props, style: pending.style };
+  }
+  // A BODY PAGEREF defers to document finalize the way a body PAGE does: the value is a
+  // property of pagination, so this paints the cached result — the width every value it can
+  // be replaced by usually shares, since TOC caches are page numbers — and marks the span
+  // with the resolved target. Empty cache paints the placeholder digit (gated on a result
+  // the file did not hide, like every synthesis). Gated on `bodyPageFields` because notes
+  // and text boxes have no substitute pass, and furniture keeps its cache (its projector
+  // knows its own page, not the target's).
+  if (pending.refSpec && ctx.refFields?.pageRefProjectionOf && ctx.bodyPageFields) {
+    const projection = ctx.refFields.pageRefProjectionOf(pending.beginId, pending.refSpec);
+    if (projection) {
+      if (pending.cachedText.length > 0) {
+        return {
+          text: pending.cachedText,
+          props: pending.props,
+          style: pending.style,
+          pageRefField: projection,
+        };
+      }
+      if (!pending.sawResultContent) {
+        return {
+          text: PAGE_FIELD_PLACEHOLDER,
+          props: pending.props,
+          style: pending.style,
+          pageRefField: projection,
+        };
+      }
+    }
   }
   // An AUTONUM-family field has no separator and no cached result — Word computes the number
   // at display time and never stores it — so the synthesized sequential value is its only

--- a/packages/core/src/layout/index.ts
+++ b/packages/core/src/layout/index.ts
@@ -354,6 +354,8 @@ export { noteMarkKey, projectedNoteMarkText, type NoteMarkContext } from './note
 export {
   parseRefInstruction,
   resolveStoryRefFields,
+  type PageRefCalibrationCell,
+  type PageRefFieldProjection,
   type RefFieldContext,
   type RefFieldSpec,
   type RefNoteParts,
@@ -363,7 +365,11 @@ export {
   type AutonumFieldKind,
   type AutonumFieldSpec,
 } from './field-autonum.ts';
-export { planRefFieldResultRefresh, type RefFieldRefreshOptions } from './field-ref-refresh.ts';
+export {
+  pageRefPageNumbersFromLayout,
+  planRefFieldResultRefresh,
+  type RefFieldRefreshOptions,
+} from './field-ref-refresh.ts';
 export { storyBlocks, noteStoryBlocks, MAX_SDT_NESTING } from './story-roots.ts';
 export {
   emptyTocPlaceholderParagraphIds,

--- a/packages/core/src/layout/layout-session.ts
+++ b/packages/core/src/layout/layout-session.ts
@@ -80,6 +80,12 @@ export interface MultiSectionLayoutState {
   previousRemapped: readonly PageRecord[];
   previousFinalized: SemanticLayout | null;
   previousPageCount: number;
+  /**
+   * The PAGEREF assignment token of the pages behind `previousFinalized`. A target can move
+   * sheets while the TOC page's own remapped record stays identity-unchanged, so the finalized
+   * restore must compare this before handing back a previously substituted sheet.
+   */
+  previousPageRefToken: string;
 }
 
 /**

--- a/packages/core/src/layout/multi-section-layout.ts
+++ b/packages/core/src/layout/multi-section-layout.ts
@@ -10,6 +10,7 @@
 
 import type { OoxmlElement } from '@docx-editor.dev/core/store';
 import { finalizePageFieldProjection, withPageFieldSources } from './field-projection.ts';
+import { pageRefAssignmentToken } from './field-page-furniture.ts';
 import { numericPictureApplies } from './field-page-furniture.ts';
 import {
   remapPage,
@@ -184,6 +185,7 @@ function ensureMultiState(
     previousRemapped: [],
     previousFinalized: null,
     previousPageCount: -1,
+    previousPageRefToken: '',
   };
   session.multi = fresh;
   return fresh;
@@ -631,6 +633,7 @@ export function layoutMultiSectionDocument(
       multi.previousRemapped = laid.pages;
       multi.previousFinalized = finalized;
       multi.previousPageCount = finalized.pages.length;
+      multi.previousPageRefToken = pageRefAssignmentToken(laid.pages);
     }
     if (session) {
       adoptMultiSectionResult(session, finalized, lineCounter);
@@ -646,12 +649,16 @@ export function layoutMultiSectionDocument(
 
   const freshlyFinalized = finalizePageFieldProjection({ revision, pages });
   let finalized = freshlyFinalized;
+  const pageRefToken = pageRefAssignmentToken(pages);
 
-  // Restore prior finalized page identities when the remapped source and total count hold.
+  // Restore prior finalized page identities when the remapped source and total count hold —
+  // and the PAGEREF assignments too: a target that changed sheets leaves the TOC page's raw
+  // record identity-unchanged, so without the token the restore hands back its stale numbers.
   if (
     multi?.previousFinalized &&
     multi.previousPageCount === freshlyFinalized.pages.length &&
-    multi.previousRemapped.length === remappedAll.length
+    multi.previousRemapped.length === remappedAll.length &&
+    multi.previousPageRefToken === pageRefToken
   ) {
     const prevFinal = multi.previousFinalized.pages;
     const prevRemapped = multi.previousRemapped;
@@ -669,6 +676,7 @@ export function layoutMultiSectionDocument(
     multi.previousRemapped = remappedAll;
     multi.previousFinalized = finalized;
     multi.previousPageCount = finalized.pages.length;
+    multi.previousPageRefToken = pageRefToken;
   }
 
   if (session) {

--- a/packages/core/src/layout/note-pagination.ts
+++ b/packages/core/src/layout/note-pagination.ts
@@ -1607,9 +1607,12 @@ function sectionEndInsertBound(
  * Inserted overflow pages already carry a `pageFieldSource` cloned from the section template;
  * document-level NUMPAGES and furniture text need finalize against the new page count.
  */
-function reindexAndFinalizeFields(pages: readonly PageRecord[]): PageRecord[] {
+function reindexAndFinalizeFields(pages: readonly PageRecord[], revision: number): PageRecord[] {
   const reindexed = reindexAndRestackPages(pages);
-  return [...finalizePageFieldProjection({ revision: 0, pages: reindexed }).pages];
+  // The REAL revision, not a sentinel: PAGEREF calibration may revoke a live latch only when
+  // a re-finalize of the SAME revision moved a target (overflow sheets shifting body pages),
+  // so this finalize has to identify itself as the body pass's own second word.
+  return [...finalizePageFieldProjection({ revision, pages: reindexed }).pages];
 }
 
 /**
@@ -2501,7 +2504,7 @@ export function attachNotesToLayout(
   if (pages.length !== pageCountBeforeOverflow) {
     // Every insertion is done, so a minted sheet's array position is the page index it keeps.
     pages = resettleMintedSheets(pages, layout);
-    pages = reindexAndFinalizeFields(pages);
+    pages = reindexAndFinalizeFields(pages, layout.revision);
   }
 
   // Body was laid with provisional marks; publish page-aware citation digits without reflow.

--- a/scripts/check-eslint-max-lines-globs.mjs
+++ b/scripts/check-eslint-max-lines-globs.mjs
@@ -42,7 +42,7 @@ const SLACK_EXEMPT = new Map([
  * diff where a reviewer sees it, instead of the file quietly gaining a thousand lines.
  */
 const BLANKET_DISABLES = new Map([
-  ['packages/core/src/editor/paginated-surface.ts', 6248],
+  ['packages/core/src/editor/paginated-surface.ts', 6249],
   ['packages/core/src/store/store/tree-op-apply.ts', 3495],
   ['packages/core/src/output/semantic-paint.ts', 3005],
   ['packages/core/src/layout/note-pagination.ts', 2939],

--- a/scripts/check-eslint-max-lines-globs.mjs
+++ b/scripts/check-eslint-max-lines-globs.mjs
@@ -42,7 +42,7 @@ const SLACK_EXEMPT = new Map([
  * diff where a reviewer sees it, instead of the file quietly gaining a thousand lines.
  */
 const BLANKET_DISABLES = new Map([
-  ['packages/core/src/editor/paginated-surface.ts', 6243],
+  ['packages/core/src/editor/paginated-surface.ts', 6248],
   ['packages/core/src/store/store/tree-op-apply.ts', 3495],
   ['packages/core/src/output/semantic-paint.ts', 3005],
   ['packages/core/src/layout/note-pagination.ts', 2939],


### PR DESCRIPTION
Body `PAGEREF <bookmark> [\h]` fields now resolve at pagination finalize: the paragraph walk marks the span with the bookmark's target, and `finalizePageFieldProjection` substitutes the number of the page that hosts the target's first fragment, formatted with that page's section number format. Table-of-contents page numbers therefore update after edits instead of painting their cached results forever.

The per-field calibration idiom from `REF` gates every field: the computed number must reproduce the authored cache or the field keeps painting that cache. The latch is scoped per revision so the note pass, which can insert overflow sheets and re-finalize, gets the pass's last word. The resolved target id joins the field paragraph's ref token, so a bookmark edit invalidates the cached fragment. The computed assignments join the finalize memo and the multi-section restore keys, so a reused page repaints when its target moves.

On save, `planRefFieldResultRefresh` rewrites stale plain-run `PAGEREF` results from the finalized pages, gated by the same verdict.

Unsupported switches (`\p`), a missing bookmark, and `PAGEREF` fields in headers, footers, notes, or text boxes keep their cached results.

Fixes #617.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/621"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790617833&installation_model_id=422592&pr_number=621&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F621&signature=cf87ba4651e16ce87e0294c46e17c3f6e4a81cb95c5746e8bafb29879ab362e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->