### PR TITLE
fix: resolve note hyperlink relationships against the notes part

### DIFF
--- a/.changeset/note-hyperlink-rels.md
+++ b/.changeset/note-hyperlink-rels.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Hyperlinks inside footnotes and endnotes now resolve their relationship ids against the notes part's own relationships instead of the body part's. Fixes #637

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -1653,6 +1653,7 @@ export interface NotesLayoutInput {
     // (undocumented)
     readonly projectFieldLink?: FieldLinkProjector;
     readonly projectLink?: HyperlinkProjector;
+    readonly projectLinkForPart?: (ownerPartName: string) => HyperlinkProjector | undefined;
     readonly refFields?: RefFieldContext;
     // (undocumented)
     readonly styleCascade?: StyleCascadeTable;

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -1645,6 +1645,7 @@ export interface NotesLayoutInput {
     readonly footnotePropsBySection: readonly ResolvedFootnoteProperties[];
     // (undocumented)
     readonly footnotesPart: OoxmlPart | null;
+    readonly linkRelsEpoch?: string;
     // (undocumented)
     readonly measurer: TextMeasurer;
     readonly numberingIndex?: NumberingIndex;

--- a/packages/core/src/editor/__tests__/note-hyperlink-rels.test.ts
+++ b/packages/core/src/editor/__tests__/note-hyperlink-rels.test.ts
@@ -64,16 +64,19 @@ describe('note hyperlink relationship scope', () => {
     const container = document.createElement('div');
     document.body.append(container);
     const editor = createDocxEditor({ container, document: conflictingRelsDoc() });
-    expect(editor.surface).not.toBeNull();
+    try {
+      expect(editor.surface).not.toBeNull();
 
-    const anchors = [...container.querySelectorAll('a.docx-hyperlink')] as HTMLElement[];
-    const hrefFor = (text: string) =>
-      anchors.find((anchor) => anchor.textContent === text)?.getAttribute('href');
+      const anchors = [...container.querySelectorAll('a.docx-hyperlink')] as HTMLElement[];
+      const hrefFor = (text: string) =>
+        anchors.find((anchor) => anchor.textContent === text)?.getAttribute('href');
 
-    expect(hrefFor('BodyLink')).toBe('https://body.example/');
-    expect(hrefFor('NoteLink')).toBe('https://note.example/');
-
-    editor.destroy();
-    container.remove();
+      expect(hrefFor('BodyLink')).toBe('https://body.example/');
+      expect(hrefFor('NoteLink')).toBe('https://note.example/');
+    } finally {
+      // A failed expect must not leave the mounted editor on the shared document.
+      editor.destroy();
+      container.remove();
+    }
   });
 });

--- a/packages/core/src/editor/__tests__/note-hyperlink-rels.test.ts
+++ b/packages/core/src/editor/__tests__/note-hyperlink-rels.test.ts
@@ -1,0 +1,79 @@
+// Hyperlink relationship scope for note stories, end to end over a mounted editor.
+//
+// A `w:hyperlink` inside `/word/footnotes.xml` declares its `r:id` in
+// `footnotes.xml.rels`, not the body part's relationships. When both parts assign the
+// same id to different targets, the painted footnote anchor must carry the footnote
+// part's target — resolving through the body's relationships handed it the body's.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import { createDocxEditor } from '../docx-editor.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+
+/** One rId, two targets: `rId7` means one thing in the body and another in the footnote. */
+function conflictingRelsDoc(): Uint8Array {
+  const body =
+    '<w:p><w:r><w:t>Ref</w:t><w:footnoteReference w:id="1"/></w:r></w:p>' +
+    '<w:p><w:hyperlink r:id="rId7"><w:r><w:t>BodyLink</w:t></w:r></w:hyperlink></w:p>';
+  const footnotes =
+    '<w:footnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:footnote>' +
+    '<w:footnote w:id="1"><w:p>' +
+    '<w:hyperlink r:id="rId7"><w:r><w:t>NoteLink</w:t></w:r></w:hyperlink>' +
+    '</w:p></w:footnote>';
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '<Override PartName="/word/footnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}">` +
+        `<Relationship Id="rIdFn" Type="${R}/footnotes" Target="footnotes.xml"/>` +
+        `<Relationship Id="rId7" Type="${R}/hyperlink" Target="https://body.example/" TargetMode="External"/>` +
+        '</Relationships>'
+    ),
+    'word/_rels/footnotes.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}">` +
+        `<Relationship Id="rId7" Type="${R}/hyperlink" Target="https://note.example/" TargetMode="External"/>` +
+        '</Relationships>'
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}" xmlns:r="${R}"><w:body>${body}<w:sectPr/></w:body></w:document>`
+    ),
+    'word/footnotes.xml': strToU8(
+      `<w:footnotes xmlns:w="${W}" xmlns:r="${R}">${footnotes}</w:footnotes>`
+    ),
+  });
+}
+
+describe('note hyperlink relationship scope', () => {
+  test('a footnote link resolves its r:id against footnotes.xml.rels, not the body rels', () => {
+    const container = document.createElement('div');
+    document.body.append(container);
+    const editor = createDocxEditor({ container, document: conflictingRelsDoc() });
+    expect(editor.surface).not.toBeNull();
+
+    const anchors = [...container.querySelectorAll('a.docx-hyperlink')] as HTMLElement[];
+    const hrefFor = (text: string) =>
+      anchors.find((anchor) => anchor.textContent === text)?.getAttribute('href');
+
+    expect(hrefFor('BodyLink')).toBe('https://body.example/');
+    expect(hrefFor('NoteLink')).toBe('https://note.example/');
+
+    editor.destroy();
+    container.remove();
+  });
+});

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -20,6 +20,7 @@ import {
   parseTocInstruction,
   planTocEntries,
   readViewSettings,
+  relationshipTargetIn,
   resolveTocRowHeadings,
   validateTreeOp,
   type DetectedToc,
@@ -850,17 +851,26 @@ export function mountPaginatedSurface(
    * produces the sanitized projection; everything downstream — paint, click routing, the
    * popover, the clipboard — consumes only that.
    */
-  const projectLink = (link: Parameters<typeof hyperlinkTargetOf>[0]) => {
-    const target = hyperlinkTargetOf(link, (id) => session.relationshipTarget(id));
-    if (link.kind === 'textValue') return null;
-    return {
-      id: link.id,
-      kind: target.kind,
-      href: target.href,
-      ...(target.anchor !== undefined ? { anchor: target.anchor } : {}),
-      ...(target.tooltip !== undefined ? { tooltip: target.tooltip } : {}),
+  const projectLinkResolvedBy =
+    (resolveRel: Parameters<typeof hyperlinkTargetOf>[1]) =>
+    (link: Parameters<typeof hyperlinkTargetOf>[0]) => {
+      const target = hyperlinkTargetOf(link, resolveRel);
+      if (link.kind === 'textValue') return null;
+      return {
+        id: link.id,
+        kind: target.kind,
+        href: target.href,
+        ...(target.anchor !== undefined ? { anchor: target.anchor } : {}),
+        ...(target.tooltip !== undefined ? { tooltip: target.tooltip } : {}),
+      };
     };
-  };
+  const projectLink = projectLinkResolvedBy((id) => session.relationshipTarget(id));
+  // The SAME boundary scoped to one notes part: a `w:hyperlink` in `footnotes.xml` or
+  // `endnotes.xml` declares its `r:id` in that part's own `.rels`, so resolving through the
+  // body's relationships either found nothing or — when both parts assign one id — the
+  // body's target.
+  const projectLinkForPart = (partName: string) =>
+    projectLinkResolvedBy((id) => relationshipTargetIn(session.currentPackage(), partName, id));
 
   /**
    * The SAME boundary for HYPERLINK fields: the raw instruction target crosses
@@ -1200,6 +1210,7 @@ export function mountPaginatedSurface(
       drawingTokenForParagraphForPart: (partName, paragraph) =>
         drawingBundle.drawingTokenForParagraph(paragraph, partName),
       drawingLayoutEpochForPart: (partName) => drawingBundle.cacheTokenForPart(partName),
+      projectLinkForPart,
     });
     return layoutSemanticDocument(session.part(), revision, {
       measurer,

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -854,8 +854,8 @@ export function mountPaginatedSurface(
   const projectLinkResolvedBy =
     (resolveRel: Parameters<typeof hyperlinkTargetOf>[1]) =>
     (link: Parameters<typeof hyperlinkTargetOf>[0]) => {
-      const target = hyperlinkTargetOf(link, resolveRel);
       if (link.kind === 'textValue') return null;
+      const target = hyperlinkTargetOf(link, resolveRel);
       return {
         id: link.id,
         kind: target.kind,

--- a/packages/core/src/editor/surface-pages.ts
+++ b/packages/core/src/editor/surface-pages.ts
@@ -517,6 +517,12 @@ export function createNotesLayoutInput(env: {
   ) => string;
   /** Part-level drawing epoch, so the notes-pass memo can trust the closures above. */
   readonly drawingLayoutEpochForPart?: (partName: string) => string;
+  /**
+   * Link projector scoped to one notes part, so a `w:hyperlink` inside `footnotes.xml` or
+   * `endnotes.xml` resolves its `r:id` against that part's own relationships — the same
+   * per-part rule pictures follow just below.
+   */
+  readonly projectLinkForPart?: NotesLayoutInput['projectLinkForPart'];
 }): NotesLayoutInput | undefined {
   const pkg = env.session.currentPackage();
   const footnotesPart = resolveNotesPart(pkg, 'footnote');
@@ -585,6 +591,7 @@ export function createNotesLayoutInput(env: {
     styleCascade: env.styleCascade?.(),
     numberingIndex: env.numberingIndex?.(),
     defaultTabStopPt: env.defaultTabStopPt,
+    ...(env.projectLinkForPart ? { projectLinkForPart: env.projectLinkForPart } : {}),
     ...(drawingsForPart ? { drawingsForPart } : {}),
     // One epoch over both notes parts: either part's drawing state moving must invalidate
     // the notes-pass memo.

--- a/packages/core/src/editor/surface-pages.ts
+++ b/packages/core/src/editor/surface-pages.ts
@@ -591,7 +591,17 @@ export function createNotesLayoutInput(env: {
     styleCascade: env.styleCascade?.(),
     numberingIndex: env.numberingIndex?.(),
     defaultTabStopPt: env.defaultTabStopPt,
-    ...(env.projectLinkForPart ? { projectLinkForPart: env.projectLinkForPart } : {}),
+    ...(env.projectLinkForPart
+      ? {
+          projectLinkForPart: env.projectLinkForPart,
+          // Content token over both notes parts' relationship records: what the per-part
+          // projector reads can move without splicing the part (a replicated rels-only
+          // change), so the notes-pass memo pins it by content, like drawingLayoutEpoch.
+          linkRelsEpoch: [footnotesPart, endnotesPart]
+            .map((notesPart) => (notesPart ? linkRelsTokenFor(pkg, notesPart.name) : ''))
+            .join('\0'),
+        }
+      : {}),
     ...(drawingsForPart ? { drawingsForPart } : {}),
     // One epoch over both notes parts: either part's drawing state moving must invalidate
     // the notes-pass memo.
@@ -603,6 +613,26 @@ export function createNotesLayoutInput(env: {
         }
       : {}),
   };
+}
+
+/**
+ * One part's relationship records as a content string, for the notes-pass memo.
+ *
+ * Covers both maps `relationshipTargetIn` reads — internal records and external targets —
+ * plus `sinkSafe`, because the sanitized projection depends on it too.
+ */
+function linkRelsTokenFor(
+  pkg: ReturnType<TreeDocxSessionView['currentPackage']>,
+  partName: string
+): string {
+  const internal = (pkg.relationships.get(partName) ?? [])
+    .map((record) => `${record.id}>${record.rawTarget}`)
+    .join(',');
+  const external = pkg.externalTargets
+    .filter((record) => record.ownerPart === partName)
+    .map((record) => `${record.id}>${record.rawTarget}|${record.sinkSafe ? 1 : 0}`)
+    .join(',');
+  return `${internal};${external}`;
 }
 
 /** SectPr nodes index-aligned with {@link enumerateDocumentSections}. */

--- a/packages/core/src/layout/__tests__/note-link-projection.test.ts
+++ b/packages/core/src/layout/__tests__/note-link-projection.test.ts
@@ -117,4 +117,58 @@ describe('note-story link projection', () => {
       href: 'https://example.com',
     });
   });
+
+  test('a per-part projector wins over the inherited body projector for note stories', () => {
+    const loaded = readOoxmlPackage(linkedNotesDoc());
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) throw new Error(loaded.reason);
+    const part = loaded.package.parts.get(loaded.package.mainDocumentPart)!;
+    const settings = settingsPartOf(loaded.package);
+    const documentFootnoteProps = resolveFootnoteProperties(
+      undefined,
+      authoredDocumentFootnoteProperties(settings)
+    );
+    const documentEndnoteProps = resolveEndnoteProperties(
+      undefined,
+      authoredDocumentEndnoteProperties(settings)
+    );
+    const askedParts: string[] = [];
+    const notes: NotesLayoutInput = {
+      footnotesPart: resolveNotesPart(loaded.package, 'footnote'),
+      endnotesPart: null,
+      footnotePropsBySection: [documentFootnoteProps],
+      endnotePropsBySection: [documentEndnoteProps],
+      documentFootnoteProps,
+      documentEndnoteProps,
+      measurer: createFixedMeasurer(),
+      producer: 'note-link-scoped',
+      // The r:id of a link in a note declares itself in THAT part's relationships, so the
+      // per-part projector must win over the body's inherited one.
+      projectLinkForPart: (ownerPartName) => {
+        askedParts.push(ownerPartName);
+        return (node) =>
+          node.kind === 'textValue'
+            ? null
+            : { id: `scoped:${node.id}`, kind: 'external', href: 'https://note.example/' };
+      },
+    };
+    const layout = layoutSemanticDocument(part, 1, {
+      measurer: notes.measurer,
+      notes,
+      producer: 'note-link-scoped',
+      projectLink: (node) =>
+        node.kind === 'textValue'
+          ? null
+          : { id: `body:${node.id}`, kind: 'external', href: 'https://body.example/' },
+    });
+
+    const noteSpans = layout.pages
+      .flatMap((page) => page.footnotes?.notes ?? [])
+      .flatMap((note) => note.fragments)
+      .flatMap((fragment) => (fragment.kind === 'paragraph' ? fragment.lines : []))
+      .flatMap((line) => line.spans);
+    const typedLinked = noteSpans.find((span) => span.text === 'Jump');
+    expect(typedLinked?.link).toMatchObject({ kind: 'external', href: 'https://note.example/' });
+    expect(askedParts).toContain(notes.footnotesPart!.name);
+  });
 });

--- a/packages/core/src/layout/note-layout.ts
+++ b/packages/core/src/layout/note-layout.ts
@@ -149,6 +149,16 @@ export interface LayoutNoteStoryOptions {
    * paint to anchor and navigation to activate.
    */
   readonly projectLink?: HyperlinkProjector;
+  /**
+   * Per-part projector, preferred over `projectLink` when `ownerPartName` names the part.
+   *
+   * A `w:hyperlink` in `/word/footnotes.xml` declares its `r:id` in `footnotes.xml.rels`,
+   * so it must resolve there — the body projector answers from the body part's
+   * relationships, and when the two parts assign one id to different targets the footnote
+   * link navigated to the body's target. Same per-part rule pictures follow through
+   * {@link drawingsForPart}.
+   */
+  readonly projectLinkForPart?: (ownerPartName: string) => HyperlinkProjector | undefined;
   readonly projectFieldLink?: FieldLinkProjector;
   /** Document properties for a document-property field inside a note story. */
   readonly documentProperties?: import('@docx-editor.dev/core/store').DocumentProperties;
@@ -239,6 +249,12 @@ export function layoutNoteStory(
     ? options.drawingsForPart?.(options.ownerPartName)
     : undefined;
 
+  // The link projector scoped to the part this note lives in; the body projector is only
+  // the fallback for callers that supply no per-part resolution.
+  const projectLink =
+    (options.ownerPartName ? options.projectLinkForPart?.(options.ownerPartName) : undefined) ??
+    options.projectLink;
+
   const listItems = withResolvedListItems(
     { numberingIndex: options.numberingIndex, styleCascade: options.styleCascade },
     blocks
@@ -252,7 +268,7 @@ export function layoutNoteStory(
     styleCascade: options.styleCascade,
     ...(listItems ? { listItems } : {}),
     noteMarks,
-    ...(options.projectLink ? { projectLink: options.projectLink } : {}),
+    ...(projectLink ? { projectLink } : {}),
     ...(options.projectFieldLink ? { projectFieldLink: options.projectFieldLink } : {}),
     ...(options.documentProperties ? { documentProperties: options.documentProperties } : {}),
     ...(options.refFields ? { refFields: options.refFields } : {}),

--- a/packages/core/src/layout/note-pagination.ts
+++ b/packages/core/src/layout/note-pagination.ts
@@ -197,6 +197,15 @@ export interface NotesLayoutInput {
    * sanitized record a body one does instead of painting dead text.
    */
   readonly projectLink?: import('./field-pieces.ts').HyperlinkProjector;
+  /**
+   * Per notes-part link projector, preferred over `projectLink`: a `w:hyperlink` inside
+   * `/word/footnotes.xml` or `/word/endnotes.xml` declares its `r:id` in that part's own
+   * `.rels`, not the body part's. The surface supplies this; the inherited body projector
+   * remains only a fallback for callers without per-part resolution.
+   */
+  readonly projectLinkForPart?: (
+    ownerPartName: string
+  ) => import('./field-pieces.ts').HyperlinkProjector | undefined;
   readonly projectFieldLink?: import('./field-pieces.ts').FieldLinkProjector;
   /** Document properties for a document-property field inside a note story. */
   readonly documentProperties?: import('@docx-editor.dev/core/store').DocumentProperties;
@@ -351,8 +360,11 @@ function fingerprintNotesInput(input: NotesLayoutInput): string | null {
     input.refFields?.valuesToken ?? '',
     // By CONTENT for the same reason as the REF values above: the properties object is
     // re-read per package revision, and only a value move should repaint a DOCPROPERTY
-    // field inside a note. The link projectors are deliberately absent: they are rebuilt
-    // per pass but are pure over parts this memo already pins.
+    // field inside a note. The link projectors (projectLink, projectLinkForPart,
+    // projectFieldLink) are deliberately absent: they are rebuilt per pass but are pure
+    // over parts this memo already pins — retargeting a hyperlink mints a fresh `r:id`
+    // into the story's XML rather than rewriting the relationship, so a resolution change
+    // always moves the notes part identity too.
     input.documentProperties ? JSON.stringify(input.documentProperties) : '',
     fingerprintNoteProps(input.documentFootnoteProps),
     fingerprintNoteProps(input.documentEndnoteProps),
@@ -712,6 +724,7 @@ function layoutOpts(input: NotesLayoutInput, noteMarks?: NoteMarkContext): Layou
     numberingIndex: input.numberingIndex,
     defaultTabStopPt: input.defaultTabStopPt,
     projectLink: input.projectLink,
+    projectLinkForPart: input.projectLinkForPart,
     projectFieldLink: input.projectFieldLink,
     documentProperties: input.documentProperties,
     refFields: input.refFields,

--- a/packages/core/src/layout/note-pagination.ts
+++ b/packages/core/src/layout/note-pagination.ts
@@ -206,6 +206,15 @@ export interface NotesLayoutInput {
   readonly projectLinkForPart?: (
     ownerPartName: string
   ) => import('./field-pieces.ts').HyperlinkProjector | undefined;
+  /**
+   * Content token over the notes parts' relationship records, standing in for
+   * {@link projectLinkForPart}'s closure in the notes-pass memo. The projector reads
+   * relationship state the pinned part identity cannot see move: a replicated rels-only
+   * change lands without splicing the notes part, so only a content token catches it.
+   * Required whenever `projectLinkForPart` is supplied — without it the memo is disabled,
+   * the same fail-closed rule `drawingsForPart` follows through `drawingLayoutEpoch`.
+   */
+  readonly linkRelsEpoch?: string;
   readonly projectFieldLink?: import('./field-pieces.ts').FieldLinkProjector;
   /** Document properties for a document-property field inside a note story. */
   readonly documentProperties?: import('@docx-editor.dev/core/store').DocumentProperties;
@@ -351,20 +360,23 @@ function fingerprintNoteProps(props: {
  */
 function fingerprintNotesInput(input: NotesLayoutInput): string | null {
   if (input.drawingsForPart !== undefined && input.drawingLayoutEpoch === undefined) return null;
+  if (input.projectLinkForPart !== undefined && input.linkRelsEpoch === undefined) return null;
   return [
     input.producer,
     input.defaultTabStopPt ?? '',
     input.drawingLayoutEpoch ?? '',
+    input.linkRelsEpoch ?? '',
     // By CONTENT, not identity: a keystroke rebuilds the context object while every
     // resolved value stands still, and only a value move should invalidate the memo.
     input.refFields?.valuesToken ?? '',
     // By CONTENT for the same reason as the REF values above: the properties object is
     // re-read per package revision, and only a value move should repaint a DOCPROPERTY
-    // field inside a note. The link projectors (projectLink, projectLinkForPart,
-    // projectFieldLink) are deliberately absent: they are rebuilt per pass but are pure
-    // over parts this memo already pins — retargeting a hyperlink mints a fresh `r:id`
-    // into the story's XML rather than rewriting the relationship, so a resolution change
-    // always moves the notes part identity too.
+    // field inside a note. projectLink and projectFieldLink are deliberately absent: they
+    // are rebuilt per pass but pure over parts this memo already pins. projectLinkForPart
+    // is NOT — it reads relationship records a replicated rels-only change can move
+    // without touching the notes part — so linkRelsEpoch above stands in for it, and the
+    // guard at the top disables the memo for a caller that supplies the projector without
+    // the epoch.
     input.documentProperties ? JSON.stringify(input.documentProperties) : '',
     fingerprintNoteProps(input.documentFootnoteProps),
     fingerprintNoteProps(input.documentEndnoteProps),

--- a/scripts/check-eslint-max-lines-globs.mjs
+++ b/scripts/check-eslint-max-lines-globs.mjs
@@ -42,7 +42,7 @@ const SLACK_EXEMPT = new Map([
  * diff where a reviewer sees it, instead of the file quietly gaining a thousand lines.
  */
 const BLANKET_DISABLES = new Map([
-  ['packages/core/src/editor/paginated-surface.ts', 6249],
+  ['packages/core/src/editor/paginated-surface.ts', 6260],
   ['packages/core/src/store/store/tree-op-apply.ts', 3495],
   ['packages/core/src/output/semantic-paint.ts', 3005],
   ['packages/core/src/layout/note-pagination.ts', 2939],

--- a/scripts/check-eslint-max-lines-globs.mjs
+++ b/scripts/check-eslint-max-lines-globs.mjs
@@ -45,7 +45,7 @@ const BLANKET_DISABLES = new Map([
   ['packages/core/src/editor/paginated-surface.ts', 6260],
   ['packages/core/src/store/store/tree-op-apply.ts', 3495],
   ['packages/core/src/output/semantic-paint.ts', 3005],
-  ['packages/core/src/layout/note-pagination.ts', 2939],
+  ['packages/core/src/layout/note-pagination.ts', 2954],
   ['packages/core/src/store/package/note-lifecycle.ts', 1320],
 ]);
 


### PR DESCRIPTION
A `w:hyperlink` inside `/word/footnotes.xml` or `/word/endnotes.xml` declares its `r:id` in that part's own `.rels`. The layout link projector resolved every id against the body part's relationships, so a footnote link whose id collides with a body one navigated to the body's target, and an id declared only in the notes part resolved as dangling.

Note stories now receive a per-part projector that resolves through the notes part's relationships, the same per-part rule pictures already follow. The body projector remains only a fallback for callers without per-part resolution. A content token over the notes parts' relationship records joins the notes-pass memo fingerprint, so a replicated rels-only change repaints the affected note instead of serving a memoized layout with a stale target; a caller that supplies the projector without the token loses the memo instead of risking staleness.

An end-to-end test maps one relationship id to different targets in the body and footnote parts and asserts each painted anchor carries its own part's target. The same gap in header, footer, and text-box stories is tracked in #643.

Fixes #637

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790685401&installation_model_id=422592&pr_number=644&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F644&signature=4a647d109e4c2b3ff0598dfa14d33c512a77305b1e2cb3088a67bf4fcd7fb649"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->