### PR TITLE
fix: price the keepNext lookahead at the placed column width (fixes #623)

### DIFF
--- a/.changeset/keepnext-unequal-column-width.md
+++ b/.changeset/keepnext-unequal-column-width.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Price the `w:keepNext` group-height lookahead at the placed column's width, so a keep group in a section with unequal explicit column widths breaks on the correct block. Fixes #623

--- a/packages/core/src/layout/__tests__/multi-column-layout.test.ts
+++ b/packages/core/src/layout/__tests__/multi-column-layout.test.ts
@@ -431,4 +431,43 @@ describe('multi-column section layout', () => {
       )?.columnSeparators
     ).toHaveLength(1);
   });
+
+  test('keepNext lookahead prices the group at the placed column width', () => {
+    // Column 0 is 300pt (one line holds 50 chars); column 1 is 36pt (6 chars). The body
+    // paragraph is 1 line at column 0's width but 2 at column 1's, so a lookahead that
+    // measures at the prepass width (column 0) under-prices the group by one line.
+    //
+    // Content height is 145pt; the default 10pt run makes each line 12.73pt. Eleven filler
+    // lines fill column 0; nine more leave column 1 at y=114.5 with 30.4pt free when the
+    // heading arrives. The true group — the heading line plus the body's two
+    // widow-controlled lines, 38.2pt — must move the heading; the under-priced 25.5pt
+    // group left it stranded at the column bottom while the body opened the next page.
+    const filler = Array.from({ length: 20 }, (_, index) => paragraph(`f${index}`)).join('');
+    const part = packageWithBody(
+      filler +
+        '<w:p><w:pPr><w:keepNext/></w:pPr><w:r><w:t>hh</w:t></w:r></w:p>' +
+        paragraph('aaaa bbbb') +
+        '<w:sectPr>' +
+        '<w:pgSz w:w="8400" w:h="4340"/>' +
+        '<w:pgMar w:top="720" w:right="720" w:bottom="720" w:left="720"/>' +
+        '<w:cols w:num="2" w:equalWidth="0">' +
+        '<w:col w:w="6000" w:space="240"/><w:col w:w="720"/>' +
+        '</w:cols>' +
+        '</w:sectPr>'
+    );
+
+    const layout = layoutSemanticDocument(part, 1, {
+      measurer: createFixedMeasurer(6, 14),
+    });
+
+    const pageOf = (text: string): number =>
+      layout.pages.findIndex((page) =>
+        page.fragments.some((fragment) => fragmentText(fragment).includes(text))
+      );
+    // The filler ends on page one; the keep moves the heading WITH its paragraph.
+    expect(layout.pages).toHaveLength(2);
+    expect(pageOf('f19')).toBe(0);
+    expect(pageOf('hh')).toBe(1);
+    expect(pageOf('hh')).toBe(pageOf('aaaa'));
+  });
 });

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -2239,9 +2239,14 @@ function layoutBlocksPass(
       // ONCE per chain, at its head — a member whose predecessor keeps too already moved with
       // the group. A chain that cannot fit a page of its own is abandoned.
       if (keeps.keepNext && !keepsNext[index - 1]) {
+        // Members are measured at THIS column's width, not the `prepared` entries': the
+        // prepass builds at column 0's width, and a section with unequal explicit column
+        // widths would otherwise price a group placed into a narrower or wider column with
+        // the wrong line breaks, landing the keep break on the wrong block. Equal-width
+        // sections re-prepare into a memo hit, so the lookahead still re-measures nothing.
         const group = keepNextGroupHeight(prepared, index, previousSpaceAfter, (at) => {
-          const member = prepared[at];
-          return member?.kind === 'paragraph' ? breakBlock(member, at).map((l) => l.height) : [];
+          const member = prepareBlock(bodies[at]!, columnWidth());
+          return member.kind === 'paragraph' ? breakBlock(member, at).map((l) => l.height) : [];
         });
         if (group !== null && group + topExtent <= contentHeight()) {
           needed = Math.max(needed, group + topExtent);


### PR DESCRIPTION
The `w:keepNext` group-height lookahead measured kept-with blocks from the prepass entries, which are built at column 0's width. In a section with unequal explicit column widths, a group placed into a narrower or wider column was priced with the wrong line breaks, so the keep break could land on the wrong block. The lookahead now re-prepares each member at the placed column's width; equal-width sections resolve to a memo hit and re-measure nothing.

Fixes #623.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/646"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790686217&installation_model_id=422592&pr_number=646&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F646&signature=2469087738ba416f213015564ef2c11820b9d04677514e58583952b3d752f037"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
