### PR TITLE
docs: add roadmap section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,3 +196,7 @@ This repository is licensed under [Apache 2.0](LICENSE), except `packages/editor
 
 > [!TIP]
 > Questions or custom features? Email **[docx-editor@eigenpal.com](mailto:docx-editor@eigenpal.com)**.
+
+## Roadmap
+
+See the [public roadmap](https://github.com/orgs/eigenpal/projects/2) for planned work and priorities.


### PR DESCRIPTION
## Summary

Adds a dedicated link to the public roadmap at the end of the README.

## Test plan

- `bun run format`
- Pre-commit checks passed through parity and license checks.
- `api:check` remains blocked by existing `core/layout` API snapshot drift.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790694789&installation_model_id=422592&pr_number=648&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F648&signature=be1f68057d79d0fecbed6b2abdaf420eec40e5c26b521e4965ad795a0a782712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->