### PR TITLE
fix: re-break renumbered list paragraphs whose ordinal overflows the hanging slot

### DIFF
--- a/.changeset/list-renumber-first-line.md
+++ b/.changeset/list-renumber-first-line.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Re-break a renumbered list paragraph when its wider ordinal overflows the hanging indent, so the first line moves to the next tab stop instead of keeping its pre-renumber position under the marker.

--- a/packages/core/src/editor/__tests__/list-renumber-first-line.test.ts
+++ b/packages/core/src/editor/__tests__/list-renumber-first-line.test.ts
@@ -1,0 +1,134 @@
+// A list ordinal is DERIVED state: inserting items above a numbered paragraph renumbers it
+// while its own subtree stays byte-identical. When the wider ordinal overflows the hanging
+// slot, the suffix tab moves the FIRST LINE to the next stop — so the renumbered paragraph
+// must be re-broken, not served its pre-renumber first-line geometry.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { mountPaginatedSurface, type PaginatedSurface } from '../paginated-surface.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+const NUMREL = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering';
+
+// Starts at XXXVII so the LAST item sits at XL. — the widest ordinal that still fits the
+// 360-twip hanging slot under the fixed measurer. Four insertions push it to XLIV., which
+// overflows the slot and must move the first line to the next tab stop.
+const NUMBERING =
+  `<w:numbering xmlns:w="${W}"><w:abstractNum w:abstractNumId="0"><w:lvl w:ilvl="0">` +
+  '<w:start w:val="37"/><w:numFmt w:val="upperRoman"/><w:lvlText w:val="%1."/>' +
+  '<w:pPr><w:ind w:left="720" w:hanging="360"/></w:pPr></w:lvl></w:abstractNum>' +
+  '<w:num w:numId="1"><w:abstractNumId w:val="0"/></w:num></w:numbering>';
+
+const item = (text: string) =>
+  '<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr></w:pPr>' +
+  `<w:r><w:t>${text}</w:t></w:r></w:p>`;
+
+function docx(body: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '<Override PartName="/word/numbering.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml"/></Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId9" Type="${NUMREL}" Target="numbering.xml"/></Relationships>`
+    ),
+    'word/numbering.xml': strToU8(NUMBERING),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
+    ),
+  });
+}
+
+interface ItemGeometry {
+  readonly marker: string | undefined;
+  readonly markerEnd: number | undefined;
+  readonly contentX: number | undefined;
+}
+
+function geometryOf(surface: PaginatedSurface, paragraphId: string): ItemGeometry {
+  for (const page of surface.layout().pages) {
+    for (const fragment of page.fragments) {
+      if (fragment.kind !== 'paragraph' || fragment.paragraphId !== paragraphId) continue;
+      return {
+        marker: fragment.marker?.text,
+        markerEnd: fragment.marker ? fragment.marker.box.x + fragment.marker.box.width : undefined,
+        contentX: fragment.lines[0]?.contentX,
+      };
+    }
+  }
+  throw new Error(`no fragment for ${paragraphId}`);
+}
+
+/** By CONTENT, not position: save/reopen owes this test no promise about paragraph order. */
+function paragraphIdByFirstLineText(surface: PaginatedSurface, text: string): string {
+  for (const page of surface.layout().pages) {
+    for (const fragment of page.fragments) {
+      if (fragment.kind !== 'paragraph') continue;
+      const firstLine = fragment.lines[0]?.spans.map((span) => span.text).join('') ?? '';
+      if (firstLine === text) return fragment.paragraphId;
+    }
+  }
+  throw new Error(`no paragraph reading "${text}"`);
+}
+
+function withSurface(bytes: Uint8Array, run: (surface: PaginatedSurface) => void): void {
+  const container = document.createElement('div');
+  document.body.append(container);
+  try {
+    const opened = mountPaginatedSurface(container, bytes);
+    if (!opened.ok) throw new Error(opened.reason);
+    try {
+      run(opened.surface);
+    } finally {
+      opened.surface.destroy();
+    }
+  } finally {
+    container.remove();
+  }
+}
+
+describe('a renumbered ordinal that overflows its slot moves the first line', () => {
+  test('insertions above push the last item across the tab threshold', () => {
+    withSurface(
+      docx(item('Introduction') + item('Analysis') + item('Discussion') + item('Conclusions')),
+      (surface) => {
+        const ids = surface.session.paragraphIds();
+        const conclusions = ids[3]!;
+        const before = geometryOf(surface, conclusions);
+        expect(before.marker).toBe('XL.');
+
+        // Four Enters at the end of 'Discussion' insert four numbered items above 'Conclusions'.
+        surface.setSelection({
+          anchor: { paragraphId: ids[2]!, offset: 'Discussion'.length },
+          head: { paragraphId: ids[2]!, offset: 'Discussion'.length },
+        });
+        for (let count = 0; count < 4; count += 1) surface.splitParagraph();
+
+        const incremental = geometryOf(surface, conclusions);
+        expect(incremental.marker).toBe('XLIV.');
+        // The threshold must actually be crossed, or every assertion below holds trivially
+        // and the regression this test pins could return unseen.
+        expect(incremental.contentX!).toBeGreaterThan(before.contentX!);
+        // The first line may never start under the marker that numbers it.
+        expect(incremental.contentX!).toBeGreaterThanOrEqual(incremental.markerEnd!);
+
+        // Cold oracle: the same bytes reopened have no warm caches to serve stale geometry.
+        withSurface(surface.session.save(), (reopened) => {
+          const cold = geometryOf(reopened, paragraphIdByFirstLineText(reopened, 'Conclusions'));
+          expect(cold.marker).toBe('XLIV.');
+          expect(incremental.contentX).toBe(cold.contentX!);
+        });
+      }
+    );
+  });
+});

--- a/packages/core/src/layout/layout-cache.ts
+++ b/packages/core/src/layout/layout-cache.ts
@@ -60,17 +60,24 @@ export interface ParagraphLayoutCache<T> {
   readonly stats: LayoutCacheStats;
 }
 
-/** Serialize a property list stably: element order matters, attribute order does not. */
+/**
+ * Serialize a property list stably: element order matters, attribute order does not.
+ *
+ * Boundaries are NUL-framed because attribute VALUES carry file-derived text (marker
+ * `w:lvlText`, resolved REF results). A printable join would let a crafted value spell out
+ * another property's serialization, and two different property lists would alias to one
+ * cache key. XML text cannot carry U+0000, so no file-derived value can forge a boundary.
+ */
 function propertyToken(property: OoxmlProperty): string {
   const attributes = Object.entries(property.attributes ?? {})
     .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
     .map(([name, value]) => `${name}=${value}`)
-    .join(',');
-  return `${property.localName}(${attributes})`;
+    .join('\0,');
+  return `${property.localName}(\0${attributes}\0)`;
 }
 
 function propertiesToken(properties: readonly OoxmlProperty[]): string {
-  return properties.map(propertyToken).join(';');
+  return properties.map(propertyToken).join('\0;');
 }
 
 /**
@@ -96,6 +103,63 @@ const nodeTokens = new WeakMap<object, string>();
  * bounds retention while leaving every realistic paragraph and table memoized.
  */
 const MAX_MEMOIZED_TOKEN_LENGTH = 1 << 18;
+
+/**
+ * Namespaces a break-cache token by the inline-drawing CONTEXT that minted it.
+ *
+ * The context changes how a paragraph breaks — inline drawings are measured as atoms only
+ * when it is present — so two passes over the same bytes may not share cache entries just
+ * because their per-block tokens agree. One helper for every key path (body blocks, table
+ * cells, the section-prepass epoch), so the namespace cannot diverge per lane.
+ */
+export function withDrawingContext(token: string, inlineDrawingContext: boolean): string {
+  return `${token}|${inlineDrawingContext ? 'drawing' : ''}`;
+}
+
+/**
+ * Aggregate the list tokens of every paragraph a table contains, memoized per (table,
+ * listItems) pair — both immutable, so the walk runs once per numbering state instead of
+ * once per pass.
+ *
+ * NUL-framed, with an empty slot for every unlisted paragraph: a `cacheToken` embeds
+ * file-controlled marker text (`w:lvlText` may contain any printable separator), so a
+ * printable join — or skipping the unlisted paragraphs — lets two different token
+ * SEQUENCES over one byte-identical subtree concatenate to the same string, and the cache
+ * serves the pre-renumber table.
+ */
+const tableListTokens = new WeakMap<object, WeakMap<object, string>>();
+export function listTokenForTableBlock(
+  table: OoxmlNode,
+  listItems: ReadonlyMap<string, { readonly cacheToken: string }> | undefined
+): string {
+  if (!listItems || listItems.size === 0) return '';
+  // Nested weak keying: neither the table nor the list map is retained by the memo, and two
+  // consumers preparing one table under different list maps both stay warm.
+  let byListItems = tableListTokens.get(table);
+  const cached = byListItems?.get(listItems);
+  if (cached !== undefined) return cached;
+  const tokens: string[] = [];
+  let any = false;
+  const visit = (node: OoxmlNode): void => {
+    if (node.kind === 'paragraph') {
+      const token = listItems.get(node.id)?.cacheToken ?? '';
+      if (token) any = true;
+      tokens.push(token);
+      return;
+    }
+    if ('children' in node) for (const child of node.children) visit(child);
+  };
+  visit(table);
+  const token = any ? tokens.join('\0') : '';
+  if (token.length <= MAX_MEMOIZED_TOKEN_LENGTH) {
+    if (!byListItems) {
+      byListItems = new WeakMap();
+      tableListTokens.set(table, byListItems);
+    }
+    byListItems.set(listItems, token);
+  }
+  return token;
+}
 
 function nodeToken(node: OoxmlNode): string {
   if (node.kind === 'textValue') return `t:${node.value}`;

--- a/packages/core/src/layout/section-prepass-guards.ts
+++ b/packages/core/src/layout/section-prepass-guards.ts
@@ -30,6 +30,9 @@ export const SECTION_PREPASS_GUARDS = {
   contentWidth: 'validity-checked',
   styleCascade: 'validity-checked',
   listItems: 'validity-checked',
+  // What `hostedTextboxListToken` reads. A numbering edit that only renumbers a text-box
+  // hosted list leaves `listItems` (the story's own map) identity-equal; this clause sees it.
+  numberingIndex: 'validity-checked',
   // Stands in for the per-block drawing tokens; a caller that threads per-paragraph
   // tokens WITHOUT an epoch keeps the recompute path (`drawingEpoch !== null`).
   drawingEpoch: 'validity-checked',

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -25,9 +25,11 @@ import {
   type HyperlinkProjector,
 } from './field-projection.ts';
 import {
+  listTokenForTableBlock,
   paragraphLayoutKey,
   registerTableCellBreakKeys,
   retainLiveBreakKeys,
+  withDrawingContext,
   type ParagraphLayoutCache,
 } from './layout-cache.ts';
 import {
@@ -421,26 +423,13 @@ interface PreparedBlockMemo {
    * width and producer all stay identical. `''` for the common REF-free block.
    */
   readonly refToken: string;
+  /**
+   * Whether the inline-drawing context was present. Pass-constant, but the memo lives
+   * across passes, so it must be compared here for {@link PreparedBlock.key} (which folds
+   * it via `withDrawingContext`) to stay current when a caller toggles the context.
+   */
+  readonly drawingContext: boolean;
   readonly entry: PreparedBlock;
-}
-
-/** Aggregate the list tokens of every paragraph a table contains, for its memo key. */
-function listTokenForTableBlock(
-  table: OoxmlNode,
-  listItems: ReadonlyMap<string, ResolvedListItem> | undefined
-): string {
-  if (!listItems || listItems.size === 0) return '';
-  const tokens: string[] = [];
-  const visit = (node: OoxmlNode): void => {
-    if (node.kind === 'paragraph') {
-      const token = listItems.get(node.id)?.cacheToken;
-      if (token) tokens.push(token);
-      return;
-    }
-    if ('children' in node) for (const child of node.children) visit(child);
-  };
-  visit(table);
-  return tokens.join(';');
 }
 
 const preparedBlocks = new WeakMap<OoxmlNode, PreparedBlockMemo>();
@@ -511,6 +500,13 @@ export interface SectionPrepass {
   readonly contentWidth: number;
   readonly styleCascade: StyleCascadeTable | undefined;
   readonly listItems: ReadonlyMap<string, ResolvedListItem> | undefined;
+  /**
+   * The numbering index `hostedTextboxListToken` reads. Compared by IDENTITY: a story with
+   * no numbered paragraphs of its own can host a text box whose list a numbering edit
+   * renumbers, and then `listItems` is the same (empty) map while every hosted token in
+   * `entry.key` is stale.
+   */
+  readonly numberingIndex: NumberingIndex | undefined;
   readonly drawingEpoch: string;
   readonly prepared: PreparedBlock[];
   readonly keys: string[];
@@ -1100,17 +1096,28 @@ function layoutBlocksPass(
   // and the producer. Recomputing the key — a serialization of the paragraph's subtree —
   // for every paragraph on every pass made the prepass, not placement, the cost of an
   // incremental layout: a one-character edit re-keyed the entire document.
+  // Constant per pass. `withDrawingContext` folds it into EVERY per-block drawing token
+  // and into the prepass epoch below, so key namespacing and memo validity can never
+  // disagree about which context minted a key — including a caller that supplies tokens
+  // while toggling the context, which a fallback-only namespace could not separate.
+  const hasInlineDrawingContext = options.inlineDrawingLayout !== undefined;
   const prepareBlock = (block: OoxmlElement, availableWidth: number): PreparedBlock => {
+    // The RAW token, compared by the memo below so a table's kilobyte aggregate keeps its
+    // identity fast path; the context joins only when a key is actually built. `||`, not
+    // `??`, matching the cell lane: a per-paragraph callback answering `''` falls through
+    // to the document-wide token.
     const paragraphDrawingToken =
       block.kind === 'paragraph'
-        ? (options.drawingTokenForParagraph?.(block) ?? options.drawingLayoutToken ?? '')
+        ? options.drawingTokenForParagraph?.(block) || options.drawingLayoutToken || ''
         : block.kind === 'table' && options.drawingTokenForParagraph
           ? drawingTokenForTableBlockMemo(
               block,
               options.drawingLayoutEpoch,
               options.drawingTokenForParagraph
-            )
-          : '';
+            ) ||
+            options.drawingLayoutToken ||
+            ''
+          : options.drawingLayoutToken || '';
     // A TABLE'S LIST STATE IS ITS CELLS'. `listItems` is keyed by PARAGRAPH, and a numbered
     // list that continues inside a table cell has its markers there — so reading the table's
     // own id gave an empty token, and a renumbering that left the table's flow key untouched
@@ -1125,10 +1132,15 @@ function layoutBlocksPass(
       styleCascade,
       displayMode
     );
-    const listToken =
-      (block.kind === 'table'
+    // NUL between the block's own token and the hosted one: both embed file-influenced
+    // marker text, so a printable join would let two different (own, hosted) pairs
+    // concatenate to one string.
+    const ownListToken =
+      block.kind === 'table'
         ? listTokenForTableBlock(block, listItems)
-        : (listItems?.get(block.id)?.cacheToken ?? '')) + hostedListToken;
+        : (listItems?.get(block.id)?.cacheToken ?? '');
+    const listToken =
+      ownListToken === '' && hostedListToken === '' ? '' : `${ownListToken}\0${hostedListToken}`;
     // The RESOLVED VALUES this block's REF fields paint. The block's own subtree is identical
     // after a renumbering edit elsewhere, so only this token can invalidate its memo and key.
     const refToken =
@@ -1144,27 +1156,30 @@ function layoutBlocksPass(
       memo.producer === producer &&
       memo.drawingToken === paragraphDrawingToken &&
       memo.listToken === listToken &&
-      memo.refToken === refToken
+      memo.refToken === refToken &&
+      memo.drawingContext === hasInlineDrawingContext
     ) {
       return memo.entry;
     }
+    const keyedDrawingToken = withDrawingContext(paragraphDrawingToken, hasInlineDrawingContext);
     let entry: PreparedBlock;
     if (block.kind === 'table') {
-      // `nodeToken` hashes the whole subtree, so one key covers every cell edit.
+      // `nodeToken` hashes the whole subtree, so one key covers every cell edit. The list
+      // token is the CELL aggregate plus any hosted text-box stories: a renumbering that
+      // only moves ordinals inside a cell leaves the subtree byte-identical, and this token
+      // is the only thing that can move the key with it.
       entry = {
         kind: 'table',
         table: block,
         key: paragraphLayoutKey({
           paragraph: block,
           properties: [
-            ...(hostedListToken
-              ? [{ localName: 'txbxList', attributes: { token: hostedListToken } }]
-              : []),
+            ...(listToken ? [{ localName: 'list', attributes: { token: listToken } }] : []),
             ...(refToken ? [{ localName: 'refFields', attributes: { token: refToken } }] : []),
           ],
           width: availableWidth,
           producer,
-          ...(paragraphDrawingToken ? { drawingToken: paragraphDrawingToken } : {}),
+          drawingToken: keyedDrawingToken,
         }),
       };
     } else {
@@ -1242,7 +1257,7 @@ function layoutBlocksPass(
           ],
           width: available,
           producer,
-          ...(paragraphDrawingToken ? { drawingToken: paragraphDrawingToken } : {}),
+          drawingToken: keyedDrawingToken,
         }),
       };
     }
@@ -1252,6 +1267,7 @@ function layoutBlocksPass(
       drawingToken: paragraphDrawingToken,
       listToken,
       refToken,
+      drawingContext: hasInlineDrawingContext,
       entry,
     });
     return entry;
@@ -1262,12 +1278,15 @@ function layoutBlocksPass(
   // arrays anyway made the prepass, not placement, the floor cost of a keystroke.
   // `drawingLayoutEpoch` stands in for the per-block drawing tokens (the epoch moves
   // whenever any drawing projection or resource in the part does); a caller that threads
-  // per-paragraph drawing tokens WITHOUT an epoch keeps the recompute path, because the
-  // memo could not see a token move.
+  // per-paragraph drawing tokens WITHOUT an epoch keeps the recompute path (null), because
+  // the memo could not see a token move. The inline-drawing context joins the epoch
+  // exactly as it joins every per-block token, so a session that toggles the context
+  // between passes is never served the other context's keys.
   const drawingEpoch =
-    options.drawingTokenForParagraph === undefined && options.drawingLayoutToken === undefined
-      ? (options.drawingLayoutEpoch ?? '')
-      : (options.drawingLayoutEpoch ?? null);
+    (options.drawingTokenForParagraph !== undefined || options.drawingLayoutToken !== undefined) &&
+    options.drawingLayoutEpoch === undefined
+      ? null
+      : withDrawingContext(options.drawingLayoutEpoch ?? '', hasInlineDrawingContext);
   const prepassMemo = session?.prepass as SectionPrepass | null | undefined;
   const prepassValid =
     prepassMemo != null &&
@@ -1277,6 +1296,7 @@ function layoutBlocksPass(
     prepassMemo.contentWidth === contentWidth &&
     prepassMemo.styleCascade === styleCascade &&
     prepassMemo.listItems === listItems &&
+    prepassMemo.numberingIndex === options.numberingIndex &&
     prepassMemo.tocToken === tocToken &&
     prepassMemo.refToken === (refFields?.valuesToken ?? '') &&
     prepassMemo.bodies.length === bodies.length &&
@@ -1328,6 +1348,7 @@ function layoutBlocksPass(
       contentWidth,
       styleCascade,
       listItems,
+      numberingIndex: options.numberingIndex,
       drawingEpoch: drawingEpoch ?? '',
       prepared,
       keys,
@@ -1728,7 +1749,11 @@ function layoutBlocksPass(
     bodyPageFields: bodyPageFieldContext,
     ...(refFields ? { refFields } : {}),
     ...(options.noteMarks ? { noteMarks: options.noteMarks } : {}),
-    ...(options.inlineDrawingLayout ? { inlineDrawingLayout: options.inlineDrawingLayout } : {}),
+    // `!== undefined`, matching how every key lane derives the context bit, so the cell
+    // lane's namespace can never disagree with the body's about whether a context exists.
+    ...(options.inlineDrawingLayout !== undefined
+      ? { inlineDrawingLayout: options.inlineDrawingLayout }
+      : {}),
     ...(options.drawingTokenForParagraph
       ? { drawingTokenForParagraph: options.drawingTokenForParagraph }
       : options.drawingLayoutToken
@@ -1802,38 +1827,31 @@ function layoutBlocksPass(
       return true;
     });
     const exclusionToken = exclusionLayoutToken(pageZones);
-    const drawingKeyed =
-      options.drawingTokenForParagraph?.(entry.paragraph) ??
-      options.drawingLayoutToken ??
-      (options.inlineDrawingLayout ? 'drawing' : undefined);
-    // The drawing/exclusion key path rebuilds from `entry.props`, which cannot see a REF
-    // value move — fold the paragraph's ref token in so a float-adjacent reference is not
-    // served its pre-renumber break.
-    const refToken = refFields?.tokenForParagraph(paragraphId) ?? '';
-    const cacheKey =
-      cache && !suppressChrome
-        ? exclusionToken || drawingKeyed
-          ? paragraphLayoutKey({
-              paragraph: entry.paragraph,
-              properties: refToken
-                ? [...entry.props, { localName: 'refFields', attributes: { token: refToken } }]
-                : entry.props,
-              width: available,
-              producer,
-              ...(drawingKeyed ? { drawingToken: drawingKeyed } : {}),
-              // `cursorY` belongs in the key: the zones are page-content bands, so the same
-              // text at the same width breaks differently depending on where down the page
-              // it starts. Keying on zone geometry alone lets a paragraph clear of the float
-              // reuse the wrapped break of an identical one that crosses it.
-              ...(exclusionToken
-                ? { exclusionToken: `${flowColumnIndex}|${cursorY.toFixed(3)}|${exclusionToken}` }
-                : {}),
-              ...(startOffset > 0 ? { startOffset } : {}),
-            })
-          : startOffset === 0
-            ? entry.key
-            : `${entry.key}|from:${startOffset}`
-        : null;
+    // `entry.key` already folds the content, the cascade props, the tab stops, and the
+    // list/textbox/drawing/REF tokens — `prepareBlock` memo-validates each per pass, and
+    // `refFields` is one frozen projection per pass, so nothing here can drift from the
+    // prepass. This used to rebuild from `entry.props` whenever a drawing token was
+    // present, which dropped the list token: a renumbered ordinal that crossed its tab
+    // stop kept its pre-renumber first line and the wider marker painted over it. Only
+    // what varies per PLACEMENT joins below; the common path must stay `entry.key` BY
+    // IDENTITY, because retention names the prepass keys (suffixed and off-prepass-width
+    // keys are transient by design) and V8 caches the shared string's hash.
+    // A new placement-varying input joins BOTH this suffix chain and the cell path's
+    // `paragraphLayoutKey` call in `semantic-table-layout.ts` — the roles map in
+    // `layout-cache.ts` guards only the typed inputs, not these suffixes.
+    let cacheKey: string | null = null;
+    if (cache && !suppressChrome) {
+      // `cursorY` belongs in the key: the zones are page-content bands, so the same text at
+      // the same width breaks differently depending on where down the page it starts. Keying
+      // on zone geometry alone lets a paragraph clear of the float reuse the wrapped break
+      // of an identical one that crosses it. NUL-framed: XML text cannot carry U+0000, so
+      // no file-derived token can forge a suffix boundary.
+      cacheKey = entry.key;
+      if (exclusionToken) {
+        cacheKey += `\0excl:${flowColumnIndex}|${cursorY.toFixed(3)}|${exclusionToken}`;
+      }
+      if (startOffset > 0) cacheKey += `\0from:${startOffset}`;
+    }
     const usePageColumnCoords = columnCount > 1;
     return breakParagraph(
       entry.paragraph,

--- a/packages/core/src/layout/semantic-table-layout.ts
+++ b/packages/core/src/layout/semantic-table-layout.ts
@@ -36,7 +36,11 @@ import type {
   FieldPageContext,
   HyperlinkProjector,
 } from './field-projection.ts';
-import { paragraphLayoutKey, type ParagraphLayoutCache } from './layout-cache.ts';
+import {
+  paragraphLayoutKey,
+  withDrawingContext,
+  type ParagraphLayoutCache,
+} from './layout-cache.ts';
 import { alignDrawings, alignSpans, breakParagraph, type PendingLine } from './paragraph-flow.ts';
 import { mergeBoundariesOf, remapMergedLines } from './merged-paragraph-ranges.ts';
 import { isEmptyCellTerminator, paragraphMergeGroupOf } from './story-roots.ts';
@@ -497,11 +501,15 @@ function placeCellParagraph(
     ],
     width: available,
     producer: deps.producer,
-    ...(deps.drawingTokenForParagraph?.(paragraph)
-      ? { drawingToken: deps.drawingTokenForParagraph(paragraph) }
-      : deps.drawingLayoutToken
-        ? { drawingToken: deps.drawingLayoutToken }
-        : {}),
+    // The inline-drawing CONTEXT joins the token exactly as it does in the body flow: the
+    // context changes how a paragraph breaks (drawings become measured atoms), so a
+    // token-less pass with the context may not share cell entries with one without it.
+    // `||`, not `??`: a per-paragraph callback answering `''` falls through to the
+    // document-wide token, as it always has.
+    drawingToken: withDrawingContext(
+      deps.drawingTokenForParagraph?.(paragraph) || deps.drawingLayoutToken || '',
+      deps.inlineDrawingLayout !== undefined
+    ),
     ...(positionedExclusionToken ? { exclusionToken: positionedExclusionToken } : {}),
   });
   if (deps.cache) deps.onCellBreakKey?.(key);


### PR DESCRIPTION
Inserting items above a numbered paragraph can widen its ordinal (for example `XL.` to `XLIV.`) past the hanging indent, which moves the first line to the next tab stop. The placement-time break-cache key dropped the list token whenever a drawing token was present — the editor always supplies one — so the cache served the pre-renumber first line and the wider marker painted over the text.

The key now derives from the prepared block's key, which folds every invalidation token, and the property serializer NUL-frames its boundaries so file-derived marker text cannot alias two states to one key. The regression test drives a real surface and compares incremental geometry against a cold reopen.

Pre-existing gaps found during review are tracked in #622, #623, and #626.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/628"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790628067&installation_model_id=422592&pr_number=628&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F628&signature=77de9cbf1ee1425952f5a66ded56db3a98f2e26a483a23f27f47faf52adc101e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->