### PR TITLE
Fix packaged font asset resolution in browser bundlers

### DIFF
--- a/.changeset/static-font-assets.md
+++ b/.changeset/static-font-assets.md
@@ -1,0 +1,7 @@
+---
+'@docx-editor.dev/fonts': patch
+---
+
+Preserve one literal asset URL per packaged font face in the ESM browser build so Next.js with
+Turbopack, Vite, and webpack resolve every requested filename instead of collapsing dynamic URLs
+to one font. Keep the CommonJS build resolving the same packaged files in Node.

--- a/packages/fonts/package.json
+++ b/packages/fonts/package.json
@@ -26,7 +26,8 @@
     "THIRD_PARTY_NOTICES.md"
   ],
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && node scripts/check-built-assets.mjs",
+    "assets:check": "node scripts/check-built-assets.mjs",
     "typecheck": "tsc --noEmit",
     "manifest": "node scripts/generate-manifest.mjs",
     "manifest:check": "node scripts/generate-manifest.mjs --check",

--- a/packages/fonts/scripts/check-built-assets.mjs
+++ b/packages/fonts/scripts/check-built-assets.mjs
@@ -1,0 +1,61 @@
+// Verifies the PUBLISHED build, not just TypeScript source. Browser bundlers consume the
+// ESM/import condition and need literal `new URL(..., import.meta.url)` expressions. The
+// CJS/require condition is for Node and must still resolve every asset beside the package.
+
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const assetsDir = join(packageRoot, 'assets');
+const distDir = join(packageRoot, 'dist');
+const assetFiles = readdirSync(assetsDir)
+  .filter((file) => file.endsWith('.ttf') || file.endsWith('.otf'))
+  .sort();
+
+const esm = readdirSync(distDir)
+  .filter((file) => file.endsWith('.js'))
+  .map((file) => readFileSync(join(distDir, file), 'utf8'))
+  .join('\n');
+const emittedUrls = [
+  ...esm.matchAll(
+    /new URL\(\s*['"]\.\.\/assets\/([^'"]+\.(?:ttf|otf))['"]\s*,\s*import\.meta\.url\s*\)/g
+  ),
+]
+  .map((match) => match[1])
+  .sort();
+
+assert.deepEqual(
+  emittedUrls,
+  assetFiles,
+  'ESM build must preserve one literal import.meta.url expression per packaged face'
+);
+
+const require = createRequire(import.meta.url);
+const cjs = require(join(distDir, 'index.cjs'));
+const requestedUrls = [];
+const fragment = await cjs.loadDefaultFonts({
+  families: cjs.ALL_WORD_DEFAULT_FAMILIES,
+  fetcher: async (input) => {
+    const url = new URL(String(input));
+    requestedUrls.push(url.href);
+    return new Response(readFileSync(url));
+  },
+});
+const requestedFiles = requestedUrls
+  .map((url) => fileURLToPath(url))
+  .map((file) => file.slice(assetsDir.length + 1))
+  .sort();
+
+assert.equal(fragment.failures.length, 0, 'CJS build must load every packaged face in Node');
+assert.equal(fragment.sources.length, assetFiles.length);
+assert.deepEqual(requestedFiles, assetFiles);
+for (const url of requestedUrls) {
+  assert.equal(new URL(url).protocol, pathToFileURL(assetsDir).protocol);
+}
+
+console.log(
+  `built font assets OK (${assetFiles.length} ESM URLs, ${requestedUrls.length} CJS reads)`
+);

--- a/packages/fonts/scripts/generate-manifest.mjs
+++ b/packages/fonts/scripts/generate-manifest.mjs
@@ -1,7 +1,7 @@
-// Generates src/manifest.generated.ts: one entry per shipped face with its byte length
-// and `sha256:` content hash, BAKED at authoring time so the runtime never hashes and a
-// consumer can pin what it loads. `--check` re-derives and fails on drift, which is the
-// CI guard that the recorded hashes always match the shipped bytes.
+// Generates src/manifest.generated.ts: one entry per shipped face with its byte length,
+// `sha256:` content hash, and a statically analyzable asset URL. The URL arguments must be
+// literals: bundlers cannot reliably expand a runtime filename inside `new URL(...,
+// import.meta.url)`. `--check` re-derives and fails on metadata or URL-map drift.
 
 import { createHash } from 'node:crypto';
 import { readFileSync, readdirSync, writeFileSync, existsSync } from 'node:fs';
@@ -35,11 +35,11 @@ const body =
   ' * fetched asset is content-checked without hashing at runtime.\n' +
   ' */\n' +
   'export interface FontAssetManifestEntry {\n' +
-  '  /** Asset filename under the package\'s `assets/` directory, e.g. `Carlito-Bold.ttf`. */\n' +
+  "  /** Asset filename under the package's `assets/` directory, e.g. `Carlito-Bold.ttf`. */\n" +
   '  readonly file: string;\n' +
   '  /** Exact packaged size. A fetch returning any other length is rejected. */\n' +
   '  readonly byteLength: number;\n' +
-  '  /** `sha256:`-prefixed digest, re-derived and compared by the engine\'s admission path. */\n' +
+  "  /** `sha256:`-prefixed digest, re-derived and compared by the engine's admission path. */\n" +
   '  readonly hash: string;\n' +
   '}\n\n' +
   '/**\n' +
@@ -54,7 +54,19 @@ const body =
         `  { file: '${entry.file}', byteLength: ${entry.byteLength}, hash: '${entry.hash}' },`
     )
     .join('\n') +
-  '\n];\n';
+  '\n];\n\n' +
+  '/**\n' +
+  ' * Bundler-visible URL for every packaged face. Each `new URL` argument is deliberately\n' +
+  ' * a literal so Vite, webpack, and Turbopack emit the matching asset instead of collapsing\n' +
+  ' * a dynamic template to one arbitrary file.\n' +
+  ' *\n' +
+  ' * @internal\n' +
+  ' */\n' +
+  'export const FONT_ASSET_URLS: Readonly<Record<string, URL>> = {\n' +
+  entries
+    .map((entry) => `  '${entry.file}': new URL('../assets/${entry.file}', import.meta.url),`)
+    .join('\n') +
+  '\n};\n';
 
 if (process.argv.includes('--check')) {
   // Compare PARSED entries, not raw text: prettier re-wraps the generated file (the
@@ -67,11 +79,23 @@ if (process.argv.includes('--check')) {
   for (const match of current.matchAll(entryPattern)) {
     recorded.set(match[1], { byteLength: Number(match[2]), hash: match[3] });
   }
+  const recordedUrls = new Map();
+  const urlPattern =
+    /'([^']+\.(?:ttf|otf))'\s*:\s*new URL\(\s*'\.\.\/assets\/([^']+)'\s*,\s*import\.meta\.url\s*\)/g;
+  for (const match of current.matchAll(urlPattern)) {
+    recordedUrls.set(match[1], match[2]);
+  }
   const stale =
     recorded.size !== entries.length ||
+    recordedUrls.size !== entries.length ||
     entries.some((entry) => {
       const found = recorded.get(entry.file);
-      return !found || found.byteLength !== entry.byteLength || found.hash !== entry.hash;
+      return (
+        !found ||
+        found.byteLength !== entry.byteLength ||
+        found.hash !== entry.hash ||
+        recordedUrls.get(entry.file) !== entry.file
+      );
     });
   if (stale) {
     console.error(

--- a/packages/fonts/src/__tests__/default-fonts.test.ts
+++ b/packages/fonts/src/__tests__/default-fonts.test.ts
@@ -200,6 +200,20 @@ describe('loadDefaultFonts', () => {
       expect(source.includes('base64')).toBe(false);
     }
   });
+
+  test('every packaged face uses a literal bundler-visible asset URL', () => {
+    const moduleSource = readFileSync(new URL('../index.ts', import.meta.url), 'utf8');
+    const manifestSource = readFileSync(
+      new URL('../manifest.generated.ts', import.meta.url),
+      'utf8'
+    );
+
+    expect(moduleSource).not.toContain('new URL(`../assets/${');
+    for (const entry of FONT_ASSET_MANIFEST) {
+      expect(manifestSource).toContain(`'../assets/${entry.file}'`);
+    }
+    expect(manifestSource.match(/new URL\(/g)).toHaveLength(FONT_ASSET_MANIFEST.length);
+  });
 });
 
 describe('lane boundary', () => {

--- a/packages/fonts/src/index.ts
+++ b/packages/fonts/src/index.ts
@@ -63,7 +63,7 @@
 
 import { FACES, FAMILY_PLANS, planFaceFile, planLineBox } from './family-plans.ts';
 import type { WordDefaultFamily } from './family-plans.ts';
-import { FONT_ASSET_MANIFEST } from './manifest.generated.ts';
+import { FONT_ASSET_MANIFEST, FONT_ASSET_URLS } from './manifest.generated.ts';
 
 export type { WordDefaultFamily } from './family-plans.ts';
 
@@ -139,7 +139,7 @@ export interface LoadDefaultFontsOptions {
 const manifestByFile = new Map(FONT_ASSET_MANIFEST.map((entry) => [entry.file, entry]));
 
 /** Bundler-visible asset URL for one packaged face. */
-const assetUrl = (file: string): URL => new URL(`../assets/${file}`, import.meta.url);
+const assetUrl = (file: string): URL => FONT_ASSET_URLS[file];
 
 /**
  * The families Word applies to a document by DEFAULT, and what

--- a/packages/fonts/src/manifest.generated.ts
+++ b/packages/fonts/src/manifest.generated.ts
@@ -143,3 +143,49 @@ export const FONT_ASSET_MANIFEST: readonly FontAssetManifestEntry[] = [
     hash: 'sha256:17bfc0a97d48393453f28422f109d47099d54875600ea88a8d61c5ddd2dbffc4',
   },
 ];
+
+/**
+ * Bundler-visible URL for every packaged face. Each `new URL` argument is deliberately
+ * a literal so Vite, webpack, and Turbopack emit the matching asset instead of collapsing
+ * a dynamic template to one arbitrary file.
+ *
+ * @internal
+ */
+export const FONT_ASSET_URLS: Readonly<Record<string, URL>> = {
+  'Caladea-Bold.ttf': new URL('../assets/Caladea-Bold.ttf', import.meta.url),
+  'Caladea-BoldItalic.ttf': new URL('../assets/Caladea-BoldItalic.ttf', import.meta.url),
+  'Caladea-Italic.ttf': new URL('../assets/Caladea-Italic.ttf', import.meta.url),
+  'Caladea-Regular.ttf': new URL('../assets/Caladea-Regular.ttf', import.meta.url),
+  'Carlito-Bold.ttf': new URL('../assets/Carlito-Bold.ttf', import.meta.url),
+  'Carlito-BoldItalic.ttf': new URL('../assets/Carlito-BoldItalic.ttf', import.meta.url),
+  'Carlito-Italic.ttf': new URL('../assets/Carlito-Italic.ttf', import.meta.url),
+  'Carlito-Regular.ttf': new URL('../assets/Carlito-Regular.ttf', import.meta.url),
+  'LiberationMono-Bold.ttf': new URL('../assets/LiberationMono-Bold.ttf', import.meta.url),
+  'LiberationMono-BoldItalic.ttf': new URL(
+    '../assets/LiberationMono-BoldItalic.ttf',
+    import.meta.url
+  ),
+  'LiberationMono-Italic.ttf': new URL('../assets/LiberationMono-Italic.ttf', import.meta.url),
+  'LiberationMono-Regular.ttf': new URL('../assets/LiberationMono-Regular.ttf', import.meta.url),
+  'LiberationSans-Bold.ttf': new URL('../assets/LiberationSans-Bold.ttf', import.meta.url),
+  'LiberationSans-BoldItalic.ttf': new URL(
+    '../assets/LiberationSans-BoldItalic.ttf',
+    import.meta.url
+  ),
+  'LiberationSans-Italic.ttf': new URL('../assets/LiberationSans-Italic.ttf', import.meta.url),
+  'LiberationSans-Regular.ttf': new URL('../assets/LiberationSans-Regular.ttf', import.meta.url),
+  'LiberationSerif-Bold.ttf': new URL('../assets/LiberationSerif-Bold.ttf', import.meta.url),
+  'LiberationSerif-BoldItalic.ttf': new URL(
+    '../assets/LiberationSerif-BoldItalic.ttf',
+    import.meta.url
+  ),
+  'LiberationSerif-Italic.ttf': new URL('../assets/LiberationSerif-Italic.ttf', import.meta.url),
+  'LiberationSerif-Regular.ttf': new URL('../assets/LiberationSerif-Regular.ttf', import.meta.url),
+  'TeXGyreAdventor-Bold.otf': new URL('../assets/TeXGyreAdventor-Bold.otf', import.meta.url),
+  'TeXGyreAdventor-BoldItalic.otf': new URL(
+    '../assets/TeXGyreAdventor-BoldItalic.otf',
+    import.meta.url
+  ),
+  'TeXGyreAdventor-Italic.otf': new URL('../assets/TeXGyreAdventor-Italic.otf', import.meta.url),
+  'TeXGyreAdventor-Regular.otf': new URL('../assets/TeXGyreAdventor-Regular.otf', import.meta.url),
+};


### PR DESCRIPTION
## Summary

- replace the dynamic packaged-font URL template with a generated map of 24 literal asset URLs
- keep generated URLs synchronized with the font manifest
- validate fresh ESM builds and CommonJS Node reads
- add a patch changeset

## Root cause

Next/Turbopack collapsed the dynamic font URL expression to one asset (Caladea-Bold.ttf, 84,492 bytes), so every requested face returned the wrong bytes.

## User-perspective verification

- packed the real @docx-editor.dev/fonts package and installed that tarball into a clean docx-editor.dev checkout
- used the public API: useFonts(packagedFonts(), googleFonts())
- built the website in production with Next 16.1.6 and Turbopack
- confirmed 24 font files became 24 unique emitted asset modules
- opened /editor in headless Chromium and confirmed the four Carlito faces returned their distinct packaged sizes: 615236, 628032, 682468, and 808508 bytes
- observed zero font warnings, console errors, or page errors

## Checks

- independent reviewer: no findings
- font tests: 63 passed
- full package build and workspace typechecks
- built asset check: 24 ESM URLs and 24 CommonJS reads
- manifest, package artifact, package size, API report, lint, formatting, and diff checks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790844478&installation_model_id=422592&pr_number=680&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F680&signature=bba89dc213fd24bdb8fb38aaa7c5b47922ef8bbbf5e614f2a7c671c886e9ff06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->