### PR TITLE
fix: stop demo builds from scanning node_modules and shipping raw @tailwind

### DIFF
--- a/examples/collaboration-hocuspocus/vite.config.ts
+++ b/examples/collaboration-hocuspocus/vite.config.ts
@@ -3,6 +3,7 @@ import { readFile } from 'node:fs/promises';
 import react from '@vitejs/plugin-react';
 import tailwindcss from 'tailwindcss';
 import autoprefixer from 'autoprefixer';
+import { stripUnexpandedTailwind } from '../shared/strip-unexpanded-tailwind';
 import path from 'path';
 
 const monorepoRoot = path.resolve(__dirname, '../..');
@@ -116,6 +117,7 @@ export default defineConfig({
       plugins: [
         tailwindcss({ config: path.join(monorepoRoot, 'tailwind.config.js') }),
         autoprefixer(),
+        stripUnexpandedTailwind,
       ],
     },
   },

--- a/examples/custom-nodes/vite.config.ts
+++ b/examples/custom-nodes/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from 'tailwindcss';
 import autoprefixer from 'autoprefixer';
+import { stripUnexpandedTailwind } from '../shared/strip-unexpanded-tailwind';
 import path from 'path';
 
 const monorepoRoot = path.resolve(__dirname, '../..');
@@ -64,6 +65,7 @@ export default defineConfig({
       plugins: [
         tailwindcss({ config: path.join(monorepoRoot, 'tailwind.config.js') }),
         autoprefixer(),
+        stripUnexpandedTailwind,
       ],
     },
   },

--- a/examples/happy-path/vite.config.ts
+++ b/examples/happy-path/vite.config.ts
@@ -3,6 +3,7 @@ import { readFile } from 'node:fs/promises';
 import react from '@vitejs/plugin-react';
 import tailwindcss from 'tailwindcss';
 import autoprefixer from 'autoprefixer';
+import { stripUnexpandedTailwind } from '../shared/strip-unexpanded-tailwind';
 import path from 'path';
 
 const monorepoRoot = path.resolve(__dirname, '../..');
@@ -102,6 +103,7 @@ export default defineConfig({
       plugins: [
         tailwindcss({ config: path.join(monorepoRoot, 'tailwind.config.js') }),
         autoprefixer(),
+        stripUnexpandedTailwind,
       ],
     },
   },

--- a/examples/igloo/vite.config.ts
+++ b/examples/igloo/vite.config.ts
@@ -3,6 +3,7 @@ import { readFile } from 'node:fs/promises';
 import react from '@vitejs/plugin-react';
 import tailwindcss from 'tailwindcss';
 import autoprefixer from 'autoprefixer';
+import { stripUnexpandedTailwind } from '../shared/strip-unexpanded-tailwind';
 import path from 'path';
 import type { Plugin } from 'vite';
 
@@ -96,6 +97,7 @@ export default defineConfig({
       plugins: [
         tailwindcss({ config: path.join(monorepoRoot, 'tailwind.config.js') }),
         autoprefixer(),
+        stripUnexpandedTailwind,
       ],
     },
   },

--- a/examples/shared/strip-unexpanded-tailwind.ts
+++ b/examples/shared/strip-unexpanded-tailwind.ts
@@ -1,0 +1,28 @@
+import type { Plugin } from 'postcss';
+
+/**
+ * Removes `@tailwind` at-rules that survive the Tailwind pass.
+ *
+ * The demos `@import` core's SOURCE `packages/core/src/styles/editor.css`,
+ * which carries the shared `@tailwind utilities` directive, and also declare
+ * their own. Tailwind v3 expands only the LAST duplicate of a directive and
+ * leaves the earlier one in the output verbatim, where the CSS minifier warns
+ * (`Unknown at rule: @tailwind`) and the raw directive ships to the browser.
+ * The expansion already happened at the surviving directive, so the leftover
+ * is dead weight; drop it.
+ *
+ * Only `@tailwind utilities` is stripped: that is the one directive core's
+ * stylesheet shares, so it is the only known-dead duplicate. A surviving
+ * `base`/`components` directive means Tailwind did not run at all (missing
+ * plugin, broken config path, wrong plugin order), and stripping it would turn
+ * that misconfiguration into a silently unstyled build — leave it in so the
+ * minifier keeps warning loudly.
+ */
+export const stripUnexpandedTailwind: Plugin = {
+  postcssPlugin: 'strip-unexpanded-tailwind',
+  OnceExit(root) {
+    root.walkAtRules('tailwind', (atRule) => {
+      if (atRule.params.trim() === 'utilities') atRule.remove();
+    });
+  },
+};

--- a/examples/vite/vite.config.ts
+++ b/examples/vite/vite.config.ts
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react';
 import tailwindcss from 'tailwindcss';
 import autoprefixer from 'autoprefixer';
 import path from 'path';
+import { stripUnexpandedTailwind } from '../shared/strip-unexpanded-tailwind';
 
 const monorepoRoot = path.resolve(__dirname, '../..');
 
@@ -186,6 +187,7 @@ export default defineConfig(async (): Promise<UserConfig> => {
         plugins: [
           tailwindcss({ config: path.join(monorepoRoot, 'tailwind.config.js') }),
           autoprefixer(),
+          stripUnexpandedTailwind,
         ] as UserConfig['css'] extends { postcss?: { plugins?: infer P } } ? P : never,
       },
     },

--- a/examples/vue/vite.config.ts
+++ b/examples/vue/vite.config.ts
@@ -4,6 +4,7 @@ import vue from '@vitejs/plugin-vue';
 import vueJsx from '@vitejs/plugin-vue-jsx';
 import tailwindcss from 'tailwindcss';
 import autoprefixer from 'autoprefixer';
+import { stripUnexpandedTailwind } from '../shared/strip-unexpanded-tailwind';
 import path from 'path';
 
 const monorepoRoot = path.resolve(__dirname, '../..');
@@ -148,6 +149,7 @@ export default defineConfig({
       plugins: [
         tailwindcss({ config: path.join(monorepoRoot, 'tailwind.config.js') }),
         autoprefixer(),
+        stripUnexpandedTailwind,
       ],
     },
   },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,9 +22,18 @@ const corePreset = (() => {
 export default {
   presets: [corePreset],
   // Absolute paths so example builds (cd examples/vite && vite build) still scan the right files.
+  //
+  // Scan package sources and example sources by name — never `examples/**`. That
+  // glob swept every `examples/*/node_modules` (Tailwind warns about it on each
+  // build) and, through the workspace symlinks in there, was the only thing that
+  // reached `packages/pro/src`. Pro chrome carries Tailwind classes (the shipped
+  // stylesheet's tailwind.dist.config.cjs scans it for the same reason), so it
+  // gets its own entry now that node_modules is out of the walk.
   content: [
     path.join(__configDir, 'packages/react/src/**/*.{ts,tsx}'),
+    path.join(__configDir, 'packages/pro/src/**/*.{ts,tsx}'),
     path.join(__configDir, 'packages/vue/src/**/*.{ts,tsx}'),
-    path.join(__configDir, 'examples/**/*.{ts,tsx,vue}'),
+    path.join(__configDir, 'examples/*/src/**/*.{ts,tsx,vue}'),
+    path.join(__configDir, 'examples/shared/**/*.{ts,tsx,vue}'),
   ],
 };


### PR DESCRIPTION
The Vercel demo build logs two warnings on every deploy: Tailwind reports a content pattern that matches all of `node_modules`, and lightningcss reports `Unknown at rule: @tailwind` while minifying.

The root `tailwind.config.js` content glob `examples/**/*.{ts,tsx,vue}` swept every `examples/*/node_modules`. The narrowed globs scan package and example sources by name, and list `packages/pro/src` explicitly because the `node_modules` sweep was the only path that reached it through workspace symlinks.

The demos also `@import` core's source `editor.css`, which carries the shared `@tailwind utilities` directive, while declaring their own. Tailwind v3 expands only the last duplicate and ships the first one raw to the browser. A shared PostCSS plugin now strips a `utilities` directive that survives the Tailwind pass; `base` and `components` leftovers stay in so a missing Tailwind pass still fails loudly.

An A/B build shows the narrowed scan drops only utilities detected inside `node_modules`; none are referenced by any demo bundle. All six demos that use the root config build with no warnings and no leftover directive. Demo-only change, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/649"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790696163&installation_model_id=422592&pr_number=649&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F649&signature=1591843ca538833a4fe631bdbf731507aef486d9f7262da7a7636aa2a2a1d528"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->