### PR TITLE
docs: require a native issue type alongside the roadmap labels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -398,7 +398,10 @@ dev` → `http://localhost:5173/`. Live demo `http://docx-editor.dev/editor`.
   Area/Priority single-select fields. An option name must keep matching its
   label slug (lowercase, spaces→dashes) or the sync warns and skips; an issue
   with no `area:*` label is removed from the board; two labels of one prefix
-  clear the field. When you file an issue, set both labels.
+  clear the field. ALWAYS file an issue with both labels AND a native issue
+  type: `gh issue create --type Bug|Feature|Task --label "area:...,priority:..."`
+  (`gh issue edit <N> --type ...` to fix one). Never leave an issue without a
+  type or an area.
 - **ESM only** — no `require()`.
 - **Tailwind** — scoped to `.docx-editor`; the scoping is baked into `dist/editor.css`
   at core build time (`scripts/build-core-styles.mjs` + `packages/core/tailwind.dist.config.cjs`),


### PR DESCRIPTION
Extends the issue-labels convention in `CLAUDE.md`: every issue gets one `area:*` label, one `priority:*` label, and a native issue type (Bug, Feature, or Task), set with `gh issue create --type`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/625"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790621705&installation_model_id=422592&pr_number=625&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F625&signature=5b5c42f45a5a610bb1b370b26e4856055de3d88caf43788e1492d004302cff80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->