### PR TITLE
docs: document all chrome slots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,11 @@ jobs:
         # it on the PR, not in `docx-editor-page`'s build.
         run: bun run check:docs-mdx
 
+      - name: Docs chrome slot coverage
+        # Keep the authored slot reference aligned with the public core union and
+        # both adapter toolbar namespaces as those APIs grow.
+        run: bun run check:docs-chrome-slots
+
       - name: Docs Vue ref check
         # A Vue template unwraps a ref only when the ref is a top-level binding.
         # Most composables return a plain object of refs, so a sample that drops

--- a/docs/site/content/core/index.mdx
+++ b/docs/site/content/core/index.mdx
@@ -18,6 +18,8 @@ npm install @docx-editor.dev/core
 ## Entry points
 
 The root is the entry point for typical editor creation and typing: create an editor over bytes, the contract it implements, fonts, and the chrome registry.
+See the [chrome slot reference](/docs/2.x/guides/chrome-slots) for the complete
+registry vocabulary and its React and Vue toolbar parts.
 
 ```ts
 import { createDocxEditor, loadFonts, WORD_DEFAULT_FONT } from '@docx-editor.dev/core';

--- a/docs/site/content/guides/chrome-slots.mdx
+++ b/docs/site/content/guides/chrome-slots.mdx
@@ -1,0 +1,165 @@
+---
+title: 'Chrome slot reference'
+description: 'Reference every editor chrome slot and its React and Vue toolbar part across default, contextual, menu, dialog, and header or footer surfaces.'
+category: 'Guides'
+---
+
+Chrome slots are stable control identifiers. Use fixed-command slots with
+`useEditorCommand()`, `ContextMenu.Slot`, or the generic toolbar button. Use
+named parts for controls that collect a value or open host UI.
+
+## Read the tables
+
+The **Toolbar part** column gives the shared suffix. For example, `Bold` means
+`DocxEditor.Toolbar.Bold` in React and `DocxEditorToolbar.Bold` in Vue. An em
+dash means that neither adapter provides a named part.
+
+The **Packaged surface** column shows where the standard editor places the
+control. **Explicit composition** means that you must add its named part to a
+custom toolbar.
+
+Use the named part for controls that collect a value or open UI, such as
+`FontColor`, `TableBorderWidth`, or `ImageProperties`. Use `Toolbar.Button` in
+React or `DocxEditorToolbar.Button` in Vue for a fixed-command slot without a
+named part:
+
+<FrameworkTabs>
+<Framework value="react">
+
+```tsx
+<DocxEditor.Toolbar.Button slot="format.painter" />
+```
+
+</Framework>
+<Framework value="vue">
+
+```vue
+<DocxEditorToolbar.Button slot="format.painter" />
+```
+
+</Framework>
+</FrameworkTabs>
+
+Use `Action` for a host-owned action without a registry slot. Use `Separator`
+only for layout. The `Button`, `Action`, and `Separator` helpers don't add slot
+IDs.
+
+## History, zoom, styles, and font
+
+| Slot           | Packaged surface | Toolbar part  | Purpose                       |
+| -------------- | ---------------- | ------------- | ----------------------------- |
+| `history.undo` | Default toolbar  | `Undo`        | Undo the last document change |
+| `history.redo` | Default toolbar  | `Redo`        | Redo the last undone change   |
+| `zoom.level`   | Default toolbar  | `Zoom`        | Change the viewport zoom      |
+| `styles.style` | Default toolbar  | `StylePicker` | Apply a paragraph style       |
+| `font.family`  | Default toolbar  | `FontFamily`  | Choose a font family          |
+| `font.size`    | Default toolbar  | `FontSize`    | Choose a font size            |
+
+## Text and script
+
+| Slot             | Packaged surface | Toolbar part  | Purpose                     |
+| ---------------- | ---------------- | ------------- | --------------------------- |
+| `text.bold`      | Default toolbar  | `Bold`        | Toggle bold                 |
+| `text.italic`    | Default toolbar  | `Italic`      | Toggle italic               |
+| `text.underline` | Default toolbar  | `Underline`   | Toggle underline            |
+| `text.strike`    | Default toolbar  | `Strike`      | Toggle strikethrough        |
+| `text.color`     | Default toolbar  | `FontColor`   | Choose and apply text color |
+| `text.highlight` | Default toolbar  | `Highlight`   | Choose and apply highlight  |
+| `text.link`      | Default toolbar  | `Link`        | Open the link editor        |
+| `script.super`   | Default toolbar  | `Superscript` | Toggle superscript          |
+| `script.sub`     | Default toolbar  | `Subscript`   | Toggle subscript            |
+
+## Alignment, lists, and formatting
+
+The default toolbar combines the four alignment slots into `Alignment`. Use
+the four `Align*` parts when you want separate controls.
+
+| Slot                | Packaged surface | Toolbar part             | Purpose                   |
+| ------------------- | ---------------- | ------------------------ | ------------------------- |
+| `alignment.left`    | Default toolbar  | `Alignment`, `AlignLeft` | Align left                |
+| `alignment.center`  | Default toolbar  | `AlignCenter`            | Align center              |
+| `alignment.right`   | Default toolbar  | `AlignRight`             | Align right               |
+| `alignment.justify` | Default toolbar  | `AlignJustify`           | Justify                   |
+| `list.bullet`       | Default toolbar  | `BulletList`             | Toggle a bulleted list    |
+| `list.numbered`     | Default toolbar  | `NumberedList`           | Toggle a numbered list    |
+| `list.outdent`      | Default toolbar  | `Outdent`                | Decrease list indent      |
+| `list.indent`       | Default toolbar  | `Indent`                 | Increase list indent      |
+| `list.lineSpacing`  | Default toolbar  | `LineSpacing`            | Set line spacing          |
+| `format.painter`    | Default toolbar  | —                        | Copy and apply formatting |
+| `format.clear`      | Default toolbar  | `ClearFormatting`        | Clear direct formatting   |
+| `paragraph.dialog`  | Format menu      | —                        | Open paragraph settings   |
+
+## Review and content controls
+
+Comments and reviewer filtering require the Pro review module. Content-control
+slots require the typed content-control capability. The two surface toggles can
+be composed anywhere; inspector and remove become enabled when the selection
+supports them.
+
+| Slot                       | Packaged surface     | Toolbar part              | Purpose                         |
+| -------------------------- | -------------------- | ------------------------- | ------------------------------- |
+| `review.comments`          | Default toolbar      | `Comments`                | Open comments and changes       |
+| `review.authors`           | Review menu          | `Reviewers`               | Filter markup by reviewer       |
+| `review.editingMode`       | Default toolbar      | `EditingMode`             | Select editing or review mode   |
+| `contentControl.showAll`   | Explicit composition | `ContentControlShowAll`   | Show content-control boundaries |
+| `contentControl.formFill`  | Explicit composition | `ContentControlFormFill`  | Toggle form-fill mode           |
+| `contentControl.inspector` | Explicit composition | `ContentControlInspector` | Open content-control properties |
+| `contentControl.remove`    | Explicit composition | `ContentControlRemove`    | Remove the selected control     |
+
+## Images and tables
+
+The toolbar shows image controls when you select an image. It shows table border
+and fill controls when you place the caret or a cell selection in a table. The
+Insert menu also provides image and table insertion.
+
+| Slot                 | Packaged surface           | Toolbar part        | Purpose                        |
+| -------------------- | -------------------------- | ------------------- | ------------------------------ |
+| `image.insert`       | Insert menu, image context | `ImageInsert`       | Insert an image                |
+| `image.properties`   | Image context              | `ImageProperties`   | Open image properties          |
+| `image.wrap`         | Image context              | `ImageWrap`         | Choose text wrapping           |
+| `image.altText`      | Image context              | `ImageAltText`      | Edit alternative text          |
+| `table.insert`       | Insert menu                | `TableInsert`       | Insert a table                 |
+| `table.borderTarget` | Table context              | `TableBorderTarget` | Choose which borders to affect |
+| `table.borderColor`  | Table context              | `TableBorderColor`  | Choose and apply border color  |
+| `table.borderStyle`  | Table context              | `TableBorderStyle`  | Choose border style            |
+| `table.borderWidth`  | Table context              | `TableBorderWidth`  | Choose border width            |
+| `table.cellFill`     | Table context              | `TableCellFill`     | Choose and apply cell fill     |
+
+## File and insert
+
+The packaged menus provide file, break, note, and table-of-contents slots.
+Header/footer options provide page-field slots.
+
+| Slot                            | Packaged surface      | Toolbar part | Purpose                               |
+| ------------------------------- | --------------------- | ------------ | ------------------------------------- |
+| `file.open`                     | File menu             | —            | Load a document                       |
+| `file.save`                     | File menu             | `Save`       | Save a document                       |
+| `file.pageSetup`                | File menu             | —            | Open page setup                       |
+| `insert.footnote`               | Insert menu           | —            | Insert a footnote                     |
+| `insert.endnote`                | Insert menu           | —            | Insert an endnote                     |
+| `insert.pageNumber`             | Header/footer options | —            | Insert the current page number        |
+| `insert.totalPages`             | Header/footer options | —            | Insert the document page count        |
+| `insert.sectionPages`           | Header/footer options | —            | Insert the current section page count |
+| `insert.pageXofY`               | Header/footer options | —            | Insert a Page X of Y field pair       |
+| `insert.pageBreak`              | Insert menu           | —            | Insert a page break                   |
+| `insert.sectionBreakNextPage`   | Insert menu           | —            | Start a section on the next page      |
+| `insert.sectionBreakContinuous` | Insert menu           | —            | Start a section on the current page   |
+| `insert.toc`                    | Insert menu           | —            | Insert a table of contents            |
+
+## Use a slot directly
+
+For a fixed-command slot, `useEditorCommand(slot)` supplies enabled state,
+active state, the engine's disabled reason, and `execute()`. Value and dialog
+controls also need input from your UI. Pass their complete `EditorCommand` to
+`useEditorCommand()`, or use the packaged part or menu. Handle `file.open` and
+`file.save` with the document loading and saving APIs.
+
+For complete signatures, see the [core API reference](/docs/2.x/api/core),
+[React API reference](/docs/2.x/api/react), or
+[Vue API reference](/docs/2.x/api/vue).
+
+## Next steps
+
+- [Customize the toolbar](/docs/2.x/guides/toolbar)
+- [Compose a React editor](/docs/2.x/react/composition)
+- [Compose a Vue editor](/docs/2.x/vue/composition)

--- a/docs/site/content/guides/meta.json
+++ b/docs/site/content/guides/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "loading-and-saving",
     "toolbar",
+    "chrome-slots",
     "zoom",
     "content-controls",
     "headers-footers",

--- a/docs/site/content/guides/toolbar.mdx
+++ b/docs/site/content/guides/toolbar.mdx
@@ -174,6 +174,9 @@ const bold = useEditorCommand('text.bold');
 </Framework>
 </FrameworkTabs>
 
+See the [chrome slot reference](/docs/2.x/guides/chrome-slots) for every slot,
+its packaged surface, and the matching React and Vue toolbar part.
+
 ## Format painter
 
 The `format.painter` slot copies the formatting at the selection and applies it somewhere
@@ -224,6 +227,7 @@ custom icons, and two host actions. See the
 
 ## Next steps
 
+- [Chrome slot reference](/docs/2.x/guides/chrome-slots)
 - [React package overview](/docs/2.x/react) and [Vue package overview](/docs/2.x/vue)
 - [React props](/docs/2.x/react/props) and [Vue props](/docs/2.x/vue/props)
 - [React examples](/docs/2.x/react/examples) and [Vue examples](/docs/2.x/vue/examples)

--- a/docs/site/content/meta.json
+++ b/docs/site/content/meta.json
@@ -32,6 +32,7 @@
     "---Guides---",
     "guides/loading-and-saving",
     "guides/toolbar",
+    "guides/chrome-slots",
     "guides/zoom",
     "guides/content-controls",
     "guides/headers-footers",

--- a/docs/site/content/react/composition.mdx
+++ b/docs/site/content/react/composition.mdx
@@ -155,7 +155,9 @@ This example builds a custom toolbar from packaged parts:
 </DocxEditor.Toolbar>
 ```
 
-Each part name maps to a `ChromeSlotId`.
+Most named parts map to one `ChromeSlotId`. `Alignment` combines the four
+`alignment.*` slots. The [chrome slot reference](/docs/2.x/guides/chrome-slots)
+lists every slot and named React and Vue part.
 The default arrangement includes slots that the registry adds later.
 A manual arrangement includes only the parts that you specify.
 

--- a/docs/site/content/react/hooks.mdx
+++ b/docs/site/content/react/hooks.mdx
@@ -13,7 +13,9 @@ The packaged toolbar, menu, and navigation pane use the same hooks.
 
 ## `useEditorCommand`
 
-Pass a chrome slot ID to `useEditorCommand`.
+Pass a chrome slot ID to `useEditorCommand`. The
+[chrome slot reference](/docs/2.x/guides/chrome-slots) lists every available
+ID and its named toolbar part.
 The hook returns the state and action for a control:
 
 ```tsx
@@ -338,5 +340,5 @@ These hooks provide context-free variants of the corresponding hooks.
 ## Next steps
 
 - [React composition](/docs/2.x/react/composition)
-- [Toolbar slots](/docs/2.x/guides/toolbar)
+- [Chrome slot reference](/docs/2.x/guides/chrome-slots)
 - [React API reference](/docs/2.x/api/react)

--- a/docs/site/content/vue/composables.mdx
+++ b/docs/site/content/vue/composables.mdx
@@ -15,7 +15,9 @@ script code.
 
 ## useEditorCommand
 
-Pass a chrome slot ID to get its action and reactive command state:
+Pass a chrome slot ID to get its action and reactive command state. The
+[chrome slot reference](/docs/2.x/guides/chrome-slots) lists every available
+ID and its named toolbar part:
 
 ```vue
 <script setup lang="ts">
@@ -442,5 +444,5 @@ The package also exports `DocxEditorReview`. Mount it inside
 ## Next steps
 
 - [Vue composition](/docs/2.x/vue/composition): place custom controls.
-- [Toolbar guide](/docs/2.x/guides/toolbar): find command slot IDs.
+- [Chrome slot reference](/docs/2.x/guides/chrome-slots): find every slot ID and toolbar part.
 - [Vue API reference](/docs/2.x/api/vue): inspect all composable types.

--- a/docs/site/content/vue/composition.mdx
+++ b/docs/site/content/vue/composition.mdx
@@ -144,6 +144,10 @@ state and disabled reasons from the editor.
 </DocxEditorToolbar>
 ```
 
+Most named parts map to one `ChromeSlotId`. `Alignment` combines the four
+`alignment.*` slots. The [chrome slot reference](/docs/2.x/guides/chrome-slots)
+lists every slot and named React and Vue part.
+
 ### Add a host toolbar action
 
 Use `DocxEditorToolbar.Action` for an action without a registry slot. Call

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "check:pro-license-headers": "bun run --filter '@docx-editor.dev/pro' license:check",
     "fix:pro-license-headers": "bun run --filter '@docx-editor.dev/pro' license:add",
     "check:consumer-install": "node scripts/check-consumer-install.mjs",
+    "check:docs-chrome-slots": "node scripts/check-docs-chrome-slots.mjs",
     "check:docs-mdx": "node scripts/check-docs-mdx.mjs",
     "check:docs-vue-refs": "node scripts/check-docs-vue-refs.mjs",
     "check:editor-api-license-headers": "bun run --filter '@docx-editor.dev/editor-api' license:check",

--- a/scripts/check-docs-chrome-slots.mjs
+++ b/scripts/check-docs-chrome-slots.mjs
@@ -1,0 +1,92 @@
+/**
+ * Keep the authored chrome-slot reference aligned with the public core union and
+ * the adapter toolbar namespace. Generated API pages expose the types, but they do
+ * not explain where a control appears or which compound part drives it.
+ */
+import { readFileSync } from 'node:fs';
+import { relative, resolve } from 'node:path';
+
+const root = resolve(import.meta.dirname, '..');
+const corePath = resolve(root, 'packages/core/src/editor/chrome-controls.ts');
+const reactPath = resolve(root, 'packages/react/src/editor/toolbar/DocxEditorToolbar.tsx');
+const vuePath = resolve(root, 'packages/vue/src/editor/toolbar/DocxEditorToolbar.tsx');
+const docsPath = resolve(root, 'docs/site/content/guides/chrome-slots.mdx');
+const guideMetaPath = resolve(root, 'docs/site/content/guides/meta.json');
+const rootMetaPath = resolve(root, 'docs/site/content/meta.json');
+
+function publicSlots(source) {
+  const declaration = source.match(/export type ChromeSlotId =([\s\S]*?);/);
+  if (!declaration) throw new Error('Could not find the ChromeSlotId declaration.');
+  return [...declaration[1].matchAll(/\|\s*'([^']+)'/g)].map((match) => match[1]);
+}
+
+function toolbarParts(source, adapter) {
+  const start = source.indexOf('Object.assign(DocxEditorToolbarRoot, {');
+  if (start === -1) throw new Error(`Could not find the ${adapter} toolbar namespace.`);
+  const end = source.indexOf('\n})', start);
+  if (end === -1) throw new Error(`Could not find the end of the ${adapter} toolbar namespace.`);
+  return [...source.slice(start, end).matchAll(/^\s{2}([A-Z][A-Za-z0-9]*)(?=:|,)/gm)].map(
+    (match) => match[1]
+  );
+}
+
+function difference(left, right) {
+  return left.filter((value) => !right.has(value));
+}
+
+const core = readFileSync(corePath, 'utf8');
+const react = readFileSync(reactPath, 'utf8');
+const vue = readFileSync(vuePath, 'utf8');
+const docs = readFileSync(docsPath, 'utf8');
+const guidePages = JSON.parse(readFileSync(guideMetaPath, 'utf8')).pages;
+const rootPages = JSON.parse(readFileSync(rootMetaPath, 'utf8')).pages;
+
+const expectedSlots = publicSlots(core);
+const documentedSlots = [...docs.matchAll(/^\|\s*`([a-z][A-Za-z0-9]*\.[A-Za-z0-9]+)`\s*\|/gm)].map(
+  (match) => match[1]
+);
+const expectedSlotSet = new Set(expectedSlots);
+const documentedSlotSet = new Set(documentedSlots);
+
+const helpers = new Set(['Button', 'Action', 'Separator']);
+const reactParts = toolbarParts(react, 'React').filter((part) => !helpers.has(part));
+const vueParts = toolbarParts(vue, 'Vue').filter((part) => !helpers.has(part));
+const documentedPartCells = [
+  ...docs.matchAll(/^\|\s*`[a-z][A-Za-z0-9]*\.[A-Za-z0-9]+`\s*\|\s*[^|]*\|\s*([^|]*)\|/gm),
+].map((match) => match[1]);
+const documentedParts = new Set(
+  documentedPartCells.flatMap((cell) => [...cell.matchAll(/`([^`]+)`/g)].map((match) => match[1]))
+);
+
+const errors = [];
+if (!guidePages.includes('chrome-slots')) errors.push('missing from guides/meta.json');
+if (!rootPages.includes('guides/chrome-slots')) errors.push('missing from root meta.json');
+const missingSlots = difference(expectedSlots, documentedSlotSet);
+const unknownSlots = difference(documentedSlots, expectedSlotSet);
+const duplicateSlots = documentedSlots.filter(
+  (slot, index) => documentedSlots.indexOf(slot) !== index
+);
+if (missingSlots.length > 0) errors.push(`missing slots: ${missingSlots.join(', ')}`);
+if (unknownSlots.length > 0) errors.push(`unknown slots: ${unknownSlots.join(', ')}`);
+if (duplicateSlots.length > 0)
+  errors.push(`duplicate slots: ${[...new Set(duplicateSlots)].join(', ')}`);
+
+const reactPartSet = new Set(reactParts);
+const vuePartSet = new Set(vueParts);
+const onlyReact = difference(reactParts, vuePartSet);
+const onlyVue = difference(vueParts, reactPartSet);
+if (onlyReact.length > 0) errors.push(`toolbar parts missing from Vue: ${onlyReact.join(', ')}`);
+if (onlyVue.length > 0) errors.push(`toolbar parts missing from React: ${onlyVue.join(', ')}`);
+
+const missingParts = difference(reactParts, documentedParts);
+if (missingParts.length > 0) errors.push(`undocumented toolbar parts: ${missingParts.join(', ')}`);
+
+if (errors.length > 0) {
+  console.error(`${relative(root, docsPath)} is out of sync:\n`);
+  for (const error of errors) console.error(`  - ${error}`);
+  process.exit(1);
+}
+
+console.log(
+  `docs chrome slots: OK — ${expectedSlots.length} slots and ${reactParts.length} named toolbar parts`
+);


### PR DESCRIPTION
## Summary

- add one shared reference for all 57 ChromeSlotId values and all 44 named React and Vue toolbar parts
- document each packaged surface and the correct path for command, value, dialog, loading, and saving controls
- link the reference from the toolbar, core, React, and Vue documentation
- add a CI drift check for slot coverage, adapter parity, named-part coverage, and both navigation files

## Validation

- bun run check:docs-chrome-slots
- bun run check:docs-mdx
- bun run check:docs-vue-refs
- bun run format:check
- git diff --check
- two-pass independent review: no medium-or-higher findings remain

## Local environment note

The docs JSON smoke test requires built package declarations. The package build was blocked by the existing local harfbuzzjs dependency mismatch in the shared node_modules; the docs-specific checks above pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790832277&installation_model_id=422592&pr_number=676&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F676&signature=103e8cc59414888d79685885d8b894126cbc5d75902f13f2099aa3f5c7b2c1e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->