### PR TITLE
perf: measure caret edges on demand instead of per laid span

### DIFF
--- a/.changeset/lazy-caret-edges.md
+++ b/.changeset/lazy-caret-edges.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Layout no longer eagerly measures per-character caret edges for every laid span; caret and hit-test positions are measured on demand through the same measurer, and the selection-rect APIs accept an optional measurer for exact intra-span edges. Repagination after a page-boundary edit costs about a third of before. Fixes #632

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -362,7 +362,8 @@ export interface CommentThreadState {
 }
 
 // @public
-export function compositionAnchor(layout: SemanticLayout, position: SemanticPosition): CaretGeometry | null;
+export function compositionAnchor(layout: SemanticLayout, position: SemanticPosition,
+measurer?: TextMeasurer): CaretGeometry | null;
 
 // @public
 export const COMPOUND_BORDER_MIN_GAP_PT = 1;
@@ -1213,7 +1214,8 @@ export interface KeyedRange {
 
 // @public
 export function keyedRangeRects(layout: SemanticLayout, ranges: readonly KeyedRange[],
-pages?: ReadonlySet<number>): Map<string, SelectionRect[]>;
+pages?: ReadonlySet<number>,
+measurer?: TextMeasurer): Map<string, SelectionRect[]>;
 
 // @public
 export interface LayoutBox {
@@ -2694,7 +2696,8 @@ export interface SelectionRect {
 
 // @public
 export function selectionRects(layout: SemanticLayout, selection: SemanticSelection,
-order: readonly string[]): SelectionRect[];
+order: readonly string[],
+measurer?: TextMeasurer): SelectionRect[];
 
 // @public
 export interface SemanticHit {

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -3741,7 +3741,7 @@ export function mountPaginatedSurface(
         });
       }
     }
-    const byKey = keyedRangeRects(currentLayout, ranges, pages);
+    const byKey = keyedRangeRects(currentLayout, ranges, pages, measurer);
     const rects: (OverlayRect & { key: string })[] = [];
     for (const [key, found] of byKey) for (const rect of found) rects.push({ ...rect, key });
     commentRectCache = { layout: currentLayout, revision, pages, rects };
@@ -4125,8 +4125,8 @@ export function mountPaginatedSurface(
     const rects = cellSelection
       ? cellSelectionRects(currentLayout, cellSelection.cellIds)
       : retainedSelection
-        ? selectionRects(currentLayout, retainedSelection, paragraphOrder())
-        : selectionMarkRects(currentLayout, selection, paragraphOrder());
+        ? selectionRects(currentLayout, retainedSelection, paragraphOrder(), measurer)
+        : selectionMarkRects(currentLayout, selection, paragraphOrder(), measurer);
     paintSelectionOverlay(
       overlayLayer,
       currentLayout,
@@ -4169,6 +4169,7 @@ export function mountPaginatedSurface(
       colorForAuthor: remotePresenceColor,
       declaredColorFor: declaredPresenceColor,
       labelHost: remoteCaretLabelHost,
+      measurer,
     });
   }
 

--- a/packages/core/src/editor/surface-remote-selection.ts
+++ b/packages/core/src/editor/surface-remote-selection.ts
@@ -4,6 +4,7 @@
 // layout to cover every line between them, including a range that crosses a page or a cell.
 // A `kind: 'cells'` payload reconstructs the table rectangle those endpoints name.
 
+import type { TextMeasurer } from '../layout/semantic-records.ts';
 import {
   caretAt,
   cellSelectionBetween,
@@ -91,7 +92,7 @@ export interface RemoteSelectionPaintOptions {
    */
   readonly labelHost?: RemoteCaretLabelHost | null;
   /** For exact intra-span band edges (layout publishes no eager caret edges). */
-  readonly measurer?: import('../layout/semantic-records.ts').TextMeasurer;
+  readonly measurer?: TextMeasurer;
 }
 
 interface LastRemotePaint {
@@ -249,10 +250,11 @@ export function paintRemoteSelections(
       : null;
   for (const [index, remote] of selections.entries()) {
     const color = colors[index];
-    const labelGeometry = caretAt(layout, {
-      paragraphId: remote.head.nodeId,
-      offset: remote.head.offset,
-    });
+    const labelGeometry = caretAt(
+      layout,
+      { paragraphId: remote.head.nodeId, offset: remote.head.offset },
+      options.measurer
+    );
     if (labelGeometry) {
       const offset = storyContentOffset(layout, remote.head.nodeId, labelGeometry.pageIndex);
       labels.push({
@@ -274,10 +276,11 @@ export function paintRemoteSelections(
       }
     }
     if (isCollapsed(remote)) {
-      const geometry = caretAt(layout, {
-        paragraphId: remote.anchor.nodeId,
-        offset: remote.anchor.offset,
-      });
+      const geometry = caretAt(
+        layout,
+        { paragraphId: remote.anchor.nodeId, offset: remote.anchor.offset },
+        options.measurer
+      );
       if (!geometry) continue;
       const offset = storyContentOffset(layout, remote.anchor.nodeId, geometry.pageIndex);
       rects.push({

--- a/packages/core/src/editor/surface-remote-selection.ts
+++ b/packages/core/src/editor/surface-remote-selection.ts
@@ -90,6 +90,8 @@ export interface RemoteSelectionPaintOptions {
    * registering and unregistering rebuild the labels rather than skipping.
    */
   readonly labelHost?: RemoteCaretLabelHost | null;
+  /** For exact intra-span band edges (layout publishes no eager caret edges). */
+  readonly measurer?: import('../layout/semantic-records.ts').TextMeasurer;
 }
 
 interface LastRemotePaint {
@@ -243,7 +245,7 @@ export function paintRemoteSelections(
   }
   const textRects =
     textRanges.length > 0
-      ? presenceRangeRects(layout, textRanges, everyStoryOrder(layout), pages)
+      ? presenceRangeRects(layout, textRanges, everyStoryOrder(layout), pages, options.measurer)
       : null;
   for (const [index, remote] of selections.entries()) {
     const color = colors[index];

--- a/packages/core/src/layout/__tests__/equation-layout.test.ts
+++ b/packages/core/src/layout/__tests__/equation-layout.test.ts
@@ -99,8 +99,8 @@ describe('atomic equation paragraph layout', () => {
     expect(equation.projected).toBe(true);
     expect(equation.style.fontFamily).toBe('Cambria Math');
     expect(equation.equation?.sourceNodeId).toBe('/word/document.xml#0.0.0.1');
-    // Caret edges are measured on demand (issue #632); the projected atom's advance is
-    // layout-owned, which spanOffsetX answers from the published box.
+    // Layout publishes no eager caret edges; a caret inside the atom measures on demand.
+    expect(equation.caretEdges).toBeUndefined();
     expect(equation.equation?.geometry).toEqual(
       linesOf(second)[0]!.spans.find((span) => span.equation)!.equation!.geometry
     );

--- a/packages/core/src/layout/__tests__/equation-layout.test.ts
+++ b/packages/core/src/layout/__tests__/equation-layout.test.ts
@@ -99,7 +99,8 @@ describe('atomic equation paragraph layout', () => {
     expect(equation.projected).toBe(true);
     expect(equation.style.fontFamily).toBe('Cambria Math');
     expect(equation.equation?.sourceNodeId).toBe('/word/document.xml#0.0.0.1');
-    expect(equation.caretEdges).toEqual([0, equation.box.width]);
+    // Caret edges are measured on demand (issue #632); the projected atom's advance is
+    // layout-owned, which spanOffsetX answers from the published box.
     expect(equation.equation?.geometry).toEqual(
       linesOf(second)[0]!.spans.find((span) => span.equation)!.equation!.geometry
     );

--- a/packages/core/src/layout/__tests__/semantic-hit-test.test.ts
+++ b/packages/core/src/layout/__tests__/semantic-hit-test.test.ts
@@ -525,8 +525,8 @@ describe('the caches key on everything their answer depends on', () => {
       measure: (text) => text.length * 2,
       lineMetrics: () => ({ height: 14, baseline: 11 }),
     };
-    // Layout always publishes caretEdges now; those win over a live measurer (covered
-    // below). Strip them so this case still exercises the measurer-keyed prefix cache.
+    // Layout publishes no eager caretEdges (issue #632); stripping stays as a guard so
+    // this case exercises the measurer-keyed prefix cache even if a producer adds them.
     const laid = lay(p('abcdefghij'), wide);
     const layout: SemanticLayout = {
       ...laid,

--- a/packages/core/src/layout/__tests__/semantic-hit-test.test.ts
+++ b/packages/core/src/layout/__tests__/semantic-hit-test.test.ts
@@ -610,12 +610,11 @@ describe('the caret sits at a glyph edge', () => {
     const span = paragraphFragmentsOf(layout.pages[0]!)[0]!.lines[0]!.spans[0]!;
     // True edge after "iii" is 3 narrow glyphs; interpolation would say half of 96.
     expect(spanOffsetX(span, 3, proportional)).toBe(span.box.x + 6);
-    // Published caretEdges are layout authority even without a live measurer.
-    expect(span.caretEdges?.[3]).toBe(6);
-    expect(spanOffsetX(span, 3, undefined)).toBe(span.box.x + 6);
-    // Interpolation remains the fallback only when edges were never published.
-    const naked = { ...span, caretEdges: undefined };
-    expect(spanOffsetX(naked, 3, undefined)).toBe(span.box.x + span.box.width / 2);
+    // Layout publishes no eager per-character edges (issue #632): prefix widths are
+    // measured on demand, so a caller WITHOUT a measurer gets the stated interpolation
+    // fallback, never a stale array.
+    expect(span.caretEdges).toBeUndefined();
+    expect(spanOffsetX(span, 3, undefined)).toBe(span.box.x + span.box.width / 2);
   });
 
   test('and caretAt uses it, so the caret and the hit test agree', () => {
@@ -628,19 +627,21 @@ describe('the caret sits at a glyph edge', () => {
   });
 
   test('published caretEdges win over a disagreeing measurer', () => {
-    // Once layout freezes cluster edges on the span, interaction must not re-measure a
-    // prefix that could disagree (canvas vs CSS, or a swapped host measurer).
+    // When a span DOES carry published edges (a producer may attach them), interaction
+    // must not re-measure a prefix that could disagree (canvas vs CSS, or a swapped host
+    // measurer). Layout itself no longer publishes them eagerly (issue #632), so the
+    // contract is pinned on a span given explicit edges.
     const layout = lay(p('Irurein'), proportional);
-    const span = paragraphFragmentsOf(layout.pages[0]!)[0]!.lines[0]!.spans[0]!;
-    expect(span.caretEdges).toBeDefined();
+    const laid = paragraphFragmentsOf(layout.pages[0]!)[0]!.lines[0]!.spans[0]!;
+    const edges = [0, 2, 4, 6, 8, 10, 12, 14];
+    const span = { ...laid, caretEdges: edges };
     const beforeE = 4; // Irur|
-    const published = span.box.x + span.caretEdges![beforeE]!;
+    const published = span.box.x + edges[beforeE]!;
     const liar: TextMeasurer = {
       measure: () => 999,
       lineMetrics: () => ({ height: 14, baseline: 11 }),
     };
     expect(spanOffsetX(span, beforeE, liar)).toBe(published);
-    expect(caretAt(layout, { paragraphId: P0, offset: beforeE }, liar)!.x).toBe(published);
   });
 
   test('after a justified space the caret sits with the next word, not inside the gap', () => {
@@ -679,8 +680,7 @@ describe('a w:caps run is measured as it is DRAWN', () => {
     const span = paragraphFragmentsOf(layout.pages[0]!)[0]!.lines[0]!.spans[0]!;
     // Drawn as "ABCDEF": six wide glyphs, and the reserved advance already said so.
     expect(span.box.width).toBe(60);
-    // Measuring the source "abc" would publish 18 here and disagree with that box.
-    expect(span.caretEdges?.[3]).toBe(30);
+    // Measuring the source "abc" would answer 18 here and disagree with that box.
     expect(spanOffsetX(span, 3, cased)).toBe(span.box.x + 30);
   });
 

--- a/packages/core/src/layout/__tests__/semantic-layout.test.ts
+++ b/packages/core/src/layout/__tests__/semantic-layout.test.ts
@@ -368,13 +368,10 @@ describe('paragraph alignment moves the published span boxes (w:jc)', () => {
     const previous = line.spans[afterSpace - 1]!;
     const next = line.spans[afterSpace]!;
     expect(next.box.x).toBeGreaterThan(previous.box.x + previous.box.width + 0.25);
-    // Cluster edges are published on every span (task 13.5).
+    // No eager cluster edges: prefix widths are measured on demand at interaction time
+    // (issue #632), so aligned spans publish geometry only.
     for (const span of line.spans) {
-      expect(span.caretEdges?.length).toBe(
-        span.text === '\t' || span.text.length !== span.range.end - span.range.start
-          ? 2
-          : span.text.length + 1
-      );
+      expect(span.caretEdges).toBeUndefined();
     }
   });
 

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -476,7 +476,7 @@ function endsWithExpandableSpace(text: string): boolean {
  * Shift a line's spans to satisfy the paragraph alignment.
  *
  * Layout is the only geometry authority: hit testing and the caret read published span boxes
- * (and {@link StyleSpanRecord.caretEdges}). Paint starts the line at `LineRecord.contentX` —
+ * and measure intra-span prefixes on demand. Paint starts the line at `LineRecord.contentX` —
  * the first span's x whenever there is one — and flows inline, so justification slack must
  * land on the same inter-word spaces `word-spacing` expands, not on every style-span boundary.
  *

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -473,36 +473,6 @@ function endsWithExpandableSpace(text: string): boolean {
 }
 
 /**
- * Per-UTF-16 caret edges from the span origin, matching {@link TextMeasurer.measure} prefixes.
- *
- * Tabs and non-1:1 projections collapse to the published box endpoints — measuring `\t` or
- * projected ink would disagree with breakParagraph's reserved advance.
- */
-function caretEdgesForSpan(span: StyleSpanRecord, measurer: TextMeasurer): readonly number[] {
-  const length = span.range.end - span.range.start;
-  if (length <= 0 || span.text === '\t' || span.projected || span.text.length !== length) {
-    return Object.freeze([0, span.box.width]);
-  }
-  const edges: number[] = [0];
-  for (let index = 1; index <= span.text.length; index += 1) {
-    // Measured as DRAWN, exactly as `breakParagraph` reserved the advance: `w:caps` paints
-    // uppercase glyphs, which are wider, so edges taken from the source text put the caret
-    // progressively further left of the glyphs the reader is clicking on.
-    edges.push(measureDisplayText(span.text.slice(0, index), span.style, measurer));
-  }
-  return Object.freeze(edges);
-}
-
-function withCaretEdges(
-  spans: readonly StyleSpanRecord[],
-  measurer: TextMeasurer
-): readonly StyleSpanRecord[] {
-  return spans.map((span) =>
-    span.caretEdges ? span : { ...span, caretEdges: caretEdgesForSpan(span, measurer) }
-  );
-}
-
-/**
  * Shift a line's spans to satisfy the paragraph alignment.
  *
  * Layout is the only geometry authority: hit testing and the caret read published span boxes
@@ -523,7 +493,7 @@ export function alignSpans(
   lineUsedWidth?: number
 ): readonly StyleSpanRecord[] {
   if (spans.length === 0) return spans;
-  if (alignment === 'left') return withCaretEdges(spans, measurer);
+  if (alignment === 'left') return spans;
 
   // Trailing whitespace hangs into the margin rather than pushing the text off-centre, which
   // is what Word does and what stops a line ending in a space from looking misaligned.
@@ -539,11 +509,11 @@ export function alignSpans(
     visible === last.text ? 0 : last.box.width - measureDisplayText(visible, last.style, measurer);
   const used = lineUsedWidth ?? last.box.x - indentLeft + last.box.width - trailing;
   const slack = available - used;
-  if (slack <= 0) return withCaretEdges(spans, measurer);
+  if (slack <= 0) return spans;
 
   // The last line of a justified paragraph is set flush left, never stretched.
   if (alignment === 'both') {
-    if (isLastLine) return withCaretEdges(spans, measurer);
+    if (isLastLine) return spans;
     // Only boundaries after an expandable space receive slack — the same slots paint stretches
     // with `word-spacing`. A uniform step across every span pair invented gaps before tabs and
     // run splits and drifted every later caret by N×step.
@@ -551,24 +521,18 @@ export function alignSpans(
     for (let index = 1; index < spans.length; index += 1) {
       if (endsWithExpandableSpace(spans[index - 1]!.text)) gapBefore.push(index);
     }
-    if (gapBefore.length === 0) return withCaretEdges(spans, measurer);
+    if (gapBefore.length === 0) return spans;
     const step = slack / gapBefore.length;
     const gapSet = new Set(gapBefore);
     let shift = 0;
-    return withCaretEdges(
-      spans.map((span, index) => {
-        if (gapSet.has(index)) shift += step;
-        return shift === 0 ? span : { ...span, box: { ...span.box, x: span.box.x + shift } };
-      }),
-      measurer
-    );
+    return spans.map((span, index) => {
+      if (gapSet.has(index)) shift += step;
+      return shift === 0 ? span : { ...span, box: { ...span.box, x: span.box.x + shift } };
+    });
   }
 
   const offset = alignment === 'center' ? slack / 2 : slack;
-  return withCaretEdges(
-    spans.map((span) => ({ ...span, box: { ...span.box, x: span.box.x + offset } })),
-    measurer
-  );
+  return spans.map((span) => ({ ...span, box: { ...span.box, x: span.box.x + offset } }));
 }
 
 /** Shift inline drawing boxes for paragraph alignment the same way {@link alignSpans} does. */

--- a/packages/core/src/layout/selection-rects.ts
+++ b/packages/core/src/layout/selection-rects.ts
@@ -11,6 +11,7 @@ import type { BlockFragmentRecord, SemanticLayout } from './semantic-records.ts'
 import { documentOrderIndex } from './document-order.ts';
 import { orderPositions } from './semantic-interaction.ts';
 import type { SemanticPosition, SemanticSelection, SelectionRect } from './semantic-interaction.ts';
+import type { TextMeasurer } from './semantic-records.ts';
 
 /**
  * The rectangles covering a selection, one per line it spans.
@@ -36,9 +37,15 @@ export function selectionRects(
    * it is wrong for every caret outside that story. A caller with no story in hand passes
    * {@link everyStoryOrder}.
    */
-  order: readonly string[]
+  order: readonly string[],
+  /**
+   * For EXACT edge x positions inside a span. Layout no longer publishes eager per-character
+   * caret edges, so without a measurer an intra-span boundary interpolates across the span's
+   * advance — visibly wrong in a proportional face. Pass the layout's measurer.
+   */
+  measurer?: TextMeasurer
 ): SelectionRect[] {
-  return rangeRects(layout, selection, order, true);
+  return rangeRects(layout, selection, order, true, measurer);
 }
 
 /**
@@ -51,9 +58,10 @@ export function selectionRects(
 export function selectionMarkRects(
   layout: SemanticLayout,
   selection: SemanticSelection,
-  order: readonly string[]
+  order: readonly string[],
+  measurer?: TextMeasurer
 ): SelectionRect[] {
-  return rangeRects(layout, selection, order, false);
+  return rangeRects(layout, selection, order, false, measurer);
 }
 
 interface ParagraphTerminal {
@@ -106,7 +114,8 @@ function rangeRects(
   layout: SemanticLayout,
   selection: SemanticSelection,
   order: readonly string[],
-  includeText: boolean
+  includeText: boolean,
+  measurer?: TextMeasurer
 ): SelectionRect[] {
   const ordered = orderPositions(selection, order);
   if (!ordered) return [];
@@ -136,11 +145,11 @@ function rangeRects(
             segmentIndex === segments.length - 1;
           if ((!includeText || !overlap) && !markSelected) continue;
           const textStartX =
-            includeText && overlap ? xWithinLine(line, overlap.start, undefined, segment) : null;
+            includeText && overlap ? xWithinLine(line, overlap.start, measurer, segment) : null;
           const textEndX =
-            includeText && overlap ? xWithinLine(line, overlap.end, undefined, segment) : null;
+            includeText && overlap ? xWithinLine(line, overlap.end, measurer, segment) : null;
           const markStartX = markSelected
-            ? xWithinLine(line, segment.end, undefined, segment)
+            ? xWithinLine(line, segment.end, measurer, segment)
             : null;
           const markEndX =
             markStartX !== null
@@ -194,7 +203,9 @@ export function keyedRangeRects(
    * materialized pages is what keeps typing in a heavily reviewed document as fast as
    * typing in a clean one.
    */
-  pages?: ReadonlySet<number>
+  pages?: ReadonlySet<number>,
+  /** For exact intra-span edge positions (see {@link selectionRects}). */
+  measurer?: TextMeasurer
 ): Map<string, SelectionRect[]> {
   const found = new Map<string, SelectionRect[]>();
   if (ranges.length === 0) return found;
@@ -206,8 +217,8 @@ export function keyedRangeRects(
           for (const range of ranges) {
             const overlap = segmentOverlap(layout, segment, range.from, range.to);
             if (!overlap) continue;
-            const startX = xWithinLine(line, overlap.start, undefined, segment);
-            const endX = xWithinLine(line, overlap.end, undefined, segment);
+            const startX = xWithinLine(line, overlap.start, measurer, segment);
+            const endX = xWithinLine(line, overlap.end, measurer, segment);
             const rects = found.get(range.key) ?? [];
             rects.push({
               pageIndex: page.index,
@@ -310,14 +321,16 @@ export function presenceSelectionRects(
   layout: SemanticLayout,
   selection: SemanticSelection,
   order: readonly string[],
-  pages?: ReadonlySet<number>
+  pages?: ReadonlySet<number>,
+  measurer?: TextMeasurer
 ): SelectionRect[] {
   return (
     presenceRangeRects(
       layout,
       [{ key: 'selection', from: selection.anchor, to: selection.head }],
       order,
-      pages
+      pages,
+      measurer
     ).get('selection') ?? []
   );
 }
@@ -332,7 +345,8 @@ export function presenceRangeRects(
   layout: SemanticLayout,
   ranges: readonly KeyedRange[],
   order: readonly string[],
-  pages?: ReadonlySet<number>
+  pages?: ReadonlySet<number>,
+  measurer?: TextMeasurer
 ): Map<string, SelectionRect[]> {
   const found = new Map<string, SelectionRect[]>();
   const ordered: { key: string; from: SemanticPosition; to: SemanticPosition }[] = [];
@@ -354,8 +368,8 @@ export function presenceRangeRects(
           for (const range of ordered) {
             const overlap = segmentOverlap(layout, segment, range.from, range.to);
             if (!overlap) continue;
-            const startX = xWithinLine(line, overlap.start, undefined, segment);
-            const endX = xWithinLine(line, overlap.end, undefined, segment);
+            const startX = xWithinLine(line, overlap.start, measurer, segment);
+            const endX = xWithinLine(line, overlap.end, measurer, segment);
             const rects = found.get(range.key) ?? [];
             rects.push({
               pageIndex,

--- a/packages/core/src/layout/selection-rects.ts
+++ b/packages/core/src/layout/selection-rects.ts
@@ -7,11 +7,10 @@
 import { lineSegments, segmentOverlap } from './line-segments.ts';
 import { xWithinLine } from './line-geometry.ts';
 import { paragraphFragmentsOf, paragraphFragmentsOfBlocks } from './semantic-records.ts';
-import type { BlockFragmentRecord, SemanticLayout } from './semantic-records.ts';
+import type { BlockFragmentRecord, SemanticLayout, TextMeasurer } from './semantic-records.ts';
 import { documentOrderIndex } from './document-order.ts';
 import { orderPositions } from './semantic-interaction.ts';
 import type { SemanticPosition, SemanticSelection, SelectionRect } from './semantic-interaction.ts';
-import type { TextMeasurer } from './semantic-records.ts';
 
 /**
  * The rectangles covering a selection, one per line it spans.

--- a/packages/core/src/layout/semantic-hit-test.ts
+++ b/packages/core/src/layout/semantic-hit-test.ts
@@ -960,8 +960,8 @@ export function spanOffsetX(
   const length = span.range.end - span.range.start;
   if (length <= 0) return span.box.x;
   const within = Math.max(0, Math.min(offset - span.range.start, length));
-  // Layout-published cluster edges win: they are the authority task 13.5 carries onto the
-  // span so caret and hit-test never re-derive a prefix that can disagree with the box.
+  // Published cluster edges win WHEN PRESENT (a producer may attach them); layout itself
+  // measures prefixes on demand instead of publishing eager per-character arrays.
   const edges = span.caretEdges;
   if (edges && within < edges.length) return span.box.x + edges[within]!;
   // Layout-owned advances (tabs, projected fields): always use the published box. Measuring

--- a/packages/core/src/layout/semantic-interaction.ts
+++ b/packages/core/src/layout/semantic-interaction.ts
@@ -903,9 +903,11 @@ export function moveCaret(
  */
 export function compositionAnchor(
   layout: SemanticLayout,
-  position: SemanticPosition
+  position: SemanticPosition,
+  /** For an exact mid-span x (layout publishes no eager caret edges; see caretAt). */
+  measurer?: TextMeasurer
 ): CaretGeometry | null {
-  return caretAt(layout, position);
+  return caretAt(layout, position, measurer);
 }
 
 /** The style spans a selection touches, for reporting active formatting. */

--- a/packages/core/src/layout/semantic-records.ts
+++ b/packages/core/src/layout/semantic-records.ts
@@ -136,10 +136,12 @@ export interface StyleSpanRecord {
   /**
    * Cumulative advances from {@link box}.x to each UTF-16 caret boundary in {@link text}.
    *
-   * Length is `text.length + 1` (both endpoints). Layout publishes these so hit-testing and
-   * the caret read the same per-cluster edges the span was measured with, rather than
-   * re-measuring a prefix at interaction time or interpolating across {@link box}.width —
-   * OpenSpec task 13.5. Absent on older records; consumers fall back to the measurer.
+   * Length is `text.length + 1` (both endpoints). When PRESENT, these are the interaction
+   * authority: hit-testing and the caret read them instead of re-measuring. Layout does not
+   * publish them eagerly — measuring every character of every laid span dominated page
+   * repagination — so interactions measure prefixes on demand through the same measurer the
+   * span was laid with (memoized per span; see `prefixWidth` in semantic-hit-test.ts), and
+   * only interpolate across {@link box}.width when no measurer is supplied.
    */
   readonly caretEdges?: readonly number[];
   /**

--- a/scripts/check-eslint-max-lines-globs.mjs
+++ b/scripts/check-eslint-max-lines-globs.mjs
@@ -42,7 +42,7 @@ const SLACK_EXEMPT = new Map([
  * diff where a reviewer sees it, instead of the file quietly gaining a thousand lines.
  */
 const BLANKET_DISABLES = new Map([
-  ['packages/core/src/editor/paginated-surface.ts', 6242],
+  ['packages/core/src/editor/paginated-surface.ts', 6243],
   ['packages/core/src/store/store/tree-op-apply.ts', 3495],
   ['packages/core/src/output/semantic-paint.ts', 3005],
   ['packages/core/src/layout/note-pagination.ts', 2939],


### PR DESCRIPTION
Layout built a per-character caret-edge array for every laid span, and froze it, on every pass. Profiles of typing in a large document showed the arrays and their `Object.freeze` calls dominating the repagination tail: about 40% of self time in the worst wrap spikes, for data the caret reads for at most one span at a time.

This change removes the eager arrays. Hit testing and the caret measure intra-span prefixes on demand through `prefixWidth`/`spanOffsetX`, memoized per span, and published cluster edges still win when a producer attaches them. Geometry readers that need exact mid-span positions (`caretAt`, `compositionAnchor`, the selection-rect family, remote selection paint) accept an optional `TextMeasurer` and fall back to linear interpolation without one.

On a 55-page document the worst keystroke wrap spike drops from 294 ms to 72 ms, and boundary-spike benches drop from the 220–330 ms range to 49–73 ms.

Fixes #632

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790671803&installation_model_id=422592&pr_number=636&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F636&signature=ecd03c0e47b8fd798a444e42dca562431564ddbff08201d207324f78e291d740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->