### PR TITLE
perf: keep the notes memo and note stories across keystrokes

### DIFF
--- a/.changeset/notes-memo-keystroke.md
+++ b/.changeset/notes-memo-keystroke.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Typing in a paragraph that carries a footnote reference no longer re-lays every note story in the document, and unchanged footnote pages keep their identity across passes so the painter keeps their DOM. Fixes #631

--- a/packages/core/src/layout/__tests__/footnote-reserves.test.ts
+++ b/packages/core/src/layout/__tests__/footnote-reserves.test.ts
@@ -6,6 +6,8 @@ import { describe, expect, test } from 'bun:test';
 import { zipSync, strToU8 } from 'fflate';
 import { readOoxmlPackage } from '../../store/package/ooxml-package.ts';
 import { resolveNotesPart } from '../../store/package/note-references.ts';
+import { TreePackageStore } from '../../store/store/tree-package-store.ts';
+import { normalizeParagraphIdentity } from '../../store/package/para-id.ts';
 import {
   resolveEndnoteProperties,
   resolveFootnoteProperties,
@@ -649,6 +651,70 @@ describe('incremental notes layout (reserve persistence)', () => {
     expect(session.stats.reusedPages).toBeGreaterThan(0);
     // Seeded reserves: the edit resumes — no extra full pass for reserve rediscovery.
     expect(session.stats.fullPasses).toBe(fullPassesAfterCold);
+  });
+
+  test('typing in a referencing paragraph keeps distant note areas by identity', () => {
+    // A keystroke in a paragraph that carries a footnote reference only SHIFTS the
+    // reference's atom offset. The notes memo must survive that (marks, per-page reserve
+    // and attach caches), so every page far from the edit hands the painter the SAME
+    // attached page object — re-laying all note stories per keystroke is the regression
+    // this pins (issue #631).
+    const bytes = multiPageFootnoteDoc(120, 20);
+    const loaded = readOoxmlPackage(bytes);
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) throw new Error(loaded.reason);
+    const main = loaded.package.parts.get(loaded.package.mainDocumentPart)!;
+    const normalized = normalizeParagraphIdentity(main);
+    const store = new TreePackageStore(loaded.package, normalized);
+    const bodyStore = store.bodyStore();
+    const documentFootnoteProps = resolveFootnoteProperties(undefined, undefined);
+    const documentEndnoteProps = resolveEndnoteProperties(undefined, undefined);
+    const notes: NotesLayoutInput = {
+      footnotesPart: resolveNotesPart(loaded.package, 'footnote'),
+      endnotesPart: null,
+      footnotePropsBySection: [documentFootnoteProps],
+      endnotePropsBySection: [documentEndnoteProps],
+      documentFootnoteProps,
+      documentEndnoteProps,
+      measurer: createFixedMeasurer(),
+      producer: 'notes-keystroke-reuse',
+    };
+    const session = createLayoutSession();
+    const layoutNow = (revision: number) =>
+      layoutSemanticDocument(bodyStore.part, revision, {
+        measurer: notes.measurer,
+        notes,
+        session,
+        producer: 'notes-keystroke-reuse',
+      });
+    const before = layoutNow(1);
+    layoutNow(2);
+
+    // Paragraph 60 carries footnote 3 in this fixture (every 20th paragraph cites).
+    const body = bodyStore.part.root.children?.[0];
+    const refParagraph = (body?.children ?? []).filter((n) => n.kind === 'paragraph')[60]!;
+    const applied = bodyStore.transact((ctx) =>
+      ctx.apply({ op: 'insertText', paragraphId: refParagraph.id, offset: 1, text: 'x' })
+    );
+    expect(applied.ok).toBe(true);
+
+    const after = layoutNow(3);
+    const clean = layoutSemanticDocument(bodyStore.part, 3, {
+      measurer: notes.measurer,
+      notes,
+      producer: 'notes-keystroke-reuse',
+    });
+    expect(layoutShape(after)).toBe(layoutShape(clean));
+
+    // Every page except the edited one keeps its attached record — footnote area included —
+    // by IDENTITY, which is what proves no note story on those pages was re-laid.
+    let reusedWithNotes = 0;
+    for (let i = 0; i < after.pages.length; i += 1) {
+      const now = after.pages[i]!;
+      const was = before.pages[i]!;
+      if (now === was && now.footnotes !== undefined) reusedWithNotes += 1;
+    }
+    expect(reusedWithNotes).toBeGreaterThanOrEqual(after.pages.length - 3);
   });
 
   test('900-paragraph footnote document: warm pass is one resumed body layout', () => {

--- a/packages/core/src/layout/note-layout.ts
+++ b/packages/core/src/layout/note-layout.ts
@@ -320,10 +320,13 @@ export function layoutNoteById(
 }
 
 /**
- * Pass-local note story layouts, keyed by part, note id and width. Valid for exactly one
- * layout pass: every other input rides `opts`, which the caller builds once per pass from
- * a fixed mark context — the key deliberately omits it, so a cache must never outlive the
- * pass (or the marks) it was created for.
+ * Note story layouts, keyed by part, note id and width, and OWNED by a mark context: the
+ * caller keys each cache off one `NoteMarkContext` whose lifetime a notes-pass memo pins.
+ * The key deliberately omits everything else riding `LayoutNoteStoryOptions` because the
+ * memo's input fingerprint and identity checks pin those inputs for as long as the marks
+ * (and so this cache) live. ADDING A FIELD to `LayoutNoteStoryOptions` therefore means
+ * joining it to `fingerprintNotesInput`/`notesInputIdentities` in note-pagination.ts, or
+ * a cached story silently outlives the input that shaped it.
  */
 export type NoteStoryLayoutCache = Map<string, NoteStoryLayout | null>;
 

--- a/packages/core/src/layout/note-pagination.ts
+++ b/packages/core/src/layout/note-pagination.ts
@@ -33,7 +33,6 @@ import {
   type NoteReferenceSite,
 } from './note-numbering.ts';
 import {
-  layoutNoteById,
   layoutNoteCached,
   layoutNoteSeparator,
   noteSeparatorAreaBox,

--- a/packages/core/src/layout/note-pagination.ts
+++ b/packages/core/src/layout/note-pagination.ts
@@ -227,7 +227,8 @@ export interface NotesLayoutInput {
 // ---------------------------------------------------------------------------------------
 
 interface NotesPageAttachEntry {
-  readonly allHits: readonly PageRefHit[];
+  /** The page's own footnote refs at compute time (content-compared on reuse). */
+  readonly pageRefs: readonly PageRefHit[];
   readonly marks: NoteMarkContext;
   readonly attached: PageRecord;
   readonly reserve: number;
@@ -236,15 +237,20 @@ interface NotesPageAttachEntry {
 
 /**
  * Incremental state for the notes pass, carried on the layout session's opaque `notes`
- * slot. Validity is layered: the memo object itself is replaced whenever the reference
- * fingerprint or the notes-input fingerprint moves, so anything read THROUGH a live memo
- * (the hit array, the mark contexts, per-page results keyed by identical hit/mark
- * identities) is current by construction.
+ * slot. Validity is layered: the memo object is replaced whenever the reference IDENTITY
+ * fingerprint (which notes exist, where, in what order — but not their character offsets)
+ * or the notes-input fingerprint moves, so the mark contexts read through a live memo are
+ * current by construction. Offsets shift on every keystroke in a referencing paragraph
+ * without changing any note, mark or story; per-page entries therefore revalidate against
+ * the page's OWN reference list (offsets included) rather than the whole hit array — a
+ * page whose refs moved re-laid its paragraph anyway, so its page identity is new too.
  */
 interface NotesPassMemo {
-  readonly hitsFingerprint: string;
+  hitsFingerprint: string;
+  /** {@link fingerprintHitsIdentity} of {@link allHits} — offsets excluded. */
+  readonly identityFingerprint: string;
   readonly inputFingerprint: string;
-  readonly allHits: readonly PageRefHit[];
+  allHits: readonly PageRefHit[];
   readonly provisionalMarks: NoteMarkContext;
   finalMarks: { readonly sitesFingerprint: string; readonly marks: NoteMarkContext } | null;
   /**
@@ -274,7 +280,8 @@ interface NotesPassMemo {
   readonly pageReserve: WeakMap<
     PageRecord,
     {
-      readonly allHits: readonly PageRefHit[];
+      /** The page's own footnote refs at compute time (content-compared on reuse). */
+      readonly pageRefs: readonly PageRefHit[];
       readonly marks: NoteMarkContext;
       readonly reserve: number;
       /** The raw note-area height (hold-out's `existingAreaHeight` input). */
@@ -292,6 +299,43 @@ function fingerprintHits(hits: readonly PageRefHit[]): string {
     );
   }
   return parts.join(';');
+}
+
+/**
+ * {@link fingerprintHits} without the character offsets. This is the fingerprint that
+ * decides the MEMO's lifetime: marks, numbering and note stories depend on which notes
+ * exist, their order, sections and custom-mark flags — never on where in the paragraph
+ * the citation sits. A keystroke that only shifts offsets keeps the memo.
+ */
+function fingerprintHitsIdentity(hits: readonly PageRefHit[]): string {
+  const parts: string[] = [];
+  for (const hit of hits) {
+    parts.push(
+      `${hit.noteKind}|${hit.noteId}|${hit.paragraphId}|${hit.customMarkFollows ? 1 : 0}|${hit.sectionIndex}`
+    );
+  }
+  return parts.join(';');
+}
+
+/** Content equality of two per-page ref lists (order, ids, owners, offsets, flags). */
+function pageRefsEqual(a: readonly PageRefHit[], b: readonly PageRefHit[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    const x = a[i]!;
+    const y = b[i]!;
+    if (
+      x.noteId !== y.noteId ||
+      x.noteKind !== y.noteKind ||
+      x.paragraphId !== y.paragraphId ||
+      x.atomOffset !== y.atomOffset ||
+      x.customMarkFollows !== y.customMarkFollows ||
+      x.sectionIndex !== y.sectionIndex
+    ) {
+      return false;
+    }
+  }
+  return true;
 }
 
 function fingerprintNoteProps(props: {
@@ -350,11 +394,11 @@ function notesMemoFor(
   }
   const hitsFingerprint = fingerprintHits(allHits);
   const existing = session.notes as NotesPassMemo | null;
-  if (existing && existing.hitsFingerprint === hitsFingerprint) {
+  if (existing) {
     const identity = notesInputIdentities.get(existing);
-    if (
+    const inputUnchanged =
       existing.inputFingerprint === inputFingerprint &&
-      identity &&
+      identity !== undefined &&
       identity.footnotesPart === input.footnotesPart &&
       identity.endnotesPart === input.endnotesPart &&
       identity.measurer === input.measurer &&
@@ -362,13 +406,24 @@ function notesMemoFor(
       identity.styleCascade === input.styleCascade &&
       // By identity, like the cascade beside it. `numbering.xml` is a different part from the
       // notes part, so an edit to it moves nothing else this fingerprint compares.
-      identity.numberingIndex === input.numberingIndex
-    ) {
+      identity.numberingIndex === input.numberingIndex;
+    if (inputUnchanged && existing.hitsFingerprint === hitsFingerprint) {
       return { memo: existing, allHits: existing.allHits, reused: true };
+    }
+    if (inputUnchanged && existing.identityFingerprint === fingerprintHitsIdentity(allHits)) {
+      // Only offsets moved (typing in a referencing paragraph): the reference set, marks
+      // and note stories are unchanged, so the memo — and every cache hanging off its
+      // mark contexts — survives. The fresh hit array replaces the stale one; per-page
+      // entries revalidate against each page's own refs, and any page whose refs moved
+      // re-laid its paragraph and carries a new page identity anyway.
+      existing.hitsFingerprint = hitsFingerprint;
+      existing.allHits = allHits;
+      return { memo: existing, allHits, reused: true };
     }
   }
   const fresh: NotesPassMemo = {
     hitsFingerprint,
+    identityFingerprint: fingerprintHitsIdentity(allHits),
     inputFingerprint,
     allHits,
     provisionalMarks: provisionalNoteMarks(allHits, input),
@@ -1571,6 +1626,8 @@ function buildEndnoteArea(
   options?: {
     readonly separatorKind?: 'separator' | 'continuationSeparator';
     readonly separatorCache?: NoteSeparatorCache;
+    /** Pass-local note story layouts (see the footnote twin). */
+    readonly noteLayoutCache?: NoteStoryLayoutCache;
   }
 ): { area: NoteAreaRecord | undefined; nextCarry: NoteCarryMap; remainingRefs: PageRefHit[] } {
   const nextCarry: NoteCarryMap = new Map(continuationCarry);
@@ -1680,7 +1737,7 @@ function buildEndnoteArea(
       break;
     }
     const part = notesPartFor(ref.noteKind);
-    const laid = layoutNoteById(part, ref.noteId, contentWidth, opts);
+    const laid = layoutNoteCached(part, ref.noteId, contentWidth, opts, options?.noteLayoutCache);
     if (!laid) {
       reasons.push('missing-note-body');
       continue;
@@ -1792,6 +1849,7 @@ function drainFootnoteCarryPages(
   reasons: NotePaginationFallbackReason[],
   overflowBudget: NoteOverflowBudget,
   separatorCache: NoteSeparatorCache,
+  noteLayoutCache: NoteStoryLayoutCache,
   mint: OverflowSheetMinter
 ): { pages: PageRecord[]; carry: NoteCarryMap } {
   let nextPages = pages;
@@ -1809,6 +1867,7 @@ function drainFootnoteCarryPages(
     });
     const built = buildFootnoteArea(page, [], input, noteMarks, 'pageBottom', nextCarry, reasons, {
       separatorCache,
+      noteLayoutCache,
     });
     const notesPlaced = built.area?.notes.length ?? 0;
     nextCarry = built.nextCarry;
@@ -1894,6 +1953,8 @@ function placeEndnotesFromPage(
     /** First page index of the owning section (for SECTIONPAGES patching). */
     readonly sectionStartIndex?: number;
     readonly separatorCache?: NoteSeparatorCache;
+    /** Pass-local note story layouts (see the footnote twin). */
+    readonly noteLayoutCache?: NoteStoryLayoutCache;
     /** Mints an overflow sheet with the shell its own index resolves to. */
     readonly mint: OverflowSheetMinter;
   }
@@ -1950,6 +2011,7 @@ function placeEndnotesFromPage(
     const built = buildEndnoteArea(page, pending, input, noteMarks, placement, carry, reasons, {
       separatorKind,
       ...(separatorCache ? { separatorCache } : {}),
+      ...(options.noteLayoutCache ? { noteLayoutCache: options.noteLayoutCache } : {}),
     });
     carry = built.nextCarry;
     pending = built.remainingRefs;
@@ -2116,12 +2178,12 @@ export function computeFootnoteReserves(
       continue;
     }
 
-    // An unchanged page whose refs and marks are the previous pass's exact objects sized
-    // to the same PAGE-LOCAL reserve; carry chains are the exception and rebuild. The
+    // An unchanged page whose own refs and marks match the previous pass, sized to the
+    // same PAGE-LOCAL reserve; carry chains are the exception and rebuild. The
     // neighbour-reading hold-out is recomputed below either way.
     if (memo && carry.size === 0) {
       const cached = memo.pageReserve.get(page);
-      if (cached && cached.allHits === allRefs && cached.marks === noteMarks) {
+      if (cached && cached.marks === noteMarks && pageRefsEqual(fnRefs, cached.pageRefs)) {
         for (const reason of cached.reasons) reasons.push(reason);
         recordReserve(page.index, Math.max(cached.reserve, holdOutFor(cached.areaHeight)), maxArea);
         continue;
@@ -2172,7 +2234,7 @@ export function computeFootnoteReserves(
     const localNeeded = Math.min(Math.max(areaHeight, evictionNeed), maxArea);
     if (memo && carryWasEmpty && carry.size === 0) {
       memo.pageReserve.set(page, {
-        allHits: allRefs,
+        pageRefs: fnRefs,
         marks: noteMarks,
         reserve: localNeeded,
         areaHeight,
@@ -2258,6 +2320,13 @@ export function attachNotesToLayout(
     noteMarks = buildMarkContext(footnoteSites, endnoteSites, input);
     if (memo) memo.finalMarks = { sitesFingerprint, marks: noteMarks };
   }
+  // Keyed on the FINAL mark context, whose identity the memo keeps while the sites
+  // fingerprint stands, so unchanged notes reuse their story layouts across passes.
+  let noteLayoutCache = noteStoryCachesByMarks.get(noteMarks);
+  if (!noteLayoutCache) {
+    noteLayoutCache = new Map();
+    noteStoryCachesByMarks.set(noteMarks, noteLayoutCache);
+  }
 
   let carry: NoteCarryMap = new Map();
   const endnotesBySection = new Map<number, PageRefHit[]>();
@@ -2291,13 +2360,13 @@ export function attachNotesToLayout(
       }
     }
 
-    // An unchanged page attaches to the same result as last pass when the hit array and
-    // mark context are the previous pass's exact objects and no continuation chains in or
-    // out of it. The endnote collectors above already ran, so skipping the build here
-    // loses nothing.
+    // An unchanged page attaches to the same result as last pass when its OWN refs match
+    // by content, the mark context is the previous pass's exact object, and no
+    // continuation chains in or out of it. The endnote collectors above already ran, so
+    // skipping the build here loses nothing.
     if (memo && carry.size === 0) {
       const cached = memo.pageAttach.get(page);
-      if (cached && cached.allHits === allRefs && cached.marks === noteMarks) {
+      if (cached && cached.marks === noteMarks && pageRefsEqual(fnRefs, cached.pageRefs)) {
         for (const reason of cached.reasons) reasons.push(reason);
         return cached.attached;
       }
@@ -2322,7 +2391,7 @@ export function attachNotesToLayout(
         props.pos,
         carry,
         reasons,
-        { separatorCache }
+        { separatorCache, noteLayoutCache }
       );
       footnotes = built.area;
       carry = built.nextCarry;
@@ -2332,13 +2401,20 @@ export function attachNotesToLayout(
     // it came in as, and saying so is what lets the painter keep its DOM.
     const attached = footnotes ? { ...bodyPage, footnotes } : bodyPage;
     if (memo && carryWasEmpty && carry.size === 0) {
-      memo.pageAttach.set(page, {
-        allHits: allRefs,
+      const entry: NotesPageAttachEntry = {
+        pageRefs: fnRefs,
         marks: noteMarks,
         attached,
         reserve: 0,
         reasons: reasons.slice(reasonsBefore),
-      });
+      };
+      memo.pageAttach.set(page, entry);
+      // ALSO under the OUTPUT page: the next pass's body layout hands back the ATTACHED
+      // page by identity (it is what the session published), so an entry keyed only on
+      // this pass's input is one generation behind and never hits — every pass then
+      // republished a fresh page object for every footnote-bearing page, and the painter
+      // rebuilt their DOM on every keystroke.
+      if (attached !== page) memo.pageAttach.set(attached, entry);
     }
     return attached;
   });
@@ -2363,6 +2439,7 @@ export function attachNotesToLayout(
       reasons,
       overflowBudget,
       separatorCache,
+      noteLayoutCache,
       mint
     );
     pages = drained.pages;
@@ -2398,6 +2475,7 @@ export function attachNotesToLayout(
           stopBeforeIndex: stopBefore,
           sectionStartIndex: sectionStart,
           separatorCache,
+          noteLayoutCache,
           mint,
         }
       );
@@ -2416,7 +2494,7 @@ export function attachNotesToLayout(
       'docEnd',
       reasons,
       overflowBudget,
-      { separatorCache, mint }
+      { separatorCache, noteLayoutCache, mint }
     );
   }
 

--- a/packages/core/src/layout/note-pagination.ts
+++ b/packages/core/src/layout/note-pagination.ts
@@ -290,12 +290,16 @@ interface NotesPassMemo {
   >;
 }
 
+/** ONE per-hit key: every fingerprint and equality below derives from it, so a new
+ * {@link PageRefHit} field joins the caches' validity in exactly one place. */
+function hitIdentityKey(hit: PageRefHit): string {
+  return `${hit.noteKind}|${hit.noteId}|${hit.paragraphId}|${hit.customMarkFollows ? 1 : 0}|${hit.sectionIndex}`;
+}
+
 function fingerprintHits(hits: readonly PageRefHit[]): string {
   const parts: string[] = [];
   for (const hit of hits) {
-    parts.push(
-      `${hit.noteKind}|${hit.noteId}|${hit.paragraphId}|${hit.atomOffset}|${hit.customMarkFollows ? 1 : 0}|${hit.sectionIndex}`
-    );
+    parts.push(`${hitIdentityKey(hit)}|${hit.atomOffset}`);
   }
   return parts.join(';');
 }
@@ -307,13 +311,7 @@ function fingerprintHits(hits: readonly PageRefHit[]): string {
  * the citation sits. A keystroke that only shifts offsets keeps the memo.
  */
 function fingerprintHitsIdentity(hits: readonly PageRefHit[]): string {
-  const parts: string[] = [];
-  for (const hit of hits) {
-    parts.push(
-      `${hit.noteKind}|${hit.noteId}|${hit.paragraphId}|${hit.customMarkFollows ? 1 : 0}|${hit.sectionIndex}`
-    );
-  }
-  return parts.join(';');
+  return hits.map(hitIdentityKey).join(';');
 }
 
 /** Content equality of two per-page ref lists (order, ids, owners, offsets, flags). */
@@ -323,16 +321,7 @@ function pageRefsEqual(a: readonly PageRefHit[], b: readonly PageRefHit[]): bool
   for (let i = 0; i < a.length; i += 1) {
     const x = a[i]!;
     const y = b[i]!;
-    if (
-      x.noteId !== y.noteId ||
-      x.noteKind !== y.noteKind ||
-      x.paragraphId !== y.paragraphId ||
-      x.atomOffset !== y.atomOffset ||
-      x.customMarkFollows !== y.customMarkFollows ||
-      x.sectionIndex !== y.sectionIndex
-    ) {
-      return false;
-    }
+    if (x.atomOffset !== y.atomOffset || hitIdentityKey(x) !== hitIdentityKey(y)) return false;
   }
   return true;
 }
@@ -397,6 +386,7 @@ function notesMemoFor(
     return { memo: null, allHits, reused: false };
   }
   const hitsFingerprint = fingerprintHits(allHits);
+  let identityFingerprint: string | null = null;
   const existing = session.notes as NotesPassMemo | null;
   if (existing) {
     const identity = notesInputIdentities.get(existing);
@@ -414,7 +404,7 @@ function notesMemoFor(
     if (inputUnchanged && existing.hitsFingerprint === hitsFingerprint) {
       return { memo: existing, allHits: existing.allHits, reused: true };
     }
-    const identityFingerprint = inputUnchanged ? fingerprintHitsIdentity(allHits) : null;
+    identityFingerprint = inputUnchanged ? fingerprintHitsIdentity(allHits) : null;
     if (identityFingerprint !== null && existing.identityFingerprint === identityFingerprint) {
       // Only offsets moved (typing in a referencing paragraph): the reference set, marks
       // and note stories are unchanged, so the memo — and every cache hanging off its
@@ -428,9 +418,7 @@ function notesMemoFor(
   }
   const fresh: NotesPassMemo = {
     hitsFingerprint,
-    identityFingerprint: fingerprintHitsIdentity(allHits),
-    // (Recomputed here only when the memo above did not match; the common keystroke path
-    // computes it once.)
+    identityFingerprint: identityFingerprint ?? fingerprintHitsIdentity(allHits),
     inputFingerprint,
     allHits,
     provisionalMarks: provisionalNoteMarks(allHits, input),
@@ -2416,15 +2404,14 @@ export function attachNotesToLayout(
         reserve: 0,
         reasons: reasons.slice(reasonsBefore),
       };
-      memo.pageAttach.set(page, entry);
-      // ALSO under the OUTPUT page: the next pass's body layout hands back the ATTACHED
-      // page by identity (it is what the session published), so an entry keyed only on
-      // this pass's input is one generation behind and never hits — every pass then
+      // Keyed under the OUTPUT page: the next pass's body layout hands back the ATTACHED
+      // page by identity (it is what the session publishes), so an entry keyed on this
+      // pass's input would be one generation behind and never hit — every pass then
       // republished a fresh page object for every footnote-bearing page, and the painter
       // rebuilt their DOM on every keystroke. The reserve entry forwards for the same
-      // reason: the next reserve pass reads the published page.
+      // reason: the next reserve pass reads the published page too.
+      memo.pageAttach.set(attached, entry);
       if (attached !== page) {
-        memo.pageAttach.set(attached, entry);
         const reserveEntry = memo.pageReserve.get(page);
         if (reserveEntry) memo.pageReserve.set(attached, reserveEntry);
       }

--- a/packages/core/src/layout/note-pagination.ts
+++ b/packages/core/src/layout/note-pagination.ts
@@ -360,6 +360,11 @@ function fingerprintNotesInput(input: NotesLayoutInput): string | null {
     // By CONTENT, not identity: a keystroke rebuilds the context object while every
     // resolved value stands still, and only a value move should invalidate the memo.
     input.refFields?.valuesToken ?? '',
+    // By CONTENT for the same reason as the REF values above: the properties object is
+    // re-read per package revision, and only a value move should repaint a DOCPROPERTY
+    // field inside a note. The link projectors are deliberately absent: they are rebuilt
+    // per pass but are pure over parts this memo already pins.
+    input.documentProperties ? JSON.stringify(input.documentProperties) : '',
     fingerprintNoteProps(input.documentFootnoteProps),
     fingerprintNoteProps(input.documentEndnoteProps),
     input.footnotePropsBySection.map(fingerprintNoteProps).join(';'),
@@ -409,7 +414,8 @@ function notesMemoFor(
     if (inputUnchanged && existing.hitsFingerprint === hitsFingerprint) {
       return { memo: existing, allHits: existing.allHits, reused: true };
     }
-    if (inputUnchanged && existing.identityFingerprint === fingerprintHitsIdentity(allHits)) {
+    const identityFingerprint = inputUnchanged ? fingerprintHitsIdentity(allHits) : null;
+    if (identityFingerprint !== null && existing.identityFingerprint === identityFingerprint) {
       // Only offsets moved (typing in a referencing paragraph): the reference set, marks
       // and note stories are unchanged, so the memo — and every cache hanging off its
       // mark contexts — survives. The fresh hit array replaces the stale one; per-page
@@ -423,6 +429,8 @@ function notesMemoFor(
   const fresh: NotesPassMemo = {
     hitsFingerprint,
     identityFingerprint: fingerprintHitsIdentity(allHits),
+    // (Recomputed here only when the memo above did not match; the common keystroke path
+    // computes it once.)
     inputFingerprint,
     allHits,
     provisionalMarks: provisionalNoteMarks(allHits, input),
@@ -639,6 +647,15 @@ function collectsAtEnd(pos: FootnotePosition): boolean {
  * marks and the old cache is released with them.
  */
 const noteStoryCachesByMarks = new WeakMap<NoteMarkContext, NoteStoryLayoutCache>();
+
+function noteStoryCacheFor(marks: NoteMarkContext): NoteStoryLayoutCache {
+  let cache = noteStoryCachesByMarks.get(marks);
+  if (!cache) {
+    cache = new Map();
+    noteStoryCachesByMarks.set(marks, cache);
+  }
+  return cache;
+}
 
 /** ONE cache-or-layout separator fetch, so the fallback-reason handling has one shape. */
 function separatorLayoutOf(
@@ -2108,14 +2125,10 @@ export function computeFootnoteReserves(
   let carry: NoteCarryMap = new Map();
   const refIndex = buildPageRefIndex(allRefs);
   const separatorCache = createNoteSeparatorCache();
-  // Keyed on the mark-context object: the reflow loop's rounds all share one marks
-  // object, so every round of a search lays each note once; a new pass mints new marks
-  // and with them a fresh cache (see {@link NoteStoryLayoutCache} for what the key omits).
-  let noteLayoutCache = noteStoryCachesByMarks.get(noteMarks);
-  if (!noteLayoutCache) {
-    noteLayoutCache = new Map();
-    noteStoryCachesByMarks.set(noteMarks, noteLayoutCache);
-  }
+  // Keyed on the mark-context object, which the memo keeps across keystrokes: unchanged
+  // notes reuse their story layouts until the memo (which pins the parts and inputs the
+  // key omits) is replaced. See {@link NoteStoryLayoutCache}.
+  const noteLayoutCache = noteStoryCacheFor(noteMarks);
   const holdOutOpts = layoutOpts(input, noteMarks);
   const isPageBottomFootnoteRef = (ref: PageRefHit): boolean =>
     ref.noteKind === 'footnote' && !collectsAtEnd(footnotePropsFor(input, ref.sectionIndex).pos);
@@ -2321,11 +2334,7 @@ export function attachNotesToLayout(
   }
   // Keyed on the FINAL mark context, whose identity the memo keeps while the sites
   // fingerprint stands, so unchanged notes reuse their story layouts across passes.
-  let noteLayoutCache = noteStoryCachesByMarks.get(noteMarks);
-  if (!noteLayoutCache) {
-    noteLayoutCache = new Map();
-    noteStoryCachesByMarks.set(noteMarks, noteLayoutCache);
-  }
+  const noteLayoutCache = noteStoryCacheFor(noteMarks);
 
   let carry: NoteCarryMap = new Map();
   const endnotesBySection = new Map<number, PageRefHit[]>();
@@ -2412,8 +2421,13 @@ export function attachNotesToLayout(
       // page by identity (it is what the session published), so an entry keyed only on
       // this pass's input is one generation behind and never hits — every pass then
       // republished a fresh page object for every footnote-bearing page, and the painter
-      // rebuilt their DOM on every keystroke.
-      if (attached !== page) memo.pageAttach.set(attached, entry);
+      // rebuilt their DOM on every keystroke. The reserve entry forwards for the same
+      // reason: the next reserve pass reads the published page.
+      if (attached !== page) {
+        memo.pageAttach.set(attached, entry);
+        const reserveEntry = memo.pageReserve.get(page);
+        if (reserveEntry) memo.pageReserve.set(attached, reserveEntry);
+      }
     }
     return attached;
   });
@@ -2705,9 +2719,11 @@ export function layoutSemanticDocumentWithNotes<
     optionsWithLists.session
   );
   const builtHits = buildPageRefHits(packageRefs, paragraphSectionIndex);
-  // The session memo hands back the PREVIOUS pass's hit array and provisional marks by
-  // identity when their content is unchanged, which is what lets every per-page result
-  // below validate with two identity compares.
+  // The session memo hands back the previous pass's hit array by identity when nothing
+  // moved, and KEEPS its mark contexts when only offsets moved (a keystroke in a
+  // referencing paragraph). Per-page results below validate on the marks identity plus a
+  // content compare of the page's own refs — never on the hit array's identity, which is
+  // fresh whenever any offset moved.
   const notesMemoState = notesMemoFor(optionsWithLists.session, builtHits, notesInput);
   const notesMemo = notesMemoState.memo;
   const allHits = notesMemoState.allHits;

--- a/scripts/check-eslint-max-lines-globs.mjs
+++ b/scripts/check-eslint-max-lines-globs.mjs
@@ -45,7 +45,7 @@ const BLANKET_DISABLES = new Map([
   ['packages/core/src/editor/paginated-surface.ts', 6242],
   ['packages/core/src/store/store/tree-op-apply.ts', 3495],
   ['packages/core/src/output/semantic-paint.ts', 3005],
-  ['packages/core/src/layout/note-pagination.ts', 2846],
+  ['packages/core/src/layout/note-pagination.ts', 2924],
   ['packages/core/src/store/package/note-lifecycle.ts', 1320],
 ]);
 

--- a/scripts/check-eslint-max-lines-globs.mjs
+++ b/scripts/check-eslint-max-lines-globs.mjs
@@ -45,7 +45,7 @@ const BLANKET_DISABLES = new Map([
   ['packages/core/src/editor/paginated-surface.ts', 6242],
   ['packages/core/src/store/store/tree-op-apply.ts', 3495],
   ['packages/core/src/output/semantic-paint.ts', 3005],
-  ['packages/core/src/layout/note-pagination.ts', 2924],
+  ['packages/core/src/layout/note-pagination.ts', 2939],
   ['packages/core/src/store/package/note-lifecycle.ts', 1320],
 ]);
 


### PR DESCRIPTION
Typing in a paragraph that references a footnote re-laid out every note story on every keystroke: the notes memo keyed its lifetime on the refs' atom offsets, which move with each insertion, so the memo and every note story cache died per keystroke.

This change splits the memo key into an identity fingerprint (note ids, owners, marks — without offsets) and a full fingerprint. An offsets-only change now keeps the memo, its mark contexts, and the per-mark-context note story caches alive. Per-page reserve and attach entries validate on the marks identity plus a content compare of the page's own refs, and attach entries key on the published page so the next pass hits them. Document properties join the input fingerprint by content, so a `DOCPROPERTY` field inside a note still repaints when the value changes.

On a 55-page legal document with dense footnotes, median keystroke layout in a referencing paragraph drops from 27.1 ms to 1.6 ms, and cold open drops from 1427 ms to 528 ms. In the browser the end-to-end typing frame median drops from 66.6 ms to 29.8 ms with long tasks going from 35 to 0.

Fixes #631

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790671798&installation_model_id=422592&pr_number=635&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F635&signature=c3d32df1e2c413c892ce7d61811e06895e89919a80473bda4ef2f8d2aea58068"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->