### PR TITLE
fix: keep a footnote whole with its reference line

### DIFF
--- a/.changeset/footnote-keep-whole-reference.md
+++ b/.changeset/footnote-keep-whole-reference.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Keep a footnote whole with its reference: a note that cannot fit below its reference line moves to the next page with the line instead of splitting mid-sentence or trailing its reference as an unmarked continuation. Fixes #627

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -386,7 +386,8 @@ export function computeDoubleBorderMetricsPt(widthPt: number): CompoundBorderMet
 
 // @public
 export function computeFootnoteReserves(layout: SemanticLayout, allRefs: readonly PageRefHit[], input: NotesLayoutInput, noteMarks: NoteMarkContext,
-passMemo?: unknown): {
+passMemo?: unknown,
+previousReserves?: ReadonlyMap<number, number>): {
     readonly reasons: readonly NotePaginationFallbackReason[];
     readonly reserves: ReadonlyMap<number, number>;
     readonly stable: boolean;
@@ -1476,7 +1477,7 @@ export const MAX_NOTE_FRAGMENTS = 512;
 export const MAX_NOTE_OVERFLOW_PAGES = 256;
 
 // @public
-export const MAX_NOTE_REFLOW_ATTEMPTS = 8;
+export const MAX_NOTE_REFLOW_ATTEMPTS = 64;
 
 // @public
 export const MAX_NOTES_LAID_OUT = 10000;

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -689,7 +689,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'Both adapters have a typed note model, note layout (pageBottom, beneathText, sectEnd, docEnd), scoped note editing, insert, delete, convert, and chrome slots. Overflow sheets retain separate page rectangles for painting and hit testing. Editing inside a note matches the body: lists, tables, content controls, pictures, fonts, comments, bookmarks, and page setup. Tracked note inserts and notes in headers and footers are out of scope.',
+      'Both adapters have a typed note model, note layout (pageBottom, beneathText, sectEnd, docEnd), scoped note editing, insert, delete, convert, and chrome slots. A footnote stays whole with its reference: when it cannot fit below the referencing line, the line moves to the next page instead of the note splitting, and only a note taller than the page note column splits across pages. Overflow sheets retain separate page rectangles for painting and hit testing. Editing inside a note matches the body: lists, tables, content controls, pictures, fonts, comments, bookmarks, and page setup. Tracked note inserts and notes in headers and footers are out of scope.',
   },
   {
     id: 'layout.columns',

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -689,7 +689,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'Both adapters have a typed note model, note layout (pageBottom, beneathText, sectEnd, docEnd), scoped note editing, insert, delete, convert, and chrome slots. A footnote stays whole with its reference: when it cannot fit below the referencing line, the line moves to the next page instead of the note splitting, and only a note taller than the page note column splits across pages. Overflow sheets retain separate page rectangles for painting and hit testing. Editing inside a note matches the body: lists, tables, content controls, pictures, fonts, comments, bookmarks, and page setup. Tracked note inserts and notes in headers and footers are out of scope.',
+      'Both adapters have a typed note model, note layout (pageBottom, beneathText, sectEnd, docEnd), scoped note editing, insert, delete, convert, and chrome slots. A footnote stays whole with its reference: when it cannot fit below the referencing line, the line moves to the next page instead of the note splitting. Only a note taller than the page note column splits across pages. Overflow sheets retain separate page rectangles for painting and hit testing. Editing inside a note matches the body: lists, tables, content controls, pictures, fonts, comments, bookmarks, and page setup. Tracked note inserts and notes in headers and footers are out of scope.',
   },
   {
     id: 'layout.columns',

--- a/packages/core/src/layout/__tests__/footnote-page-overflow.test.ts
+++ b/packages/core/src/layout/__tests__/footnote-page-overflow.test.ts
@@ -324,6 +324,19 @@ describe('oversized footnote starts on its reference page (issue #608)', () => {
     expectFullyDrained(cold, noteLines);
     expectNoStarvedPages(cold);
 
+    // Anti-avalanche co-location gate over the same cold layout: no note may start after
+    // its reference's page, and no page-column-sized note may split at all. This is the
+    // real-document failure shape — notes trailing their references by whole pages, every
+    // record a bare "continuation" with no mark.
+    for (const [paragraphIndex, id] of refs) {
+      const refPages = pagesOwningParagraph(cold, paragraphIndex);
+      const head = noteHeadPage(cold, id);
+      expect(head).not.toBeNull();
+      expect(refPages).toContain(head!);
+      // ~19-line notes fit a page column whole, so none of them may split.
+      expect(noteRecordCount(cold, id)).toBe(1);
+    }
+
     // Session-seeded passes continue the reserve iteration where the cold pass stopped;
     // by the third the packing is interleaved everywhere and a further pass changes nothing.
     const session = createLayoutSession();
@@ -464,30 +477,6 @@ describe('a footnote that cannot fit below its reference moves with it (keep-who
 
     expect(noteRecordCount(layout, 1)).toBe(1);
     expect(noteHeadPage(layout, 1)).toBe(pagesOwningParagraph(layout, refAt)[0]!);
-  });
-
-  // Anti-avalanche gate over a reference-dense document: no note may start after its
-  // reference's page, and no page-column-sized note may split at all. This is the
-  // real-document failure shape — notes trailing their references by whole pages, every
-  // record a bare "continuation" with no mark.
-  test('every note starts on the page that references it', () => {
-    const refs = new Map(Array.from({ length: 24 }, (_, i) => [(i + 1) * 8, i + 1] as const));
-    const notesXml = Array.from(
-      { length: 24 },
-      (_, i) =>
-        `<w:footnote w:id="${i + 1}"><w:p><w:r><w:t>${'n'.repeat(1500)}</w:t></w:r></w:p></w:footnote>`
-    ).join('');
-    const layout = layoutOf(packageXml(bodyParas(200, refs), notesXml), 'fn-colocation');
-
-    for (const [paragraphIndex, id] of refs) {
-      const refPages = pagesOwningParagraph(layout, paragraphIndex);
-      const head = noteHeadPage(layout, id);
-      expect(head).not.toBeNull();
-      expect(refPages).toContain(head!);
-      // ~19-line notes fit a page column whole, so none of them may split.
-      expect(noteRecordCount(layout, id)).toBe(1);
-    }
-    expectNoStarvedPages(layout);
   });
 });
 

--- a/packages/core/src/layout/__tests__/footnote-page-overflow.test.ts
+++ b/packages/core/src/layout/__tests__/footnote-page-overflow.test.ts
@@ -367,13 +367,18 @@ describe('oversized footnote starts on its reference page (issue #608)', () => {
 
 /** Pages (in order) whose body fragments draw `paragraph "Body para <n>"` text. */
 function pagesOwningParagraph(layout: SemanticLayout, paragraphIndex: number): number[] {
-  const needle = `Body para ${paragraphIndex}`;
+  // Word boundary, not a substring: "Body para 8" must not also claim "Body para 80".
+  const needle = new RegExp(`Body para ${paragraphIndex}\\b`);
   const found: number[] = [];
   for (const page of layout.pages) {
     for (const fragment of page.fragments) {
       if (fragment.kind !== 'paragraph') continue;
-      const text = fragment.lines.flatMap((line) => line.spans.map((span) => span.text)).join('');
-      if (text.includes(needle)) {
+      // Projected spans (the citation mark digits) are excluded: the mark "1" is its own
+      // span right after "Body para 40", and concatenating it would read "Body para 401".
+      const text = fragment.lines
+        .flatMap((line) => line.spans.filter((span) => !span.projected).map((span) => span.text))
+        .join('');
+      if (needle.test(text)) {
         found.push(page.index);
         break;
       }
@@ -449,15 +454,12 @@ describe('a footnote that cannot fit below its reference moves with it (keep-who
   test('trailing paragraph after-spacing does not shrink the note area', () => {
     const refAt = 40;
     const spaced = Array.from({ length: 60 }, (_, i) => {
-      const ref = refs40(i) === undefined ? '' : `<w:footnoteReference w:id="${refs40(i)!}"/>`;
+      const ref = i === refAt ? '<w:footnoteReference w:id="1"/>' : '';
       return (
         '<w:p><w:pPr><w:spacing w:after="120"/></w:pPr>' +
         `<w:r><w:t>Body para ${i}</w:t>${ref}</w:r></w:p>`
       );
     }).join('');
-    function refs40(i: number): number | undefined {
-      return i === refAt ? 1 : undefined;
-    }
     const layout = layoutOf(packageXml(spaced, singleRunFootnote(1, 400)), 'fn-after-spacing');
 
     expect(noteRecordCount(layout, 1)).toBe(1);

--- a/packages/core/src/layout/__tests__/footnote-page-overflow.test.ts
+++ b/packages/core/src/layout/__tests__/footnote-page-overflow.test.ts
@@ -315,7 +315,12 @@ describe('oversized footnote starts on its reference page (issue #608)', () => {
     const noteLines = 24 * Math.ceil(1500 / CHARS_PER_LINE);
     const cold = layoutOf(bytes, 'fn-adoption');
     const expected = Math.ceil(((200 + noteLines) * LINE_H) / cold.pages[0]!.contentBox.height);
-    expect(Math.abs(cold.pages.length - expected)).toBeLessThanOrEqual(1);
+    // Within TWO pages of the dense hand-packing, not one: a note that cannot fit whole
+    // below its reference moves forward with its reference line (Word keeps a footnote
+    // whole unless it exceeds the note column), and each such move can leave up to a
+    // note's height of legitimate slack at a page bottom. Starvation — the failure this
+    // gate exists for — is still asserted exactly by expectNoStarvedPages below.
+    expect(Math.abs(cold.pages.length - expected)).toBeLessThanOrEqual(2);
     expectFullyDrained(cold, noteLines);
     expectNoStarvedPages(cold);
 
@@ -357,6 +362,130 @@ describe('oversized footnote starts on its reference page (issue #608)', () => {
     const clean = layoutOf(editedBytes, 'fn-warm-converge', undefined, 2);
     expect(shapeOf(warm)).toBe(shapeOf(clean));
     expectNoStarvedPages(warm);
+  });
+});
+
+/** Pages (in order) whose body fragments draw `paragraph "Body para <n>"` text. */
+function pagesOwningParagraph(layout: SemanticLayout, paragraphIndex: number): number[] {
+  const needle = `Body para ${paragraphIndex}`;
+  const found: number[] = [];
+  for (const page of layout.pages) {
+    for (const fragment of page.fragments) {
+      if (fragment.kind !== 'paragraph') continue;
+      const text = fragment.lines.flatMap((line) => line.spans.map((span) => span.text)).join('');
+      if (text.includes(needle)) {
+        found.push(page.index);
+        break;
+      }
+    }
+  }
+  return found;
+}
+
+/** The page index that hosts note `id`'s FIRST (non-continuation) record, or null. */
+function noteHeadPage(layout: SemanticLayout, id: number): number | null {
+  for (const page of layout.pages) {
+    for (const note of page.footnotes?.notes ?? []) {
+      if (note.noteId === id && note.continuation !== true) return page.index;
+    }
+  }
+  return null;
+}
+
+function noteRecordCount(layout: SemanticLayout, id: number): number {
+  let count = 0;
+  for (const page of layout.pages) {
+    for (const note of page.footnotes?.notes ?? []) {
+      if (note.noteId === id) count += 1;
+    }
+  }
+  return count;
+}
+
+describe('a footnote that cannot fit below its reference moves with it (keep-whole)', () => {
+  // ~50 body lines fill a page; the reference sits close to the bottom, and the 4-line
+  // note cannot fit below it. Word does not split a footnote that fits in a page's note
+  // column: the reference LINE moves to the next page and the note lays out whole there.
+  test('short note near the page bottom does not split', () => {
+    const refAt = 47;
+    const layout = layoutOf(
+      packageXml(bodyParas(60, new Map([[refAt, 1]])), singleRunFootnote(1, 300)),
+      'fn-keep-whole'
+    );
+
+    expect(noteRecordCount(layout, 1)).toBe(1);
+    const refPages = pagesOwningParagraph(layout, refAt);
+    expect(refPages).toHaveLength(1);
+    expect(noteHeadPage(layout, 1)).toBe(refPages[0]!);
+    expectNoStarvedPages(layout);
+  });
+
+  // The reported real-document shape: earlier references' notes stack down to a later
+  // reference's line, its own note gets no room, and the note used to render whole as an
+  // unmarked "continuation" on the next page — or split mid-sentence — while body text
+  // stayed put. The reference and its whole note must travel together instead.
+  test('a reference starved by the stack above it keeps its note', () => {
+    const refs = new Map([
+      [10, 1],
+      [44, 2],
+    ]);
+    const layout = layoutOf(
+      packageXml(bodyParas(60, refs), singleRunFootnote(1, 3200) + singleRunFootnote(2, 300)),
+      'fn-starved-ref'
+    );
+
+    for (const id of [1, 2]) {
+      expect(noteRecordCount(layout, id)).toBe(1);
+      const refPages = pagesOwningParagraph(layout, id === 1 ? 10 : 44);
+      expect(noteHeadPage(layout, id)).toBe(refPages[0]!);
+    }
+    expectNoStarvedPages(layout);
+  });
+
+  // The fit rule admits a paragraph without charging its `w:spacing w:after`, but the
+  // fragment box includes it. The note passes must measure the body the same way, or the
+  // reserve under-claims by the trailing after-spacing and the attach pass splits a note
+  // the reserve fitted whole.
+  test('trailing paragraph after-spacing does not shrink the note area', () => {
+    const refAt = 40;
+    const spaced = Array.from({ length: 60 }, (_, i) => {
+      const ref = refs40(i) === undefined ? '' : `<w:footnoteReference w:id="${refs40(i)!}"/>`;
+      return (
+        '<w:p><w:pPr><w:spacing w:after="120"/></w:pPr>' +
+        `<w:r><w:t>Body para ${i}</w:t>${ref}</w:r></w:p>`
+      );
+    }).join('');
+    function refs40(i: number): number | undefined {
+      return i === refAt ? 1 : undefined;
+    }
+    const layout = layoutOf(packageXml(spaced, singleRunFootnote(1, 400)), 'fn-after-spacing');
+
+    expect(noteRecordCount(layout, 1)).toBe(1);
+    expect(noteHeadPage(layout, 1)).toBe(pagesOwningParagraph(layout, refAt)[0]!);
+  });
+
+  // Anti-avalanche gate over a reference-dense document: no note may start after its
+  // reference's page, and no page-column-sized note may split at all. This is the
+  // real-document failure shape — notes trailing their references by whole pages, every
+  // record a bare "continuation" with no mark.
+  test('every note starts on the page that references it', () => {
+    const refs = new Map(Array.from({ length: 24 }, (_, i) => [(i + 1) * 8, i + 1] as const));
+    const notesXml = Array.from(
+      { length: 24 },
+      (_, i) =>
+        `<w:footnote w:id="${i + 1}"><w:p><w:r><w:t>${'n'.repeat(1500)}</w:t></w:r></w:p></w:footnote>`
+    ).join('');
+    const layout = layoutOf(packageXml(bodyParas(200, refs), notesXml), 'fn-colocation');
+
+    for (const [paragraphIndex, id] of refs) {
+      const refPages = pagesOwningParagraph(layout, paragraphIndex);
+      const head = noteHeadPage(layout, id);
+      expect(head).not.toBeNull();
+      expect(refPages).toContain(head!);
+      // ~19-line notes fit a page column whole, so none of them may split.
+      expect(noteRecordCount(layout, id)).toBe(1);
+    }
+    expectNoStarvedPages(layout);
   });
 });
 

--- a/packages/core/src/layout/__tests__/footnote-reserves.test.ts
+++ b/packages/core/src/layout/__tests__/footnote-reserves.test.ts
@@ -601,8 +601,10 @@ describe('incremental notes layout (reserve persistence)', () => {
     expect(session.notePageBottomReserves).not.toBeNull();
     expect(session.notePageBottomReserves!.size).toBeGreaterThan(0);
     const fullPassesAfterCold = session.stats.fullPasses;
-    // Cold start: empty seed then reserved reflow → two full body passes.
-    expect(fullPassesAfterCold).toBe(2);
+    // Cold start: empty seed, the reserved reflow, then one hold-out round — the page
+    // before a reference-opening page claims its slack so the opening line cannot pull
+    // back, which is one more adoption than the pre-keep-whole pipeline needed.
+    expect(fullPassesAfterCold).toBe(3);
 
     const second = layoutSemanticDocument(part, 2, {
       measurer: notes.measurer,

--- a/packages/core/src/layout/line-segments.ts
+++ b/packages/core/src/layout/line-segments.ts
@@ -32,6 +32,21 @@ export interface LineSegment {
   readonly drawings: readonly InlineDrawingRecord[];
 }
 
+/**
+ * Whether a line segment owns the atom at `atomOffset` for `paragraphId` — half-open
+ * `[start, end)` with downstream boundary affinity, ONE predicate for every reader that
+ * pairs a position with the segment that draws it.
+ */
+export function segmentOwnsAtomOffset(
+  segment: LineSegment,
+  paragraphId: string,
+  atomOffset: number
+): boolean {
+  return (
+    segment.paragraphId === paragraphId && atomOffset >= segment.start && atomOffset < segment.end
+  );
+}
+
 /** Cached per line: a mixed line is rare, and asking costs a walk of every span. */
 const lineSegmentsCache = new WeakMap<LineRecord, readonly LineSegment[]>();
 

--- a/packages/core/src/layout/note-fragment-geometry.ts
+++ b/packages/core/src/layout/note-fragment-geometry.ts
@@ -80,11 +80,11 @@ export function fragmentFlowBottom(fragments: readonly BlockFragmentRecord[]): n
 }
 
 /**
- * Bottom (content-relative pt) of the body line on `page` that carries `ref` — the band
- * body text must KEEP for this reference when its footnote reserve is measured.
+ * The body band (content-relative pt) of the line on `page` that carries `ref`.
  *
- * Word's rule: a footnote STARTS on the page that references it. A reserve capped only by
- * the minimum body band (`MIN_FOOTNOTE_BODY_BAND_PT`) can exceed the room below the
+ * `bottom` is the band body text must KEEP for this reference when its footnote reserve is
+ * measured. Word's rule: a footnote STARTS on the page that references it. A reserve capped
+ * only by the minimum body band (`MIN_FOOTNOTE_BODY_BAND_PT`) can exceed the room below the
  * referencing line, which evicts that line — and with it the reference — to the next page.
  * The next reserve pass then follows the reference forward, the reflow loop oscillates
  * between the two placements, and the fingerprint lock freezes whichever phase it happens
@@ -96,41 +96,70 @@ export function fragmentFlowBottom(fragments: readonly BlockFragmentRecord[]): n
  * note may push body down to ITS OWN reference line. On a page carrying many references, a
  * single floor at the lowest one strangles every note above it to the sliver under that
  * line — and that state is a fixed point, so the reflow loop keeps it. The caller sizes
- * note `i`'s room against reference `i`'s floor; references whose room reaches zero simply
- * carry forward, and the next pass finds them on the page body pushed them to.
+ * note `i`'s room against reference `i`'s floor; a reference whose note cannot even START
+ * in that room moves forward instead: `top` is where the reserve must reach to evict the
+ * reference's own line, so the next pass finds the reference — and lays its note whole —
+ * on the page the shrunken body pushes it to.
  *
- * A ref inside a table floors at the TABLE fragment's bottom: nested line geometry is not
- * in page-content coordinates, and keeping the whole block band is the conservative reading
- * of the same rule. A ref no fragment on this page owns floors at zero.
+ * `evictable` is false when the line's geometry cannot support that move: a ref inside a
+ * table (nested line geometry is not in page-content coordinates; the band is the TABLE
+ * fragment's box, and evicting a whole table for one note is not the conservative reading),
+ * and a ref no fragment on this page owns (band zero).
  */
-export function noteReferenceFloorPt(
+export interface NoteReferenceLineBand {
+  /** Top of the referencing line (content-relative pt); reserve past this evicts the line. */
+  readonly top: number;
+  /** Bottom of the referencing line — the floor a same-page reserve must not rise above. */
+  readonly bottom: number;
+  /** Whether the reserve may claim the line itself to move the reference forward. */
+  readonly evictable: boolean;
+}
+
+export function noteReferenceLineBandPt(
   page: PageRecord,
   ref: { readonly paragraphId: string; readonly atomOffset: number }
-): number {
-  let floor = 0;
+): NoteReferenceLineBand {
+  let top = 0;
+  let bottom = 0;
+  let evictable = false;
   for (const block of page.fragments) {
     if (block.kind === 'paragraph') {
       if (!fragmentOwnsPosition(block, ref.paragraphId, ref.atomOffset)) continue;
-      floor = Math.max(floor, referenceLineBottom(block, ref) ?? block.box.y + block.box.height);
+      const line = referenceLineBand(block, ref);
+      const lineTop = line?.top ?? block.box.y;
+      const lineBottom = line?.bottom ?? block.box.y + block.box.height;
+      if (lineBottom > bottom) {
+        top = lineTop;
+        bottom = lineBottom;
+        // Only a located LINE may be evicted; an ownership match without a line segment
+        // (merged/projected offsets) falls back to the fragment band and stays put.
+        evictable = line !== null;
+      }
       continue;
     }
     if (tableOwnsAnyRef(block, [ref])) {
-      floor = Math.max(floor, block.box.y + block.box.height);
+      const blockBottom = block.box.y + block.box.height;
+      if (blockBottom > bottom) {
+        top = block.box.y;
+        bottom = blockBottom;
+        evictable = false;
+      }
     }
   }
-  return Math.min(Math.max(0, floor), page.contentBox.height);
+  const clamp = (value: number): number => Math.min(Math.max(0, value), page.contentBox.height);
+  return { top: clamp(top), bottom: clamp(bottom), evictable };
 }
 
-/** The owning line's bottom inside a fragment already known to own the ref, or null. */
-function referenceLineBottom(
+/** The owning line's band inside a fragment already known to own the ref, or null. */
+function referenceLineBand(
   fragment: ParagraphFragmentRecord,
   ref: { readonly paragraphId: string; readonly atomOffset: number }
-): number | null {
+): { readonly top: number; readonly bottom: number } | null {
   for (const line of fragment.lines) {
     for (const segment of lineSegments(line)) {
       if (segment.paragraphId !== ref.paragraphId) continue;
       if (ref.atomOffset < segment.start || ref.atomOffset >= segment.end) continue;
-      return line.box.y + line.box.height;
+      return { top: line.box.y, bottom: line.box.y + line.box.height };
     }
   }
   return null;

--- a/packages/core/src/layout/note-fragment-geometry.ts
+++ b/packages/core/src/layout/note-fragment-geometry.ts
@@ -93,10 +93,15 @@ export function fragmentFlowBottom(fragments: readonly BlockFragmentRecord[]): n
 export function bodyFitBottomPt(page: PageRecord): number {
   let bottom = 0;
   for (const fragment of page.fragments) {
-    const trailingAfter = fragment.kind === 'paragraph' ? fragment.spacing.after : 0;
-    bottom = Math.max(bottom, fragment.box.y + fragment.box.height - trailingAfter);
+    bottom = Math.max(bottom, fragmentFitBottomPt(fragment));
   }
   return bottom;
+}
+
+/** One fragment's fit-rule bottom — its box minus a paragraph's trailing after-spacing. */
+export function fragmentFitBottomPt(fragment: BlockFragmentRecord): number {
+  const trailingAfter = fragment.kind === 'paragraph' ? fragment.spacing.after : 0;
+  return fragment.box.y + fragment.box.height - trailingAfter;
 }
 
 /**
@@ -155,7 +160,34 @@ export interface NoteReferenceLineBand {
   readonly evictable: boolean;
 }
 
+/**
+ * Memoized per fragments-array identity and ref object identity: the reserve pass asks for
+ * the same page's bands as `bodyPage` and again as the previous page's hold-out neighbour,
+ * every reflow round, and both the fragment arrays and the ref objects are identity-stable
+ * across rounds.
+ */
+const referenceLineBandMemos = new WeakMap<
+  readonly BlockFragmentRecord[],
+  WeakMap<object, NoteReferenceLineBand>
+>();
+
 export function noteReferenceLineBandPt(
+  page: PageRecord,
+  ref: { readonly paragraphId: string; readonly atomOffset: number }
+): NoteReferenceLineBand {
+  let perPage = referenceLineBandMemos.get(page.fragments);
+  if (!perPage) {
+    perPage = new WeakMap();
+    referenceLineBandMemos.set(page.fragments, perPage);
+  }
+  const cached = perPage.get(ref);
+  if (cached) return cached;
+  const band = computeReferenceLineBand(page, ref);
+  perPage.set(ref, band);
+  return band;
+}
+
+function computeReferenceLineBand(
   page: PageRecord,
   ref: { readonly paragraphId: string; readonly atomOffset: number }
 ): NoteReferenceLineBand {

--- a/packages/core/src/layout/note-fragment-geometry.ts
+++ b/packages/core/src/layout/note-fragment-geometry.ts
@@ -80,6 +80,59 @@ export function fragmentFlowBottom(fragments: readonly BlockFragmentRecord[]): n
 }
 
 /**
+ * Body bottom (content-relative pt) the note passes BUDGET against.
+ *
+ * MINUS each paragraph's trailing after-spacing: the page-fit decision admits a paragraph
+ * without charging its `w:spacing w:after` (it moves to the next page with the flow), but
+ * the fragment BOX includes it — so a page whose last paragraph carries after-spacing
+ * "uses" more height here than the fit rule budgeted, the reserve the reflow settles on
+ * under-claims by that amount, and the attach pass splits a note the reserve fit whole.
+ * Word lets the footnote area rise into that blank band the same way. PLACEMENT of an
+ * area that hangs off the body keeps {@link fragmentFlowBottom} unless the room is needed.
+ */
+export function bodyFitBottomPt(page: PageRecord): number {
+  let bottom = 0;
+  for (const fragment of page.fragments) {
+    const trailingAfter = fragment.kind === 'paragraph' ? fragment.spacing.after : 0;
+    bottom = Math.max(bottom, fragment.box.y + fragment.box.height - trailingAfter);
+  }
+  return bottom;
+}
+
+/**
+ * Top (content-relative pt) of the page's topmost body content, or 0 on an empty page.
+ *
+ * The MINIMUM over every fragment, not the first one's: document order is not y order
+ * when a float exclusion zone displaces the first paragraph below a later block, and the
+ * eviction guard that reads this must never conclude a page's true first line has content
+ * above it.
+ */
+export function firstBodyContentTopPt(page: PageRecord): number {
+  let top = Number.POSITIVE_INFINITY;
+  for (const fragment of page.fragments) {
+    const fragmentTop =
+      fragment.kind === 'paragraph' ? (fragment.lines[0]?.box.y ?? fragment.box.y) : fragment.box.y;
+    top = Math.min(top, fragmentTop);
+  }
+  return Number.isFinite(top) ? top : 0;
+}
+
+/**
+ * Whether a line segment owns the atom at `atomOffset` for `paragraphId` — half-open
+ * `[start, end)` with downstream boundary affinity, ONE predicate for every reader that
+ * pairs a note reference with the line that draws it.
+ */
+export function segmentOwnsAtomOffset(
+  segment: { readonly paragraphId: string; readonly start: number; readonly end: number },
+  paragraphId: string,
+  atomOffset: number
+): boolean {
+  return (
+    segment.paragraphId === paragraphId && atomOffset >= segment.start && atomOffset < segment.end
+  );
+}
+
+/**
  * The body band (content-relative pt) of the line on `page` that carries `ref`.
  *
  * `bottom` is the band body text must KEEP for this reference when its footnote reserve is
@@ -157,8 +210,7 @@ function referenceLineBand(
 ): { readonly top: number; readonly bottom: number } | null {
   for (const line of fragment.lines) {
     for (const segment of lineSegments(line)) {
-      if (segment.paragraphId !== ref.paragraphId) continue;
-      if (ref.atomOffset < segment.start || ref.atomOffset >= segment.end) continue;
+      if (!segmentOwnsAtomOffset(segment, ref.paragraphId, ref.atomOffset)) continue;
       return { top: line.box.y, bottom: line.box.y + line.box.height };
     }
   }

--- a/packages/core/src/layout/note-fragment-geometry.ts
+++ b/packages/core/src/layout/note-fragment-geometry.ts
@@ -1,7 +1,7 @@
 // Fragment geometry for note pagination: story-relative shifts, flow bottoms, and the
 // body band a page must keep so its footnote references stay with their first fragment.
 
-import { fragmentOwnsPosition, lineSegments } from './line-segments.ts';
+import { fragmentOwnsPosition, lineSegments, segmentOwnsAtomOffset } from './line-segments.ts';
 import type {
   BlockFragmentRecord,
   PageRecord,
@@ -118,21 +118,6 @@ export function firstBodyContentTopPt(page: PageRecord): number {
 }
 
 /**
- * Whether a line segment owns the atom at `atomOffset` for `paragraphId` — half-open
- * `[start, end)` with downstream boundary affinity, ONE predicate for every reader that
- * pairs a note reference with the line that draws it.
- */
-export function segmentOwnsAtomOffset(
-  segment: { readonly paragraphId: string; readonly start: number; readonly end: number },
-  paragraphId: string,
-  atomOffset: number
-): boolean {
-  return (
-    segment.paragraphId === paragraphId && atomOffset >= segment.start && atomOffset < segment.end
-  );
-}
-
-/**
  * The body band (content-relative pt) of the line on `page` that carries `ref`.
  *
  * `bottom` is the band body text must KEEP for this reference when its footnote reserve is
@@ -164,6 +149,8 @@ export interface NoteReferenceLineBand {
   readonly top: number;
   /** Bottom of the referencing line — the floor a same-page reserve must not rise above. */
   readonly bottom: number;
+  /** Top of the owning block's fragment — where the line lands when its block moves whole. */
+  readonly blockTop: number;
   /** Whether the reserve may claim the line itself to move the reference forward. */
   readonly evictable: boolean;
 }
@@ -174,6 +161,7 @@ export function noteReferenceLineBandPt(
 ): NoteReferenceLineBand {
   let top = 0;
   let bottom = 0;
+  let blockTop = 0;
   let evictable = false;
   for (const block of page.fragments) {
     if (block.kind === 'paragraph') {
@@ -184,6 +172,7 @@ export function noteReferenceLineBandPt(
       if (lineBottom > bottom) {
         top = lineTop;
         bottom = lineBottom;
+        blockTop = block.box.y;
         // Only a located LINE may be evicted; an ownership match without a line segment
         // (merged/projected offsets) falls back to the fragment band and stays put.
         evictable = line !== null;
@@ -200,7 +189,17 @@ export function noteReferenceLineBandPt(
     }
   }
   const clamp = (value: number): number => Math.min(Math.max(0, value), page.contentBox.height);
-  return { top: clamp(top), bottom: clamp(bottom), evictable };
+  const clampedTop = clamp(top);
+  const clampedBottom = clamp(bottom);
+  return {
+    top: clampedTop,
+    bottom: clampedBottom,
+    blockTop: clamp(blockTop),
+    // A band the clamp collapsed (a line at or below the content bottom — overflow the
+    // body pass tolerated) must not evict: the eviction reserve computed from its top
+    // would be zero, and the reference's note would be neither placed nor carried.
+    evictable: evictable && clampedBottom > clampedTop,
+  };
 }
 
 /** The owning line's band inside a fragment already known to own the ref, or null. */
@@ -245,4 +244,27 @@ function tableOwnsAnyRef(
     }
   }
   return false;
+}
+
+/** Remove note-pass output before recomputing it from canonical references. */
+export function bodyOnlyPage(page: PageRecord): PageRecord {
+  // IDENTITY WHEN THERE IS NOTHING TO STRIP. The rest-destructure allocates a new object
+  // every time, and a page record is what the painter reuses BY IDENTITY — so a document
+  // with a notes part and no notes at all handed the painter a whole new set of pages on
+  // every pass, and every visible page's DOM was rebuilt on every keystroke. The lane runs
+  // for any package that HAS a footnotes or endnotes part, which is nearly every Word file.
+  // Its three siblings — `withPageFieldSources`, `attachContentControlBoundaries` and
+  // `reprojectBodyNoteMarks` — all return the original page when nothing moved.
+  if (
+    page.footnotes === undefined &&
+    page.endnotes === undefined &&
+    page.noteStream === undefined
+  ) {
+    return page;
+  }
+  const { footnotes, endnotes, noteStream, ...body } = page;
+  void footnotes;
+  void endnotes;
+  void noteStream;
+  return body;
 }

--- a/packages/core/src/layout/note-layout.ts
+++ b/packages/core/src/layout/note-layout.ts
@@ -320,6 +320,30 @@ export function layoutNoteById(
 }
 
 /**
+ * Pass-local note story layouts, keyed by part, note id and width. Valid for exactly one
+ * layout pass: every other input rides `opts`, which the caller builds once per pass from
+ * a fixed mark context — the key deliberately omits it, so a cache must never outlive the
+ * pass (or the marks) it was created for.
+ */
+export type NoteStoryLayoutCache = Map<string, NoteStoryLayout | null>;
+
+export function layoutNoteCached(
+  part: OoxmlPart | null,
+  noteId: number,
+  contentWidth: number,
+  opts: LayoutNoteStoryOptions,
+  cache: NoteStoryLayoutCache | undefined
+): NoteStoryLayout | null {
+  if (!cache) return layoutNoteById(part, noteId, contentWidth, opts);
+  const key = `${part?.name ?? 'none'}\0${noteId}\0${contentWidth}`;
+  const cached = cache.get(key);
+  if (cached !== undefined) return cached;
+  const laid = layoutNoteById(part, noteId, contentWidth, opts);
+  cache.set(key, laid);
+  return laid;
+}
+
+/**
  * Word-default paint style for a separator marker.
  *
  * Footnote and endnote separators both use a short single rule. A full-width double

--- a/packages/core/src/layout/note-pagination.ts
+++ b/packages/core/src/layout/note-pagination.ts
@@ -8,7 +8,7 @@
 // sectEnd / docEnd. Hostile counts and oscillation fail closed with named reasons.
 
 import type { OoxmlElement, OoxmlNode, OoxmlPart } from '@docx-editor.dev/core/store';
-import { fragmentOwnsPosition, fragmentParagraphs } from './line-segments.ts';
+import { fragmentOwnsPosition, fragmentParagraphs, lineSegments } from './line-segments.ts';
 import { collectNoteReferences } from '../store/package/note-references.ts';
 import type { DocumentSection } from './section-properties.ts';
 import { storyBlocks } from './story-roots.ts';
@@ -55,8 +55,9 @@ import {
 export { notesReserveContextKey };
 import {
   fragmentFlowBottom,
-  noteReferenceFloorPt,
+  noteReferenceLineBandPt,
   shiftFragments,
+  type NoteReferenceLineBand,
 } from './note-fragment-geometry.ts';
 import { reindexAndRestackPages } from './page-restacking.ts';
 import type {
@@ -80,8 +81,17 @@ import { finalizePageFieldProjection } from './field-projection.ts';
 import { overflowPageShellAt, type OverflowPageShell } from './page-furniture-insets.ts';
 import { DEFAULT_REVISION_DISPLAY_MODE, type RevisionDisplayMode } from './revision-projection.ts';
 
-/** Bound on reflow attempts per document layout pass. */
-export const MAX_NOTE_REFLOW_ATTEMPTS = 8;
+/**
+ * Bound on reflow attempts per document layout pass.
+ *
+ * Sized for a COLD OPEN of a reference-dense document: adoption is a forward fixed-point
+ * iteration whose settled prefix extends a few pages per round, so a legal document with a
+ * hundred footnotes converges in tens of rounds (a 53-page/108-note fixture took 24), and
+ * a round over a settled prefix is nearly free (checkpointed body layout + per-page
+ * reserve memos). Orbits exit earlier through the fingerprint/envelope checks below, so
+ * the cap is a safety bound, not the expected cost.
+ */
+export const MAX_NOTE_REFLOW_ATTEMPTS = 64;
 
 /**
  * Total reserve-map adoptions allowed per BODY-PART identity, across passes.
@@ -115,6 +125,13 @@ interface NoteOverflowBudget {
  * the shared overflow budget instead of evacuating the referencing page.
  */
 const MIN_FOOTNOTE_BODY_BAND_PT = 14;
+
+/**
+ * Half-point back-off applied to reserves derived from an observed line boundary (eviction,
+ * hold-out), so the body budget falls mid-line instead of edge-to-edge on a kept line's
+ * exact bottom, where the body pass's strict fit compare flips on float drift.
+ */
+const RESERVE_BOUNDARY_BACKOFF_PT = 0.5;
 
 /** One document-wide allowance shared by every footnote/endnote overflow stream. */
 interface NoteOverflowBudget {
@@ -253,6 +270,12 @@ interface NotesPassMemo {
       readonly marks: NoteMarkContext;
       readonly reserve: number;
       readonly reasons: readonly NotePaginationFallbackReason[];
+      /**
+       * The NEXT page's fragments at compute time (null = no next page). The hold-out
+       * check reads the next page's first line, so a reserve computed against one
+       * neighbour must not answer for another.
+       */
+      readonly nextFragments: readonly BlockFragmentRecord[] | null;
     }
   >;
 }
@@ -911,10 +934,21 @@ function buildMarkContext(
   };
 }
 
+/**
+ * Body bottom (content-relative pt) the note passes measure against.
+ *
+ * MINUS each paragraph's trailing after-spacing: the page-fit decision admits a paragraph
+ * without charging its `w:spacing w:after` (it moves to the next page with the flow), but
+ * the fragment BOX includes it — so a page whose last paragraph carries after-spacing
+ * "uses" more height here than the fit rule budgeted, the reserve the reflow settles on
+ * under-claims by that amount, and the attach pass splits a note the reserve fit whole.
+ * Word lets the footnote area rise into that blank band the same way.
+ */
 function bodyUsedHeight(page: PageRecord): number {
   let bottom = 0;
   for (const fragment of page.fragments) {
-    bottom = Math.max(bottom, fragment.box.y + fragment.box.height);
+    const trailingAfter = fragment.kind === 'paragraph' ? fragment.spacing.after : 0;
+    bottom = Math.max(bottom, fragment.box.y + fragment.box.height - trailingAfter);
   }
   return bottom;
 }
@@ -1118,20 +1152,32 @@ function buildFootnoteArea(
      */
     readonly reserveColumnBudget?: boolean;
     /**
-     * Body band (content-relative pt) each REFERENCE keeps — the bottom of its own line
-     * ({@link noteReferenceFloorPt}). Keeps a note's first fragment on its reference page:
-     * a budget that ignores where the reference sits evicts the referencing line itself,
-     * and the reflow loop then chases the reference across pages instead of converging.
-     * Per reference, because the stack tightens as it grows: note `i` may fill down to
-     * reference `i`'s line, so an earlier note keeps its full room while a later one whose
-     * line sits under the accumulated stack gets nothing and carries — one shared floor at
-     * the page's lowest reference strangles them all to the sliver under it, stably. Only
-     * read with {@link reserveColumnBudget}; attach passes size from real body slack.
+     * Band (content-relative pt) of each REFERENCE's own line
+     * ({@link noteReferenceLineBandPt}). The BOTTOM keeps a note's first fragment on its
+     * reference page: a budget that ignores where the reference sits evicts the
+     * referencing line itself, and the reflow loop then chases the reference across pages
+     * instead of converging. Per reference, because the stack tightens as it grows: note
+     * `i` may fill down to reference `i`'s line, so an earlier note keeps its full room
+     * while a later one whose line sits under the accumulated stack gets nothing — one
+     * shared floor at the page's lowest reference strangles them all to the sliver under
+     * it, stably. The TOP is where the reserve reaches when the note cannot even start in
+     * that room: Word keeps a footnote whole with its reference, so the reference's LINE
+     * moves to the next page instead of the note splitting (see the eviction branch in the
+     * reference loop). Only read with {@link reserveColumnBudget}; attach passes size from
+     * real body slack.
      */
-    readonly reserveFloorOf?: (ref: PageRefHit) => number;
+    readonly reserveBandOf?: (ref: PageRefHit) => NoteReferenceLineBand;
     readonly separatorCache?: NoteSeparatorCache;
   }
-): { area: NoteAreaRecord | undefined; nextCarry: NoteCarryMap } {
+): {
+  area: NoteAreaRecord | undefined;
+  nextCarry: NoteCarryMap;
+  /**
+   * Content-relative top the page's reserve must reach to push an unplaceable reference's
+   * line to the next page (reserve mode only; undefined when nothing needs evicting).
+   */
+  evictionTopPt?: number;
+} {
   const nextCarry: NoteCarryMap = new Map(continuationCarry);
   const pageRefs = refs.filter((ref) => ref.noteKind === 'footnote');
   const contentWidth = page.contentBox.width;
@@ -1244,6 +1290,7 @@ function buildFootnoteArea(
     }
   }
 
+  let evictionTopPt: number | undefined;
   for (const ref of pageRefs) {
     if (notes.length >= MAX_NOTES_LAID_OUT) {
       reasons.push('note-count-limit');
@@ -1257,15 +1304,15 @@ function buildFootnoteArea(
     const mark = noteMarks.marks.get(noteMarkKey('footnote', ref.noteId)) ?? null;
     // Reserve mode tightens each note's budget to ITS reference's floor; the stack may not
     // rise above any line that cites into it. Later references sit lower, so their budgets
-    // only shrink — a note whose room hits zero carries whole, and the reflow loop finds
-    // its reference on the page the shrunken body pushes it to.
-    const refBudget = options?.reserveFloorOf
+    // only shrink.
+    const band = options?.reserveBandOf?.(ref);
+    const refBudget = band
       ? Math.min(
           availableForNotes,
           Math.max(
             0,
             page.contentBox.height -
-              Math.max(MIN_FOOTNOTE_BODY_BAND_PT, options.reserveFloorOf(ref)) -
+              Math.max(MIN_FOOTNOTE_BODY_BAND_PT, band.bottom) -
               separator.flowHeight
           )
         )
@@ -1274,6 +1321,24 @@ function buildFootnoteArea(
     fragmentBudget -= laid.fragments.length;
     if (fragmentBudget < 0) {
       reasons.push('note-area-fragment-limit');
+      break;
+    }
+    // Word keeps a footnote whole with its reference: a note that cannot fit whole below
+    // its reference line — but could fit in a page's note column — does not split. The
+    // reference's LINE moves to the next page instead, so the reserve must reach the
+    // line's TOP; the next reflow pass finds the reference there and lays the note whole
+    // beside it. Every later reference on this page sits on or after the evicted line and
+    // moves with it, so the loop ends here. Splitting remains for a note taller than the
+    // column (nothing can hold it whole) and for a reference already inside the minimum
+    // body band (evicting it would chase blank pages).
+    if (
+      band &&
+      band.evictable &&
+      laid.flowHeight > room + 0.001 &&
+      laid.flowHeight <= columnBudget + 0.001 &&
+      band.top > MIN_FOOTNOTE_BODY_BAND_PT + 0.001
+    ) {
+      evictionTopPt = evictionTopPt === undefined ? band.top : Math.min(evictionTopPt, band.top);
       break;
     }
     if (laid.flowHeight <= room + 0.001) {
@@ -1320,7 +1385,11 @@ function buildFootnoteArea(
   }
 
   if (notes.length === 0 && continuationCarry.size === 0) {
-    return { area: undefined, nextCarry };
+    return {
+      area: undefined,
+      nextCarry,
+      ...(evictionTopPt !== undefined ? { evictionTopPt } : {}),
+    };
   }
 
   const sepHeight = separator.flowHeight;
@@ -1366,7 +1435,7 @@ function buildFootnoteArea(
     },
     notes: placedNotes,
   };
-  return { area, nextCarry };
+  return { area, nextCarry, ...(evictionTopPt !== undefined ? { evictionTopPt } : {}) };
 }
 
 /**
@@ -2127,6 +2196,92 @@ function placeEndnotesFromPage(
  * notes then compete for the same band. Oversized notes still split/continue within the budget;
  * {@link MIN_FOOTNOTE_BODY_BAND_PT} keeps a body band so reflow cannot chase blank sheets.
  */
+/**
+ * Reserve (pt) `bodyPage` must keep so the first line of `nextPage` stays put.
+ *
+ * Zero when there is nothing to hold out: no next page, the next page does not open with a
+ * paragraph line, that line carries no page-bottom footnote reference, or the line and its
+ * notes would fit back here (then the line SHOULD return — a deleted note must release its
+ * room). A note taller than the note column is splittable and never holds out: its line may
+ * legitimately return with a head. Otherwise the answer claims the page's remaining slack,
+ * which reproduces the current body end exactly and gives the reflow loop its fixed point.
+ */
+function holdOutReserveNeed(
+  bodyPage: PageRecord,
+  nextPage: PageRecord | undefined,
+  refIndex: PageRefIndex,
+  existingAreaHeight: number,
+  input: NotesLayoutInput,
+  noteMarks: NoteMarkContext,
+  separatorCache: NoteSeparatorCache,
+  reasons: NotePaginationFallbackReason[]
+): number {
+  if (!nextPage) return 0;
+  const firstBlock = bodyOnlyPage(nextPage).fragments[0];
+  if (!firstBlock || firstBlock.kind !== 'paragraph') return 0;
+  // Walk the opening fragment's lines to the FIRST reference-bearing one, accumulating the
+  // band the pull-back would occupy. The eviction reserve names the reference's line, but
+  // widow/orphan control moves its companion with it, so the reference is not necessarily
+  // the very first line of the next page — and the companions can only return together.
+  const pulled: PageRefHit[] = [];
+  let pulledBandHeight = 0;
+  let refLineHeight = 0;
+  for (const line of firstBlock.lines) {
+    pulledBandHeight += line.box.height;
+    refLineHeight = line.box.height;
+    for (const segment of lineSegments(line)) {
+      const candidates = refIndex.get(segment.paragraphId);
+      if (!candidates) continue;
+      for (const ref of candidates) {
+        if (ref.noteKind !== 'footnote') continue;
+        const pos = footnotePropsFor(input, ref.sectionIndex).pos;
+        if (pos === 'sectEnd' || pos === 'docEnd') continue;
+        if (ref.atomOffset >= segment.start && ref.atomOffset < segment.end) pulled.push(ref);
+      }
+    }
+    if (pulled.length > 0) break;
+  }
+  if (pulled.length === 0) return 0;
+
+  const contentWidth = bodyPage.contentBox.width;
+  const opts = layoutOpts(input, noteMarks);
+  const separator = separatorCache.get(
+    input.footnotesPart,
+    'separator',
+    contentWidth,
+    'footnote',
+    Math.max(0, bodyPage.contentBox.height),
+    opts,
+    reasons
+  );
+  const columnBudget = Math.max(
+    0,
+    bodyPage.contentBox.height - MIN_FOOTNOTE_BODY_BAND_PT - separator.flowHeight
+  );
+  let pulledNotesHeight = 0;
+  for (const ref of pulled) {
+    const laid = layoutNoteById(input.footnotesPart, ref.noteId, contentWidth, opts);
+    if (!laid) continue;
+    if (laid.flowHeight > columnBudget + 0.001) return 0;
+    pulledNotesHeight += laid.flowHeight;
+  }
+  if (pulledNotesHeight <= 0) return 0;
+  const bodyBottom = bodyUsedHeight(bodyPage);
+  const areaWithPulled =
+    (existingAreaHeight > 0 ? existingAreaHeight : separator.flowHeight) + pulledNotesHeight;
+  // One reference-line of headroom: the split tail wraps from the split offset, so the
+  // reference sits up to one line higher here than the joined re-wrap a pull-back produces.
+  // Releasing on the tail's optimistic geometry re-splits the note the next round; erring
+  // toward the hold keeps the note whole, which is the Word behavior this reserve encodes.
+  const fits =
+    bodyBottom + pulledBandHeight + refLineHeight + areaWithPulled <=
+    bodyPage.contentBox.height + 0.001;
+  if (fits) return 0;
+  // Same half-point back-off as the eviction reserve: the last kept body line's bottom is
+  // exactly `bodyBottom`, and a budget equal to it flips on float drift.
+  return Math.max(0, bodyPage.contentBox.height - bodyBottom - RESERVE_BOUNDARY_BACKOFF_PT);
+}
+
 export function computeFootnoteReserves(
   layout: SemanticLayout,
   allRefs: readonly PageRefHit[],
@@ -2146,7 +2301,8 @@ export function computeFootnoteReserves(
   const refIndex = buildPageRefIndex(allRefs);
   const separatorCache = createNoteSeparatorCache();
 
-  for (const page of layout.pages) {
+  for (let pageAt = 0; pageAt < layout.pages.length; pageAt += 1) {
+    const page = layout.pages[pageAt]!;
     // Strip any prior note-pass output so reserve height is body-only.
     const bodyPage = bodyOnlyPage(page);
     const pageRefs = filterRefsOnPage(bodyPage, allRefs, refIndex);
@@ -2159,11 +2315,17 @@ export function computeFootnoteReserves(
       continue;
     }
 
+    const nextPage = layout.pages[pageAt + 1];
     // An unchanged page whose refs and marks are the previous pass's exact objects sized
     // to the same reserve; carry chains are the exception and rebuild.
     if (memo && carry.size === 0) {
       const cached = memo.pageReserve.get(page);
-      if (cached && cached.allHits === allRefs && cached.marks === noteMarks) {
+      if (
+        cached &&
+        cached.allHits === allRefs &&
+        cached.marks === noteMarks &&
+        cached.nextFragments === (nextPage ? nextPage.fragments : null)
+      ) {
         for (const reason of cached.reasons) reasons.push(reason);
         if (cached.reserve > 0) {
           reserves.set(page.index, Math.max(reserves.get(page.index) ?? 0, cached.reserve));
@@ -2183,7 +2345,7 @@ export function computeFootnoteReserves(
 
     const carryWasEmpty = carry.size === 0;
     const reasonsBefore = reasons.length;
-    const { area, nextCarry } = buildFootnoteArea(
+    const { area, nextCarry, evictionTopPt } = buildFootnoteArea(
       bodyPage,
       fnRefs,
       input,
@@ -2193,18 +2355,47 @@ export function computeFootnoteReserves(
       reasons,
       {
         reserveColumnBudget: true,
-        reserveFloorOf: (ref) => noteReferenceFloorPt(bodyPage, ref),
+        reserveBandOf: (ref) => noteReferenceLineBandPt(bodyPage, ref),
         separatorCache,
       }
     );
     carry = nextCarry;
-    const needed = Math.min(area?.box.height ?? 0, maxArea);
+    // An eviction reaches past the note stack to the unplaceable reference's own line, so
+    // the body pass pushes that line — and the reference — to the next page. The eviction
+    // top sits below the minimum body band by construction, so the cap holds either way.
+    // Backed off by half a point so the body budget lands MID-line: edge-to-edge the
+    // previous line's bottom equals the budget exactly, the body pass's strict compare
+    // flips on float drift, and an extra evicted line rewraps the tail into geometry the
+    // next round cannot reproduce.
+    const evictionNeed =
+      evictionTopPt !== undefined
+        ? Math.max(0, bodyPage.contentBox.height - evictionTopPt - RESERVE_BOUNDARY_BACKOFF_PT)
+        : 0;
+    // Hold-out: the fixed point of an eviction. Once the body pass has pushed a reference
+    // line forward, THIS page's recomputed reserve no longer sees that reference — the
+    // note-stack height alone under-claims, the next round pulls the line back, and the
+    // loop orbits the two placements forever. When the next page OPENS with a reference
+    // whose note cannot return here, this page's assignment is final under Word's rule
+    // (the note stays whole with its reference), so the reserve claims the remaining
+    // slack and reproduces itself round over round.
+    const holdOutNeed = holdOutReserveNeed(
+      bodyPage,
+      nextPage,
+      refIndex,
+      area?.box.height ?? 0,
+      input,
+      noteMarks,
+      separatorCache,
+      reasons
+    );
+    const needed = Math.min(Math.max(area?.box.height ?? 0, evictionNeed, holdOutNeed), maxArea);
     if (memo && carryWasEmpty && carry.size === 0) {
       memo.pageReserve.set(page, {
         allHits: allRefs,
         marks: noteMarks,
         reserve: needed > 0 ? needed : 0,
         reasons: reasons.slice(reasonsBefore),
+        nextFragments: nextPage ? nextPage.fragments : null,
       });
     }
     // Omit zero entries so a page the citation left does not linger as `0` in the map

--- a/packages/core/src/layout/note-pagination.ts
+++ b/packages/core/src/layout/note-pagination.ts
@@ -34,9 +34,11 @@ import {
 } from './note-numbering.ts';
 import {
   layoutNoteById,
+  layoutNoteCached,
   layoutNoteSeparator,
   noteSeparatorAreaBox,
   MAX_NOTES_LAID_OUT,
+  type NoteStoryLayoutCache,
   type NoteLayoutFallbackReason,
   type NoteSeparatorLayout,
   type NoteStoryDrawings,
@@ -51,6 +53,7 @@ import {
   notesReserveContextKey,
   MIN_FOOTNOTE_BODY_BAND_PT,
   noteColumnBudgetPt,
+  recordFootnoteReserve,
   RESERVE_BOUNDARY_BACKOFF_PT,
 } from './note-reserves.ts';
 export { notesReserveContextKey };
@@ -63,11 +66,7 @@ import {
   type NoteReferenceLineBand,
 } from './note-fragment-geometry.ts';
 import { splitNoteFragments } from './note-splitting.ts';
-import {
-  holdOutReserveNeed,
-  layoutNoteCached,
-  type NoteStoryLayoutCache,
-} from './note-reserve-holdout.ts';
+import { holdOutReserveNeed } from './note-reserve-holdout.ts';
 import { reindexAndRestackPages } from './page-restacking.ts';
 import type {
   BlockFragmentRecord,
@@ -575,6 +574,35 @@ function createNoteSeparatorCache(): NoteSeparatorCache {
   };
 }
 
+/** Whether a footnote position collects at a section or document end (no per-page area). */
+function collectsAtEnd(pos: FootnotePosition): boolean {
+  return pos === 'sectEnd' || pos === 'docEnd';
+}
+
+/**
+ * Note story layouts per mark-context identity. One reflow search shares one marks object
+ * across all of its rounds, so each note lays out once per search; a new pass mints new
+ * marks and the old cache is released with them.
+ */
+const noteStoryCachesByMarks = new WeakMap<NoteMarkContext, NoteStoryLayoutCache>();
+
+/** ONE cache-or-layout separator fetch, so the fallback-reason handling has one shape. */
+function separatorLayoutOf(
+  cache: NoteSeparatorCache | undefined,
+  part: OoxmlPart | null | undefined,
+  kind: 'separator' | 'continuationSeparator',
+  contentWidth: number,
+  noteKind: NoteKind,
+  maxFlowHeightPt: number,
+  opts: LayoutNoteStoryOptions,
+  reasons: NotePaginationFallbackReason[]
+): NoteSeparatorLayout {
+  if (cache) return cache.get(part, kind, contentWidth, noteKind, maxFlowHeightPt, opts, reasons);
+  const laid = layoutNoteSeparator(part, kind, contentWidth, opts, noteKind, maxFlowHeightPt);
+  if (laid.fallbackReason) reasons.push(laid.fallbackReason);
+  return laid;
+}
+
 /** Scan an OOXML part's laid-out paragraph ids → refs already collected from the package. */
 export function buildPageRefHits(
   refs: readonly {
@@ -936,6 +964,13 @@ function buildFootnoteArea(
     readonly separatorCache?: NoteSeparatorCache;
     /** Pass-local note story layouts shared with the hold-out (reserve mode). */
     readonly noteLayoutCache?: NoteStoryLayoutCache;
+    /**
+     * Whether the keep-whole eviction may fire (reserve mode). False when the NEXT page's
+     * content geometry differs (a section boundary): the eviction guard measures the
+     * destination with THIS page's column, and the hold-out refuses cross-geometry pages,
+     * so an eviction there could never reach its fixed point — split instead.
+     */
+    readonly evictionAllowed?: boolean;
   }
 ): {
   area: NoteAreaRecord | undefined;
@@ -951,59 +986,41 @@ function buildFootnoteArea(
   const contentWidth = page.contentBox.width;
   const opts = layoutOpts(input, noteMarks);
 
-  // Continuations from previous page first.
   const notes: NoteStoryRecord[] = [];
   let stackHeight = 0;
   let fragmentBudget = MAX_NOTE_AREA_FRAGMENTS;
   const separatorKind =
     continuationCarry.size > 0 ? ('continuationSeparator' as const) : ('separator' as const);
   const maxSepHeight = Math.max(0, page.contentBox.height);
-  const fetchSeparator = (kind: 'separator' | 'continuationSeparator'): NoteSeparatorLayout => {
-    if (options?.separatorCache) {
-      return options.separatorCache.get(
-        input.footnotesPart,
-        kind,
-        contentWidth,
-        'footnote',
-        maxSepHeight,
-        opts,
-        reasons
-      );
-    }
-    const laid = layoutNoteSeparator(
+  const fetchSeparator = (kind: 'separator' | 'continuationSeparator'): NoteSeparatorLayout =>
+    separatorLayoutOf(
+      options?.separatorCache,
       input.footnotesPart,
       kind,
       contentWidth,
-      opts,
       'footnote',
-      maxSepHeight
+      maxSepHeight,
+      opts,
+      reasons
     );
-    if (laid.fallbackReason) reasons.push(laid.fallbackReason);
-    return laid;
-  };
   const separator = fetchSeparator(separatorKind);
 
-  const slackBudget = Math.max(
-    0,
-    page.contentBox.height - bodyFitBottomPt(page) - separator.flowHeight
-  );
+  const textBottom = bodyFitBottomPt(page);
+  const slackBudget = Math.max(0, page.contentBox.height - textBottom - separator.flowHeight);
   const columnBudget = noteColumnBudgetPt(page.contentBox.height, separator.flowHeight);
   const availableForNotes = options?.reserveColumnBudget ? columnBudget : slackBudget;
   const fullNoteColumn = Math.max(0, page.contentBox.height - separator.flowHeight);
   const splitOpts = { fullContentHeight: fullNoteColumn, reasons };
   // The keep-whole guard's budget is carry-INDEPENDENT: the hold-out on the previous page
   // re-derives the same test without knowing this page's carry state, and the two must be
-  // exact complements or a note is neither evicted nor held out and the loop orbits.
-  // Lazy — only the eviction branch reads it, and on a carry page it costs a second
-  // separator fetch.
-  let keepWholeBudgetLazy: number | undefined;
-  const keepWholeBudget = (): number =>
-    (keepWholeBudgetLazy ??= noteColumnBudgetPt(
-      page.contentBox.height,
-      (separatorKind === 'separator' ? separator : fetchSeparator('separator')).flowHeight
-    ));
-  let firstContentTopLazy: number | undefined;
-  const firstContentTop = (): number => (firstContentTopLazy ??= firstBodyContentTopPt(page));
+  // exact complements or a note is neither evicted nor held out and the loop orbits. Only
+  // reserve mode evicts, so only reserve mode pays the plain-separator fetch.
+  const keepWholeBudget = !options?.reserveBandOf
+    ? 0
+    : separatorKind === 'separator'
+      ? columnBudget
+      : noteColumnBudgetPt(page.contentBox.height, fetchSeparator('separator').flowHeight);
+  const firstContentTop = options?.reserveBandOf ? firstBodyContentTopPt(page) : 0;
 
   // Continuations from the previous page place first.
   for (const [scopeId, carry] of continuationCarry) {
@@ -1083,8 +1100,17 @@ function buildFootnoteArea(
     // A reference at or below an eviction point moves with the evicted line; its note lays
     // out with it on the destination page. References ABOVE the point (document order is
     // not y order beside a float exclusion zone, or across columns) stay put and keep
-    // their notes in this page's reserve.
-    if (evictionTopPt !== undefined && band && band.bottom >= evictionTopPt - 0.001) {
+    // their notes in this page's reserve. Only a LINE-precise band may skip: a table ref's
+    // band is the whole table box, whose bottom clears the eviction point even when the
+    // referencing row stays on this page — its note must keep reserving here.
+    // Strictly BELOW the point: an edge-to-edge line whose bottom equals the eviction top
+    // is the line directly above it, which stays on the page and must keep its reserve.
+    if (
+      evictionTopPt !== undefined &&
+      band &&
+      band.evictable &&
+      band.bottom > evictionTopPt + 0.001
+    ) {
       continue;
     }
     const laid = layoutNoteCached(
@@ -1131,9 +1157,10 @@ function buildFootnoteArea(
     if (
       band &&
       band.evictable &&
+      options?.evictionAllowed !== false &&
       laid.flowHeight > room + 0.001 &&
-      laid.flowHeight <= keepWholeBudget() - (band.bottom - band.blockTop) + 0.001 &&
-      band.top > firstContentTop() + 0.001 &&
+      laid.flowHeight <= keepWholeBudget - (band.bottom - band.blockTop) + 0.001 &&
+      band.top > firstContentTop + 0.001 &&
       band.top >= MIN_FOOTNOTE_BODY_BAND_PT
     ) {
       evictionTopPt = evictionTopPt === undefined ? band.top : Math.min(evictionTopPt, band.top);
@@ -1196,7 +1223,6 @@ function buildFootnoteArea(
   // Budgets measure without trailing after-spacing ({@link bodyFitBottomPt}); PLACEMENT
   // keeps the painted flow bottom and rises into the after-spacing band only when the
   // stack needs the room, which is also where Word draws the separator in that case.
-  const textBottom = bodyFitBottomPt(page);
   const flowBottom = fragmentFlowBottom(page.fragments);
   let areaTop: number;
   if (placement === 'beneathText') {
@@ -1562,28 +1588,16 @@ function buildEndnoteArea(
   // still use the endnotes-area chrome (Word draws the endnote separator for doc-end notes).
   const sepPart = input.endnotesPart ?? input.footnotesPart;
   const maxSepHeight = Math.max(0, page.contentBox.height);
-  const separator = options?.separatorCache
-    ? options.separatorCache.get(
-        sepPart,
-        separatorKind,
-        contentWidth,
-        'endnote',
-        maxSepHeight,
-        opts,
-        reasons
-      )
-    : (() => {
-        const laid = layoutNoteSeparator(
-          sepPart,
-          separatorKind,
-          contentWidth,
-          opts,
-          'endnote',
-          maxSepHeight
-        );
-        if (laid.fallbackReason) reasons.push(laid.fallbackReason);
-        return laid;
-      })();
+  const separator = separatorLayoutOf(
+    options?.separatorCache,
+    sepPart,
+    separatorKind,
+    contentWidth,
+    'endnote',
+    maxSepHeight,
+    opts,
+    reasons
+  );
   const sepHeight = separator.flowHeight;
   // Endnotes anchor beneath the PAINTED flow (full boxes, trailing after-spacing kept):
   // they hang off the body in leftover room rather than joining the footnote reserve's
@@ -2021,12 +2035,7 @@ export function computeFootnoteReserves(
    * absent, the hold-out releases the ambiguous cases — a caller outside the reflow loop
    * must not manufacture holds the loop never observed.
    */
-  previousReserves?: ReadonlyMap<number, number>,
-  /**
-   * Pass-carried note story layouts. The reflow loop supplies one cache for all of its
-   * rounds — marks and parts are fixed across them; see {@link NoteStoryLayoutCache}.
-   */
-  passNoteLayoutCache?: NoteStoryLayoutCache
+  previousReserves?: ReadonlyMap<number, number>
 ): {
   readonly reserves: ReadonlyMap<number, number>;
   readonly stable: boolean;
@@ -2038,25 +2047,25 @@ export function computeFootnoteReserves(
   let carry: NoteCarryMap = new Map();
   const refIndex = buildPageRefIndex(allRefs);
   const separatorCache = createNoteSeparatorCache();
-  const noteLayoutCache: NoteStoryLayoutCache = passNoteLayoutCache ?? new Map();
+  // Keyed on the mark-context object: the reflow loop's rounds all share one marks
+  // object, so every round of a search lays each note once; a new pass mints new marks
+  // and with them a fresh cache (see {@link NoteStoryLayoutCache} for what the key omits).
+  let noteLayoutCache = noteStoryCachesByMarks.get(noteMarks);
+  if (!noteLayoutCache) {
+    noteLayoutCache = new Map();
+    noteStoryCachesByMarks.set(noteMarks, noteLayoutCache);
+  }
   const holdOutOpts = layoutOpts(input, noteMarks);
-  const isPageBottomFootnoteRef = (ref: PageRefHit): boolean => {
-    if (ref.noteKind !== 'footnote') return false;
-    const pos = footnotePropsFor(input, ref.sectionIndex).pos;
-    return pos !== 'sectEnd' && pos !== 'docEnd';
-  };
+  const isPageBottomFootnoteRef = (ref: PageRefHit): boolean =>
+    ref.noteKind === 'footnote' && !collectsAtEnd(footnotePropsFor(input, ref.sectionIndex).pos);
   // A document with no page-bottom footnote reference at all (footnote-free, or every
   // section collects at sectEnd/docEnd) has nothing for the hold-out to pull, so the
   // per-page scan is skipped wholesale.
   const anyPageBottomFootnoteRefs = allRefs.some(isPageBottomFootnoteRef);
   const pageBottomRefsOf = (page: PageRecord): readonly PageRefHit[] =>
     filterRefsOnPage(page, allRefs, refIndex).filter(isPageBottomFootnoteRef);
-  /** Clamp-and-merge, stated once: zero entries are OMITTED (convergence compares key sets). */
-  const recordReserve = (pageIndex: number, needed: number, cap: number): void => {
-    const clamped = Math.min(needed, cap);
-    if (clamped <= 0) return;
-    reserves.set(pageIndex, Math.max(reserves.get(pageIndex) ?? 0, clamped));
-  };
+  const recordReserve = (pageIndex: number, needed: number, cap: number): void =>
+    recordFootnoteReserve(reserves, pageIndex, Math.min(needed, cap));
 
   for (let pageAt = 0; pageAt < layout.pages.length; pageAt += 1) {
     const page = layout.pages[pageAt]!;
@@ -2071,16 +2080,10 @@ export function computeFootnoteReserves(
     const usedReservePt = previousReserves ? (previousReserves.get(page.index) ?? 0) : undefined;
     // The reserve ceiling: the note column beside the minimum body band.
     const maxArea = noteColumnBudgetPt(bodyPage.contentBox.height, 0);
-    // Hold-out: the fixed point of an eviction. Once the body pass has pushed a reference
-    // line forward, THIS page's recomputed reserve no longer sees that reference — the
-    // note-stack height alone under-claims, the next round pulls the line back, and the
-    // loop orbits the two placements forever. When the next page OPENS with a reference
-    // whose note cannot return here, this page's assignment is final under Word's rule
-    // (the note stays whole with its reference), so the reserve claims the remaining
-    // slack and reproduces itself round over round. Deliberately NOT memoized: it reads
-    // the NEIGHBOUR page, and a memo entry that must enumerate foreign inputs by hand is
-    // how stale reserves happen; the scan starts from a memoized page-refs answer and
-    // lays notes through the pass cache.
+    // The eviction's fixed point ({@link holdOutReserveNeed}). Deliberately NOT memoized:
+    // it reads the NEIGHBOUR page, and a memo entry that must enumerate foreign inputs by
+    // hand is how stale reserves happen; the scan starts from a memoized page-refs answer
+    // and lays notes through the pass cache.
     const holdOutFor = (existingAreaHeight: number): number =>
       anyPageBottomFootnoteRefs
         ? holdOutReserveNeed({
@@ -2103,7 +2106,7 @@ export function computeFootnoteReserves(
             noteLayoutCache,
           })
         : 0;
-    if (props.pos === 'sectEnd' || props.pos === 'docEnd') {
+    if (collectsAtEnd(props.pos)) {
       // No per-page reservation for THIS page's refs — collected later. The hold-out
       // still runs: a ref-free page in a mixed-position document (or one whose only
       // reference was evicted) answers section 0 here, and skipping it would let the
@@ -2147,6 +2150,10 @@ export function computeFootnoteReserves(
         reserveBandOf: (ref) => noteReferenceLineBandPt(bodyPage, ref),
         separatorCache,
         noteLayoutCache,
+        evictionAllowed:
+          !nextPage ||
+          (nextPage.contentBox.width === bodyPage.contentBox.width &&
+            nextPage.contentBox.height === bodyPage.contentBox.height),
       }
     );
     carry = nextCarry;
@@ -2181,7 +2188,7 @@ export function computeFootnoteReserves(
   for (const page of layout.pages) {
     const needed = reserves.get(page.index) ?? 0;
     if (needed <= 0) continue;
-    const used = bodyFitBottomPt(bodyOnlyPage(page));
+    const used = bodyFitBottomPt(page);
     if (used + needed > page.contentBox.height + 0.5) {
       stable = false;
       break;
@@ -2670,14 +2677,15 @@ export function layoutSemanticDocumentWithNotes<
     // footnotes deserves the full search, not the keystroke cap).
     const attemptCap =
       seeded && usedReserves.size > 0 ? MAX_SEEDED_NOTE_REFLOW_ATTEMPTS : MAX_NOTE_REFLOW_ATTEMPTS;
-    // One note-story layout per note for the WHOLE search: marks and parts are fixed
-    // across rounds, so every round's reserve compute shares this cache.
-    const passNoteLayoutCache: NoteStoryLayoutCache = new Map();
     // Consecutive page-count growth is the runaway signature (an eviction chain minting a
     // near-blank sheet per round on a shape none of the guards recognized); the fingerprint
     // exits never fire on it because every round's map is new. Cut it off early rather
     // than paying the full attempt cap for a degraded answer.
     let previousPageCount = bodyLayout.pages.length;
+    // Scaled with the document: legitimate cold convergence of a large document can grow
+    // the page count for more consecutive rounds than a small one (the settled prefix
+    // extends a few pages per round), while a runaway keeps growing regardless of size.
+    const growthCutoff = Math.max(8, Math.ceil(previousPageCount / 16));
     let consecutiveGrowth = 0;
     for (let attempt = 0; attempt < attemptCap; attempt += 1) {
       const computed = computeFootnoteReserves(
@@ -2686,8 +2694,7 @@ export function layoutSemanticDocumentWithNotes<
         notesInput,
         noteMarks,
         notesMemo,
-        usedReserves,
-        passNoteLayoutCache
+        usedReserves
       );
       fallbackReasons = [...computed.reasons];
       // Published pages must reflect the reserves used to produce them — not a later map.
@@ -2698,9 +2705,9 @@ export function layoutSemanticDocumentWithNotes<
         fallbackReasons.push('note-reflow-exhausted');
         break;
       }
-      // Eight: legitimate convergence oscillates (its growth streaks measure ~3 rounds on
-      // the reference-dense fixture); only a runaway grows monotonically.
-      if (consecutiveGrowth >= 8) {
+      // Legitimate convergence oscillates (its growth streaks measure ~3 rounds on the
+      // reference-dense fixture); only a runaway grows monotonically.
+      if (consecutiveGrowth >= growthCutoff) {
         fallbackReasons.push('note-reflow-exhausted');
         break;
       }

--- a/packages/core/src/layout/note-pagination.ts
+++ b/packages/core/src/layout/note-pagination.ts
@@ -82,29 +82,42 @@ import { overflowPageShellAt, type OverflowPageShell } from './page-furniture-in
 import { DEFAULT_REVISION_DISPLAY_MODE, type RevisionDisplayMode } from './revision-projection.ts';
 
 /**
- * Bound on reflow attempts per document layout pass.
+ * Bound on reflow attempts for an UNSEEDED document layout pass (cold open).
  *
- * Sized for a COLD OPEN of a reference-dense document: adoption is a forward fixed-point
+ * Sized for a cold open of a reference-dense document: adoption is a forward fixed-point
  * iteration whose settled prefix extends a few pages per round, so a legal document with a
- * hundred footnotes converges in tens of rounds (a 53-page/108-note fixture took 24), and
- * a round over a settled prefix is nearly free (checkpointed body layout + per-page
- * reserve memos). Orbits exit earlier through the fingerprint/envelope checks below, so
- * the cap is a safety bound, not the expected cost.
+ * hundred footnotes converges in tens of rounds (a 53-page/108-note fixture took 24).
+ * Orbits exit earlier through the fingerprint/envelope checks below, so the cap is a
+ * safety bound, not the expected cost.
  */
 export const MAX_NOTE_REFLOW_ATTEMPTS = 64;
 
 /**
+ * Bound on reflow attempts for a SEEDED pass — one whose session carries the reserves a
+ * previous pass settled on.
+ *
+ * A seeded pass starts at (or one edit away from) the fixed point and normally converges
+ * in a round or two; a document that still churns after this many rounds continues on the
+ * NEXT pass from where this one stopped, so the interactive path never blocks on the cold
+ * search's full depth. Every reserve delta invalidates the affected sections' context
+ * keys, so an unconverged round is a real relayout of those sections — this cap is what
+ * bounds a keystroke's worst-case synchronous layout work.
+ */
+const MAX_SEEDED_NOTE_REFLOW_ATTEMPTS = 8;
+
+/**
  * Total reserve-map adoptions allowed per BODY-PART identity, across passes.
  *
- * One pass is capped at {@link MAX_NOTE_REFLOW_ATTEMPTS}; session-seeded passes continue
- * the same iteration, so a reference-dense document converges across a few passes instead
- * of restarting. Some documents have no fixed point at all — the map's own body shifts move
- * references across page boundaries and the iteration orbits a short cycle — so the search
- * must also END: once this budget is spent, the memo records the answer and every later
- * pass over the same part reproduces it, instead of flapping an unchanged document between
- * the orbit's page counts forever. An edit replaces the part and restarts the search.
+ * Covers one full cold search ({@link MAX_NOTE_REFLOW_ATTEMPTS}); session-seeded passes
+ * continue the same iteration, so a reference-dense document converges across a few passes
+ * instead of restarting. Some documents have no fixed point at all — the map's own body
+ * shifts move references across page boundaries and the iteration orbits a short cycle —
+ * so the search must also END: once this budget is spent, the memo records the answer and
+ * every later pass over the same part reproduces it, instead of flapping an unchanged
+ * document between the orbit's page counts forever. An edit replaces the part and restarts
+ * the search.
  */
-const MAX_NOTE_REFLOW_ADOPTIONS_PER_STATE = 3 * MAX_NOTE_REFLOW_ATTEMPTS;
+const MAX_NOTE_REFLOW_ADOPTIONS_PER_STATE = MAX_NOTE_REFLOW_ATTEMPTS;
 
 /** Cap on total note story fragments attached across the document. */
 export const MAX_NOTE_AREA_FRAGMENTS = 4_096;
@@ -276,6 +289,8 @@ interface NotesPassMemo {
        * neighbour must not answer for another.
        */
       readonly nextFragments: readonly BlockFragmentRecord[] | null;
+      /** The reserve the page was laid under at compute time (hold-out refusal input). */
+      readonly usedReserve: number | undefined;
     }
   >;
 }
@@ -935,14 +950,15 @@ function buildMarkContext(
 }
 
 /**
- * Body bottom (content-relative pt) the note passes measure against.
+ * Body bottom (content-relative pt) the note passes BUDGET against.
  *
  * MINUS each paragraph's trailing after-spacing: the page-fit decision admits a paragraph
  * without charging its `w:spacing w:after` (it moves to the next page with the flow), but
  * the fragment BOX includes it — so a page whose last paragraph carries after-spacing
  * "uses" more height here than the fit rule budgeted, the reserve the reflow settles on
  * under-claims by that amount, and the attach pass splits a note the reserve fit whole.
- * Word lets the footnote area rise into that blank band the same way.
+ * Word lets the footnote area rise into that blank band the same way. PLACEMENT of an
+ * area that hangs off the body keeps {@link bodyFlowBottom} unless the room is needed.
  */
 function bodyUsedHeight(page: PageRecord): number {
   let bottom = 0;
@@ -951,6 +967,33 @@ function bodyUsedHeight(page: PageRecord): number {
     bottom = Math.max(bottom, fragment.box.y + fragment.box.height - trailingAfter);
   }
   return bottom;
+}
+
+/** Bottom of the painted body flow (full fragment boxes) — where a hanging area anchors. */
+function bodyFlowBottom(page: PageRecord): number {
+  let bottom = 0;
+  for (const fragment of page.fragments) {
+    bottom = Math.max(bottom, fragment.box.y + fragment.box.height);
+  }
+  return bottom;
+}
+
+/** Top (content-relative pt) of the page's first body content, or 0 on an empty page. */
+function firstBodyContentTop(page: PageRecord): number {
+  const first = page.fragments[0];
+  if (!first) return 0;
+  if (first.kind === 'paragraph') return first.lines[0]?.box.y ?? first.box.y;
+  return first.box.y;
+}
+
+/**
+ * The tallest footnote stack a page can host beside the minimum body band. ONE formula:
+ * the eviction guard ("could this note fit whole on a page?") and the hold-out's
+ * oversized-note test must be exact complements, or a note is neither evicted nor held
+ * out and the reflow loop orbits.
+ */
+function noteColumnBudgetPt(contentHeight: number, separatorHeight: number): number {
+  return Math.max(0, contentHeight - MIN_FOOTNOTE_BODY_BAND_PT - separatorHeight);
 }
 
 /** Remove note-pass output before recomputing it from canonical references. */
@@ -1217,15 +1260,14 @@ function buildFootnoteArea(
     0,
     page.contentBox.height - bodyUsedHeight(page) - separator.flowHeight
   );
-  const columnBudget = Math.max(
-    0,
-    page.contentBox.height - MIN_FOOTNOTE_BODY_BAND_PT - separator.flowHeight
-  );
+  const columnBudget = noteColumnBudgetPt(page.contentBox.height, separator.flowHeight);
   const availableForNotes = options?.reserveColumnBudget ? columnBudget : slackBudget;
   const fullNoteColumn = Math.max(0, page.contentBox.height - separator.flowHeight);
   const splitOpts = { fullContentHeight: fullNoteColumn, reasons };
 
-  // Place continuations.
+  // Place continuations. `carry.mark` is non-null only for a note whose HEAD never landed
+  // anywhere (a degraded, budget-exhausted state): its first painted record then still
+  // carries the number, instead of an unmarked body the reader cannot attribute.
   for (const [scopeId, carry] of continuationCarry) {
     const parsed = scopeId.match(/^(footnote|endnote):(-?\d+)$/);
     if (!parsed || parsed[1] !== 'footnote') continue;
@@ -1236,7 +1278,7 @@ function buildFootnoteArea(
         noteKind: 'footnote',
         noteId,
         scopeId,
-        mark: null,
+        mark: carry.mark,
         continuation: true,
         box: {
           x: page.contentBox.x,
@@ -1266,7 +1308,7 @@ function buildFootnoteArea(
           noteKind: 'footnote',
           noteId,
           scopeId,
-          mark: null,
+          mark: carry.mark,
           continuation: true,
           box: {
             x: page.contentBox.x,
@@ -1282,7 +1324,7 @@ function buildFootnoteArea(
         nextCarry.set(scopeId, {
           fragments: split.tail,
           height: split.tailHeight,
-          mark: null,
+          mark: split.head.length > 0 ? null : carry.mark,
         });
       } else {
         nextCarry.delete(scopeId);
@@ -1329,14 +1371,16 @@ function buildFootnoteArea(
     // line's TOP; the next reflow pass finds the reference there and lays the note whole
     // beside it. Every later reference on this page sits on or after the evicted line and
     // moves with it, so the loop ends here. Splitting remains for a note taller than the
-    // column (nothing can hold it whole) and for a reference already inside the minimum
-    // body band (evicting it would chase blank pages).
+    // column (nothing can hold it whole) and for a reference in the page's FIRST body
+    // line: pushing that line only re-creates the same shape on the next page — a
+    // section-opening paragraph keeps its `w:spacing w:before` at page top, so a fixed
+    // band threshold would re-fire there every round and mint a chain of near-blank pages.
     if (
       band &&
       band.evictable &&
       laid.flowHeight > room + 0.001 &&
       laid.flowHeight <= columnBudget + 0.001 &&
-      band.top > MIN_FOOTNOTE_BODY_BAND_PT + 0.001
+      band.top > firstBodyContentTop(page) + 0.001
     ) {
       evictionTopPt = evictionTopPt === undefined ? band.top : Math.min(evictionTopPt, band.top);
       break;
@@ -1378,7 +1422,9 @@ function buildFootnoteArea(
         nextCarry.set(laid.scopeId, {
           fragments: split.tail,
           height: split.tailHeight,
-          mark: null,
+          // A head that never landed keeps the mark on its carry, so the note's first
+          // painted record (a continuation on a later page) still shows its number.
+          mark: split.head.length > 0 ? null : ref.customMarkFollows ? null : mark,
         });
       }
     }
@@ -1394,15 +1440,21 @@ function buildFootnoteArea(
 
   const sepHeight = separator.flowHeight;
   const totalHeight = sepHeight + stackHeight;
-  const bodyBottom = bodyUsedHeight(page);
+  // Budgets measure without trailing after-spacing ({@link bodyUsedHeight}); PLACEMENT
+  // keeps the painted flow bottom and rises into the after-spacing band only when the
+  // stack needs the room, which is also where Word draws the separator in that case.
+  const textBottom = bodyUsedHeight(page);
+  const flowBottom = bodyFlowBottom(page);
   let areaTop: number;
   if (placement === 'beneathText') {
-    areaTop = page.contentBox.y + bodyBottom;
+    areaTop =
+      page.contentBox.y +
+      Math.max(textBottom, Math.min(flowBottom, page.contentBox.height - totalHeight));
   } else {
     // pageBottom — pin to bottom of content column.
     areaTop = page.contentBox.y + page.contentBox.height - totalHeight;
     // Never overlap body text.
-    areaTop = Math.max(areaTop, page.contentBox.y + bodyBottom);
+    areaTop = Math.max(areaTop, page.contentBox.y + textBottom);
   }
 
   let cursorY = areaTop + sepHeight;
@@ -1780,7 +1832,10 @@ function buildEndnoteArea(
         return laid;
       })();
   const sepHeight = separator.flowHeight;
-  const bodyBottom = bodyUsedHeight(page);
+  // Endnotes anchor beneath the PAINTED flow (full boxes, trailing after-spacing kept):
+  // they hang off the body in leftover room rather than joining the footnote reserve's
+  // fit arithmetic, so the after-less measure has nothing to reconcile here.
+  const bodyBottom = bodyFlowBottom(page);
   // Existing endnotes already consume room below body (merged on re-entry).
   const existingEndnoteBottom = page.endnotes
     ? Math.max(bodyBottom, page.endnotes.box.y - page.contentBox.y + page.endnotes.box.height)
@@ -1806,7 +1861,7 @@ function buildEndnoteArea(
         noteKind,
         noteId,
         scopeId,
-        mark: null,
+        mark: carry.mark,
         continuation: true,
         box: { x: page.contentBox.x, y: 0, width: contentWidth, height: carry.height },
         fragments: carry.fragments,
@@ -1831,7 +1886,7 @@ function buildEndnoteArea(
           noteKind,
           noteId,
           scopeId,
-          mark: null,
+          mark: carry.mark,
           continuation: true,
           box: { x: page.contentBox.x, y: 0, width: contentWidth, height: split.headHeight },
           fragments: split.head,
@@ -1839,7 +1894,11 @@ function buildEndnoteArea(
         stackHeight += split.headHeight;
       }
       if (split.tail.length > 0) {
-        nextCarry.set(scopeId, { fragments: split.tail, height: split.tailHeight, mark: null });
+        nextCarry.set(scopeId, {
+          fragments: split.tail,
+          height: split.tailHeight,
+          mark: split.head.length > 0 ? null : carry.mark,
+        });
       } else {
         nextCarry.delete(scopeId);
       }
@@ -1904,7 +1963,8 @@ function buildEndnoteArea(
         nextCarry.set(laid.scopeId, {
           fragments: split.tail,
           height: split.tailHeight,
-          mark: null,
+          // A head that never landed keeps the mark on its carry (see the footnote twin).
+          mark: split.head.length > 0 ? null : ref.customMarkFollows ? null : mark,
         });
       }
       remainingRefs.push(...refs.slice(i + 1));
@@ -2187,24 +2247,34 @@ function placeEndnotesFromPage(
   return nextPages;
 }
 
+/** How many of the next page's opening blocks the hold-out scans for a pulled reference. */
+const MAX_HOLD_OUT_SCAN_BLOCKS = 6;
+
 /**
- * Compute per-page bottom reserves (points) needed for footnotes given a provisional layout.
- * Used by the bounded reflow loop before final attach.
+ * Reserve (pt) `bodyPage` must keep so the opening lines of `nextPage` stay put.
  *
- * Height is measured against a column-derived note budget (not leftover body slack). Measuring
- * from slack makes `stable` true on the first pass and never shrinks the body — references and
- * notes then compete for the same band. Oversized notes still split/continue within the budget;
- * {@link MIN_FOOTNOTE_BODY_BAND_PT} keeps a body band so reflow cannot chase blank sheets.
- */
-/**
- * Reserve (pt) `bodyPage` must keep so the first line of `nextPage` stays put.
+ * Zero when there is nothing to hold out: no next page, the next page opens with a table
+ * or with more than {@link MAX_HOLD_OUT_SCAN_BLOCKS} reference-free paragraphs (nothing
+ * this reserve can reason about), no scanned line carries a page-bottom footnote
+ * reference, or the pulled band and its notes would fit back here — then the lines SHOULD
+ * return; a deleted note must release its room. A note taller than the note column is
+ * splittable and never blocks the pull-back on its own: its line may legitimately return
+ * with a head, so it is excluded from the demand rather than aborting the hold (a
+ * co-pulled column-sized note still holds). Otherwise the answer claims the page's
+ * remaining slack, which reproduces the current body end exactly and gives the reflow
+ * loop its fixed point.
  *
- * Zero when there is nothing to hold out: no next page, the next page does not open with a
- * paragraph line, that line carries no page-bottom footnote reference, or the line and its
- * notes would fit back here (then the line SHOULD return — a deleted note must release its
- * room). A note taller than the note column is splittable and never holds out: its line may
- * legitimately return with a head. Otherwise the answer claims the page's remaining slack,
- * which reproduces the current body end exactly and gives the reflow loop its fixed point.
+ * The scan spans BLOCKS, not just the first fragment: the eviction reserve names the
+ * reference's line, but widow/orphan control and `w:keepNext` move companions with it, so
+ * the reference may open the next page behind a heading or a sibling line — and the
+ * companions can only return together.
+ *
+ * Known approximation: the pull-back fit charges the pulled band's page-top geometry plus
+ * one reference-line of headroom (the split tail wraps from the split offset, so the
+ * reference sits up to one line higher here than the joined re-wrap a pull-back
+ * produces). A pulled paragraph whose applied `w:spacing w:before` exceeds that headroom
+ * can still release early; the loop then degrades to the pre-eviction envelope/exhaustion
+ * exit rather than diverging.
  */
 function holdOutReserveNeed(
   bodyPage: PageRecord,
@@ -2214,73 +2284,117 @@ function holdOutReserveNeed(
   input: NotesLayoutInput,
   noteMarks: NoteMarkContext,
   separatorCache: NoteSeparatorCache,
+  /** Whether `bodyPage` receives continuation carry (selects its separator kind). */
+  hasCarry: boolean,
+  /** The reserve `bodyPage` was laid under (for the observed-refusal test), if known. */
+  usedReservePt: number | undefined,
   reasons: NotePaginationFallbackReason[]
 ): number {
   if (!nextPage) return 0;
-  const firstBlock = bodyOnlyPage(nextPage).fragments[0];
-  if (!firstBlock || firstBlock.kind !== 'paragraph') return 0;
-  // Walk the opening fragment's lines to the FIRST reference-bearing one, accumulating the
-  // band the pull-back would occupy. The eviction reserve names the reference's line, but
-  // widow/orphan control moves its companion with it, so the reference is not necessarily
-  // the very first line of the next page — and the companions can only return together.
+  const nextBody = bodyOnlyPage(nextPage);
   const pulled: PageRefHit[] = [];
-  let pulledBandHeight = 0;
-  let refLineHeight = 0;
-  for (const line of firstBlock.lines) {
-    pulledBandHeight += line.box.height;
-    refLineHeight = line.box.height;
-    for (const segment of lineSegments(line)) {
-      const candidates = refIndex.get(segment.paragraphId);
-      if (!candidates) continue;
-      for (const ref of candidates) {
-        if (ref.noteKind !== 'footnote') continue;
-        const pos = footnotePropsFor(input, ref.sectionIndex).pos;
-        if (pos === 'sectEnd' || pos === 'docEnd') continue;
-        if (ref.atomOffset >= segment.start && ref.atomOffset < segment.end) pulled.push(ref);
+  let firstTop: number | undefined;
+  let refLine: LineRecord | undefined;
+  let refBlockBottom = 0;
+  let scanned = 0;
+  for (const block of nextBody.fragments) {
+    if (block.kind !== 'paragraph') return 0;
+    if (scanned >= MAX_HOLD_OUT_SCAN_BLOCKS) return 0;
+    scanned += 1;
+    firstTop ??= block.lines[0]?.box.y ?? block.box.y;
+    for (const line of block.lines) {
+      for (const segment of lineSegments(line)) {
+        const candidates = refIndex.get(segment.paragraphId);
+        if (!candidates) continue;
+        for (const ref of candidates) {
+          if (ref.noteKind !== 'footnote') continue;
+          const pos = footnotePropsFor(input, ref.sectionIndex).pos;
+          if (pos === 'sectEnd' || pos === 'docEnd') continue;
+          if (ref.atomOffset >= segment.start && ref.atomOffset < segment.end) {
+            pulled.push(ref);
+          }
+        }
+      }
+      if (pulled.length > 0) {
+        refLine = line;
+        refBlockBottom = block.box.y + block.box.height;
+        break;
       }
     }
-    if (pulled.length > 0) break;
+    if (refLine) break;
   }
-  if (pulled.length === 0) return 0;
+  if (!refLine || pulled.length === 0) return 0;
+  const firstContentTop = firstTop ?? 0;
+  const refLineHeight = refLine.box.height;
+  // Two pull-back quanta: the OPTIMISTIC one ends at the reference's line (a splittable
+  // paragraph returns just its opening lines), the WHOLE-BLOCK one at the reference
+  // paragraph's fragment bottom (a `w:keepLines`/keep-with-next group returns only as one
+  // piece). Which quantum the body pass actually uses is not readable off the fragments.
+  const lineBandHeight = Math.max(0, refLine.box.y + refLineHeight - firstContentTop);
+  const blockBandHeight = Math.max(0, refBlockBottom - firstContentTop);
 
   const contentWidth = bodyPage.contentBox.width;
   const opts = layoutOpts(input, noteMarks);
   const separator = separatorCache.get(
     input.footnotesPart,
-    'separator',
+    hasCarry ? 'continuationSeparator' : 'separator',
     contentWidth,
     'footnote',
     Math.max(0, bodyPage.contentBox.height),
     opts,
     reasons
   );
-  const columnBudget = Math.max(
-    0,
-    bodyPage.contentBox.height - MIN_FOOTNOTE_BODY_BAND_PT - separator.flowHeight
-  );
+  const columnBudget = noteColumnBudgetPt(bodyPage.contentBox.height, separator.flowHeight);
   let pulledNotesHeight = 0;
   for (const ref of pulled) {
     const laid = layoutNoteById(input.footnotesPart, ref.noteId, contentWidth, opts);
     if (!laid) continue;
-    if (laid.flowHeight > columnBudget + 0.001) return 0;
+    if (laid.flowHeight > columnBudget + 0.001) continue;
     pulledNotesHeight += laid.flowHeight;
   }
   if (pulledNotesHeight <= 0) return 0;
   const bodyBottom = bodyUsedHeight(bodyPage);
+  const contentHeight = bodyPage.contentBox.height;
   const areaWithPulled =
     (existingAreaHeight > 0 ? existingAreaHeight : separator.flowHeight) + pulledNotesHeight;
-  // One reference-line of headroom: the split tail wraps from the split offset, so the
-  // reference sits up to one line higher here than the joined re-wrap a pull-back produces.
-  // Releasing on the tail's optimistic geometry re-splits the note the next round; erring
-  // toward the hold keeps the note whole, which is the Word behavior this reserve encodes.
-  const fits =
-    bodyBottom + pulledBandHeight + refLineHeight + areaWithPulled <=
-    bodyPage.contentBox.height + 0.001;
-  if (fits) return 0;
-  // Same half-point back-off as the eviction reserve: the last kept body line's bottom is
-  // exactly `bodyBottom`, and a budget equal to it flips on float drift.
-  return Math.max(0, bodyPage.contentBox.height - bodyBottom - RESERVE_BOUNDARY_BACKOFF_PT);
+  const hold = Math.max(0, contentHeight - bodyBottom - RESERVE_BOUNDARY_BACKOFF_PT);
+  // One reference-line of headroom in both fit tests: the split tail wraps from the split
+  // offset, so the reference sits up to one line higher here than the joined re-wrap a
+  // pull-back produces. (A pulled paragraph whose applied `w:spacing w:before` exceeds
+  // that headroom can still release early; the loop then degrades to the pre-eviction
+  // envelope/exhaustion exit rather than diverging.)
+  const fitsLineQuantum =
+    bodyBottom + lineBandHeight + refLineHeight + areaWithPulled <= contentHeight + 0.001;
+  if (!fitsLineQuantum) return hold;
+  const fitsWholeBlock =
+    bodyBottom + blockBandHeight + refLineHeight + areaWithPulled <= contentHeight + 0.001;
+  // The optimistic quantum fits but the whole block does not. Whether releasing is safe
+  // depends on whether the block can SPLIT, which the body pass has already answered:
+  // when the used reserve left room for the line quantum and the body still declined it,
+  // the block only moves whole (`w:keepLines` and friends) — release would re-open the
+  // evict/pull-back orbit, so hold. A page already held at this value KEEPS the hold (a
+  // held page offers no gap, so the refusal cannot be re-observed there); upstream
+  // shrinkage releases through the whole-block test above, and a vanished note releases
+  // through the pulled scan. Only a page that was never offered the room — and is not
+  // currently held — releases to let the next round observe the answer.
+  if (fitsWholeBlock) return 0;
+  if (usedReservePt === undefined) return hold;
+  const offeredGap = Math.max(0, contentHeight - usedReservePt - bodyBottom);
+  const lineQuantum = lineBandHeight + refLineHeight;
+  if (lineQuantum <= offeredGap + 0.001) return hold;
+  if (Math.abs(usedReservePt - hold) <= 1) return hold;
+  return 0;
 }
+
+/**
+ * Compute per-page bottom reserves (points) needed for footnotes given a provisional layout.
+ * Used by the bounded reflow loop before final attach.
+ *
+ * Height is measured against a column-derived note budget (not leftover body slack). Measuring
+ * from slack makes `stable` true on the first pass and never shrinks the body — references and
+ * notes then compete for the same band. Oversized notes still split/continue within the budget;
+ * {@link MIN_FOOTNOTE_BODY_BAND_PT} keeps a body band so reflow cannot chase blank sheets.
+ */
 
 export function computeFootnoteReserves(
   layout: SemanticLayout,
@@ -2288,7 +2402,13 @@ export function computeFootnoteReserves(
   input: NotesLayoutInput,
   noteMarks: NoteMarkContext,
   /** Session-carried notes memo (opaque; owned by this module). */
-  passMemo?: unknown
+  passMemo?: unknown,
+  /**
+   * The reserve map `layout` was laid under. Feeds the hold-out's observed-refusal test
+   * (a block the body pass declined to split under a known budget only moves whole);
+   * absent, the hold-out errs toward holding.
+   */
+  previousReserves?: ReadonlyMap<number, number>
 ): {
   readonly reserves: ReadonlyMap<number, number>;
   readonly stable: boolean;
@@ -2310,12 +2430,33 @@ export function computeFootnoteReserves(
     // Position from first ref's section (Word uses section of the page).
     const sectionIndex = fnRefs[0]?.sectionIndex ?? 0;
     const props = footnotePropsFor(input, sectionIndex);
+    const nextPage = layout.pages[pageAt + 1];
+    const usedReservePt = previousReserves ? (previousReserves.get(page.index) ?? 0) : undefined;
     if (props.pos === 'sectEnd' || props.pos === 'docEnd') {
-      // No per-page reservation — collected later.
+      // No per-page reservation for THIS page's refs — collected later. The hold-out
+      // still runs: a ref-free page in a mixed-position document (or one whose only
+      // reference was evicted) answers section 0 here, and skipping it would let the
+      // next page's opening reference pull back and reopen the eviction orbit. The
+      // hold-out filters pulled refs by their OWN section's position.
+      const holdOut = holdOutReserveNeed(
+        bodyPage,
+        nextPage,
+        refIndex,
+        0,
+        input,
+        noteMarks,
+        separatorCache,
+        carry.size > 0,
+        usedReservePt,
+        reasons
+      );
+      if (holdOut > 0) {
+        const cap = Math.max(0, bodyPage.contentBox.height - MIN_FOOTNOTE_BODY_BAND_PT);
+        const prev = reserves.get(page.index) ?? 0;
+        reserves.set(page.index, Math.max(prev, Math.min(holdOut, cap)));
+      }
       continue;
     }
-
-    const nextPage = layout.pages[pageAt + 1];
     // An unchanged page whose refs and marks are the previous pass's exact objects sized
     // to the same reserve; carry chains are the exception and rebuild.
     if (memo && carry.size === 0) {
@@ -2324,7 +2465,8 @@ export function computeFootnoteReserves(
         cached &&
         cached.allHits === allRefs &&
         cached.marks === noteMarks &&
-        cached.nextFragments === (nextPage ? nextPage.fragments : null)
+        cached.nextFragments === (nextPage ? nextPage.fragments : null) &&
+        cached.usedReserve === usedReservePt
       ) {
         for (const reason of cached.reasons) reasons.push(reason);
         if (cached.reserve > 0) {
@@ -2386,6 +2528,8 @@ export function computeFootnoteReserves(
       input,
       noteMarks,
       separatorCache,
+      !carryWasEmpty,
+      usedReservePt,
       reasons
     );
     const needed = Math.min(Math.max(area?.box.height ?? 0, evictionNeed, holdOutNeed), maxArea);
@@ -2396,6 +2540,7 @@ export function computeFootnoteReserves(
         reserve: needed > 0 ? needed : 0,
         reasons: reasons.slice(reasonsBefore),
         nextFragments: nextPage ? nextPage.fragments : null,
+        usedReserve: usedReservePt,
       });
     }
     // Omit zero entries so a page the citation left does not linger as `0` in the map
@@ -2893,13 +3038,19 @@ export function layoutSemanticDocumentWithNotes<
     if (notesMemo) notesMemo.reflowSpent = spent;
     let adoptedThisPass = 0;
 
-    for (let attempt = 0; attempt < MAX_NOTE_REFLOW_ATTEMPTS; attempt += 1) {
+    // A seeded pass starts at the previous fixed point and answers a keystroke; its
+    // synchronous relayout depth stays at the interactive cap, and an unconverged search
+    // continues on the next pass (same `spent` budget). Only a cold, unseeded pass pays
+    // the full search depth.
+    const attemptCap = seeded ? MAX_SEEDED_NOTE_REFLOW_ATTEMPTS : MAX_NOTE_REFLOW_ATTEMPTS;
+    for (let attempt = 0; attempt < attemptCap; attempt += 1) {
       const computed = computeFootnoteReserves(
         bodyLayout,
         allHits,
         notesInput,
         noteMarks,
-        notesMemo
+        notesMemo,
+        usedReserves
       );
       fallbackReasons = [...computed.reasons];
       // Published pages must reflect the reserves used to produce them — not a later map.
@@ -2949,7 +3100,7 @@ export function layoutSemanticDocumentWithNotes<
         noteMarks,
         pageBottomReserves: usedReserves,
       });
-      if (attempt === MAX_NOTE_REFLOW_ATTEMPTS - 1) {
+      if (attempt === attemptCap - 1) {
         fallbackReasons.push('note-reflow-exhausted');
       }
     }

--- a/packages/core/src/layout/note-pagination.ts
+++ b/packages/core/src/layout/note-pagination.ts
@@ -8,7 +8,7 @@
 // sectEnd / docEnd. Hostile counts and oscillation fail closed with named reasons.
 
 import type { OoxmlElement, OoxmlNode, OoxmlPart } from '@docx-editor.dev/core/store';
-import { fragmentOwnsPosition, fragmentParagraphs, lineSegments } from './line-segments.ts';
+import { fragmentOwnsPosition, fragmentParagraphs } from './line-segments.ts';
 import { collectNoteReferences } from '../store/package/note-references.ts';
 import type { DocumentSection } from './section-properties.ts';
 import { storyBlocks } from './story-roots.ts';
@@ -40,7 +40,6 @@ import {
   type NoteLayoutFallbackReason,
   type NoteSeparatorLayout,
   type NoteStoryDrawings,
-  type NoteStoryLayout,
   type LayoutNoteStoryOptions,
 } from './note-layout.ts';
 import { noteMarkKey, type NoteMarkContext } from './note-projection.ts';
@@ -50,7 +49,6 @@ import {
   footnoteReservesFingerprint,
   growFootnoteReserves,
   notesReserveContextKey,
-  HELD_RESERVE_TOLERANCE_PT,
   MIN_FOOTNOTE_BODY_BAND_PT,
   noteColumnBudgetPt,
   RESERVE_BOUNDARY_BACKOFF_PT,
@@ -58,13 +56,18 @@ import {
 export { notesReserveContextKey };
 import {
   bodyFitBottomPt,
+  bodyOnlyPage,
   firstBodyContentTopPt,
   fragmentFlowBottom,
   noteReferenceLineBandPt,
-  segmentOwnsAtomOffset,
   type NoteReferenceLineBand,
 } from './note-fragment-geometry.ts';
 import { splitNoteFragments } from './note-splitting.ts';
+import {
+  holdOutReserveNeed,
+  layoutNoteCached,
+  type NoteStoryLayoutCache,
+} from './note-reserve-holdout.ts';
 import { reindexAndRestackPages } from './page-restacking.ts';
 import type {
   BlockFragmentRecord,
@@ -114,16 +117,18 @@ const MAX_SEEDED_NOTE_REFLOW_ATTEMPTS = 8;
 /**
  * Total reserve-map adoptions allowed per BODY-PART identity, across passes.
  *
- * Covers one full cold search ({@link MAX_NOTE_REFLOW_ATTEMPTS}); session-seeded passes
- * continue the same iteration, so a reference-dense document converges across a few passes
- * instead of restarting. Some documents have no fixed point at all — the map's own body
+ * Covers one full cold search ({@link MAX_NOTE_REFLOW_ATTEMPTS}) PLUS seeded headroom —
+ * a cold pass that spends its whole cap must leave session-seeded passes room to continue
+ * the same iteration, or a document needing more rounds than the cold cap freezes
+ * unconverged forever. Some documents have no fixed point at all — the map's own body
  * shifts move references across page boundaries and the iteration orbits a short cycle —
  * so the search must also END: once this budget is spent, the memo records the answer and
  * every later pass over the same part reproduces it, instead of flapping an unchanged
  * document between the orbit's page counts forever. An edit replaces the part and restarts
  * the search.
  */
-const MAX_NOTE_REFLOW_ADOPTIONS_PER_STATE = MAX_NOTE_REFLOW_ATTEMPTS;
+const MAX_NOTE_REFLOW_ADOPTIONS_PER_STATE =
+  MAX_NOTE_REFLOW_ATTEMPTS + 2 * MAX_SEEDED_NOTE_REFLOW_ATTEMPTS;
 
 /** Cap on total note story fragments attached across the document. */
 export const MAX_NOTE_AREA_FRAGMENTS = 4_096;
@@ -161,11 +166,7 @@ export type NotePaginationFallbackReason =
    * abort rather than minting blank separator-only sheets up to the page budget.
    */
   | 'note-overflow-stalled'
-  /**
-   * A single note line exceeds the full content column; content is not placed overflowing.
-   * Spelled as the literal (not {@link NoteSplitFallbackReason}, which equals it) so the
-   * public union does not name an unexported type.
-   */
+  /** A single note line exceeds the full content column; content is not placed overflowing. */
   | 'note-line-exceeds-page';
 
 /**
@@ -632,16 +633,6 @@ function layoutOpts(input: NotesLayoutInput, noteMarks?: NoteMarkContext): Layou
   };
 }
 
-/**
- * The mark a split's carried tail keeps: null once a head has landed (the number was
- * painted there), the head's own mark when nothing landed — so a note whose first painted
- * record is a continuation on a later page (a degraded, budget-exhausted state) still
- * shows its number instead of an unmarked body the reader cannot attribute.
- */
-function tailCarryMark(headPlaced: boolean, headMark: string | null): string | null {
-  return headPlaced ? null : headMark;
-}
-
 function effectiveNoteMarkStyle(
   noteKind: NoteKind,
   styleCascade: StyleCascadeTable | undefined
@@ -749,29 +740,6 @@ function buildMarkContext(
     marks,
     ...(reservedMarkText ? { reservedMarkText } : {}),
   };
-}
-
-/** Remove note-pass output before recomputing it from canonical references. */
-function bodyOnlyPage(page: PageRecord): PageRecord {
-  // IDENTITY WHEN THERE IS NOTHING TO STRIP. The rest-destructure allocates a new object
-  // every time, and a page record is what the painter reuses BY IDENTITY — so a document
-  // with a notes part and no notes at all handed the painter a whole new set of pages on
-  // every pass, and every visible page's DOM was rebuilt on every keystroke. The lane runs
-  // for any package that HAS a footnotes or endnotes part, which is nearly every Word file.
-  // Its three siblings — `withPageFieldSources`, `attachContentControlBoundaries` and
-  // `reprojectBodyNoteMarks` — all return the original page when nothing moved.
-  if (
-    page.footnotes === undefined &&
-    page.endnotes === undefined &&
-    page.noteStream === undefined
-  ) {
-    return page;
-  }
-  const { footnotes, endnotes, noteStream, ...body } = page;
-  void footnotes;
-  void endnotes;
-  void noteStream;
-  return body;
 }
 
 /**
@@ -990,28 +958,30 @@ function buildFootnoteArea(
   const separatorKind =
     continuationCarry.size > 0 ? ('continuationSeparator' as const) : ('separator' as const);
   const maxSepHeight = Math.max(0, page.contentBox.height);
-  const separator = options?.separatorCache
-    ? options.separatorCache.get(
+  const fetchSeparator = (kind: 'separator' | 'continuationSeparator'): NoteSeparatorLayout => {
+    if (options?.separatorCache) {
+      return options.separatorCache.get(
         input.footnotesPart,
-        separatorKind,
+        kind,
         contentWidth,
         'footnote',
         maxSepHeight,
         opts,
         reasons
-      )
-    : (() => {
-        const laid = layoutNoteSeparator(
-          input.footnotesPart,
-          separatorKind,
-          contentWidth,
-          opts,
-          'footnote',
-          maxSepHeight
-        );
-        if (laid.fallbackReason) reasons.push(laid.fallbackReason);
-        return laid;
-      })();
+      );
+    }
+    const laid = layoutNoteSeparator(
+      input.footnotesPart,
+      kind,
+      contentWidth,
+      opts,
+      'footnote',
+      maxSepHeight
+    );
+    if (laid.fallbackReason) reasons.push(laid.fallbackReason);
+    return laid;
+  };
+  const separator = fetchSeparator(separatorKind);
 
   const slackBudget = Math.max(
     0,
@@ -1024,27 +994,18 @@ function buildFootnoteArea(
   // The keep-whole guard's budget is carry-INDEPENDENT: the hold-out on the previous page
   // re-derives the same test without knowing this page's carry state, and the two must be
   // exact complements or a note is neither evicted nor held out and the loop orbits.
-  const keepWholeBudget =
-    options?.reserveBandOf === undefined
-      ? columnBudget
-      : noteColumnBudgetPt(
-          page.contentBox.height,
-          separatorKind === 'separator'
-            ? separator.flowHeight
-            : (options.separatorCache?.get(
-                input.footnotesPart,
-                'separator',
-                contentWidth,
-                'footnote',
-                maxSepHeight,
-                opts,
-                reasons
-              ).flowHeight ?? separator.flowHeight)
-        );
+  // Lazy — only the eviction branch reads it, and on a carry page it costs a second
+  // separator fetch.
+  let keepWholeBudgetLazy: number | undefined;
+  const keepWholeBudget = (): number =>
+    (keepWholeBudgetLazy ??= noteColumnBudgetPt(
+      page.contentBox.height,
+      (separatorKind === 'separator' ? separator : fetchSeparator('separator')).flowHeight
+    ));
+  let firstContentTopLazy: number | undefined;
+  const firstContentTop = (): number => (firstContentTopLazy ??= firstBodyContentTopPt(page));
 
-  // Place continuations. `carry.mark` is non-null only for a note whose HEAD never landed
-  // anywhere (a degraded, budget-exhausted state): its first painted record then still
-  // carries the number, instead of an unmarked body the reader cannot attribute.
+  // Continuations from the previous page place first.
   for (const [scopeId, carry] of continuationCarry) {
     const parsed = scopeId.match(/^(footnote|endnote):(-?\d+)$/);
     if (!parsed || parsed[1] !== 'footnote') continue;
@@ -1055,7 +1016,7 @@ function buildFootnoteArea(
         noteKind: 'footnote',
         noteId,
         scopeId,
-        mark: carry.mark,
+        mark: null,
         continuation: true,
         box: {
           x: page.contentBox.x,
@@ -1085,7 +1046,7 @@ function buildFootnoteArea(
           noteKind: 'footnote',
           noteId,
           scopeId,
-          mark: carry.mark,
+          mark: null,
           continuation: true,
           box: {
             x: page.contentBox.x,
@@ -1101,7 +1062,7 @@ function buildFootnoteArea(
         nextCarry.set(scopeId, {
           fragments: split.tail,
           height: split.tailHeight,
-          mark: tailCarryMark(split.head.length > 0, carry.mark),
+          mark: null,
         });
       } else {
         nextCarry.delete(scopeId);
@@ -1115,6 +1076,17 @@ function buildFootnoteArea(
       reasons.push('note-count-limit');
       break;
     }
+    // Reserve mode tightens each note's budget to ITS reference's floor; the stack may not
+    // rise above any line that cites into it. Later references sit lower, so their budgets
+    // only shrink.
+    const band = options?.reserveBandOf?.(ref);
+    // A reference at or below an eviction point moves with the evicted line; its note lays
+    // out with it on the destination page. References ABOVE the point (document order is
+    // not y order beside a float exclusion zone, or across columns) stay put and keep
+    // their notes in this page's reserve.
+    if (evictionTopPt !== undefined && band && band.bottom >= evictionTopPt - 0.001) {
+      continue;
+    }
     const laid = layoutNoteCached(
       input.footnotesPart,
       ref.noteId,
@@ -1127,10 +1099,6 @@ function buildFootnoteArea(
       continue;
     }
     const mark = noteMarks.marks.get(noteMarkKey('footnote', ref.noteId)) ?? null;
-    // Reserve mode tightens each note's budget to ITS reference's floor; the stack may not
-    // rise above any line that cites into it. Later references sit lower, so their budgets
-    // only shrink.
-    const band = options?.reserveBandOf?.(ref);
     const refBudget = band
       ? Math.min(
           availableForNotes,
@@ -1144,32 +1112,32 @@ function buildFootnoteArea(
       : availableForNotes;
     const room = Math.max(0, refBudget - stackHeight);
     // Word keeps a footnote whole with its reference: a note that cannot fit whole below
-    // its reference line — but could fit in a page's note column — does not split. The
+    // its reference line — but could fit below it on the NEXT page — does not split. The
     // reference's LINE moves to the next page instead, so the reserve must reach the
     // line's TOP; the next reflow pass finds the reference there and lays the note whole
-    // beside it. Every later reference on this page sits on or after the evicted line and
-    // moves with it, so the loop ends here (the fragment budget is untouched: nothing was
-    // placed). Splitting remains for three shapes the move cannot help: a note taller
-    // than the column (nothing can hold it whole); a reference in the page's TOPMOST body
-    // line, where pushing only re-creates the same shape on the next page — a
-    // section-opening paragraph keeps its `w:spacing w:before` at page top, so a fixed
-    // band threshold would re-fire there every round and mint a chain of near-blank
-    // pages; and a line inside the minimum body band, whose eviction reserve the
-    // {@link MIN_FOOTNOTE_BODY_BAND_PT} cap would clip into not evicting at all.
-    // Multi-column sections are a known approximation: document order is not y order
-    // there, so an eviction for a column-1 reference also shortens column 2; the loop
-    // then degrades to the envelope/exhaustion exit (the pre-eviction behavior) rather
-    // than converging on a column-aware answer.
+    // beside it. Splitting remains for the shapes the move cannot help:
+    // - a note that does not fit the destination either — measured with the line's own
+    //   BLOCK opening the next page (`band.bottom - band.blockTop` of content above the
+    //   line), because a `w:keepLines` paragraph moves whole and a fixed column budget
+    //   would re-evict there every round, minting a chain of near-blank pages;
+    // - a reference in the page's TOPMOST body line, where pushing only re-creates the
+    //   same shape (a section-opening paragraph keeps its `w:spacing w:before` at page
+    //   top, so a fixed band threshold would re-fire there);
+    // - a line inside the minimum body band, whose eviction reserve the
+    //   {@link MIN_FOOTNOTE_BODY_BAND_PT} cap would clip into not evicting at all.
+    // Multi-column sections are a known approximation: an eviction for a column-1
+    // reference also shortens column 2; refs above the eviction point still reserve
+    // (the skip above), and the loop otherwise degrades to the envelope/exhaustion exit.
     if (
       band &&
       band.evictable &&
       laid.flowHeight > room + 0.001 &&
-      laid.flowHeight <= keepWholeBudget + 0.001 &&
-      band.top > firstBodyContentTopPt(page) + 0.001 &&
+      laid.flowHeight <= keepWholeBudget() - (band.bottom - band.blockTop) + 0.001 &&
+      band.top > firstContentTop() + 0.001 &&
       band.top >= MIN_FOOTNOTE_BODY_BAND_PT
     ) {
-      evictionTopPt = band.top;
-      break;
+      evictionTopPt = evictionTopPt === undefined ? band.top : Math.min(evictionTopPt, band.top);
+      continue;
     }
     fragmentBudget -= laid.fragments.length;
     if (fragmentBudget < 0) {
@@ -1213,7 +1181,7 @@ function buildFootnoteArea(
         nextCarry.set(laid.scopeId, {
           fragments: split.tail,
           height: split.tailHeight,
-          mark: tailCarryMark(split.head.length > 0, ref.customMarkFollows ? null : mark),
+          mark: null,
         });
       }
     }
@@ -1646,7 +1614,7 @@ function buildEndnoteArea(
         noteKind,
         noteId,
         scopeId,
-        mark: carry.mark,
+        mark: null,
         continuation: true,
         box: { x: page.contentBox.x, y: 0, width: contentWidth, height: carry.height },
         fragments: carry.fragments,
@@ -1671,7 +1639,7 @@ function buildEndnoteArea(
           noteKind,
           noteId,
           scopeId,
-          mark: carry.mark,
+          mark: null,
           continuation: true,
           box: { x: page.contentBox.x, y: 0, width: contentWidth, height: split.headHeight },
           fragments: split.head,
@@ -1682,7 +1650,7 @@ function buildEndnoteArea(
         nextCarry.set(scopeId, {
           fragments: split.tail,
           height: split.tailHeight,
-          mark: tailCarryMark(split.head.length > 0, carry.mark),
+          mark: null,
         });
       } else {
         nextCarry.delete(scopeId);
@@ -1748,7 +1716,7 @@ function buildEndnoteArea(
         nextCarry.set(laid.scopeId, {
           fragments: split.tail,
           height: split.tailHeight,
-          mark: tailCarryMark(split.head.length > 0, ref.customMarkFollows ? null : mark),
+          mark: null,
         });
       }
       remainingRefs.push(...refs.slice(i + 1));
@@ -2031,178 +1999,6 @@ function placeEndnotesFromPage(
   return nextPages;
 }
 
-/** How many of the next page's opening blocks the hold-out scans for a pulled reference. */
-const MAX_HOLD_OUT_SCAN_BLOCKS = 6;
-
-/**
- * Pass-local note story layouts, keyed by part, note id and width. Marks are fixed for a
- * reserve pass, so the hold-out on page N and the area build on page N+1 lay each note
- * once per round instead of twice.
- */
-type NoteStoryLayoutCache = Map<string, NoteStoryLayout | null>;
-
-function layoutNoteCached(
-  part: OoxmlPart | null,
-  noteId: number,
-  contentWidth: number,
-  opts: LayoutNoteStoryOptions,
-  cache: NoteStoryLayoutCache | undefined
-): NoteStoryLayout | null {
-  if (!cache) return layoutNoteById(part, noteId, contentWidth, opts);
-  const key = `${part?.name ?? 'none'}\0${noteId}\0${contentWidth}`;
-  const cached = cache.get(key);
-  if (cached !== undefined) return cached;
-  const laid = layoutNoteById(part, noteId, contentWidth, opts);
-  cache.set(key, laid);
-  return laid;
-}
-
-/**
- * Reserve (pt) `bodyPage` must keep so the opening lines of `nextPage` stay put.
- *
- * Zero when there is nothing to hold out: no next page, the next page opens with a table
- * or with more than {@link MAX_HOLD_OUT_SCAN_BLOCKS} reference-free paragraphs (nothing
- * this reserve can reason about), no scanned line carries a page-bottom footnote
- * reference, or the pulled band and its notes would fit back here — then the lines SHOULD
- * return; a deleted note must release its room. A note taller than the note column is
- * splittable and never blocks the pull-back on its own: its line may legitimately return
- * with a head, so it is excluded from the demand rather than aborting the hold (a
- * co-pulled column-sized note still holds). Otherwise the answer claims the page's
- * remaining slack, which reproduces the current body end exactly and gives the reflow
- * loop its fixed point.
- *
- * The scan spans BLOCKS, not just the first fragment: the eviction reserve names the
- * reference's line, but widow/orphan control and `w:keepNext` move companions with it, so
- * the reference may open the next page behind a heading or a sibling line — and the
- * companions can only return together.
- *
- * Known approximation: the pull-back fit charges the pulled band's page-top geometry plus
- * one reference-line of headroom (the split tail wraps from the split offset, so the
- * reference sits up to one line higher here than the joined re-wrap a pull-back
- * produces). A pulled paragraph whose applied `w:spacing w:before` exceeds that headroom
- * can still release early; the loop then degrades to the pre-eviction envelope/exhaustion
- * exit rather than diverging.
- */
-function holdOutReserveNeed(args: {
-  readonly bodyPage: PageRecord;
-  readonly nextPage: PageRecord | undefined;
-  readonly refIndex: PageRefIndex;
-  readonly existingAreaHeight: number;
-  readonly input: NotesLayoutInput;
-  readonly noteMarks: NoteMarkContext;
-  readonly separatorCache: NoteSeparatorCache;
-  readonly noteLayoutCache: NoteStoryLayoutCache | undefined;
-  /** The reserve `bodyPage` was laid under (for the observed-refusal test), if known. */
-  readonly usedReservePt: number | undefined;
-  readonly reasons: NotePaginationFallbackReason[];
-}): number {
-  const { bodyPage, nextPage, refIndex, existingAreaHeight, input, noteMarks, reasons } = args;
-  if (!nextPage) return 0;
-  const nextBody = bodyOnlyPage(nextPage);
-  const pulled: PageRefHit[] = [];
-  let refLine: LineRecord | undefined;
-  let refBlockBottom = 0;
-  let scanned = 0;
-  for (const block of nextBody.fragments) {
-    if (block.kind !== 'paragraph') return 0;
-    if (scanned >= MAX_HOLD_OUT_SCAN_BLOCKS) return 0;
-    scanned += 1;
-    for (const line of block.lines) {
-      for (const segment of lineSegments(line)) {
-        const candidates = refIndex.get(segment.paragraphId);
-        if (!candidates) continue;
-        for (const ref of candidates) {
-          if (ref.noteKind !== 'footnote') continue;
-          const pos = footnotePropsFor(input, ref.sectionIndex).pos;
-          if (pos === 'sectEnd' || pos === 'docEnd') continue;
-          if (segmentOwnsAtomOffset(segment, ref.paragraphId, ref.atomOffset)) {
-            pulled.push(ref);
-          }
-        }
-      }
-      if (pulled.length > 0) {
-        refLine = line;
-        // Minus the block's trailing after-spacing, like every fit measure: the whole-
-        // block release test otherwise fails by exactly that spacing and retains a hold
-        // a real pull-back would satisfy.
-        refBlockBottom = block.box.y + block.box.height - block.spacing.after;
-        break;
-      }
-    }
-    if (refLine) break;
-  }
-  if (!refLine || pulled.length === 0) return 0;
-  const firstContentTop = firstBodyContentTopPt(nextBody);
-  const refLineHeight = refLine.box.height;
-  // Two pull-back quanta: the OPTIMISTIC one ends at the reference's line (a splittable
-  // paragraph returns just its opening lines), the WHOLE-BLOCK one at the reference
-  // paragraph's fragment bottom (a `w:keepLines`/keep-with-next group returns only as one
-  // piece). Which quantum the body pass actually uses is not readable off the fragments.
-  const lineBandHeight = Math.max(0, refLine.box.y + refLineHeight - firstContentTop);
-  const blockBandHeight = Math.max(0, refBlockBottom - firstContentTop);
-
-  const contentWidth = bodyPage.contentBox.width;
-  const opts = layoutOpts(input, noteMarks);
-  // Plain 'separator' regardless of this page's carry state: the budget must be the exact
-  // complement of the eviction guard's `keepWholeBudget`, which is carry-independent.
-  const separator = args.separatorCache.get(
-    input.footnotesPart,
-    'separator',
-    contentWidth,
-    'footnote',
-    Math.max(0, bodyPage.contentBox.height),
-    opts,
-    reasons
-  );
-  const columnBudget = noteColumnBudgetPt(bodyPage.contentBox.height, separator.flowHeight);
-  let pulledNotesHeight = 0;
-  for (const ref of pulled) {
-    const laid = layoutNoteCached(
-      input.footnotesPart,
-      ref.noteId,
-      contentWidth,
-      opts,
-      args.noteLayoutCache
-    );
-    if (!laid) continue;
-    if (laid.flowHeight > columnBudget + 0.001) continue;
-    pulledNotesHeight += laid.flowHeight;
-  }
-  if (pulledNotesHeight <= 0) return 0;
-  const bodyBottom = bodyFitBottomPt(bodyPage);
-  const contentHeight = bodyPage.contentBox.height;
-  const areaWithPulled =
-    (existingAreaHeight > 0 ? existingAreaHeight : separator.flowHeight) + pulledNotesHeight;
-  const hold = Math.max(0, contentHeight - bodyBottom - RESERVE_BOUNDARY_BACKOFF_PT);
-  // One reference-line of headroom in both fit tests: the split tail wraps from the split
-  // offset, so the reference sits up to one line higher here than the joined re-wrap a
-  // pull-back produces. (A pulled paragraph whose applied `w:spacing w:before` exceeds
-  // that headroom can still release early; the loop then degrades to the pre-eviction
-  // envelope/exhaustion exit rather than diverging.)
-  const fitsLineQuantum =
-    bodyBottom + lineBandHeight + refLineHeight + areaWithPulled <= contentHeight + 0.001;
-  if (!fitsLineQuantum) return hold;
-  const fitsWholeBlock =
-    bodyBottom + blockBandHeight + refLineHeight + areaWithPulled <= contentHeight + 0.001;
-  // The optimistic quantum fits but the whole block does not. Whether releasing is safe
-  // depends on whether the block can SPLIT, which the body pass has already answered:
-  // when the used reserve left room for the line quantum and the body still declined it,
-  // the block only moves whole (`w:keepLines` and friends) — release would re-open the
-  // evict/pull-back orbit, so hold. A page already held at this value KEEPS the hold (a
-  // held page offers no gap, so the refusal cannot be re-observed there); upstream
-  // shrinkage releases through the whole-block test above, and a vanished note releases
-  // through the pulled scan. Only a page that was never offered the room — and is not
-  // currently held — releases to let the next round observe the answer.
-  if (fitsWholeBlock) return 0;
-  const { usedReservePt } = args;
-  if (usedReservePt === undefined) return hold;
-  const offeredGap = Math.max(0, contentHeight - usedReservePt - bodyBottom);
-  const lineQuantum = lineBandHeight + refLineHeight;
-  if (lineQuantum <= offeredGap + 0.001) return hold;
-  if (Math.abs(usedReservePt - hold) <= HELD_RESERVE_TOLERANCE_PT) return hold;
-  return 0;
-}
-
 /**
  * Compute per-page bottom reserves (points) needed for footnotes given a provisional layout.
  * Used by the bounded reflow loop before final attach.
@@ -2222,9 +2018,15 @@ export function computeFootnoteReserves(
   /**
    * The reserve map `layout` was laid under. Feeds the hold-out's observed-refusal test
    * (a block the body pass declined to split under a known budget only moves whole);
-   * absent, the hold-out errs toward holding.
+   * absent, the hold-out releases the ambiguous cases — a caller outside the reflow loop
+   * must not manufacture holds the loop never observed.
    */
-  previousReserves?: ReadonlyMap<number, number>
+  previousReserves?: ReadonlyMap<number, number>,
+  /**
+   * Pass-carried note story layouts. The reflow loop supplies one cache for all of its
+   * rounds — marks and parts are fixed across them; see {@link NoteStoryLayoutCache}.
+   */
+  passNoteLayoutCache?: NoteStoryLayoutCache
 ): {
   readonly reserves: ReadonlyMap<number, number>;
   readonly stable: boolean;
@@ -2236,15 +2038,25 @@ export function computeFootnoteReserves(
   let carry: NoteCarryMap = new Map();
   const refIndex = buildPageRefIndex(allRefs);
   const separatorCache = createNoteSeparatorCache();
-  const noteLayoutCache: NoteStoryLayoutCache = new Map();
-  // A document with no page-bottom footnote reference at all (footnote-free, or every
-  // section collects at sectEnd/docEnd) has nothing for the hold-out to pull, so the
-  // per-page scan is skipped wholesale.
-  const anyPageBottomFootnoteRefs = allRefs.some((ref) => {
+  const noteLayoutCache: NoteStoryLayoutCache = passNoteLayoutCache ?? new Map();
+  const holdOutOpts = layoutOpts(input, noteMarks);
+  const isPageBottomFootnoteRef = (ref: PageRefHit): boolean => {
     if (ref.noteKind !== 'footnote') return false;
     const pos = footnotePropsFor(input, ref.sectionIndex).pos;
     return pos !== 'sectEnd' && pos !== 'docEnd';
-  });
+  };
+  // A document with no page-bottom footnote reference at all (footnote-free, or every
+  // section collects at sectEnd/docEnd) has nothing for the hold-out to pull, so the
+  // per-page scan is skipped wholesale.
+  const anyPageBottomFootnoteRefs = allRefs.some(isPageBottomFootnoteRef);
+  const pageBottomRefsOf = (page: PageRecord): readonly PageRefHit[] =>
+    filterRefsOnPage(page, allRefs, refIndex).filter(isPageBottomFootnoteRef);
+  /** Clamp-and-merge, stated once: zero entries are OMITTED (convergence compares key sets). */
+  const recordReserve = (pageIndex: number, needed: number, cap: number): void => {
+    const clamped = Math.min(needed, cap);
+    if (clamped <= 0) return;
+    reserves.set(pageIndex, Math.max(reserves.get(pageIndex) ?? 0, clamped));
+  };
 
   for (let pageAt = 0; pageAt < layout.pages.length; pageAt += 1) {
     const page = layout.pages[pageAt]!;
@@ -2257,6 +2069,8 @@ export function computeFootnoteReserves(
     const props = footnotePropsFor(input, sectionIndex);
     const nextPage = layout.pages[pageAt + 1];
     const usedReservePt = previousReserves ? (previousReserves.get(page.index) ?? 0) : undefined;
+    // The reserve ceiling: the note column beside the minimum body band.
+    const maxArea = noteColumnBudgetPt(bodyPage.contentBox.height, 0);
     // Hold-out: the fixed point of an eviction. Once the body pass has pushed a reference
     // line forward, THIS page's recomputed reserve no longer sees that reference — the
     // note-stack height alone under-claims, the next round pulls the line back, and the
@@ -2265,21 +2079,28 @@ export function computeFootnoteReserves(
     // (the note stays whole with its reference), so the reserve claims the remaining
     // slack and reproduces itself round over round. Deliberately NOT memoized: it reads
     // the NEIGHBOUR page, and a memo entry that must enumerate foreign inputs by hand is
-    // how stale reserves happen; the scan is a few opening blocks plus cached note
-    // layouts.
+    // how stale reserves happen; the scan starts from a memoized page-refs answer and
+    // lays notes through the pass cache.
     const holdOutFor = (existingAreaHeight: number): number =>
       anyPageBottomFootnoteRefs
         ? holdOutReserveNeed({
             bodyPage,
             nextPage,
-            refIndex,
             existingAreaHeight,
-            input,
-            noteMarks,
-            separatorCache,
-            noteLayoutCache,
             usedReservePt,
-            reasons,
+            pageBottomRefsOf,
+            footnotesPart: input.footnotesPart,
+            opts: holdOutOpts,
+            plainSeparatorHeight: separatorCache.get(
+              input.footnotesPart,
+              'separator',
+              bodyPage.contentBox.width,
+              'footnote',
+              Math.max(0, bodyPage.contentBox.height),
+              holdOutOpts,
+              reasons
+            ).flowHeight,
+            noteLayoutCache,
           })
         : 0;
     if (props.pos === 'sectEnd' || props.pos === 'docEnd') {
@@ -2288,22 +2109,9 @@ export function computeFootnoteReserves(
       // reference was evicted) answers section 0 here, and skipping it would let the
       // next page's opening reference pull back and reopen the eviction orbit. The
       // hold-out filters pulled refs by their OWN section's position.
-      const holdOut = holdOutFor(0);
-      if (holdOut > 0) {
-        const cap = Math.max(0, bodyPage.contentBox.height - MIN_FOOTNOTE_BODY_BAND_PT);
-        const prev = reserves.get(page.index) ?? 0;
-        reserves.set(page.index, Math.max(prev, Math.min(holdOut, cap)));
-      }
+      recordReserve(page.index, holdOutFor(0), maxArea);
       continue;
     }
-    // Column budget for the note stack (separator is added inside buildFootnoteArea).
-    // Each reference keeps the body band down to ITS OWN line (Word starts a footnote on
-    // the page that references it): a reserve that ignores the reference evicts its own
-    // line to the next page, and the reflow loop then oscillates between the two
-    // placements — reference pages with zero note height, later pages holding a
-    // reservation nothing fills. Per reference and never the page's lowest one, whose
-    // floor would stably strangle every note above it on a multi-reference page.
-    const maxArea = Math.max(0, bodyPage.contentBox.height - MIN_FOOTNOTE_BODY_BAND_PT);
 
     // An unchanged page whose refs and marks are the previous pass's exact objects sized
     // to the same PAGE-LOCAL reserve; carry chains are the exception and rebuild. The
@@ -2312,17 +2120,18 @@ export function computeFootnoteReserves(
       const cached = memo.pageReserve.get(page);
       if (cached && cached.allHits === allRefs && cached.marks === noteMarks) {
         for (const reason of cached.reasons) reasons.push(reason);
-        const cachedNeeded = Math.min(
-          Math.max(cached.reserve, holdOutFor(cached.areaHeight)),
-          maxArea
-        );
-        if (cachedNeeded > 0) {
-          reserves.set(page.index, Math.max(reserves.get(page.index) ?? 0, cachedNeeded));
-        }
+        recordReserve(page.index, Math.max(cached.reserve, holdOutFor(cached.areaHeight)), maxArea);
         continue;
       }
     }
 
+    // Column budget for the note stack (separator is added inside buildFootnoteArea).
+    // Each reference keeps the body band down to ITS OWN line (Word starts a footnote on
+    // the page that references it): a reserve that ignores the reference evicts its own
+    // line to the next page, and the reflow loop then oscillates between the two
+    // placements — reference pages with zero note height, later pages holding a
+    // reservation nothing fills. Per reference and never the page's lowest one, whose
+    // floor would stably strangle every note above it on a multi-reference page.
     const carryWasEmpty = carry.size === 0;
     const reasonsBefore = reasons.length;
     const { area, nextCarry, evictionTopPt } = buildFootnoteArea(
@@ -2363,13 +2172,7 @@ export function computeFootnoteReserves(
         reasons: reasons.slice(reasonsBefore),
       });
     }
-    const needed = Math.min(Math.max(localNeeded, holdOutFor(areaHeight)), maxArea);
-    // Omit zero entries so a page the citation left does not linger as `0` in the map
-    // (convergence compares maps by key set, and body layout treats missing as zero).
-    if (needed > 0) {
-      const prev = reserves.get(page.index) ?? 0;
-      reserves.set(page.index, Math.max(prev, needed));
-    }
+    recordReserve(page.index, Math.max(localNeeded, holdOutFor(areaHeight)), maxArea);
   }
 
   // Stable only when the body has already left enough room for the measured reserve.
@@ -2867,6 +2670,15 @@ export function layoutSemanticDocumentWithNotes<
     // footnotes deserves the full search, not the keystroke cap).
     const attemptCap =
       seeded && usedReserves.size > 0 ? MAX_SEEDED_NOTE_REFLOW_ATTEMPTS : MAX_NOTE_REFLOW_ATTEMPTS;
+    // One note-story layout per note for the WHOLE search: marks and parts are fixed
+    // across rounds, so every round's reserve compute shares this cache.
+    const passNoteLayoutCache: NoteStoryLayoutCache = new Map();
+    // Consecutive page-count growth is the runaway signature (an eviction chain minting a
+    // near-blank sheet per round on a shape none of the guards recognized); the fingerprint
+    // exits never fire on it because every round's map is new. Cut it off early rather
+    // than paying the full attempt cap for a degraded answer.
+    let previousPageCount = bodyLayout.pages.length;
+    let consecutiveGrowth = 0;
     for (let attempt = 0; attempt < attemptCap; attempt += 1) {
       const computed = computeFootnoteReserves(
         bodyLayout,
@@ -2874,7 +2686,8 @@ export function layoutSemanticDocumentWithNotes<
         notesInput,
         noteMarks,
         notesMemo,
-        usedReserves
+        usedReserves,
+        passNoteLayoutCache
       );
       fallbackReasons = [...computed.reasons];
       // Published pages must reflect the reserves used to produce them — not a later map.
@@ -2882,6 +2695,12 @@ export function layoutSemanticDocumentWithNotes<
         break;
       }
       if (spent.adopted >= MAX_NOTE_REFLOW_ADOPTIONS_PER_STATE) {
+        fallbackReasons.push('note-reflow-exhausted');
+        break;
+      }
+      // Eight: legitimate convergence oscillates (its growth streaks measure ~3 rounds on
+      // the reference-dense fixture); only a runaway grows monotonically.
+      if (consecutiveGrowth >= 8) {
         fallbackReasons.push('note-reflow-exhausted');
         break;
       }
@@ -2924,6 +2743,8 @@ export function layoutSemanticDocumentWithNotes<
         noteMarks,
         pageBottomReserves: usedReserves,
       });
+      consecutiveGrowth = bodyLayout.pages.length > previousPageCount ? consecutiveGrowth + 1 : 0;
+      previousPageCount = bodyLayout.pages.length;
       if (attempt === attemptCap - 1) {
         fallbackReasons.push('note-reflow-exhausted');
       }

--- a/packages/core/src/layout/note-pagination.ts
+++ b/packages/core/src/layout/note-pagination.ts
@@ -37,7 +37,6 @@ import {
   layoutNoteSeparator,
   noteSeparatorAreaBox,
   MAX_NOTES_LAID_OUT,
-  MAX_NOTE_FRAGMENTS,
   type NoteLayoutFallbackReason,
   type NoteSeparatorLayout,
   type NoteStoryDrawings,
@@ -51,14 +50,21 @@ import {
   footnoteReservesFingerprint,
   growFootnoteReserves,
   notesReserveContextKey,
+  HELD_RESERVE_TOLERANCE_PT,
+  MIN_FOOTNOTE_BODY_BAND_PT,
+  noteColumnBudgetPt,
+  RESERVE_BOUNDARY_BACKOFF_PT,
 } from './note-reserves.ts';
 export { notesReserveContextKey };
 import {
+  bodyFitBottomPt,
+  firstBodyContentTopPt,
   fragmentFlowBottom,
   noteReferenceLineBandPt,
-  shiftFragments,
+  segmentOwnsAtomOffset,
   type NoteReferenceLineBand,
 } from './note-fragment-geometry.ts';
+import { splitNoteFragments } from './note-splitting.ts';
 import { reindexAndRestackPages } from './page-restacking.ts';
 import type {
   BlockFragmentRecord,
@@ -131,27 +137,6 @@ interface NoteOverflowBudget {
 }
 
 /**
- * Minimum body band (points) retained when computing footnote bottom reserves.
- *
- * Reserving the full content column would shrink body flow to 1pt and chase blank
- * sheets as every reference line fails to land. Oversized notes split/continue into
- * the shared overflow budget instead of evacuating the referencing page.
- */
-const MIN_FOOTNOTE_BODY_BAND_PT = 14;
-
-/**
- * Half-point back-off applied to reserves derived from an observed line boundary (eviction,
- * hold-out), so the body budget falls mid-line instead of edge-to-edge on a kept line's
- * exact bottom, where the body pass's strict fit compare flips on float drift.
- */
-const RESERVE_BOUNDARY_BACKOFF_PT = 0.5;
-
-/** One document-wide allowance shared by every footnote/endnote overflow stream. */
-interface NoteOverflowBudget {
-  remaining: number;
-}
-
-/**
  * Cap on synthetic eachPage mark candidates measured per section (plus actual marks).
  *
  * eachPage sequences restart every page, so a page almost never carries more than a
@@ -176,7 +161,11 @@ export type NotePaginationFallbackReason =
    * abort rather than minting blank separator-only sheets up to the page budget.
    */
   | 'note-overflow-stalled'
-  /** A single note line exceeds the full content column; content is not placed overflowing. */
+  /**
+   * A single note line exceeds the full content column; content is not placed overflowing.
+   * Spelled as the literal (not {@link NoteSplitFallbackReason}, which equals it) so the
+   * public union does not name an unexported type.
+   */
   | 'note-line-exceeds-page';
 
 /**
@@ -276,21 +265,21 @@ interface NotesPassMemo {
   /** Reserve-map adoptions spent on the current body-part identity (budget above). */
   reflowSpent: { readonly part: OoxmlPart; adopted: number } | null;
   readonly pageAttach: WeakMap<PageRecord, NotesPageAttachEntry>;
+  /**
+   * PAGE-LOCAL reserve results only (area stack + eviction). The neighbour-reading
+   * hold-out is deliberately not memoized here: an entry that must enumerate foreign
+   * inputs (the next page's fragments, the reserve the page was laid under) by hand is
+   * how stale reserves happen, and the hold-out is cheap to recompute.
+   */
   readonly pageReserve: WeakMap<
     PageRecord,
     {
       readonly allHits: readonly PageRefHit[];
       readonly marks: NoteMarkContext;
       readonly reserve: number;
+      /** The raw note-area height (hold-out's `existingAreaHeight` input). */
+      readonly areaHeight: number;
       readonly reasons: readonly NotePaginationFallbackReason[];
-      /**
-       * The NEXT page's fragments at compute time (null = no next page). The hold-out
-       * check reads the next page's first line, so a reserve computed against one
-       * neighbour must not answer for another.
-       */
-      readonly nextFragments: readonly BlockFragmentRecord[] | null;
-      /** The reserve the page was laid under at compute time (hold-out refusal input). */
-      readonly usedReserve: number | undefined;
     }
   >;
 }
@@ -644,200 +633,13 @@ function layoutOpts(input: NotesLayoutInput, noteMarks?: NoteMarkContext): Layou
 }
 
 /**
- * Split one paragraph fragment at a line boundary so the head fits under `availableBottom`
- * (story-relative). Empty head means no line fits — caller must defer the fragment.
+ * The mark a split's carried tail keeps: null once a head has landed (the number was
+ * painted there), the head's own mark when nothing landed — so a note whose first painted
+ * record is a continuation on a later page (a degraded, budget-exhausted state) still
+ * shows its number instead of an unmarked body the reader cannot attribute.
  */
-function splitParagraphFragmentByBottom(
-  fragment: ParagraphFragmentRecord,
-  availableBottom: number
-): {
-  readonly head: ParagraphFragmentRecord | null;
-  readonly tail: ParagraphFragmentRecord | null;
-} {
-  if (fragment.lines.length === 0) {
-    return fragment.box.y + fragment.box.height <= availableBottom + 0.001
-      ? { head: fragment, tail: null }
-      : { head: null, tail: fragment };
-  }
-
-  let cut = 0;
-  for (; cut < fragment.lines.length; cut += 1) {
-    const line = fragment.lines[cut]!;
-    if (line.box.y + line.box.height > availableBottom + 0.001) break;
-  }
-  if (cut === 0) return { head: null, tail: fragment };
-  if (cut >= fragment.lines.length) return { head: fragment, tail: null };
-
-  const headLines = fragment.lines.slice(0, cut);
-  const tailLines = fragment.lines.slice(cut);
-  const headLast = headLines[headLines.length - 1]!;
-  const headTop = fragment.box.y;
-  const headBottom = headLast.box.y + headLast.box.height;
-  const headBorders = fragment.borders?.filter((stroke) => stroke.side !== 'bottom');
-
-  const head: ParagraphFragmentRecord = {
-    ...fragment,
-    range: {
-      paragraphId: fragment.paragraphId,
-      start: headLines[0]!.range.start,
-      end: headLast.range.end,
-    },
-    spacing: { before: fragment.spacing.before, after: 0 },
-    lines: headLines,
-    box: { ...fragment.box, height: Math.max(0, headBottom - headTop) },
-    ...(headBorders && headBorders.length > 0 ? { borders: headBorders } : { borders: undefined }),
-    bottomBorder: undefined,
-    ...(fragment.shadingBox
-      ? {
-          shadingBox: {
-            ...fragment.shadingBox,
-            height: Math.max(0, headBottom - fragment.shadingBox.y),
-          },
-        }
-      : {}),
-  };
-
-  // Keep the tail in the original story coordinate space; {@link splitNoteFragments} rebases
-  // the whole raw tail with one shift so sibling blocks stay contiguous.
-  const tailLast = tailLines[tailLines.length - 1]!;
-  const tailTop = tailLines[0]!.box.y;
-  const tailBottom = tailLast.box.y + tailLast.box.height;
-  const tailBorders = fragment.borders?.filter((stroke) => stroke.side !== 'top');
-  const tail: ParagraphFragmentRecord = {
-    ...fragment,
-    id: `${fragment.paragraphId}#f${fragment.fragmentIndex + 1}`,
-    fragmentIndex: fragment.fragmentIndex + 1,
-    range: {
-      paragraphId: fragment.paragraphId,
-      start: tailLines[0]!.range.start,
-      end: tailLines[tailLines.length - 1]!.range.end,
-    },
-    spacing: { before: 0, after: fragment.spacing.after },
-    lines: tailLines,
-    box: {
-      x: fragment.box.x,
-      y: tailTop,
-      width: fragment.box.width,
-      height: Math.max(0, tailBottom - tailTop),
-    },
-    marker: undefined,
-    ...(tailBorders && tailBorders.length > 0 ? { borders: tailBorders } : { borders: undefined }),
-    ...(fragment.bottomBorder ? { bottomBorder: fragment.bottomBorder } : {}),
-    ...(fragment.shadingBox
-      ? {
-          shadingBox: {
-            x: fragment.shadingBox.x,
-            y: tailTop,
-            width: fragment.shadingBox.width,
-            height: Math.max(0, tailBottom - tailTop),
-          },
-        }
-      : {}),
-  };
-  return { head, tail };
-}
-
-/**
- * Split a note story so the head fits in `availableHeight` (story-relative).
- *
- * Allows an empty head (entire story moves to the next page) instead of accepting a first
- * fragment taller than the remaining room. Paragraph fragments split at line boundaries;
- * a single line that exceeds a full content column records {@link note-line-exceeds-page}
- * and is not placed with overflowing geometry.
- */
-function splitNoteFragments(
-  laid: NoteStoryLayout,
-  availableHeight: number,
-  options?: {
-    readonly fullContentHeight?: number;
-    readonly reasons?: NotePaginationFallbackReason[];
-  }
-): {
-  readonly head: readonly BlockFragmentRecord[];
-  readonly headHeight: number;
-  readonly tail: readonly BlockFragmentRecord[];
-  readonly tailHeight: number;
-} {
-  if (laid.flowHeight <= availableHeight + 0.001) {
-    return {
-      head: laid.fragments,
-      headHeight: laid.flowHeight,
-      tail: [],
-      tailHeight: 0,
-    };
-  }
-  if (availableHeight <= 0.001) {
-    return {
-      head: [],
-      headHeight: 0,
-      tail: laid.fragments,
-      tailHeight: laid.flowHeight,
-    };
-  }
-
-  const head: BlockFragmentRecord[] = [];
-  let headHeight = 0;
-  let cut = 0;
-  let partialTail: BlockFragmentRecord | null = null;
-
-  for (let i = 0; i < laid.fragments.length && i < MAX_NOTE_FRAGMENTS; i += 1) {
-    const fragment = laid.fragments[i]!;
-    const next = fragment.box.y + fragment.box.height;
-    if (next <= availableHeight + 0.001) {
-      head.push(fragment);
-      headHeight = next;
-      cut = i + 1;
-      continue;
-    }
-
-    if (fragment.kind === 'paragraph') {
-      const split = splitParagraphFragmentByBottom(fragment, availableHeight);
-      if (split.head) {
-        head.push(split.head);
-        headHeight = split.head.box.y + split.head.box.height;
-        partialTail = split.tail;
-        cut = i + 1;
-      } else {
-        // No line fits in the remaining room — leave head as-is (possibly empty) and
-        // defer this fragment. When the room is a full content column and one line still
-        // does not fit, record a named fallback rather than overflowing geometry.
-        const fullH = options?.fullContentHeight ?? availableHeight;
-        const firstLine = fragment.lines[0];
-        const lineH = firstLine?.box.height ?? fragment.box.height;
-        if (head.length === 0 && availableHeight >= fullH - 0.001 && lineH > fullH + 0.001) {
-          options?.reasons?.push('note-line-exceeds-page');
-          // Skip the unsplittable fragment; continue attempting later siblings on a fresh
-          // carry rather than clipping it into the column.
-          cut = i + 1;
-          partialTail = null;
-          const rest = laid.fragments.slice(cut);
-          const dy = rest[0]?.box.y ?? 0;
-          return {
-            head: [],
-            headHeight: 0,
-            tail: shiftFragments(rest, -dy),
-            tailHeight: Math.max(0, laid.flowHeight - dy),
-          };
-        }
-        cut = i;
-        partialTail = null;
-      }
-      break;
-    }
-
-    // Tables / non-paragraph: never accept an overflowing first fragment.
-    cut = i;
-    break;
-  }
-
-  const rawTail = [...(partialTail ? [partialTail] : []), ...laid.fragments.slice(cut)];
-  if (rawTail.length === 0) {
-    return { head, headHeight, tail: [], tailHeight: 0 };
-  }
-  const dy = rawTail[0]?.box.y ?? 0;
-  const tail = shiftFragments(rawTail, -dy);
-  const tailHeight = fragmentFlowBottom(tail);
-  return { head, headHeight, tail, tailHeight };
+function tailCarryMark(headPlaced: boolean, headMark: string | null): string | null {
+  return headPlaced ? null : headMark;
 }
 
 function effectiveNoteMarkStyle(
@@ -947,53 +749,6 @@ function buildMarkContext(
     marks,
     ...(reservedMarkText ? { reservedMarkText } : {}),
   };
-}
-
-/**
- * Body bottom (content-relative pt) the note passes BUDGET against.
- *
- * MINUS each paragraph's trailing after-spacing: the page-fit decision admits a paragraph
- * without charging its `w:spacing w:after` (it moves to the next page with the flow), but
- * the fragment BOX includes it — so a page whose last paragraph carries after-spacing
- * "uses" more height here than the fit rule budgeted, the reserve the reflow settles on
- * under-claims by that amount, and the attach pass splits a note the reserve fit whole.
- * Word lets the footnote area rise into that blank band the same way. PLACEMENT of an
- * area that hangs off the body keeps {@link bodyFlowBottom} unless the room is needed.
- */
-function bodyUsedHeight(page: PageRecord): number {
-  let bottom = 0;
-  for (const fragment of page.fragments) {
-    const trailingAfter = fragment.kind === 'paragraph' ? fragment.spacing.after : 0;
-    bottom = Math.max(bottom, fragment.box.y + fragment.box.height - trailingAfter);
-  }
-  return bottom;
-}
-
-/** Bottom of the painted body flow (full fragment boxes) — where a hanging area anchors. */
-function bodyFlowBottom(page: PageRecord): number {
-  let bottom = 0;
-  for (const fragment of page.fragments) {
-    bottom = Math.max(bottom, fragment.box.y + fragment.box.height);
-  }
-  return bottom;
-}
-
-/** Top (content-relative pt) of the page's first body content, or 0 on an empty page. */
-function firstBodyContentTop(page: PageRecord): number {
-  const first = page.fragments[0];
-  if (!first) return 0;
-  if (first.kind === 'paragraph') return first.lines[0]?.box.y ?? first.box.y;
-  return first.box.y;
-}
-
-/**
- * The tallest footnote stack a page can host beside the minimum body band. ONE formula:
- * the eviction guard ("could this note fit whole on a page?") and the hold-out's
- * oversized-note test must be exact complements, or a note is neither evicted nor held
- * out and the reflow loop orbits.
- */
-function noteColumnBudgetPt(contentHeight: number, separatorHeight: number): number {
-  return Math.max(0, contentHeight - MIN_FOOTNOTE_BODY_BAND_PT - separatorHeight);
 }
 
 /** Remove note-pass output before recomputing it from canonical references. */
@@ -1211,6 +966,8 @@ function buildFootnoteArea(
      */
     readonly reserveBandOf?: (ref: PageRefHit) => NoteReferenceLineBand;
     readonly separatorCache?: NoteSeparatorCache;
+    /** Pass-local note story layouts shared with the hold-out (reserve mode). */
+    readonly noteLayoutCache?: NoteStoryLayoutCache;
   }
 ): {
   area: NoteAreaRecord | undefined;
@@ -1258,12 +1015,32 @@ function buildFootnoteArea(
 
   const slackBudget = Math.max(
     0,
-    page.contentBox.height - bodyUsedHeight(page) - separator.flowHeight
+    page.contentBox.height - bodyFitBottomPt(page) - separator.flowHeight
   );
   const columnBudget = noteColumnBudgetPt(page.contentBox.height, separator.flowHeight);
   const availableForNotes = options?.reserveColumnBudget ? columnBudget : slackBudget;
   const fullNoteColumn = Math.max(0, page.contentBox.height - separator.flowHeight);
   const splitOpts = { fullContentHeight: fullNoteColumn, reasons };
+  // The keep-whole guard's budget is carry-INDEPENDENT: the hold-out on the previous page
+  // re-derives the same test without knowing this page's carry state, and the two must be
+  // exact complements or a note is neither evicted nor held out and the loop orbits.
+  const keepWholeBudget =
+    options?.reserveBandOf === undefined
+      ? columnBudget
+      : noteColumnBudgetPt(
+          page.contentBox.height,
+          separatorKind === 'separator'
+            ? separator.flowHeight
+            : (options.separatorCache?.get(
+                input.footnotesPart,
+                'separator',
+                contentWidth,
+                'footnote',
+                maxSepHeight,
+                opts,
+                reasons
+              ).flowHeight ?? separator.flowHeight)
+        );
 
   // Place continuations. `carry.mark` is non-null only for a note whose HEAD never landed
   // anywhere (a degraded, budget-exhausted state): its first painted record then still
@@ -1324,7 +1101,7 @@ function buildFootnoteArea(
         nextCarry.set(scopeId, {
           fragments: split.tail,
           height: split.tailHeight,
-          mark: split.head.length > 0 ? null : carry.mark,
+          mark: tailCarryMark(split.head.length > 0, carry.mark),
         });
       } else {
         nextCarry.delete(scopeId);
@@ -1338,7 +1115,13 @@ function buildFootnoteArea(
       reasons.push('note-count-limit');
       break;
     }
-    const laid = layoutNoteById(input.footnotesPart, ref.noteId, contentWidth, opts);
+    const laid = layoutNoteCached(
+      input.footnotesPart,
+      ref.noteId,
+      contentWidth,
+      opts,
+      options?.noteLayoutCache
+    );
     if (!laid) {
       reasons.push('missing-note-body');
       continue;
@@ -1360,29 +1143,37 @@ function buildFootnoteArea(
         )
       : availableForNotes;
     const room = Math.max(0, refBudget - stackHeight);
-    fragmentBudget -= laid.fragments.length;
-    if (fragmentBudget < 0) {
-      reasons.push('note-area-fragment-limit');
-      break;
-    }
     // Word keeps a footnote whole with its reference: a note that cannot fit whole below
     // its reference line — but could fit in a page's note column — does not split. The
     // reference's LINE moves to the next page instead, so the reserve must reach the
     // line's TOP; the next reflow pass finds the reference there and lays the note whole
     // beside it. Every later reference on this page sits on or after the evicted line and
-    // moves with it, so the loop ends here. Splitting remains for a note taller than the
-    // column (nothing can hold it whole) and for a reference in the page's FIRST body
-    // line: pushing that line only re-creates the same shape on the next page — a
+    // moves with it, so the loop ends here (the fragment budget is untouched: nothing was
+    // placed). Splitting remains for three shapes the move cannot help: a note taller
+    // than the column (nothing can hold it whole); a reference in the page's TOPMOST body
+    // line, where pushing only re-creates the same shape on the next page — a
     // section-opening paragraph keeps its `w:spacing w:before` at page top, so a fixed
-    // band threshold would re-fire there every round and mint a chain of near-blank pages.
+    // band threshold would re-fire there every round and mint a chain of near-blank
+    // pages; and a line inside the minimum body band, whose eviction reserve the
+    // {@link MIN_FOOTNOTE_BODY_BAND_PT} cap would clip into not evicting at all.
+    // Multi-column sections are a known approximation: document order is not y order
+    // there, so an eviction for a column-1 reference also shortens column 2; the loop
+    // then degrades to the envelope/exhaustion exit (the pre-eviction behavior) rather
+    // than converging on a column-aware answer.
     if (
       band &&
       band.evictable &&
       laid.flowHeight > room + 0.001 &&
-      laid.flowHeight <= columnBudget + 0.001 &&
-      band.top > firstBodyContentTop(page) + 0.001
+      laid.flowHeight <= keepWholeBudget + 0.001 &&
+      band.top > firstBodyContentTopPt(page) + 0.001 &&
+      band.top >= MIN_FOOTNOTE_BODY_BAND_PT
     ) {
-      evictionTopPt = evictionTopPt === undefined ? band.top : Math.min(evictionTopPt, band.top);
+      evictionTopPt = band.top;
+      break;
+    }
+    fragmentBudget -= laid.fragments.length;
+    if (fragmentBudget < 0) {
+      reasons.push('note-area-fragment-limit');
       break;
     }
     if (laid.flowHeight <= room + 0.001) {
@@ -1422,29 +1213,23 @@ function buildFootnoteArea(
         nextCarry.set(laid.scopeId, {
           fragments: split.tail,
           height: split.tailHeight,
-          // A head that never landed keeps the mark on its carry, so the note's first
-          // painted record (a continuation on a later page) still shows its number.
-          mark: split.head.length > 0 ? null : ref.customMarkFollows ? null : mark,
+          mark: tailCarryMark(split.head.length > 0, ref.customMarkFollows ? null : mark),
         });
       }
     }
   }
 
   if (notes.length === 0 && continuationCarry.size === 0) {
-    return {
-      area: undefined,
-      nextCarry,
-      ...(evictionTopPt !== undefined ? { evictionTopPt } : {}),
-    };
+    return { area: undefined, nextCarry, evictionTopPt };
   }
 
   const sepHeight = separator.flowHeight;
   const totalHeight = sepHeight + stackHeight;
-  // Budgets measure without trailing after-spacing ({@link bodyUsedHeight}); PLACEMENT
+  // Budgets measure without trailing after-spacing ({@link bodyFitBottomPt}); PLACEMENT
   // keeps the painted flow bottom and rises into the after-spacing band only when the
   // stack needs the room, which is also where Word draws the separator in that case.
-  const textBottom = bodyUsedHeight(page);
-  const flowBottom = bodyFlowBottom(page);
+  const textBottom = bodyFitBottomPt(page);
+  const flowBottom = fragmentFlowBottom(page.fragments);
   let areaTop: number;
   if (placement === 'beneathText') {
     areaTop =
@@ -1487,7 +1272,7 @@ function buildFootnoteArea(
     },
     notes: placedNotes,
   };
-  return { area, nextCarry, ...(evictionTopPt !== undefined ? { evictionTopPt } : {}) };
+  return { area, nextCarry, evictionTopPt };
 }
 
 /**
@@ -1835,7 +1620,7 @@ function buildEndnoteArea(
   // Endnotes anchor beneath the PAINTED flow (full boxes, trailing after-spacing kept):
   // they hang off the body in leftover room rather than joining the footnote reserve's
   // fit arithmetic, so the after-less measure has nothing to reconcile here.
-  const bodyBottom = bodyFlowBottom(page);
+  const bodyBottom = fragmentFlowBottom(page.fragments);
   // Existing endnotes already consume room below body (merged on re-entry).
   const existingEndnoteBottom = page.endnotes
     ? Math.max(bodyBottom, page.endnotes.box.y - page.contentBox.y + page.endnotes.box.height)
@@ -1897,7 +1682,7 @@ function buildEndnoteArea(
         nextCarry.set(scopeId, {
           fragments: split.tail,
           height: split.tailHeight,
-          mark: split.head.length > 0 ? null : carry.mark,
+          mark: tailCarryMark(split.head.length > 0, carry.mark),
         });
       } else {
         nextCarry.delete(scopeId);
@@ -1963,8 +1748,7 @@ function buildEndnoteArea(
         nextCarry.set(laid.scopeId, {
           fragments: split.tail,
           height: split.tailHeight,
-          // A head that never landed keeps the mark on its carry (see the footnote twin).
-          mark: split.head.length > 0 ? null : ref.customMarkFollows ? null : mark,
+          mark: tailCarryMark(split.head.length > 0, ref.customMarkFollows ? null : mark),
         });
       }
       remainingRefs.push(...refs.slice(i + 1));
@@ -2251,6 +2035,29 @@ function placeEndnotesFromPage(
 const MAX_HOLD_OUT_SCAN_BLOCKS = 6;
 
 /**
+ * Pass-local note story layouts, keyed by part, note id and width. Marks are fixed for a
+ * reserve pass, so the hold-out on page N and the area build on page N+1 lay each note
+ * once per round instead of twice.
+ */
+type NoteStoryLayoutCache = Map<string, NoteStoryLayout | null>;
+
+function layoutNoteCached(
+  part: OoxmlPart | null,
+  noteId: number,
+  contentWidth: number,
+  opts: LayoutNoteStoryOptions,
+  cache: NoteStoryLayoutCache | undefined
+): NoteStoryLayout | null {
+  if (!cache) return layoutNoteById(part, noteId, contentWidth, opts);
+  const key = `${part?.name ?? 'none'}\0${noteId}\0${contentWidth}`;
+  const cached = cache.get(key);
+  if (cached !== undefined) return cached;
+  const laid = layoutNoteById(part, noteId, contentWidth, opts);
+  cache.set(key, laid);
+  return laid;
+}
+
+/**
  * Reserve (pt) `bodyPage` must keep so the opening lines of `nextPage` stay put.
  *
  * Zero when there is nothing to hold out: no next page, the next page opens with a table
@@ -2276,24 +2083,23 @@ const MAX_HOLD_OUT_SCAN_BLOCKS = 6;
  * can still release early; the loop then degrades to the pre-eviction envelope/exhaustion
  * exit rather than diverging.
  */
-function holdOutReserveNeed(
-  bodyPage: PageRecord,
-  nextPage: PageRecord | undefined,
-  refIndex: PageRefIndex,
-  existingAreaHeight: number,
-  input: NotesLayoutInput,
-  noteMarks: NoteMarkContext,
-  separatorCache: NoteSeparatorCache,
-  /** Whether `bodyPage` receives continuation carry (selects its separator kind). */
-  hasCarry: boolean,
+function holdOutReserveNeed(args: {
+  readonly bodyPage: PageRecord;
+  readonly nextPage: PageRecord | undefined;
+  readonly refIndex: PageRefIndex;
+  readonly existingAreaHeight: number;
+  readonly input: NotesLayoutInput;
+  readonly noteMarks: NoteMarkContext;
+  readonly separatorCache: NoteSeparatorCache;
+  readonly noteLayoutCache: NoteStoryLayoutCache | undefined;
   /** The reserve `bodyPage` was laid under (for the observed-refusal test), if known. */
-  usedReservePt: number | undefined,
-  reasons: NotePaginationFallbackReason[]
-): number {
+  readonly usedReservePt: number | undefined;
+  readonly reasons: NotePaginationFallbackReason[];
+}): number {
+  const { bodyPage, nextPage, refIndex, existingAreaHeight, input, noteMarks, reasons } = args;
   if (!nextPage) return 0;
   const nextBody = bodyOnlyPage(nextPage);
   const pulled: PageRefHit[] = [];
-  let firstTop: number | undefined;
   let refLine: LineRecord | undefined;
   let refBlockBottom = 0;
   let scanned = 0;
@@ -2301,7 +2107,6 @@ function holdOutReserveNeed(
     if (block.kind !== 'paragraph') return 0;
     if (scanned >= MAX_HOLD_OUT_SCAN_BLOCKS) return 0;
     scanned += 1;
-    firstTop ??= block.lines[0]?.box.y ?? block.box.y;
     for (const line of block.lines) {
       for (const segment of lineSegments(line)) {
         const candidates = refIndex.get(segment.paragraphId);
@@ -2310,21 +2115,24 @@ function holdOutReserveNeed(
           if (ref.noteKind !== 'footnote') continue;
           const pos = footnotePropsFor(input, ref.sectionIndex).pos;
           if (pos === 'sectEnd' || pos === 'docEnd') continue;
-          if (ref.atomOffset >= segment.start && ref.atomOffset < segment.end) {
+          if (segmentOwnsAtomOffset(segment, ref.paragraphId, ref.atomOffset)) {
             pulled.push(ref);
           }
         }
       }
       if (pulled.length > 0) {
         refLine = line;
-        refBlockBottom = block.box.y + block.box.height;
+        // Minus the block's trailing after-spacing, like every fit measure: the whole-
+        // block release test otherwise fails by exactly that spacing and retains a hold
+        // a real pull-back would satisfy.
+        refBlockBottom = block.box.y + block.box.height - block.spacing.after;
         break;
       }
     }
     if (refLine) break;
   }
   if (!refLine || pulled.length === 0) return 0;
-  const firstContentTop = firstTop ?? 0;
+  const firstContentTop = firstBodyContentTopPt(nextBody);
   const refLineHeight = refLine.box.height;
   // Two pull-back quanta: the OPTIMISTIC one ends at the reference's line (a splittable
   // paragraph returns just its opening lines), the WHOLE-BLOCK one at the reference
@@ -2335,9 +2143,11 @@ function holdOutReserveNeed(
 
   const contentWidth = bodyPage.contentBox.width;
   const opts = layoutOpts(input, noteMarks);
-  const separator = separatorCache.get(
+  // Plain 'separator' regardless of this page's carry state: the budget must be the exact
+  // complement of the eviction guard's `keepWholeBudget`, which is carry-independent.
+  const separator = args.separatorCache.get(
     input.footnotesPart,
-    hasCarry ? 'continuationSeparator' : 'separator',
+    'separator',
     contentWidth,
     'footnote',
     Math.max(0, bodyPage.contentBox.height),
@@ -2347,13 +2157,19 @@ function holdOutReserveNeed(
   const columnBudget = noteColumnBudgetPt(bodyPage.contentBox.height, separator.flowHeight);
   let pulledNotesHeight = 0;
   for (const ref of pulled) {
-    const laid = layoutNoteById(input.footnotesPart, ref.noteId, contentWidth, opts);
+    const laid = layoutNoteCached(
+      input.footnotesPart,
+      ref.noteId,
+      contentWidth,
+      opts,
+      args.noteLayoutCache
+    );
     if (!laid) continue;
     if (laid.flowHeight > columnBudget + 0.001) continue;
     pulledNotesHeight += laid.flowHeight;
   }
   if (pulledNotesHeight <= 0) return 0;
-  const bodyBottom = bodyUsedHeight(bodyPage);
+  const bodyBottom = bodyFitBottomPt(bodyPage);
   const contentHeight = bodyPage.contentBox.height;
   const areaWithPulled =
     (existingAreaHeight > 0 ? existingAreaHeight : separator.flowHeight) + pulledNotesHeight;
@@ -2378,11 +2194,12 @@ function holdOutReserveNeed(
   // through the pulled scan. Only a page that was never offered the room — and is not
   // currently held — releases to let the next round observe the answer.
   if (fitsWholeBlock) return 0;
+  const { usedReservePt } = args;
   if (usedReservePt === undefined) return hold;
   const offeredGap = Math.max(0, contentHeight - usedReservePt - bodyBottom);
   const lineQuantum = lineBandHeight + refLineHeight;
   if (lineQuantum <= offeredGap + 0.001) return hold;
-  if (Math.abs(usedReservePt - hold) <= 1) return hold;
+  if (Math.abs(usedReservePt - hold) <= HELD_RESERVE_TOLERANCE_PT) return hold;
   return 0;
 }
 
@@ -2395,7 +2212,6 @@ function holdOutReserveNeed(
  * notes then compete for the same band. Oversized notes still split/continue within the budget;
  * {@link MIN_FOOTNOTE_BODY_BAND_PT} keeps a body band so reflow cannot chase blank sheets.
  */
-
 export function computeFootnoteReserves(
   layout: SemanticLayout,
   allRefs: readonly PageRefHit[],
@@ -2420,6 +2236,15 @@ export function computeFootnoteReserves(
   let carry: NoteCarryMap = new Map();
   const refIndex = buildPageRefIndex(allRefs);
   const separatorCache = createNoteSeparatorCache();
+  const noteLayoutCache: NoteStoryLayoutCache = new Map();
+  // A document with no page-bottom footnote reference at all (footnote-free, or every
+  // section collects at sectEnd/docEnd) has nothing for the hold-out to pull, so the
+  // per-page scan is skipped wholesale.
+  const anyPageBottomFootnoteRefs = allRefs.some((ref) => {
+    if (ref.noteKind !== 'footnote') return false;
+    const pos = footnotePropsFor(input, ref.sectionIndex).pos;
+    return pos !== 'sectEnd' && pos !== 'docEnd';
+  });
 
   for (let pageAt = 0; pageAt < layout.pages.length; pageAt += 1) {
     const page = layout.pages[pageAt]!;
@@ -2432,24 +2257,38 @@ export function computeFootnoteReserves(
     const props = footnotePropsFor(input, sectionIndex);
     const nextPage = layout.pages[pageAt + 1];
     const usedReservePt = previousReserves ? (previousReserves.get(page.index) ?? 0) : undefined;
+    // Hold-out: the fixed point of an eviction. Once the body pass has pushed a reference
+    // line forward, THIS page's recomputed reserve no longer sees that reference — the
+    // note-stack height alone under-claims, the next round pulls the line back, and the
+    // loop orbits the two placements forever. When the next page OPENS with a reference
+    // whose note cannot return here, this page's assignment is final under Word's rule
+    // (the note stays whole with its reference), so the reserve claims the remaining
+    // slack and reproduces itself round over round. Deliberately NOT memoized: it reads
+    // the NEIGHBOUR page, and a memo entry that must enumerate foreign inputs by hand is
+    // how stale reserves happen; the scan is a few opening blocks plus cached note
+    // layouts.
+    const holdOutFor = (existingAreaHeight: number): number =>
+      anyPageBottomFootnoteRefs
+        ? holdOutReserveNeed({
+            bodyPage,
+            nextPage,
+            refIndex,
+            existingAreaHeight,
+            input,
+            noteMarks,
+            separatorCache,
+            noteLayoutCache,
+            usedReservePt,
+            reasons,
+          })
+        : 0;
     if (props.pos === 'sectEnd' || props.pos === 'docEnd') {
       // No per-page reservation for THIS page's refs — collected later. The hold-out
       // still runs: a ref-free page in a mixed-position document (or one whose only
       // reference was evicted) answers section 0 here, and skipping it would let the
       // next page's opening reference pull back and reopen the eviction orbit. The
       // hold-out filters pulled refs by their OWN section's position.
-      const holdOut = holdOutReserveNeed(
-        bodyPage,
-        nextPage,
-        refIndex,
-        0,
-        input,
-        noteMarks,
-        separatorCache,
-        carry.size > 0,
-        usedReservePt,
-        reasons
-      );
+      const holdOut = holdOutFor(0);
       if (holdOut > 0) {
         const cap = Math.max(0, bodyPage.contentBox.height - MIN_FOOTNOTE_BODY_BAND_PT);
         const prev = reserves.get(page.index) ?? 0;
@@ -2457,25 +2296,6 @@ export function computeFootnoteReserves(
       }
       continue;
     }
-    // An unchanged page whose refs and marks are the previous pass's exact objects sized
-    // to the same reserve; carry chains are the exception and rebuild.
-    if (memo && carry.size === 0) {
-      const cached = memo.pageReserve.get(page);
-      if (
-        cached &&
-        cached.allHits === allRefs &&
-        cached.marks === noteMarks &&
-        cached.nextFragments === (nextPage ? nextPage.fragments : null) &&
-        cached.usedReserve === usedReservePt
-      ) {
-        for (const reason of cached.reasons) reasons.push(reason);
-        if (cached.reserve > 0) {
-          reserves.set(page.index, Math.max(reserves.get(page.index) ?? 0, cached.reserve));
-        }
-        continue;
-      }
-    }
-
     // Column budget for the note stack (separator is added inside buildFootnoteArea).
     // Each reference keeps the body band down to ITS OWN line (Word starts a footnote on
     // the page that references it): a reserve that ignores the reference evicts its own
@@ -2484,6 +2304,24 @@ export function computeFootnoteReserves(
     // reservation nothing fills. Per reference and never the page's lowest one, whose
     // floor would stably strangle every note above it on a multi-reference page.
     const maxArea = Math.max(0, bodyPage.contentBox.height - MIN_FOOTNOTE_BODY_BAND_PT);
+
+    // An unchanged page whose refs and marks are the previous pass's exact objects sized
+    // to the same PAGE-LOCAL reserve; carry chains are the exception and rebuild. The
+    // neighbour-reading hold-out is recomputed below either way.
+    if (memo && carry.size === 0) {
+      const cached = memo.pageReserve.get(page);
+      if (cached && cached.allHits === allRefs && cached.marks === noteMarks) {
+        for (const reason of cached.reasons) reasons.push(reason);
+        const cachedNeeded = Math.min(
+          Math.max(cached.reserve, holdOutFor(cached.areaHeight)),
+          maxArea
+        );
+        if (cachedNeeded > 0) {
+          reserves.set(page.index, Math.max(reserves.get(page.index) ?? 0, cachedNeeded));
+        }
+        continue;
+      }
+    }
 
     const carryWasEmpty = carry.size === 0;
     const reasonsBefore = reasons.length;
@@ -2499,50 +2337,33 @@ export function computeFootnoteReserves(
         reserveColumnBudget: true,
         reserveBandOf: (ref) => noteReferenceLineBandPt(bodyPage, ref),
         separatorCache,
+        noteLayoutCache,
       }
     );
     carry = nextCarry;
     // An eviction reaches past the note stack to the unplaceable reference's own line, so
     // the body pass pushes that line — and the reference — to the next page. The eviction
-    // top sits below the minimum body band by construction, so the cap holds either way.
-    // Backed off by half a point so the body budget lands MID-line: edge-to-edge the
-    // previous line's bottom equals the budget exactly, the body pass's strict compare
-    // flips on float drift, and an extra evicted line rewraps the tail into geometry the
-    // next round cannot reproduce.
+    // guard admits only lines at or below the minimum body band, so the maxArea cap never
+    // clips the eviction into not evicting. Backed off by half a point so the body budget
+    // lands MID-line: edge-to-edge the previous line's bottom equals the budget exactly,
+    // the body pass's strict compare flips on float drift, and an extra evicted line
+    // rewraps the tail into geometry the next round cannot reproduce.
     const evictionNeed =
       evictionTopPt !== undefined
         ? Math.max(0, bodyPage.contentBox.height - evictionTopPt - RESERVE_BOUNDARY_BACKOFF_PT)
         : 0;
-    // Hold-out: the fixed point of an eviction. Once the body pass has pushed a reference
-    // line forward, THIS page's recomputed reserve no longer sees that reference — the
-    // note-stack height alone under-claims, the next round pulls the line back, and the
-    // loop orbits the two placements forever. When the next page OPENS with a reference
-    // whose note cannot return here, this page's assignment is final under Word's rule
-    // (the note stays whole with its reference), so the reserve claims the remaining
-    // slack and reproduces itself round over round.
-    const holdOutNeed = holdOutReserveNeed(
-      bodyPage,
-      nextPage,
-      refIndex,
-      area?.box.height ?? 0,
-      input,
-      noteMarks,
-      separatorCache,
-      !carryWasEmpty,
-      usedReservePt,
-      reasons
-    );
-    const needed = Math.min(Math.max(area?.box.height ?? 0, evictionNeed, holdOutNeed), maxArea);
+    const areaHeight = area?.box.height ?? 0;
+    const localNeeded = Math.min(Math.max(areaHeight, evictionNeed), maxArea);
     if (memo && carryWasEmpty && carry.size === 0) {
       memo.pageReserve.set(page, {
         allHits: allRefs,
         marks: noteMarks,
-        reserve: needed > 0 ? needed : 0,
+        reserve: localNeeded,
+        areaHeight,
         reasons: reasons.slice(reasonsBefore),
-        nextFragments: nextPage ? nextPage.fragments : null,
-        usedReserve: usedReservePt,
       });
     }
+    const needed = Math.min(Math.max(localNeeded, holdOutFor(areaHeight)), maxArea);
     // Omit zero entries so a page the citation left does not linger as `0` in the map
     // (convergence compares maps by key set, and body layout treats missing as zero).
     if (needed > 0) {
@@ -2557,7 +2378,7 @@ export function computeFootnoteReserves(
   for (const page of layout.pages) {
     const needed = reserves.get(page.index) ?? 0;
     if (needed <= 0) continue;
-    const used = bodyUsedHeight(bodyOnlyPage(page));
+    const used = bodyFitBottomPt(bodyOnlyPage(page));
     if (used + needed > page.contentBox.height + 0.5) {
       stable = false;
       break;
@@ -3040,9 +2861,12 @@ export function layoutSemanticDocumentWithNotes<
 
     // A seeded pass starts at the previous fixed point and answers a keystroke; its
     // synchronous relayout depth stays at the interactive cap, and an unconverged search
-    // continues on the next pass (same `spent` budget). Only a cold, unseeded pass pays
-    // the full search depth.
-    const attemptCap = seeded ? MAX_SEEDED_NOTE_REFLOW_ATTEMPTS : MAX_NOTE_REFLOW_ATTEMPTS;
+    // continues on the next pass (same `spent` budget). Only a cold pass pays the full
+    // search depth — and a seed with NO entries is cold in everything but name (the
+    // previous document state simply had no reserves; a paste that introduces a hundred
+    // footnotes deserves the full search, not the keystroke cap).
+    const attemptCap =
+      seeded && usedReserves.size > 0 ? MAX_SEEDED_NOTE_REFLOW_ATTEMPTS : MAX_NOTE_REFLOW_ATTEMPTS;
     for (let attempt = 0; attempt < attemptCap; attempt += 1) {
       const computed = computeFootnoteReserves(
         bodyLayout,

--- a/packages/core/src/layout/note-reserve-holdout.ts
+++ b/packages/core/src/layout/note-reserve-holdout.ts
@@ -1,62 +1,33 @@
-// The hold-out reserve: the fixed point of a footnote eviction. Once the body pass has
-// pushed a reference line forward, the source page's recomputed reserve no longer sees
-// that reference — the note-stack height alone under-claims, the next round pulls the
-// line back, and the reflow loop orbits the two placements forever. When the next page
-// opens with a reference whose note cannot return, the source page's assignment is final
-// under Word's rule (the note stays whole with its reference), so its reserve claims the
-// remaining slack and reproduces itself round over round.
+// The hold-out reserve — the fixed point of a footnote eviction. Full account on
+// {@link holdOutReserveNeed}.
 
 import { fragmentOwnsPosition } from './line-segments.ts';
 import {
   bodyFitBottomPt,
-  bodyOnlyPage,
   firstBodyContentTopPt,
+  fragmentFitBottomPt,
   noteReferenceLineBandPt,
 } from './note-fragment-geometry.ts';
 import {
-  layoutNoteById,
+  layoutNoteCached,
   type LayoutNoteStoryOptions,
-  type NoteStoryLayout,
+  type NoteStoryLayoutCache,
 } from './note-layout.ts';
 import {
   HELD_RESERVE_TOLERANCE_PT,
   noteColumnBudgetPt,
   RESERVE_BOUNDARY_BACKOFF_PT,
 } from './note-reserves.ts';
+import { MAX_KEEP_NEXT_CHAIN } from './pagination-keeps.ts';
 import type { PageRecord, ParagraphFragmentRecord } from './semantic-records.ts';
 import type { OoxmlPart } from '@docx-editor.dev/core/store';
 
 /**
- * How many of the next page's opening blocks may sit above the pulled reference's line.
- * One more than `MAX_KEEP_NEXT_CHAIN` (pagination-keeps.ts): a full keep-with-next chain
- * moves as one unit, and a window smaller than the chain would give up on exactly the
- * groups most likely to have been evicted together.
+ * How many of the next page's opening blocks may sit above the pulled reference's line:
+ * a full keep-with-next chain moves as one unit, and a window smaller than the chain
+ * would give up on exactly the groups most likely to have been evicted together.
  */
-const MAX_HOLD_OUT_SCAN_BLOCKS = 9;
-
-/**
- * Pass-local note story layouts, keyed by part, note id and width. Valid for exactly one
- * reserve pass: every other layout input rides `opts`, which the caller builds once per
- * pass from a fixed mark context — the key deliberately omits it, so a cache must never
- * outlive the pass (or the marks) it was created for.
- */
-export type NoteStoryLayoutCache = Map<string, NoteStoryLayout | null>;
-
-export function layoutNoteCached(
-  part: OoxmlPart | null,
-  noteId: number,
-  contentWidth: number,
-  opts: LayoutNoteStoryOptions,
-  cache: NoteStoryLayoutCache | undefined
-): NoteStoryLayout | null {
-  if (!cache) return layoutNoteById(part, noteId, contentWidth, opts);
-  const key = `${part?.name ?? 'none'}\0${noteId}\0${contentWidth}`;
-  const cached = cache.get(key);
-  if (cached !== undefined) return cached;
-  const laid = layoutNoteById(part, noteId, contentWidth, opts);
-  cache.set(key, laid);
-  return laid;
-}
+const MAX_HOLD_OUT_SCAN_BLOCKS = MAX_KEEP_NEXT_CHAIN + 1;
 
 /** A page-bottom footnote reference site, pre-filtered by the caller. */
 export interface HoldOutRef {
@@ -81,22 +52,31 @@ export interface HoldOutArgs {
   readonly opts: LayoutNoteStoryOptions;
   /** Height of the plain (non-continuation) footnote separator at this page's width. */
   readonly plainSeparatorHeight: number;
-  readonly noteLayoutCache: NoteStoryLayoutCache | undefined;
+  readonly noteLayoutCache: NoteStoryLayoutCache;
 }
 
 /**
  * Reserve (pt) `bodyPage` must keep so the opening lines of `nextPage` stay put.
+ *
+ * This is the fixed point of an eviction: once the body pass has pushed a reference line
+ * forward, the source page's recomputed reserve no longer sees that reference — the
+ * note-stack height alone under-claims, the next round pulls the line back, and the
+ * reflow loop orbits the two placements forever. When the next page opens with a
+ * reference whose note cannot return, the source page's assignment is final under Word's
+ * rule (the note stays whole with its reference), so its reserve claims the remaining
+ * slack and reproduces itself round over round.
  *
  * Zero when there is nothing to hold out: no next page, a next page in different section
  * geometry (a pull-back across a page-size change cannot be reasoned about here), a slack
  * too small to seat even the pulled line, the next page opening with a table or holding
  * the reference deeper than {@link MAX_HOLD_OUT_SCAN_BLOCKS} paragraphs, no page-bottom
  * footnote reference at all, or a pulled band whose notes would fit back — then the lines
- * SHOULD return; a deleted note must release its room. A note taller than the note column
- * is splittable and never blocks the pull-back on its own: its line may legitimately
- * return with a head, so it is excluded from the demand rather than aborting the hold.
- * Otherwise the answer claims the page's remaining slack, which reproduces the current
- * body end exactly and gives the reflow loop its fixed point.
+ * SHOULD return; a deleted note must release its room. A note the eviction guard would
+ * refuse to keep whole (taller than the note column minus the content above its line in
+ * its own block — the guard's exact complement) never blocks the pull-back on its own: its
+ * line may legitimately return with a split head, so it is excluded from the demand rather
+ * than aborting the hold. Otherwise the answer claims the page's remaining slack, which
+ * reproduces the current body end exactly and gives the reflow loop its fixed point.
  *
  * The reference may open the next page behind a heading or a sibling line: the eviction
  * reserve names the reference's line, but widow/orphan control and `w:keepNext` move
@@ -120,7 +100,9 @@ export function holdOutReserveNeed(args: HoldOutArgs): number {
   ) {
     return 0;
   }
-  const nextBody = bodyOnlyPage(nextPage);
+  // The next page is read as-is: every consumer below touches only `fragments` and
+  // `contentBox`, which carried note areas do not change, so stripping would just clone.
+  const nextBody = nextPage;
   const candidates = args.pageBottomRefsOf(nextBody);
   if (candidates.length === 0) return 0;
 
@@ -168,18 +150,12 @@ export function holdOutReserveNeed(args: HoldOutArgs): number {
   const firstContentTop = firstBodyContentTopPt(nextBody);
   // Two pull-back quanta: the OPTIMISTIC one ends at the reference's line (a splittable
   // paragraph returns just its opening lines), the WHOLE-BLOCK one at the reference
-  // paragraph's fragment bottom minus its trailing after-spacing, like every fit measure
-  // (a `w:keepLines`/keep-with-next group returns only as one piece). Which quantum the
-  // body pass actually uses is not readable off the fragments.
+  // paragraph's fit bottom (a `w:keepLines`/keep-with-next group returns only as one
+  // piece). Which quantum the body pass actually uses is not readable off the fragments.
   const lineBandHeight = Math.max(0, frontier.bottom - firstContentTop);
-  const blockBandHeight = Math.max(
-    0,
-    owningBlock.box.y + owningBlock.box.height - owningBlock.spacing.after - firstContentTop
-  );
+  const blockBandHeight = Math.max(0, fragmentFitBottomPt(owningBlock) - firstContentTop);
 
   const contentWidth = bodyPage.contentBox.width;
-  // Carry-independent budget: this test must be the exact complement of the eviction
-  // guard's keep-whole budget, which also derives from the plain separator.
   const columnBudget = noteColumnBudgetPt(contentHeight, args.plainSeparatorHeight);
   let pulledNotesHeight = 0;
   for (const ref of pulled) {
@@ -191,7 +167,15 @@ export function holdOutReserveNeed(args: HoldOutArgs): number {
       args.noteLayoutCache
     );
     if (!laid) continue;
-    if (laid.flowHeight > columnBudget + 0.001) continue;
+    // The eviction guard's exact complement: a note is kept whole only when it fits the
+    // column MINUS the content above its own line within its block (that block opens the
+    // destination page whole). A note the guard would split anyway does not hold. The
+    // offset applies only to a LINE-precise band — a fallback fragment band (merged or
+    // projected offsets, `evictable: false`) spans the whole block and would over-subtract
+    // it; the guard never evicts those, so the bare column is their complement.
+    const band = noteReferenceLineBandPt(nextBody, ref);
+    const inBlockOffset = band.evictable ? band.bottom - band.blockTop : 0;
+    if (laid.flowHeight > columnBudget - inBlockOffset + 0.001) continue;
     pulledNotesHeight += laid.flowHeight;
   }
   if (pulledNotesHeight <= 0) return 0;

--- a/packages/core/src/layout/note-reserve-holdout.ts
+++ b/packages/core/src/layout/note-reserve-holdout.ts
@@ -1,0 +1,226 @@
+// The hold-out reserve: the fixed point of a footnote eviction. Once the body pass has
+// pushed a reference line forward, the source page's recomputed reserve no longer sees
+// that reference — the note-stack height alone under-claims, the next round pulls the
+// line back, and the reflow loop orbits the two placements forever. When the next page
+// opens with a reference whose note cannot return, the source page's assignment is final
+// under Word's rule (the note stays whole with its reference), so its reserve claims the
+// remaining slack and reproduces itself round over round.
+
+import { fragmentOwnsPosition } from './line-segments.ts';
+import {
+  bodyFitBottomPt,
+  bodyOnlyPage,
+  firstBodyContentTopPt,
+  noteReferenceLineBandPt,
+} from './note-fragment-geometry.ts';
+import {
+  layoutNoteById,
+  type LayoutNoteStoryOptions,
+  type NoteStoryLayout,
+} from './note-layout.ts';
+import {
+  HELD_RESERVE_TOLERANCE_PT,
+  noteColumnBudgetPt,
+  RESERVE_BOUNDARY_BACKOFF_PT,
+} from './note-reserves.ts';
+import type { PageRecord, ParagraphFragmentRecord } from './semantic-records.ts';
+import type { OoxmlPart } from '@docx-editor.dev/core/store';
+
+/**
+ * How many of the next page's opening blocks may sit above the pulled reference's line.
+ * One more than `MAX_KEEP_NEXT_CHAIN` (pagination-keeps.ts): a full keep-with-next chain
+ * moves as one unit, and a window smaller than the chain would give up on exactly the
+ * groups most likely to have been evicted together.
+ */
+const MAX_HOLD_OUT_SCAN_BLOCKS = 9;
+
+/**
+ * Pass-local note story layouts, keyed by part, note id and width. Valid for exactly one
+ * reserve pass: every other layout input rides `opts`, which the caller builds once per
+ * pass from a fixed mark context — the key deliberately omits it, so a cache must never
+ * outlive the pass (or the marks) it was created for.
+ */
+export type NoteStoryLayoutCache = Map<string, NoteStoryLayout | null>;
+
+export function layoutNoteCached(
+  part: OoxmlPart | null,
+  noteId: number,
+  contentWidth: number,
+  opts: LayoutNoteStoryOptions,
+  cache: NoteStoryLayoutCache | undefined
+): NoteStoryLayout | null {
+  if (!cache) return layoutNoteById(part, noteId, contentWidth, opts);
+  const key = `${part?.name ?? 'none'}\0${noteId}\0${contentWidth}`;
+  const cached = cache.get(key);
+  if (cached !== undefined) return cached;
+  const laid = layoutNoteById(part, noteId, contentWidth, opts);
+  cache.set(key, laid);
+  return laid;
+}
+
+/** A page-bottom footnote reference site, pre-filtered by the caller. */
+export interface HoldOutRef {
+  readonly noteId: number;
+  readonly paragraphId: string;
+  readonly atomOffset: number;
+}
+
+export interface HoldOutArgs {
+  readonly bodyPage: PageRecord;
+  readonly nextPage: PageRecord | undefined;
+  /** Height of `bodyPage`'s existing note area (0 when it has none). */
+  readonly existingAreaHeight: number;
+  /** The reserve `bodyPage` was laid under (for the observed-refusal test), if known. */
+  readonly usedReservePt: number | undefined;
+  /**
+   * Page-bottom footnote references painted on a page. The caller supplies the memoized
+   * page-refs filter so merged-paragraph ownership is answered by ONE implementation.
+   */
+  readonly pageBottomRefsOf: (page: PageRecord) => readonly HoldOutRef[];
+  readonly footnotesPart: OoxmlPart | null;
+  readonly opts: LayoutNoteStoryOptions;
+  /** Height of the plain (non-continuation) footnote separator at this page's width. */
+  readonly plainSeparatorHeight: number;
+  readonly noteLayoutCache: NoteStoryLayoutCache | undefined;
+}
+
+/**
+ * Reserve (pt) `bodyPage` must keep so the opening lines of `nextPage` stay put.
+ *
+ * Zero when there is nothing to hold out: no next page, a next page in different section
+ * geometry (a pull-back across a page-size change cannot be reasoned about here), a slack
+ * too small to seat even the pulled line, the next page opening with a table or holding
+ * the reference deeper than {@link MAX_HOLD_OUT_SCAN_BLOCKS} paragraphs, no page-bottom
+ * footnote reference at all, or a pulled band whose notes would fit back — then the lines
+ * SHOULD return; a deleted note must release its room. A note taller than the note column
+ * is splittable and never blocks the pull-back on its own: its line may legitimately
+ * return with a head, so it is excluded from the demand rather than aborting the hold.
+ * Otherwise the answer claims the page's remaining slack, which reproduces the current
+ * body end exactly and gives the reflow loop its fixed point.
+ *
+ * The reference may open the next page behind a heading or a sibling line: the eviction
+ * reserve names the reference's line, but widow/orphan control and `w:keepNext` move
+ * companions with it, and the companions can only return together. The demand charges
+ * every pulled reference in the OWNING BLOCK, not just the frontier line's — a
+ * citation-dense paragraph pulls all of its notes back together.
+ *
+ * Known approximation: the pull-back fit charges the pulled band's page-top geometry plus
+ * one reference-line of headroom (the split tail wraps from the split offset, so the
+ * reference sits up to one line higher here than the joined re-wrap a pull-back
+ * produces). A pulled paragraph whose applied `w:spacing w:before` exceeds that headroom
+ * can still release early; the loop then degrades to the pre-eviction envelope/exhaustion
+ * exit rather than diverging.
+ */
+export function holdOutReserveNeed(args: HoldOutArgs): number {
+  const { bodyPage, nextPage } = args;
+  if (!nextPage) return 0;
+  if (
+    nextPage.contentBox.width !== bodyPage.contentBox.width ||
+    nextPage.contentBox.height !== bodyPage.contentBox.height
+  ) {
+    return 0;
+  }
+  const nextBody = bodyOnlyPage(nextPage);
+  const candidates = args.pageBottomRefsOf(nextBody);
+  if (candidates.length === 0) return 0;
+
+  // The EARLIEST reference line on the next page is the pull-back frontier.
+  let frontier: { readonly top: number; readonly bottom: number } | undefined;
+  let frontierRef: HoldOutRef | undefined;
+  for (const ref of candidates) {
+    const band = noteReferenceLineBandPt(nextBody, ref);
+    if (band.bottom <= band.top) continue;
+    if (!frontier || band.bottom < frontier.bottom - 0.001) {
+      frontier = band;
+      frontierRef = ref;
+    }
+  }
+  if (!frontier || !frontierRef) return 0;
+  const refLineHeight = frontier.bottom - frontier.top;
+
+  const bodyBottom = bodyFitBottomPt(bodyPage);
+  const contentHeight = bodyPage.contentBox.height;
+  // A slack that cannot seat even the pulled line needs no reserve to stay out — and
+  // publishing one for every naturally full page would churn the reserve fingerprints
+  // the reflow loop converges on.
+  if (contentHeight - bodyBottom < refLineHeight - 0.001) return 0;
+
+  // The pulled band spans from the page's first content to the reference paragraph's
+  // fragment. A table anywhere in that opening run, or a reference deeper than the scan
+  // window, is a pull-back this reserve cannot reason about — fail open.
+  let owningBlock: ParagraphFragmentRecord | undefined;
+  let scanned = 0;
+  for (const block of nextBody.fragments) {
+    if (block.kind !== 'paragraph') return 0;
+    if (scanned >= MAX_HOLD_OUT_SCAN_BLOCKS) return 0;
+    scanned += 1;
+    if (fragmentOwnsPosition(block, frontierRef.paragraphId, frontierRef.atomOffset)) {
+      owningBlock = block;
+      break;
+    }
+  }
+  if (!owningBlock) return 0;
+  const pulled = candidates.filter((ref) =>
+    fragmentOwnsPosition(owningBlock, ref.paragraphId, ref.atomOffset)
+  );
+  if (pulled.length === 0) return 0;
+
+  const firstContentTop = firstBodyContentTopPt(nextBody);
+  // Two pull-back quanta: the OPTIMISTIC one ends at the reference's line (a splittable
+  // paragraph returns just its opening lines), the WHOLE-BLOCK one at the reference
+  // paragraph's fragment bottom minus its trailing after-spacing, like every fit measure
+  // (a `w:keepLines`/keep-with-next group returns only as one piece). Which quantum the
+  // body pass actually uses is not readable off the fragments.
+  const lineBandHeight = Math.max(0, frontier.bottom - firstContentTop);
+  const blockBandHeight = Math.max(
+    0,
+    owningBlock.box.y + owningBlock.box.height - owningBlock.spacing.after - firstContentTop
+  );
+
+  const contentWidth = bodyPage.contentBox.width;
+  // Carry-independent budget: this test must be the exact complement of the eviction
+  // guard's keep-whole budget, which also derives from the plain separator.
+  const columnBudget = noteColumnBudgetPt(contentHeight, args.plainSeparatorHeight);
+  let pulledNotesHeight = 0;
+  for (const ref of pulled) {
+    const laid = layoutNoteCached(
+      args.footnotesPart,
+      ref.noteId,
+      contentWidth,
+      args.opts,
+      args.noteLayoutCache
+    );
+    if (!laid) continue;
+    if (laid.flowHeight > columnBudget + 0.001) continue;
+    pulledNotesHeight += laid.flowHeight;
+  }
+  if (pulledNotesHeight <= 0) return 0;
+
+  const areaWithPulled =
+    (args.existingAreaHeight > 0 ? args.existingAreaHeight : args.plainSeparatorHeight) +
+    pulledNotesHeight;
+  // Backed off by half a point like the eviction reserve: the last kept body line's bottom
+  // is exactly `bodyBottom`, and a budget equal to it flips on float drift.
+  const hold = Math.max(0, contentHeight - bodyBottom - RESERVE_BOUNDARY_BACKOFF_PT);
+  const fitsLineQuantum =
+    bodyBottom + lineBandHeight + refLineHeight + areaWithPulled <= contentHeight + 0.001;
+  if (!fitsLineQuantum) return hold;
+  const fitsWholeBlock =
+    bodyBottom + blockBandHeight + refLineHeight + areaWithPulled <= contentHeight + 0.001;
+  if (fitsWholeBlock) return 0;
+  // The optimistic quantum fits but the whole block does not. Whether releasing is safe
+  // depends on whether the block can SPLIT, which the body pass has already answered:
+  // when the used reserve left room for the line quantum and the body still declined it,
+  // the block only moves whole (`w:keepLines` and friends). A page already held at this
+  // value keeps the hold — a held page offers no gap, so the refusal cannot be
+  // re-observed there; upstream shrinkage releases through the whole-block test above,
+  // and a vanished note releases through the pulled scan. Release only a page that was
+  // offered the room and refused nothing — or whose lay-down reserve is unknown (a caller
+  // outside the reflow loop must not manufacture holds the loop never observed).
+  const { usedReservePt } = args;
+  if (usedReservePt === undefined) return 0;
+  const offeredGap = Math.max(0, contentHeight - usedReservePt - bodyBottom);
+  const neverOfferedTheRoom = lineBandHeight + refLineHeight > offeredGap + 0.001;
+  const alreadyHeldHere = Math.abs(usedReservePt - hold) <= HELD_RESERVE_TOLERANCE_PT;
+  return neverOfferedTheRoom && !alreadyHeldHere ? 0 : hold;
+}

--- a/packages/core/src/layout/note-reserves.ts
+++ b/packages/core/src/layout/note-reserves.ts
@@ -1,6 +1,39 @@
 // Footnote reserve maps: page-slot → bottom reserve height (points). The compute lives in
-// note-pagination.ts (computeFootnoteReserves); this module holds the pure map algebra the
-// reflow loop and the section context keys share.
+// note-pagination.ts (computeFootnoteReserves); this module holds the pure map algebra and
+// the shared reserve constants the reflow loop and the section context keys share.
+
+/**
+ * Minimum body band (points) retained when computing footnote bottom reserves.
+ *
+ * Reserving the full content column would shrink body flow to 1pt and chase blank
+ * sheets as every reference line fails to land. Oversized notes split/continue into
+ * the shared overflow budget instead of evacuating the referencing page.
+ */
+export const MIN_FOOTNOTE_BODY_BAND_PT = 14;
+
+/**
+ * The tallest footnote stack a page can host beside the minimum body band. ONE formula:
+ * the eviction guard ("could this note fit whole on a page?") and the hold-out's
+ * oversized-note test must be exact complements, or a note is neither evicted nor held
+ * out and the reflow loop orbits.
+ */
+export function noteColumnBudgetPt(contentHeight: number, separatorHeight: number): number {
+  return Math.max(0, contentHeight - MIN_FOOTNOTE_BODY_BAND_PT - separatorHeight);
+}
+
+/**
+ * Half-point back-off applied to reserves derived from an observed line boundary (eviction,
+ * hold-out), so the body budget falls mid-line instead of edge-to-edge on a kept line's
+ * exact bottom, where the body pass's strict fit compare flips on float drift.
+ */
+export const RESERVE_BOUNDARY_BACKOFF_PT = 0.5;
+
+/**
+ * How far apart two reserve values may sit and still count as "the same hold". A re-derived
+ * hold differs from the applied one by at most the boundary back-off plus float drift, so
+ * the tolerance is stated in terms of the back-off rather than as a free constant.
+ */
+export const HELD_RESERVE_TOLERANCE_PT = 2 * RESERVE_BOUNDARY_BACKOFF_PT;
 
 /**
  * The note-reserve slice of one section's layout context key.

--- a/packages/core/src/layout/note-reserves.ts
+++ b/packages/core/src/layout/note-reserves.ts
@@ -76,6 +76,20 @@ export function notesReserveContextKey(
   return `|nr:${entries.map(([localSlot, height]) => `${localSlot}=${height}`).join(',')}`;
 }
 
+/**
+ * Merge one entry into a reserve map: monotonic per-slot maximum, and non-positive heights
+ * are OMITTED rather than stored — convergence compares maps by key set, and body layout
+ * treats a missing slot as zero.
+ */
+export function recordFootnoteReserve(
+  reserves: Map<number, number>,
+  pageIndex: number,
+  height: number
+): void {
+  if (height <= 0) return;
+  reserves.set(pageIndex, Math.max(reserves.get(pageIndex) ?? 0, height));
+}
+
 /** Drop non-positive heights so missing and zero compare equal. */
 export function compactFootnoteReserves(
   reserves: ReadonlyMap<number, number>

--- a/packages/core/src/layout/note-splitting.ts
+++ b/packages/core/src/layout/note-splitting.ts
@@ -1,0 +1,208 @@
+// Note story splitting: cut a laid note at a line boundary so its head fits a page's
+// remaining note room and its tail carries to the next page. Pure fragment surgery —
+// pagination policy (when to split at all) stays in note-pagination.ts.
+
+import { fragmentFlowBottom, shiftFragments } from './note-fragment-geometry.ts';
+import { MAX_NOTE_FRAGMENTS, type NoteStoryLayout } from './note-layout.ts';
+import type { BlockFragmentRecord, ParagraphFragmentRecord } from './semantic-records.ts';
+
+/** The one fallback splitting itself can raise; the pagination reason union includes it. */
+export type NoteSplitFallbackReason = 'note-line-exceeds-page';
+
+/**
+ * Split one paragraph fragment at a line boundary so the head fits under `availableBottom`
+ * (story-relative). Empty head means no line fits — caller must defer the fragment.
+ */
+function splitParagraphFragmentByBottom(
+  fragment: ParagraphFragmentRecord,
+  availableBottom: number
+): {
+  readonly head: ParagraphFragmentRecord | null;
+  readonly tail: ParagraphFragmentRecord | null;
+} {
+  if (fragment.lines.length === 0) {
+    return fragment.box.y + fragment.box.height <= availableBottom + 0.001
+      ? { head: fragment, tail: null }
+      : { head: null, tail: fragment };
+  }
+
+  let cut = 0;
+  for (; cut < fragment.lines.length; cut += 1) {
+    const line = fragment.lines[cut]!;
+    if (line.box.y + line.box.height > availableBottom + 0.001) break;
+  }
+  if (cut === 0) return { head: null, tail: fragment };
+  if (cut >= fragment.lines.length) return { head: fragment, tail: null };
+
+  const headLines = fragment.lines.slice(0, cut);
+  const tailLines = fragment.lines.slice(cut);
+  const headLast = headLines[headLines.length - 1]!;
+  const headTop = fragment.box.y;
+  const headBottom = headLast.box.y + headLast.box.height;
+  const headBorders = fragment.borders?.filter((stroke) => stroke.side !== 'bottom');
+
+  const head: ParagraphFragmentRecord = {
+    ...fragment,
+    range: {
+      paragraphId: fragment.paragraphId,
+      start: headLines[0]!.range.start,
+      end: headLast.range.end,
+    },
+    spacing: { before: fragment.spacing.before, after: 0 },
+    lines: headLines,
+    box: { ...fragment.box, height: Math.max(0, headBottom - headTop) },
+    ...(headBorders && headBorders.length > 0 ? { borders: headBorders } : { borders: undefined }),
+    bottomBorder: undefined,
+    ...(fragment.shadingBox
+      ? {
+          shadingBox: {
+            ...fragment.shadingBox,
+            height: Math.max(0, headBottom - fragment.shadingBox.y),
+          },
+        }
+      : {}),
+  };
+
+  // Keep the tail in the original story coordinate space; {@link splitNoteFragments} rebases
+  // the whole raw tail with one shift so sibling blocks stay contiguous.
+  const tailLast = tailLines[tailLines.length - 1]!;
+  const tailTop = tailLines[0]!.box.y;
+  const tailBottom = tailLast.box.y + tailLast.box.height;
+  const tailBorders = fragment.borders?.filter((stroke) => stroke.side !== 'top');
+  const tail: ParagraphFragmentRecord = {
+    ...fragment,
+    id: `${fragment.paragraphId}#f${fragment.fragmentIndex + 1}`,
+    fragmentIndex: fragment.fragmentIndex + 1,
+    range: {
+      paragraphId: fragment.paragraphId,
+      start: tailLines[0]!.range.start,
+      end: tailLines[tailLines.length - 1]!.range.end,
+    },
+    spacing: { before: 0, after: fragment.spacing.after },
+    lines: tailLines,
+    box: {
+      x: fragment.box.x,
+      y: tailTop,
+      width: fragment.box.width,
+      height: Math.max(0, tailBottom - tailTop),
+    },
+    marker: undefined,
+    ...(tailBorders && tailBorders.length > 0 ? { borders: tailBorders } : { borders: undefined }),
+    ...(fragment.bottomBorder ? { bottomBorder: fragment.bottomBorder } : {}),
+    ...(fragment.shadingBox
+      ? {
+          shadingBox: {
+            x: fragment.shadingBox.x,
+            y: tailTop,
+            width: fragment.shadingBox.width,
+            height: Math.max(0, tailBottom - tailTop),
+          },
+        }
+      : {}),
+  };
+  return { head, tail };
+}
+
+/**
+ * Split a note story so the head fits in `availableHeight` (story-relative).
+ *
+ * Allows an empty head (entire story moves to the next page) instead of accepting a first
+ * fragment taller than the remaining room. Paragraph fragments split at line boundaries;
+ * a single line that exceeds a full content column records {@link NoteSplitFallbackReason}
+ * and is not placed with overflowing geometry.
+ */
+export function splitNoteFragments(
+  laid: NoteStoryLayout,
+  availableHeight: number,
+  options?: {
+    readonly fullContentHeight?: number;
+    /** Structurally any list whose element type includes the split fallback. */
+    readonly reasons?: { push(reason: NoteSplitFallbackReason): unknown };
+  }
+): {
+  readonly head: readonly BlockFragmentRecord[];
+  readonly headHeight: number;
+  readonly tail: readonly BlockFragmentRecord[];
+  readonly tailHeight: number;
+} {
+  if (laid.flowHeight <= availableHeight + 0.001) {
+    return {
+      head: laid.fragments,
+      headHeight: laid.flowHeight,
+      tail: [],
+      tailHeight: 0,
+    };
+  }
+  if (availableHeight <= 0.001) {
+    return {
+      head: [],
+      headHeight: 0,
+      tail: laid.fragments,
+      tailHeight: laid.flowHeight,
+    };
+  }
+
+  const head: BlockFragmentRecord[] = [];
+  let headHeight = 0;
+  let cut = 0;
+  let partialTail: BlockFragmentRecord | null = null;
+
+  for (let i = 0; i < laid.fragments.length && i < MAX_NOTE_FRAGMENTS; i += 1) {
+    const fragment = laid.fragments[i]!;
+    const next = fragment.box.y + fragment.box.height;
+    if (next <= availableHeight + 0.001) {
+      head.push(fragment);
+      headHeight = next;
+      cut = i + 1;
+      continue;
+    }
+
+    if (fragment.kind === 'paragraph') {
+      const split = splitParagraphFragmentByBottom(fragment, availableHeight);
+      if (split.head) {
+        head.push(split.head);
+        headHeight = split.head.box.y + split.head.box.height;
+        partialTail = split.tail;
+        cut = i + 1;
+      } else {
+        // No line fits in the remaining room — leave head as-is (possibly empty) and
+        // defer this fragment. When the room is a full content column and one line still
+        // does not fit, record a named fallback rather than overflowing geometry.
+        const fullH = options?.fullContentHeight ?? availableHeight;
+        const firstLine = fragment.lines[0];
+        const lineH = firstLine?.box.height ?? fragment.box.height;
+        if (head.length === 0 && availableHeight >= fullH - 0.001 && lineH > fullH + 0.001) {
+          options?.reasons?.push('note-line-exceeds-page');
+          // Skip the unsplittable fragment; continue attempting later siblings on a fresh
+          // carry rather than clipping it into the column.
+          cut = i + 1;
+          partialTail = null;
+          const rest = laid.fragments.slice(cut);
+          const dy = rest[0]?.box.y ?? 0;
+          return {
+            head: [],
+            headHeight: 0,
+            tail: shiftFragments(rest, -dy),
+            tailHeight: Math.max(0, laid.flowHeight - dy),
+          };
+        }
+        cut = i;
+        partialTail = null;
+      }
+      break;
+    }
+
+    // Tables / non-paragraph: never accept an overflowing first fragment.
+    cut = i;
+    break;
+  }
+
+  const rawTail = [...(partialTail ? [partialTail] : []), ...laid.fragments.slice(cut)];
+  if (rawTail.length === 0) {
+    return { head, headHeight, tail: [], tailHeight: 0 };
+  }
+  const dy = rawTail[0]?.box.y ?? 0;
+  const tail = shiftFragments(rawTail, -dy);
+  const tailHeight = fragmentFlowBottom(tail);
+  return { head, headHeight, tail, tailHeight };
+}

--- a/packages/core/src/layout/note-splitting.ts
+++ b/packages/core/src/layout/note-splitting.ts
@@ -7,7 +7,7 @@ import { MAX_NOTE_FRAGMENTS, type NoteStoryLayout } from './note-layout.ts';
 import type { BlockFragmentRecord, ParagraphFragmentRecord } from './semantic-records.ts';
 
 /** The one fallback splitting itself can raise; the pagination reason union includes it. */
-export type NoteSplitFallbackReason = 'note-line-exceeds-page';
+type NoteSplitFallbackReason = 'note-line-exceeds-page';
 
 /**
  * Split one paragraph fragment at a line boundary so the head fits under `availableBottom`

--- a/scripts/check-eslint-max-lines-globs.mjs
+++ b/scripts/check-eslint-max-lines-globs.mjs
@@ -45,7 +45,7 @@ const BLANKET_DISABLES = new Map([
   ['packages/core/src/editor/paginated-surface.ts', 6242],
   ['packages/core/src/store/store/tree-op-apply.ts', 3495],
   ['packages/core/src/output/semantic-paint.ts', 3005],
-  ['packages/core/src/layout/note-pagination.ts', 3018],
+  ['packages/core/src/layout/note-pagination.ts', 2839],
   ['packages/core/src/store/package/note-lifecycle.ts', 1320],
 ]);
 

--- a/scripts/check-eslint-max-lines-globs.mjs
+++ b/scripts/check-eslint-max-lines-globs.mjs
@@ -45,7 +45,7 @@ const BLANKET_DISABLES = new Map([
   ['packages/core/src/editor/paginated-surface.ts', 6242],
   ['packages/core/src/store/store/tree-op-apply.ts', 3495],
   ['packages/core/src/output/semantic-paint.ts', 3005],
-  ['packages/core/src/layout/note-pagination.ts', 2852],
+  ['packages/core/src/layout/note-pagination.ts', 3043],
   ['packages/core/src/store/package/note-lifecycle.ts', 1320],
 ]);
 

--- a/scripts/check-eslint-max-lines-globs.mjs
+++ b/scripts/check-eslint-max-lines-globs.mjs
@@ -45,7 +45,7 @@ const BLANKET_DISABLES = new Map([
   ['packages/core/src/editor/paginated-surface.ts', 6242],
   ['packages/core/src/store/store/tree-op-apply.ts', 3495],
   ['packages/core/src/output/semantic-paint.ts', 3005],
-  ['packages/core/src/layout/note-pagination.ts', 3043],
+  ['packages/core/src/layout/note-pagination.ts', 3194],
   ['packages/core/src/store/package/note-lifecycle.ts', 1320],
 ]);
 

--- a/scripts/check-eslint-max-lines-globs.mjs
+++ b/scripts/check-eslint-max-lines-globs.mjs
@@ -45,7 +45,7 @@ const BLANKET_DISABLES = new Map([
   ['packages/core/src/editor/paginated-surface.ts', 6242],
   ['packages/core/src/store/store/tree-op-apply.ts', 3495],
   ['packages/core/src/output/semantic-paint.ts', 3005],
-  ['packages/core/src/layout/note-pagination.ts', 3194],
+  ['packages/core/src/layout/note-pagination.ts', 3018],
   ['packages/core/src/store/package/note-lifecycle.ts', 1320],
 ]);
 

--- a/scripts/check-eslint-max-lines-globs.mjs
+++ b/scripts/check-eslint-max-lines-globs.mjs
@@ -45,7 +45,7 @@ const BLANKET_DISABLES = new Map([
   ['packages/core/src/editor/paginated-surface.ts', 6242],
   ['packages/core/src/store/store/tree-op-apply.ts', 3495],
   ['packages/core/src/output/semantic-paint.ts', 3005],
-  ['packages/core/src/layout/note-pagination.ts', 2839],
+  ['packages/core/src/layout/note-pagination.ts', 2846],
   ['packages/core/src/store/package/note-lifecycle.ts', 1320],
 ]);
 


### PR DESCRIPTION
Fixes #627.

The footnote reserve pass capped each note's room at its reference line and kept body text in place when that room ran out, so the note split mid-sentence or rendered whole as an unmarked continuation pages after its reference. Word moves the reference line to the next page instead, and splits only a note that cannot fit the page's note column.

The reserve pass now evicts the reference line when its note cannot start below it, and a hold-out reserve closes the fixed point: a page whose successor opens with a reference whose note cannot fit back claims its remaining slack, so the reflow loop converges instead of orbiting the two placements. Body height is measured minus trailing paragraph after-spacing, matching the page-fit rule. On a 53-page legal document with 108 footnotes, every note now starts on the page that references it; before the change, 36 notes split or trailed their references by up to three pages.

The splitting, hold-out, and body-bottom helpers move into `layout/note-splitting.ts`, `layout/note-reserve-holdout.ts`, and `layout/note-fragment-geometry.ts`, so `note-pagination.ts` ends slightly below its previous length.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/630"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790634663&installation_model_id=422592&pr_number=630&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F630&signature=1131f94ea522ccea256a4c55a54d092df01b80b03feaf778e3bfa2351b8f47ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->