### PR TITLE
feat: synthesize AUTONUM, AUTONUMLGL, and AUTONUMOUT field numbers

### DIFF
--- a/.changeset/autonum-fields-synthesize.md
+++ b/.changeset/autonum-fields-synthesize.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+`AUTONUM`, `AUTONUMLGL`, and `AUTONUMOUT` fields now paint a synthesized sequential number (one counter per kind, in document order, with `\*` format switches and `\e`) instead of nothing, and `REF` number switches resolve against bookmarked auto-numbered paragraphs. Fixes #618.

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -42,6 +42,17 @@ export const AUTO_PARAGRAPH_SPACING_PT = 14;
 // @public
 export const AUTO_PREFERRED_WIDTH: PreferredWidth;
 
+// @public (undocumented)
+export type AutonumFieldKind = 'AUTONUM' | 'AUTONUMLGL' | 'AUTONUMOUT';
+
+// @public
+export interface AutonumFieldSpec {
+    // (undocumented)
+    readonly kind: AutonumFieldKind;
+    readonly numFmt: string | null;
+    readonly suppressPeriod: boolean;
+}
+
 // @public
 export function baselineShiftPtOf(style: ResolvedRunStyle): number;
 
@@ -2057,6 +2068,9 @@ export function paragraphTabStops(pPr: OoxmlNode | undefined): ResolvedTabStops;
 export function paragraphTextFromLayout(layout: SemanticLayout, paragraphId: string): string;
 
 // @public
+export function parseAutonumInstruction(raw: string): AutonumFieldSpec | null;
+
+// @public
 export function parsePageNumbering(sectPr: OoxmlNode): SectionPageNumbering | undefined;
 
 // @public
@@ -2128,6 +2142,7 @@ displayMode?: RevisionDisplayMode): SemanticTableStructure | null;
 
 // @public
 export interface RefFieldContext {
+    autonumValueOf?(anchorId: string): string | null;
     liveValueOf(anchorId: string, spec: RefFieldSpec): string | null;
     tokenForParagraph(paragraphId: string): string;
     readonly valuesToken: string;

--- a/packages/core/src/layout/__tests__/field-autonum-layout.test.ts
+++ b/packages/core/src/layout/__tests__/field-autonum-layout.test.ts
@@ -1,0 +1,188 @@
+// AUTONUM / AUTONUMLGL / AUTONUMOUT fields through full layout: synthesized sequential
+// numbers. These fields carry no separator and no cached result — Word computes the number at
+// display time and never stores it — so the engine numbers each kind in document order and
+// formats through the shared ST_NumberFormat resolver. Unsupported switches paint nothing,
+// the fields' historical rendering.
+
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, type OoxmlElement, type OoxmlPart } from '@docx-editor.dev/core/store';
+import { createFixedMeasurer, layoutSemanticDocument } from '../semantic-layout.ts';
+import { createLayoutSession } from '../layout-session.ts';
+import { createParagraphLayoutCache } from '../layout-cache.ts';
+import { paragraphFragmentsOf, type SemanticLayout } from '../index.ts';
+import { parseAutonumInstruction } from '../field-autonum.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const measurer = createFixedMeasurer(6, 14);
+
+function load(body: string): OoxmlPart {
+  const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'application/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+/** A complex AUTONUM-family field: begin / instrText / end — NO separator, NO result runs. */
+const autonumField = (instr: string) =>
+  '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+  `<w:r><w:instrText>${instr}</w:instrText></w:r>` +
+  '<w:r><w:fldChar w:fldCharType="end"/></w:r>';
+
+const autonumParagraph = (instr: string, text: string) =>
+  `<w:p>${autonumField(instr)}<w:r><w:t> ${text}</w:t></w:r></w:p>`;
+
+const textsOf = (layout: SemanticLayout): string[] =>
+  layout.pages.flatMap((page) =>
+    paragraphFragmentsOf(page).map((fragment) =>
+      fragment.lines
+        .flatMap((line) => line.spans.map((span) => span.text))
+        .join('')
+        .trim()
+    )
+  );
+
+function layoutOf(body: string): SemanticLayout {
+  return layoutSemanticDocument(load(body), 1, { measurer });
+}
+
+describe('parseAutonumInstruction', () => {
+  test('the three keywords parse with their supported switches', () => {
+    expect(parseAutonumInstruction(' AUTONUM ')).toEqual({
+      kind: 'AUTONUM',
+      numFmt: null,
+      suppressPeriod: false,
+    });
+    expect(parseAutonumInstruction(' AUTONUMLGL \\* ALPHABETIC \\e ')).toEqual({
+      kind: 'AUTONUMLGL',
+      numFmt: 'upperLetter',
+      suppressPeriod: true,
+    });
+    expect(parseAutonumInstruction(' AUTONUMOUT \\* MERGEFORMAT ')).toEqual({
+      kind: 'AUTONUMOUT',
+      numFmt: null,
+      suppressPeriod: false,
+    });
+    // The switch's own case picks the variant, the way Word reads the general formats.
+    expect(parseAutonumInstruction(' AUTONUM \\* alphabetic ')?.numFmt).toBe('lowerLetter');
+    expect(parseAutonumInstruction(' AUTONUM \\* roman ')?.numFmt).toBe('lowerRoman');
+    expect(parseAutonumInstruction(' AUTONUM \\* ROMAN ')?.numFmt).toBe('upperRoman');
+    expect(parseAutonumInstruction(' AUTONUM \\* Arabic ')?.numFmt).toBe('decimal');
+  });
+
+  test('anything outside the grammar fails closed', () => {
+    expect(parseAutonumInstruction(' AUTONUM \\s 2 ')).toBeNull();
+    expect(parseAutonumInstruction(' AUTONUM \\* Upper ')).toBeNull();
+    expect(parseAutonumInstruction(' AUTONUM \\* ')).toBeNull();
+    expect(parseAutonumInstruction(' AUTONUMBER ')).toBeNull();
+    expect(parseAutonumInstruction(' SEQ list ')).toBeNull();
+  });
+});
+
+describe('AUTONUM-family fields synthesize sequential numbers in layout', () => {
+  test('the sampled legal-template shape paints A, B, C', () => {
+    const layout = layoutOf(
+      autonumParagraph(' AUTONUMLGL \\* ALPHABETIC \\e ', 'first annex') +
+        autonumParagraph(' AUTONUMLGL \\* ALPHABETIC \\e ', 'second annex') +
+        autonumParagraph(' AUTONUMLGL \\* ALPHABETIC \\e ', 'third annex')
+    );
+    expect(textsOf(layout)).toEqual(['A first annex', 'B second annex', 'C third annex']);
+  });
+
+  test('plain AUTONUM paints the decimal number with its trailing period', () => {
+    const layout = layoutOf(
+      autonumParagraph(' AUTONUM ', 'one') + autonumParagraph(' AUTONUM ', 'two')
+    );
+    expect(textsOf(layout)).toEqual(['1. one', '2. two']);
+  });
+
+  test('each kind counts independently', () => {
+    const layout = layoutOf(
+      autonumParagraph(' AUTONUM ', 'a') +
+        autonumParagraph(' AUTONUMLGL ', 'b') +
+        autonumParagraph(' AUTONUM ', 'c')
+    );
+    expect(textsOf(layout)).toEqual(['1. a', '1. b', '2. c']);
+  });
+
+  test('an unsupported switch paints nothing, the historical rendering', () => {
+    const layout = layoutOf(autonumParagraph(' AUTONUM \\s 2 ', 'tail'));
+    expect(textsOf(layout)).toEqual(['tail']);
+  });
+
+  test('a simple AUTONUM field synthesizes the same way', () => {
+    const layout = layoutOf(
+      `<w:p><w:fldSimple w:instr=" AUTONUM "/><w:r><w:t> via fldSimple</w:t></w:r></w:p>`
+    );
+    expect(textsOf(layout)).toEqual(['1. via fldSimple']);
+  });
+
+  test('a REF number switch resolves against a bookmarked AUTONUM paragraph', () => {
+    const layout = layoutOf(
+      `<w:p><w:bookmarkStart w:id="1" w:name="annexB"/>` +
+        `${autonumField(' AUTONUMLGL \\* ALPHABETIC \\e ')}` +
+        `<w:r><w:t> target</w:t></w:r><w:bookmarkEnd w:id="1"/></w:p>` +
+        autonumParagraph(' AUTONUMLGL \\* ALPHABETIC \\e ', 'second') +
+        `<w:p><w:r><w:t>see </w:t></w:r>` +
+        `<w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
+        `<w:r><w:instrText> REF annexB \\n \\h </w:instrText></w:r>` +
+        `<w:r><w:fldChar w:fldCharType="separate"/></w:r>` +
+        `<w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>`
+    );
+    expect(textsOf(layout)).toContain('see A');
+  });
+});
+
+/**
+ * Replace the body's block list while keeping every surviving node BY IDENTITY — the shape a
+ * `TreeDocumentStore` commit publishes (the same helper `field-ref-layout.test.ts` uses).
+ */
+function withBlocks(
+  part: OoxmlPart,
+  edit: (blocks: readonly OoxmlElement[]) => readonly OoxmlElement[]
+): OoxmlPart {
+  const body = part.root.children.find(
+    (child): child is OoxmlElement => child.kind !== 'textValue' && child.localName === 'body'
+  )!;
+  const blocks = body.children.filter(
+    (child): child is OoxmlElement => child.kind === 'paragraph' || child.kind === 'table'
+  );
+  const edited = edit(blocks);
+  const nextChildren = [
+    ...edited,
+    ...body.children.filter(
+      (child) =>
+        child.kind === 'textValue' || (child.kind !== 'paragraph' && child.kind !== 'table')
+    ),
+  ];
+  const nextBody = { ...body, children: nextChildren } as OoxmlElement;
+  const nextRoot = {
+    ...part.root,
+    children: part.root.children.map((child) => (child === body ? nextBody : child)),
+  } as OoxmlElement;
+  return { ...part, root: nextRoot };
+}
+
+describe('a document-order edit renumbers later AUTONUM fields incrementally', () => {
+  test('the warm session pass equals the cold oracle after removing the first field', () => {
+    const before = load(
+      autonumParagraph(' AUTONUM ', 'gone soon') +
+        autonumParagraph(' AUTONUM ', 'stays') +
+        autonumParagraph(' AUTONUM ', 'tail')
+    );
+    const options = {
+      measurer,
+      session: createLayoutSession(),
+      cache: createParagraphLayoutCache(),
+    };
+    const first = layoutSemanticDocument(before, 1, options);
+    expect(textsOf(first)).toEqual(['1. gone soon', '2. stays', '3. tail']);
+
+    const after = withBlocks(before, (blocks) => blocks.slice(1));
+    const warm = layoutSemanticDocument(after, 2, options);
+    const oracle = layoutSemanticDocument(after, 1, { measurer });
+    expect(textsOf(warm)).toEqual(textsOf(oracle));
+    expect(textsOf(warm)).toEqual(['1. stays', '2. tail']);
+  });
+});

--- a/packages/core/src/layout/__tests__/field-autonum-layout.test.ts
+++ b/packages/core/src/layout/__tests__/field-autonum-layout.test.ts
@@ -118,6 +118,27 @@ describe('AUTONUM-family fields synthesize sequential numbers in layout', () => 
     expect(textsOf(layout)).toEqual(['1. via fldSimple']);
   });
 
+  test('a revision-hidden field does not advance the counter in the resolved views', () => {
+    // A `w:del`-wrapped field does not exist in the proposed view: Word after accepting the
+    // deletion renumbers the survivors, so the third field must paint 2., not 3. The
+    // all-markup view keeps every field and numbers straight through.
+    const body =
+      autonumParagraph(' AUTONUM ', 'first') +
+      `<w:p><w:del w:id="9" w:author="a">${autonumField(' AUTONUM ')}</w:del>` +
+      `<w:r><w:t> second</w:t></w:r></w:p>` +
+      autonumParagraph(' AUTONUM ', 'third');
+    const proposed = layoutSemanticDocument(load(body), 1, {
+      measurer,
+      displayMode: 'proposed',
+    });
+    expect(textsOf(proposed)).toEqual(['1. first', 'second', '2. third']);
+    const allMarkup = layoutSemanticDocument(load(body), 1, {
+      measurer,
+      displayMode: 'all-markup',
+    });
+    expect(textsOf(allMarkup)).toEqual(['1. first', '2. second', '3. third']);
+  });
+
   test('a REF number switch resolves against a bookmarked AUTONUM paragraph', () => {
     const layout = layoutOf(
       `<w:p><w:bookmarkStart w:id="1" w:name="annexB"/>` +

--- a/packages/core/src/layout/field-autonum.ts
+++ b/packages/core/src/layout/field-autonum.ts
@@ -1,0 +1,113 @@
+// AUTONUM / AUTONUMLGL / AUTONUMOUT legacy auto-number fields (§17.16.5.7-9).
+//
+// Unlike REF or PAGEREF, these complex fields carry NO separator and NO cached result runs —
+// Word computes the number at display time and never stores it. The engine's inert-field
+// handling therefore painted the region between `begin` and `end` as empty, and the paragraph
+// lost its number outright. There is no cache to fall back to, so the value is synthesized:
+// one counter per kind, advanced in document order by the shared story scan in `field-ref.ts`,
+// formatted here through the same bounded ST_NumberFormat resolver list markers use.
+//
+// The instruction is attacker-controlled and NEVER executes. Recognition is one bounded
+// tokenize pass; anything outside the supported grammar — an unknown switch (`\s`, …), an
+// unknown `\*` format — fails the parse and the field paints nothing, exactly as before.
+//
+// DEVIATION: Word restarts these counters per heading context (AUTONUMOUT follows the outline
+// numbering). This engine numbers each kind sequentially in document order, which reproduces
+// the annex/rider idiom the fields are used for; a restart scheme can layer on later.
+//
+// Save behavior: Word stores no results for these fields, so serialization stays untouched.
+
+import { normalizeFieldInstruction } from './field-instruction.ts';
+import { formatNumFmt } from './numbering-format.ts';
+
+export type AutonumFieldKind = 'AUTONUM' | 'AUTONUMLGL' | 'AUTONUMOUT';
+
+/** One recognized AUTONUM-family instruction: the kind and its supported switches. */
+export interface AutonumFieldSpec {
+  readonly kind: AutonumFieldKind;
+  /** ST_NumberFormat resolved from the `\*` switch; null paints decimal. */
+  readonly numFmt: string | null;
+  /** `\e`: display the number without its trailing period. */
+  readonly suppressPeriod: boolean;
+}
+
+/**
+ * Map a `\*` general-format switch onto the shared ST_NumberFormat vocabulary.
+ *
+ * The keyword matches case-insensitively; for the alphabetic and roman forms the switch's OWN
+ * case picks the variant, which is how Word reads `\* ALPHABETIC` (A, B) against
+ * `\* alphabetic` (a, b). Anything unrecognized returns null and fails the whole parse — the
+ * field paints nothing rather than a number in the wrong form.
+ */
+function numFmtOfFormatSwitch(token: string): string | null {
+  const upper = token.toUpperCase();
+  const uppercase = token[0] === token[0]?.toUpperCase();
+  switch (upper) {
+    case 'ARABIC':
+      return 'decimal';
+    case 'ALPHABETIC':
+      return uppercase ? 'upperLetter' : 'lowerLetter';
+    case 'ROMAN':
+      return uppercase ? 'upperRoman' : 'lowerRoman';
+    case 'ORDINAL':
+      return 'ordinal';
+    case 'CARDTEXT':
+      return 'cardinalText';
+    case 'ORDTEXT':
+      return 'ordinalText';
+    case 'HEX':
+      return 'hex';
+    default:
+      return null;
+  }
+}
+
+/**
+ * Recognize `AUTONUM | AUTONUMLGL | AUTONUMOUT [\* <format>] [\e] [\* MERGEFORMAT]`, or null
+ * for anything else. Any unrecognized switch fails the parse so the field stays inert (paints
+ * nothing — its historical rendering), never the raw instruction, never a guessed number.
+ */
+export function parseAutonumInstruction(raw: string): AutonumFieldSpec | null {
+  // The shared normalizer bounds the length, collapses whitespace, uppercases, and strips a
+  // trailing `\* MERGEFORMAT`. Case never matters here: the format variant is re-read from
+  // the raw token below.
+  const normalized = normalizeFieldInstruction(raw);
+  if (normalized === null) return null;
+  const tokens = raw.replace(/\s+/g, ' ').trim().split(' ');
+  const keyword = tokens[0]?.toUpperCase();
+  if (keyword !== 'AUTONUM' && keyword !== 'AUTONUMLGL' && keyword !== 'AUTONUMOUT') return null;
+  let numFmt: string | null = null;
+  let suppressPeriod = false;
+  for (let index = 1; index < tokens.length; index += 1) {
+    const token = tokens[index]!;
+    const upper = token.toUpperCase();
+    if (upper === '\\E') {
+      suppressPeriod = true;
+      continue;
+    }
+    if (upper === '\\*') {
+      const argument = tokens[index + 1];
+      if (argument === undefined) return null;
+      index += 1;
+      if (argument.toUpperCase() === 'MERGEFORMAT') continue;
+      numFmt = numFmtOfFormatSwitch(argument);
+      if (numFmt === null) return null;
+      continue;
+    }
+    return null;
+  }
+  return { kind: keyword, numFmt, suppressPeriod };
+}
+
+/**
+ * The text one AUTONUM-family field displays for its sequential `value`.
+ *
+ * Word paints the number with a trailing period (`1.`, `A.`) unless `\e` drops it. The value
+ * comes from the story scan's own counter, never from the file, so no clamp is needed beyond
+ * what the shared resolver applies.
+ */
+export function autonumDisplayText(spec: AutonumFieldSpec, value: number): string {
+  const text = formatNumFmt(spec.numFmt ?? 'decimal', value);
+  if (text.length === 0) return '';
+  return spec.suppressPeriod ? text : `${text}.`;
+}

--- a/packages/core/src/layout/field-form.ts
+++ b/packages/core/src/layout/field-form.ts
@@ -20,6 +20,7 @@ import { parseButtonInstruction, type ButtonFieldSpec } from './field-button.ts'
 import { parseDocPropertyInstruction, type DocPropertyField } from './field-doc-property.ts';
 import { normalizeFieldInstruction } from './field-instruction.ts';
 import { parseHyperlinkInstruction, type HyperlinkFieldSpec } from './field-link.ts';
+import { parseAutonumInstruction, type AutonumFieldSpec } from './field-autonum.ts';
 import { parseRefInstruction, type RefFieldSpec } from './field-ref.ts';
 import { parseSymbolInstruction, type SymbolFieldSpec } from './field-symbol.ts';
 import { resolveRunStyle, type ResolvedRunStyle, type ThemeFonts } from './run-style.ts';
@@ -56,6 +57,7 @@ export interface CapturedInstructionSpecs {
   buttonSpec: ButtonFieldSpec | null;
   docPropertySpec: DocPropertyField | null;
   refSpec: RefFieldSpec | null;
+  autonumSpec: AutonumFieldSpec | null;
 }
 
 /**
@@ -75,6 +77,8 @@ export function captureInstructionSpecs(pending: CapturedInstructionSpecs, raw: 
   pending.docPropertySpec = parseDocPropertyInstruction(raw);
   if (pending.docPropertySpec) return;
   pending.refSpec = parseRefInstruction(raw);
+  if (pending.refSpec) return;
+  pending.autonumSpec = parseAutonumInstruction(raw);
 }
 
 /** The synthesized form-field result: text plus the props/style the piece should carry. */

--- a/packages/core/src/layout/field-pieces.ts
+++ b/packages/core/src/layout/field-pieces.ts
@@ -16,6 +16,7 @@ import type { ButtonFieldSpec } from './field-button.ts';
 import type { DocPropertyField } from './field-doc-property.ts';
 import type { FormFieldKind } from './field-form.ts';
 import type { AllowlistedPageField } from './field-instruction.ts';
+import type { AutonumFieldSpec } from './field-autonum.ts';
 import type { HyperlinkFieldSpec } from './field-link.ts';
 import type { RefFieldSpec } from './field-ref.ts';
 import type { SymbolFieldSpec } from './field-symbol.ts';
@@ -276,6 +277,14 @@ export interface PendingFieldProjection {
    * number switch) falls back to the cache, never to the raw instruction.
    */
   refSpec: RefFieldSpec | null;
+  /**
+   * Recognized AUTONUM / AUTONUMLGL / AUTONUMOUT instruction, or null when the field is none.
+   *
+   * Captured at the same points as {@link symbolSpec}. These fields carry NO separator and NO
+   * cached result — Word computes the number at display time and never stores it — so the
+   * synthesized sequential value is the only display they have; there is no cache to prefer.
+   */
+  autonumSpec: AutonumFieldSpec | null;
   /**
    * Bounded `w:ffData` render state read at `begin` (`legacyFormFieldDataOf` — state only,
    * macros never), or null when absent or malformed. {@link formField} stays presence-based:

--- a/packages/core/src/layout/field-projection.ts
+++ b/packages/core/src/layout/field-projection.ts
@@ -563,6 +563,7 @@ export function piecesOfParagraph(
             buttonSpec: null,
             docPropertySpec: null,
             refSpec: null,
+            autonumSpec: null,
             // Bounded ffData STATE read (checkbox checked/size, dropdown entries/selection —
             // macros never); `formField` below stays presence-based so an unreadable payload
             // still shades.

--- a/packages/core/src/layout/field-ref-refresh.ts
+++ b/packages/core/src/layout/field-ref-refresh.ts
@@ -83,7 +83,8 @@ export function planRefFieldResultRefresh(
     blocks,
     listItems,
     notes,
-    options.package ? noteRefNumberingForPart(options.package, part, blocks) : undefined
+    options.package ? noteRefNumberingForPart(options.package, part, blocks) : undefined,
+    options.displayMode ?? DEFAULT_REVISION_DISPLAY_MODE
   );
   if (context === null) return null;
 

--- a/packages/core/src/layout/field-ref-text.ts
+++ b/packages/core/src/layout/field-ref-text.ts
@@ -1,0 +1,132 @@
+// Bounded text collection for REF-family fields: the plain-REF bookmark range extractor,
+// the `w:fldSimple` cached-display reader, and the small WML helpers they share. Split from
+// `field-ref.ts`, which owns the grammar and the story context, so that module stays under
+// its line budget. Every walk here is node/depth/character capped — the inputs are
+// attacker-controlled OOXML.
+
+import {
+  isFldSimple,
+  WML_NAMESPACE_URI,
+  type OoxmlElement,
+  type OoxmlNode,
+} from '@docx-editor.dev/core/store';
+import {
+  consumeScanNode,
+  createScanBudget,
+  MAX_STORY_FIELD_SCAN_DEPTH,
+} from './field-instruction.ts';
+
+/** Length cap on a plain REF's extracted text — file data must not inflate keys or spans. */
+export const MAX_REF_TEXT_CHARS = 1024;
+
+export function wmlAttribute(node: OoxmlElement, localName: string): string | undefined {
+  for (const attribute of node.attributes) {
+    if (attribute.namespaceUri === WML_NAMESPACE_URI && attribute.localName === localName) {
+      return attribute.value;
+    }
+  }
+  return undefined;
+}
+
+/** A drawing hosts its own story; its bookmarks and fields are not this paragraph's. */
+export function isDrawingHost(node: OoxmlElement): boolean {
+  return node.kind === 'drawing' || node.localName === 'drawing' || node.localName === 'pict';
+}
+
+/** The `w:t` text of a `w:fldSimple`'s cached display, bounded and depth-capped. */
+export function fldSimpleCachedText(
+  simple: OoxmlElement,
+  budget: ReturnType<typeof createScanBudget>
+): string {
+  let text = '';
+  const visit = (node: OoxmlNode, depth: number): void => {
+    if (node.kind === 'textValue' || text.length >= MAX_REF_TEXT_CHARS) return;
+    if (budget.exhausted || depth > MAX_STORY_FIELD_SCAN_DEPTH) return;
+    if (!consumeScanNode(budget)) return;
+    if (node.kind === 'text') {
+      for (const value of node.children) {
+        if (value.kind === 'textValue') {
+          text += value.value.slice(0, MAX_REF_TEXT_CHARS - text.length);
+        }
+      }
+      return;
+    }
+    for (const child of node.children) visit(child, depth + 1);
+  };
+  for (const child of simple.children) visit(child, 1);
+  return text;
+}
+
+/** Plain-REF text per (target paragraph, name), memoized on the immutable paragraph. */
+const bookmarkTextMemos = new WeakMap<OoxmlElement, Map<string, string>>();
+
+/**
+ * The bookmarked text inside the target paragraph: from the named `w:bookmarkStart` to the
+ * `w:bookmarkEnd` carrying the same `w:id`, or to the paragraph's end when the range runs
+ * past it. Length-capped; collects `w:t` and tabs only — deleted text, field chrome and
+ * drawings never join a computed result.
+ */
+export function bookmarkRangeText(paragraph: OoxmlElement, name: string): string {
+  let memo = bookmarkTextMemos.get(paragraph);
+  const cached = memo?.get(name);
+  if (cached !== undefined) return cached;
+
+  let collecting = false;
+  let done = false;
+  let endId: string | undefined;
+  let text = '';
+  const budget = createScanBudget();
+
+  const append = (value: string): void => {
+    const room = MAX_REF_TEXT_CHARS - text.length;
+    if (room <= 0) {
+      done = true;
+      return;
+    }
+    text += value.length > room ? value.slice(0, room) : value;
+  };
+
+  const visit = (node: OoxmlNode, depth: number): void => {
+    if (done || node.kind === 'textValue') return;
+    if (budget.exhausted || depth > MAX_STORY_FIELD_SCAN_DEPTH) return;
+    if (node.kind === 'bookmarkStart') {
+      if (!collecting && wmlAttribute(node, 'name') === name) {
+        collecting = true;
+        endId = wmlAttribute(node, 'id');
+      }
+      return;
+    }
+    if (node.kind === 'bookmarkEnd') {
+      if (collecting && endId !== undefined && wmlAttribute(node, 'id') === endId) done = true;
+      return;
+    }
+    if (node.kind === 'run') {
+      if (!collecting) return;
+      for (const grand of node.children) {
+        if (done || !consumeScanNode(budget)) return;
+        if (grand.kind === 'text') {
+          for (const value of grand.children) {
+            if (value.kind === 'textValue') append(value.value);
+          }
+        } else if (grand.kind === 'tab') {
+          append('\t');
+        }
+      }
+      return;
+    }
+    if (isDrawingHost(node) || isFldSimple(node)) return;
+    if (!consumeScanNode(budget)) return;
+    for (const child of node.children) visit(child, depth + 1);
+  };
+  for (const child of paragraph.children) {
+    if (done || !consumeScanNode(budget)) break;
+    visit(child, 1);
+  }
+
+  if (!memo) {
+    memo = new Map();
+    bookmarkTextMemos.set(paragraph, memo);
+  }
+  memo.set(name, text);
+  return text;
+}

--- a/packages/core/src/layout/field-ref.ts
+++ b/packages/core/src/layout/field-ref.ts
@@ -79,6 +79,12 @@ import {
   noteRefMarkIndex,
   type NoteRefNumberingInput,
 } from './field-noteref.ts';
+import {
+  autonumDisplayText,
+  parseAutonumInstruction,
+  type AutonumFieldKind,
+  type AutonumFieldSpec,
+} from './field-autonum.ts';
 import { composeFullContextNumber } from './list-counters.ts';
 import {
   listItemNumberSource,
@@ -261,6 +267,14 @@ export interface RefFieldContext {
    * calibration verdict, however each walk collected the field's cached text.
    */
   liveValueOf(anchorId: string, spec: RefFieldSpec): string | null;
+  /**
+   * The synthesized display of ONE AUTONUM-family field, keyed by its begin / `w:fldSimple`
+   * node id, or null to paint nothing (unsupported switches, or an anchor this scan never
+   * saw — both the field's historical rendering). These fields carry no cached result at
+   * all, so there is no calibration: the sequential value is the only display they have.
+   * Optional so hand-built contexts predating it stay valid.
+   */
+  autonumValueOf?(anchorId: string): string | null;
 }
 
 function wmlAttribute(node: OoxmlElement, localName: string): string | undefined {
@@ -272,9 +286,12 @@ function wmlAttribute(node: OoxmlElement, localName: string): string | undefined
   return undefined;
 }
 
-/** One scanned REF field: its instruction, its anchor node id, and its NORMALIZED cache. */
+/** One scanned REF or AUTONUM-family field: instruction, anchor node id, NORMALIZED cache. */
 interface ScannedRefField {
-  readonly spec: RefFieldSpec;
+  /** The recognized REF/NOTEREF instruction, or null when {@link autonum} answers instead. */
+  readonly spec: RefFieldSpec | null;
+  /** The recognized AUTONUM-family instruction; such fields have no cache and no bookmark. */
+  readonly autonum: AutonumFieldSpec | null;
   /** Begin `w:fldChar` / `w:fldSimple` node id — stable across edits, the calibration key. */
   readonly anchorId: string;
   /** The authored cached result, whitespace-collapsed (NBSP = space) — the oracle. */
@@ -351,8 +368,13 @@ function scanParagraphRefs(paragraph: OoxmlElement): ParagraphRefScan {
   const budget = createScanBudget();
   const field = createFieldParseState();
 
-  /** The open level-1 REF field being collected, if its instruction parsed. */
-  let pending: { spec: RefFieldSpec; anchorId: string; cached: string } | null = null;
+  /** The open level-1 REF / AUTONUM field being collected, if its instruction parsed. */
+  let pending: {
+    spec: RefFieldSpec | null;
+    autonum: AutonumFieldSpec | null;
+    anchorId: string;
+    cached: string;
+  } | null = null;
   let levelOneBeginId: string | null = null;
 
   const captureLevelOne = (): void => {
@@ -360,12 +382,21 @@ function scanParagraphRefs(paragraph: OoxmlElement): ParagraphRefScan {
     const effective = effectiveFieldInstruction(field);
     if (effective.overflow || levelOneBeginId === null) return;
     const spec = parseRefInstruction(effective.instruction);
-    if (spec) pending = { spec, anchorId: levelOneBeginId, cached: '' };
+    if (spec) {
+      pending = { spec, autonum: null, anchorId: levelOneBeginId, cached: '' };
+      return;
+    }
+    // AUTONUM-family fields ride the same scan: begin/instrText/end with NO separator and no
+    // cached result, so this capture (which fires at the outermost end too) is the one place
+    // that sees them.
+    const autonum = parseAutonumInstruction(effective.instruction);
+    if (autonum) pending = { spec: null, autonum, anchorId: levelOneBeginId, cached: '' };
   };
   const finalizePending = (): void => {
     if (!pending) return;
     (fields ??= []).push({
       spec: pending.spec,
+      autonum: pending.autonum,
       anchorId: pending.anchorId,
       cached: normalizeResultText(pending.cached),
     });
@@ -429,10 +460,13 @@ function scanParagraphRefs(paragraph: OoxmlElement): ParagraphRefScan {
     if (isFldSimple(node)) {
       // The outer instruction only: a field nested in a simple field's cached result is never
       // live-projected as a REF, so descending would key on values nothing paints.
-      const spec = parseRefInstruction(fldSimpleInstr(node) ?? '');
-      if (spec) {
+      const instr = fldSimpleInstr(node) ?? '';
+      const spec = parseRefInstruction(instr);
+      const autonum = spec === null ? parseAutonumInstruction(instr) : null;
+      if (spec || autonum) {
         (fields ??= []).push({
           spec,
+          autonum,
           anchorId: node.id,
           cached: normalizeResultText(fldSimpleCachedText(node, budget)),
         });
@@ -672,13 +706,34 @@ function buildRefFieldContext(
   // never an object: bookmark names are attacker-chosen keys.
   const referenced = new Set<string>();
   for (const fields of fieldsByParagraph.values()) {
-    for (const field of fields) referenced.add(field.spec.bookmark);
+    for (const field of fields) {
+      if (field.spec) referenced.add(field.spec.bookmark);
+    }
   }
   const targets = new Map<string, OoxmlElement>();
   for (const scan of blockScans) {
     if (!scan.bookmarkOwners) continue;
     for (const [name, paragraph] of scan.bookmarkOwners) {
       if (referenced.has(name) && !targets.has(name)) targets.set(name, paragraph);
+    }
+  }
+
+  // AUTONUM prepass: one counter per kind, advanced in document order over the SAME scan (a
+  // Map iterates in insertion order, and note stories joined after the body). Computed before
+  // any REF resolves because a REF number switch aimed at an AUTONUM paragraph reads the
+  // paragraph's first value — Word numbers those targets from the field, not from a list.
+  const autonumByAnchor = new Map<string, string>();
+  const autonumByParagraph = new Map<string, string>();
+  const autonumCounters = new Map<AutonumFieldKind, number>();
+  for (const [paragraphId, fields] of fieldsByParagraph) {
+    for (const field of fields) {
+      if (!field.autonum) continue;
+      const next = (autonumCounters.get(field.autonum.kind) ?? 0) + 1;
+      autonumCounters.set(field.autonum.kind, next);
+      const value = autonumDisplayText(field.autonum, next);
+      if (value.length === 0) continue;
+      autonumByAnchor.set(field.anchorId, value);
+      if (!autonumByParagraph.has(paragraphId)) autonumByParagraph.set(paragraphId, value);
     }
   }
 
@@ -697,7 +752,14 @@ function buildRefFieldContext(
     }
     if (spec.numberSwitch !== null) {
       const item = listItems?.get(target.id);
-      if (!item) return null;
+      if (!item) {
+        // The target's number can come from an AUTONUM-family field rather than a list —
+        // the same documents use both, and the reference cites the synthesized value. `\t`
+        // has no template to filter there, so that pairing keeps the cache.
+        if (mods.suppressNonDelimiterText) return null;
+        const autonum = autonumByParagraph.get(target.id);
+        return autonum !== undefined ? trimTrailingPeriod(autonum) : null;
+      }
       // `\r` / `\w`: full context — a deep level's marker states only its own placeholder,
       // and painting bare `(c)` for a `1.2(c)` target is worse than the stale cache. `\n`:
       // the target's own level only, per Word's cached values for that switch. Items built
@@ -760,6 +822,14 @@ function buildRefFieldContext(
   for (const [paragraphId, fields] of fieldsByParagraph) {
     const pieces: string[] = [];
     for (const field of fields) {
+      // An AUTONUM-family field has no cache to calibrate against: its synthesized value is
+      // the only display it has, and the token folds it so inserting or removing an earlier
+      // field of the same kind repaints every later one.
+      if (field.spec === null) {
+        const value = field.autonum ? (autonumByAnchor.get(field.anchorId) ?? null) : null;
+        pieces.push(value !== null ? `a\u0001${value}` : `c\u0002${field.cached}`);
+        continue;
+      }
       const computed = computedOf(field.spec);
       let verdict = verdicts.get(field.anchorId);
       if (verdict === undefined) {
@@ -799,6 +869,7 @@ function buildRefFieldContext(
       }
       return entry.live;
     },
+    autonumValueOf: (anchorId) => autonumByAnchor.get(anchorId) ?? null,
   };
 }
 

--- a/packages/core/src/layout/field-ref.ts
+++ b/packages/core/src/layout/field-ref.ts
@@ -53,11 +53,17 @@
 import {
   fldSimpleInstr,
   isFldSimple,
-  WML_NAMESPACE_URI,
   type OoxmlElement,
   type OoxmlNode,
   type OoxmlPart,
 } from '@docx-editor.dev/core/store';
+import {
+  bookmarkRangeText,
+  fldSimpleCachedText,
+  isDrawingHost,
+  MAX_REF_TEXT_CHARS,
+  wmlAttribute,
+} from './field-ref-text.ts';
 import { isNormalNote, notesOf, MAX_NOTES_PER_PART } from '../store/package/note-nodes.ts';
 import { noteStoryBlocks } from './story-roots.ts';
 import {
@@ -87,6 +93,16 @@ import {
 } from './field-autonum.ts';
 import { composeFullContextNumber } from './list-counters.ts';
 import {
+  DEFAULT_REVISION_DISPLAY_MODE,
+  NO_REVISIONS,
+  isRevisionWrapper,
+  revisionAttributionOf,
+  revisionsVisible,
+  withRevision,
+  type RevisionAttribution,
+  type RevisionDisplayMode,
+} from './revision-projection.ts';
+import {
   listItemNumberSource,
   walkStoryParagraphs,
   type ResolvedListItem,
@@ -96,8 +112,6 @@ import {
 const MAX_REF_BOOKMARK_NAME_CHARS = 256;
 /** Ceiling on live-resolved REF fields per story; fields past it keep their cached results. */
 const MAX_REF_FIELDS_PER_STORY = 512;
-/** Length cap on a plain REF's extracted text — file data must not inflate keys or spans. */
-const MAX_REF_TEXT_CHARS = 1024;
 /** Ceiling on bookmark names remembered per top-level block (hostile declaration spam). */
 const MAX_REF_BOOKMARKS_PER_BLOCK = 2048;
 /** Ceiling on sticky calibration verdicts carried for one story across a session. */
@@ -277,15 +291,6 @@ export interface RefFieldContext {
   autonumValueOf?(anchorId: string): string | null;
 }
 
-function wmlAttribute(node: OoxmlElement, localName: string): string | undefined {
-  for (const attribute of node.attributes) {
-    if (attribute.namespaceUri === WML_NAMESPACE_URI && attribute.localName === localName) {
-      return attribute.value;
-    }
-  }
-  return undefined;
-}
-
 /** One scanned REF or AUTONUM-family field: instruction, anchor node id, NORMALIZED cache. */
 interface ScannedRefField {
   /** The recognized REF/NOTEREF instruction, or null when {@link autonum} answers instead. */
@@ -296,6 +301,15 @@ interface ScannedRefField {
   readonly anchorId: string;
   /** The authored cached result, whitespace-collapsed (NBSP = space) — the oracle. */
   readonly cached: string;
+  /**
+   * The revision wrappers enclosing the field's begin marker, outermost first.
+   *
+   * Recorded raw (the scan is memoized per paragraph node, shared across display modes) and
+   * resolved against the mode in the AUTONUM prepass: a `w:del`-wrapped field does not exist
+   * in the proposed view, so it must not advance the counter there — Word after accepting
+   * the deletion renumbers the survivors.
+   */
+  readonly revisions: readonly RevisionAttribution[];
 }
 
 /** REF fields and bookmark names one paragraph carries; shared empty for the common case. */
@@ -321,35 +335,6 @@ function normalizeResultText(value: string): string {
 /** Memoized per immutable paragraph node — an edit republishes only touched paragraphs. */
 const paragraphRefScans = new WeakMap<OoxmlElement, ParagraphRefScan>();
 
-/** A drawing hosts its own story; its bookmarks and fields are not this paragraph's. */
-function isDrawingHost(node: OoxmlElement): boolean {
-  return node.kind === 'drawing' || node.localName === 'drawing' || node.localName === 'pict';
-}
-
-/** The `w:t` text of a `w:fldSimple`'s cached display, bounded and depth-capped. */
-function fldSimpleCachedText(
-  simple: OoxmlElement,
-  budget: ReturnType<typeof createScanBudget>
-): string {
-  let text = '';
-  const visit = (node: OoxmlNode, depth: number): void => {
-    if (node.kind === 'textValue' || text.length >= MAX_REF_TEXT_CHARS) return;
-    if (budget.exhausted || depth > MAX_STORY_FIELD_SCAN_DEPTH) return;
-    if (!consumeScanNode(budget)) return;
-    if (node.kind === 'text') {
-      for (const value of node.children) {
-        if (value.kind === 'textValue') {
-          text += value.value.slice(0, MAX_REF_TEXT_CHARS - text.length);
-        }
-      }
-      return;
-    }
-    for (const child of node.children) visit(child, depth + 1);
-  };
-  for (const child of simple.children) visit(child, 1);
-  return text;
-}
-
 /**
  * Bounded scan of one paragraph: level-1 complex REF fields (the only ones projection
  * live-paints) with their anchor ids and cached results, `w:fldSimple` REF fields, and
@@ -374,8 +359,13 @@ function scanParagraphRefs(paragraph: OoxmlElement): ParagraphRefScan {
     autonum: AutonumFieldSpec | null;
     anchorId: string;
     cached: string;
+    revisions: readonly RevisionAttribution[];
   } | null = null;
   let levelOneBeginId: string | null = null;
+  /** The revision wrappers the walk is currently inside — captured at the field's begin. */
+  let revisions: readonly RevisionAttribution[] = NO_REVISIONS;
+  /** The stack at the level-1 begin, so the capture at separate/end reads the field's own. */
+  let levelOneRevisions: readonly RevisionAttribution[] = NO_REVISIONS;
 
   const captureLevelOne = (): void => {
     if (field.nesting !== 1 || field.phase !== 'instruction' || field.nestingOverflow) return;
@@ -383,14 +373,28 @@ function scanParagraphRefs(paragraph: OoxmlElement): ParagraphRefScan {
     if (effective.overflow || levelOneBeginId === null) return;
     const spec = parseRefInstruction(effective.instruction);
     if (spec) {
-      pending = { spec, autonum: null, anchorId: levelOneBeginId, cached: '' };
+      pending = {
+        spec,
+        autonum: null,
+        anchorId: levelOneBeginId,
+        cached: '',
+        revisions: levelOneRevisions,
+      };
       return;
     }
     // AUTONUM-family fields ride the same scan: begin/instrText/end with NO separator and no
     // cached result, so this capture (which fires at the outermost end too) is the one place
     // that sees them.
     const autonum = parseAutonumInstruction(effective.instruction);
-    if (autonum) pending = { spec: null, autonum, anchorId: levelOneBeginId, cached: '' };
+    if (autonum) {
+      pending = {
+        spec: null,
+        autonum,
+        anchorId: levelOneBeginId,
+        cached: '',
+        revisions: levelOneRevisions,
+      };
+    }
   };
   const finalizePending = (): void => {
     if (!pending) return;
@@ -399,6 +403,7 @@ function scanParagraphRefs(paragraph: OoxmlElement): ParagraphRefScan {
       autonum: pending.autonum,
       anchorId: pending.anchorId,
       cached: normalizeResultText(pending.cached),
+      revisions: pending.revisions,
     });
     pending = null;
   };
@@ -421,6 +426,7 @@ function scanParagraphRefs(paragraph: OoxmlElement): ParagraphRefScan {
           onFldCharBegin(field);
           if (field.nesting === 1) {
             levelOneBeginId = grand.id;
+            levelOneRevisions = revisions;
             pending = null;
           }
           continue;
@@ -469,12 +475,26 @@ function scanParagraphRefs(paragraph: OoxmlElement): ParagraphRefScan {
           autonum,
           anchorId: node.id,
           cached: normalizeResultText(fldSimpleCachedText(node, budget)),
+          revisions,
         });
       }
       return;
     }
     if (isDrawingHost(node)) return;
     if (!consumeScanNode(budget)) return;
+    // A revision wrapper decides whether its fields EXIST in a display mode, so the stack
+    // rides the descent — the AUTONUM prepass reads it to keep a deleted field from
+    // advancing the counter in the view that resolved the deletion away.
+    if (isRevisionWrapper(node)) {
+      const attribution = revisionAttributionOf(node);
+      if (attribution) {
+        const enclosing = revisions;
+        revisions = withRevision(enclosing, attribution);
+        for (const child of node.children) visit(child, depth + 1);
+        revisions = enclosing;
+        return;
+      }
+    }
     for (const child of node.children) visit(child, depth + 1);
   };
   for (const child of paragraph.children) {
@@ -554,80 +574,6 @@ function trimTrailingPeriod(marker: string): string {
   return marker.length > 1 && marker.endsWith('.') ? marker.slice(0, -1) : marker;
 }
 
-/** Plain-REF text per (target paragraph, name), memoized on the immutable paragraph. */
-const bookmarkTextMemos = new WeakMap<OoxmlElement, Map<string, string>>();
-
-/**
- * The bookmarked text inside the target paragraph: from the named `w:bookmarkStart` to the
- * `w:bookmarkEnd` carrying the same `w:id`, or to the paragraph's end when the range runs
- * past it. Length-capped; collects `w:t` and tabs only — deleted text, field chrome and
- * drawings never join a computed result.
- */
-function bookmarkRangeText(paragraph: OoxmlElement, name: string): string {
-  let memo = bookmarkTextMemos.get(paragraph);
-  const cached = memo?.get(name);
-  if (cached !== undefined) return cached;
-
-  let collecting = false;
-  let done = false;
-  let endId: string | undefined;
-  let text = '';
-  const budget = createScanBudget();
-
-  const append = (value: string): void => {
-    const room = MAX_REF_TEXT_CHARS - text.length;
-    if (room <= 0) {
-      done = true;
-      return;
-    }
-    text += value.length > room ? value.slice(0, room) : value;
-  };
-
-  const visit = (node: OoxmlNode, depth: number): void => {
-    if (done || node.kind === 'textValue') return;
-    if (budget.exhausted || depth > MAX_STORY_FIELD_SCAN_DEPTH) return;
-    if (node.kind === 'bookmarkStart') {
-      if (!collecting && wmlAttribute(node, 'name') === name) {
-        collecting = true;
-        endId = wmlAttribute(node, 'id');
-      }
-      return;
-    }
-    if (node.kind === 'bookmarkEnd') {
-      if (collecting && endId !== undefined && wmlAttribute(node, 'id') === endId) done = true;
-      return;
-    }
-    if (node.kind === 'run') {
-      if (!collecting) return;
-      for (const grand of node.children) {
-        if (done || !consumeScanNode(budget)) return;
-        if (grand.kind === 'text') {
-          for (const value of grand.children) {
-            if (value.kind === 'textValue') append(value.value);
-          }
-        } else if (grand.kind === 'tab') {
-          append('\t');
-        }
-      }
-      return;
-    }
-    if (isDrawingHost(node) || isFldSimple(node)) return;
-    if (!consumeScanNode(budget)) return;
-    for (const child of node.children) visit(child, depth + 1);
-  };
-  for (const child of paragraph.children) {
-    if (done || !consumeScanNode(budget)) break;
-    visit(child, 1);
-  }
-
-  if (!memo) {
-    memo = new Map();
-    bookmarkTextMemos.set(paragraph, memo);
-  }
-  memo.set(name, text);
-  return text;
-}
-
 /**
  * Note parts whose stories join the context: their REF fields resolve against the body's
  * bookmarks and numbering (a footnote citing "Section 1.2(c)" targets a body paragraph),
@@ -662,6 +608,7 @@ interface RefContextMemoEntry {
   readonly footnotesPart: OoxmlPart | null;
   readonly endnotesPart: OoxmlPart | null;
   readonly noteNumbering: NoteRefNumberingInput | undefined;
+  readonly displayMode: RevisionDisplayMode;
   readonly context: RefFieldContext | null;
 }
 /**
@@ -676,7 +623,8 @@ function buildRefFieldContext(
   blocks: readonly OoxmlElement[],
   listItems: ReadonlyMap<string, ResolvedListItem> | undefined,
   notes: RefNoteParts | undefined,
-  noteNumbering: NoteRefNumberingInput | undefined
+  noteNumbering: NoteRefNumberingInput | undefined,
+  displayMode: RevisionDisplayMode
 ): RefFieldContext | null {
   const fieldsByParagraph = new Map<string, readonly ScannedRefField[]>();
   const blockScans: BlockRefScan[] = [];
@@ -728,6 +676,9 @@ function buildRefFieldContext(
   for (const [paragraphId, fields] of fieldsByParagraph) {
     for (const field of fields) {
       if (!field.autonum) continue;
+      // A field the display mode resolves away does not exist in that view, so it must not
+      // advance the counter: Word after accepting a deletion renumbers the survivors.
+      if (!revisionsVisible(field.revisions, displayMode)) continue;
       const next = (autonumCounters.get(field.autonum.kind) ?? 0) + 1;
       autonumCounters.set(field.autonum.kind, next);
       const value = autonumDisplayText(field.autonum, next);
@@ -900,7 +851,8 @@ export function resolveStoryRefFieldsWithNoteNumbers(
   blocks: readonly OoxmlElement[],
   listItems: ReadonlyMap<string, ResolvedListItem> | undefined,
   notes: RefNoteParts | undefined,
-  noteNumbering: NoteRefNumberingInput | undefined
+  noteNumbering: NoteRefNumberingInput | undefined,
+  displayMode: RevisionDisplayMode = DEFAULT_REVISION_DISPLAY_MODE
 ): RefFieldContext | null {
   const footnotesPart = notes?.footnotesPart ?? null;
   const endnotesPart = notes?.endnotesPart ?? null;
@@ -910,12 +862,20 @@ export function resolveStoryRefFieldsWithNoteNumbers(
     memo.listItems === listItems &&
     memo.footnotesPart === footnotesPart &&
     memo.endnotesPart === endnotesPart &&
-    memo.noteNumbering === noteNumbering
+    memo.noteNumbering === noteNumbering &&
+    memo.displayMode === displayMode
   ) {
     return memo.context;
   }
-  const context = buildRefFieldContext(blocks, listItems, notes, noteNumbering);
-  refContextMemos.set(blocks, { listItems, footnotesPart, endnotesPart, noteNumbering, context });
+  const context = buildRefFieldContext(blocks, listItems, notes, noteNumbering, displayMode);
+  refContextMemos.set(blocks, {
+    listItems,
+    footnotesPart,
+    endnotesPart,
+    noteNumbering,
+    displayMode,
+    context,
+  });
   return context;
 }
 

--- a/packages/core/src/layout/field-simple-result.ts
+++ b/packages/core/src/layout/field-simple-result.ts
@@ -19,6 +19,7 @@ import { parseButtonInstruction } from './field-button.ts';
 import { docPropertyValue, parseDocPropertyInstruction } from './field-doc-property.ts';
 import { parseHyperlinkInstruction } from './field-link.ts';
 import type { FieldLinkProjector } from './field-pieces.ts';
+import { parseAutonumInstruction } from './field-autonum.ts';
 import { parseRefInstruction, type RefFieldContext } from './field-ref.ts';
 import {
   modelTextOfRunChild,
@@ -363,6 +364,15 @@ export function projectSimpleFieldResult(args: {
     const refSpec = parseRefInstruction(instr);
     if (refSpec) {
       const value = args.refFields.liveValueOf(simple.id, refSpec);
+      if (value !== null) {
+        const style = display.resultStyle ?? resolveRunStyle(inheritedRunProperties, themeFonts);
+        if (style.hidden) return null;
+        return { text: value, props, style };
+      }
+    } else if (args.refFields.autonumValueOf && parseAutonumInstruction(instr)) {
+      // A simple AUTONUM-family field synthesizes exactly like the complex shape: the
+      // sequential value is the only display these fields have.
+      const value = args.refFields.autonumValueOf(simple.id);
       if (value !== null) {
         const style = display.resultStyle ?? resolveRunStyle(inheritedRunProperties, themeFonts);
         if (style.hidden) return null;

--- a/packages/core/src/layout/field-synthesis.ts
+++ b/packages/core/src/layout/field-synthesis.ts
@@ -105,6 +105,14 @@ export function synthesizeAtomicField(
     const value = ctx.refFields.liveValueOf(pending.beginId, pending.refSpec);
     if (value !== null) return { text: value, props: pending.props, style: pending.style };
   }
+  // An AUTONUM-family field has no separator and no cached result — Word computes the number
+  // at display time and never stores it — so the synthesized sequential value is its only
+  // display, and it wins over whatever stray cache a producer wrote. An anchor the scan never
+  // saw paints nothing, the field's historical rendering.
+  if (pending.autonumSpec && ctx.refFields?.autonumValueOf) {
+    const value = ctx.refFields.autonumValueOf(pending.beginId);
+    if (value !== null) return { text: value, props: pending.props, style: pending.style };
+  }
   // A non-empty cached result is what Word last painted; it wins over synthesis.
   if (pending.cachedText.length > 0) {
     return { text: pending.cachedText, props: pending.props, style: pending.style };

--- a/packages/core/src/layout/index.ts
+++ b/packages/core/src/layout/index.ts
@@ -358,6 +358,11 @@ export {
   type RefFieldSpec,
   type RefNoteParts,
 } from './field-ref.ts';
+export {
+  parseAutonumInstruction,
+  type AutonumFieldKind,
+  type AutonumFieldSpec,
+} from './field-autonum.ts';
 export { planRefFieldResultRefresh, type RefFieldRefreshOptions } from './field-ref-refresh.ts';
 export { storyBlocks, noteStoryBlocks, MAX_SDT_NESTING } from './story-roots.ts';
 export {

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -628,7 +628,8 @@ export function layoutSemanticDocument(
     options.notes
       ? { footnotesPart: options.notes.footnotesPart, endnotesPart: options.notes.endnotesPart }
       : undefined,
-    options.notes ? noteRefNumberingFromNotes(options.notes, sections) : undefined
+    options.notes ? noteRefNumberingFromNotes(options.notes, sections) : undefined,
+    displayMode
   );
   const optionsForBody = refFields === null ? optionsWithLists : { ...optionsWithLists, refFields };
 


### PR DESCRIPTION
The `AUTONUM` family carries no separator and no cached result runs — Word computes the number at display time and never stores it — so the engine painted the field region as empty and the paragraph lost its number. These fields now paint a synthesized value: one counter per kind, advanced in document order, formatted through the shared `ST_NumberFormat` resolver, with `\* <format>` switches and `\e` (no trailing period). Unsupported switches keep painting nothing.

A field hidden by the active revision display mode does not advance the counter, so the proposed and original views renumber the survivors after resolving the change. `REF` number switches aimed at a bookmarked auto-numbered paragraph resolve against the synthesized value. The values fold into the field paragraphs' ref tokens, so an edit that inserts or removes an earlier field renumbers the later ones incrementally.

Word stores no results for these fields, so serialization is untouched.

Fixes #618.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790620117&installation_model_id=422592&pr_number=624&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F624&signature=194c0bba0598cd9f6e99e93e06fac161d34c8816ed3cbb015facb58147d7e3a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->