### PR TITLE
fix: preserve concurrent text edits

### DIFF
--- a/.changeset/warm-plums-collaborate.md
+++ b/.changeset/warm-plums-collaborate.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/pro': patch
+---
+
+Preserve concurrent text edits when another collaborator formats the same run. Fixes #590.

--- a/packages/pro/src/collaboration/__tests__/document-concurrent-run-format.test.ts
+++ b/packages/pro/src/collaboration/__tests__/document-concurrent-run-format.test.ts
@@ -211,4 +211,59 @@ describe('concurrent run-format convergence (#581)', () => {
     expect(bodyText(alice)).toBe(expected);
     expect(bodyText(bob)).toBe(expected);
   });
+
+  test('concurrent typing survives after the formatting peer leaves', async () => {
+    const { alice, bob, pause, resume } = await harness.pair(doc());
+    pause();
+    harness.apply(alice, [runProps(alice, 0, 0, 5, 'b')]);
+    harness.apply(bob, [
+      {
+        op: 'insertText',
+        paragraphId: harness.paragraphIdAt(bob, 0),
+        offset: 15,
+        text: 'ZZZ',
+      },
+    ]);
+    harness.leave(alice);
+    resume();
+    const expected = PARA0.slice(0, 15) + 'ZZZ' + PARA0.slice(15) + PARA1;
+    expect(bodyText(bob)).toBe(expected);
+    expect(markCount(bob, 'b')).toBeGreaterThan(0);
+    const carol = await harness.join(bob, 'carol');
+    harness.expectConverged(bob, carol);
+    expect(bodyText(carol)).toBe(expected);
+  });
+
+  test('concurrent typing survives when the typing peer receives the format', async () => {
+    const { alice, bob } = await race(
+      (peer): TreeDocOp => ({
+        op: 'insertText',
+        paragraphId: harness.paragraphIdAt(peer, 0),
+        offset: 15,
+        text: 'ZZZ',
+      }),
+      (peer) => runProps(peer, 0, 0, 5, 'b')
+    );
+    const expected = PARA0.slice(0, 15) + 'ZZZ' + PARA0.slice(15) + PARA1;
+    expect(bodyText(alice)).toBe(expected);
+    expect(bodyText(bob)).toBe(expected);
+    expect(markCount(alice, 'b')).toBeGreaterThan(0);
+  });
+
+  test('undo of concurrent typing updates the formatted products', async () => {
+    const { alice, bob } = await race(
+      (peer) => runProps(peer, 0, 0, 5, 'b'),
+      (peer): TreeDocOp => ({
+        op: 'insertText',
+        paragraphId: harness.paragraphIdAt(peer, 0),
+        offset: 15,
+        text: 'ZZZ',
+      })
+    );
+    expect(bob.room.session.undo()).toBe(true);
+    bob.port.flushPendingJournals();
+    harness.expectConverged(alice, bob);
+    expect(bodyText(alice)).toBe(PARA0 + PARA1);
+    expect(markCount(alice, 'b')).toBeGreaterThan(0);
+  });
 });

--- a/packages/pro/src/collaboration/__tests__/document-concurrent-run-format.test.ts
+++ b/packages/pro/src/collaboration/__tests__/document-concurrent-run-format.test.ts
@@ -168,11 +168,7 @@ describe('concurrent run-format convergence (#581)', () => {
     harness.expectConverged(bob, carol);
   });
 
-  test('concurrent typing and formatting converges without duplicating text', async () => {
-    // This peer's insert grows the origin run in place rather than splitting it, so it never
-    // enters the dedup. The concurrent format split still discards the typed characters when it
-    // copies the origin (issue #590, a separate concurrency gap); what this pins is that the
-    // dedup does not compound it — the peers converge and the text is not doubled.
+  test('concurrent typing survives formatting the same run', async () => {
     const { alice, bob } = await race(
       (peer) => runProps(peer, 0, 0, 5, 'b'),
       (peer): TreeDocOp => ({
@@ -182,8 +178,37 @@ describe('concurrent run-format convergence (#581)', () => {
         text: 'ZZZ',
       })
     );
-    // Converged (asserted by race), and the base text appears once, not doubled.
-    expect(bodyText(alice)).toBe(PARA0 + PARA1);
-    expect(bodyText(bob)).toBe(PARA0 + PARA1);
+    const expected = PARA0.slice(0, 15) + 'ZZZ' + PARA0.slice(15) + PARA1;
+    expect(bodyText(alice)).toBe(expected);
+    expect(bodyText(bob)).toBe(expected);
+    harness.apply(bob, [
+      {
+        op: 'insertText',
+        paragraphId: harness.paragraphIdAt(bob, 0),
+        offset: 18,
+        text: 'Q',
+      },
+    ]);
+    harness.expectConverged(alice, bob);
+    const edited = expected.slice(0, 18) + 'Q' + expected.slice(18);
+    expect(bodyText(alice)).toBe(edited);
+    const carol = await harness.join(alice, 'carol');
+    harness.expectConverged(alice, carol);
+    expect(bodyText(carol)).toBe(edited);
+  });
+
+  test('concurrent deletion survives formatting the same run', async () => {
+    const { alice, bob } = await race(
+      (peer) => runProps(peer, 0, 0, 5, 'b'),
+      (peer): TreeDocOp => ({
+        op: 'deleteText',
+        paragraphId: harness.paragraphIdAt(peer, 0),
+        start: 3,
+        end: 8,
+      })
+    );
+    const expected = PARA0.slice(0, 3) + PARA0.slice(8) + PARA1;
+    expect(bodyText(alice)).toBe(expected);
+    expect(bodyText(bob)).toBe(expected);
   });
 });

--- a/packages/pro/src/collaboration/__tests__/document-concurrent-run-format.test.ts
+++ b/packages/pro/src/collaboration/__tests__/document-concurrent-run-format.test.ts
@@ -299,4 +299,31 @@ describe('concurrent run-format convergence (#581)', () => {
     expect(bodyText(alice)).toBe('HelloWoXrld' + PARA1);
     expect(markCount(alice, 'tab')).toBe(1);
   });
+
+  test('concurrent source typing merges with typing on a split product', async () => {
+    const { alice, bob, pause, resume } = await harness.pair(doc());
+    pause();
+    harness.apply(alice, [runProps(alice, 0, 0, 5, 'b')]);
+    harness.apply(alice, [
+      {
+        op: 'insertText',
+        paragraphId: harness.paragraphIdAt(alice, 0),
+        offset: 2,
+        text: 'A',
+      },
+    ]);
+    harness.apply(bob, [
+      {
+        op: 'insertText',
+        paragraphId: harness.paragraphIdAt(bob, 0),
+        offset: 15,
+        text: 'B',
+      },
+    ]);
+    resume();
+    harness.expectConverged(alice, bob);
+    const expected = 'AlApha bravo canBvas delta editor' + PARA1;
+    expect(bodyText(alice)).toBe(expected);
+    expect(bodyText(bob)).toBe(expected);
+  });
 });

--- a/packages/pro/src/collaboration/__tests__/document-concurrent-run-format.test.ts
+++ b/packages/pro/src/collaboration/__tests__/document-concurrent-run-format.test.ts
@@ -37,6 +37,13 @@ function doc(): Uint8Array {
   );
 }
 
+function mixedRunDoc(): Uint8Array {
+  return zipDocument(
+    '<w:p><w:r><w:t>HelloWorld</w:t></w:r></w:p>' +
+      `<w:p><w:r><w:t>${PARA1}</w:t></w:r></w:p><w:sectPr/>`
+  );
+}
+
 function bodyText(peer: Peer): string {
   const texts: string[] = [];
   walk(peer.store.bodyStore().part.root, (node: OoxmlNode) => {
@@ -265,5 +272,31 @@ describe('concurrent run-format convergence (#581)', () => {
     harness.expectConverged(alice, bob);
     expect(bodyText(alice)).toBe(PARA0 + PARA1);
     expect(markCount(alice, 'b')).toBeGreaterThan(0);
+  });
+
+  test('concurrent typing survives formatting a run that contains a tab', async () => {
+    const { alice, bob, pause, resume } = await harness.pair(mixedRunDoc());
+    harness.apply(alice, [
+      {
+        op: 'insertTab',
+        paragraphId: harness.paragraphIdAt(alice, 0),
+        offset: 5,
+      },
+    ]);
+    harness.expectConverged(alice, bob);
+    pause();
+    harness.apply(alice, [runProps(alice, 0, 0, 5, 'b')]);
+    harness.apply(bob, [
+      {
+        op: 'insertText',
+        paragraphId: harness.paragraphIdAt(bob, 0),
+        offset: 8,
+        text: 'X',
+      },
+    ]);
+    resume();
+    harness.expectConverged(alice, bob);
+    expect(bodyText(alice)).toBe('HelloWoXrld' + PARA1);
+    expect(markCount(alice, 'tab')).toBe(1);
   });
 });

--- a/packages/pro/src/collaboration/__tests__/document-security.test.ts
+++ b/packages/pro/src/collaboration/__tests__/document-security.test.ts
@@ -19,6 +19,7 @@ import {
   seedPackage,
   MemoryBlobStore,
 } from '../document/index.ts';
+import { NODE_SPLIT_BASE_TEXT_FIELD, nodeRecordSplitBaseText } from '../document/schema.ts';
 import * as Y from 'yjs';
 
 describe('shared-state security and limits', () => {
@@ -189,6 +190,19 @@ describe('shared-state security and limits', () => {
       });
     } finally {
       destroyReplica(replica);
+    }
+  });
+
+  test('rejects an oversized split text baseline before projection', () => {
+    const doc = new Y.Doc();
+    try {
+      const record = new Y.Map<unknown>();
+      doc.getMap<Y.Map<unknown>>('nodes').set('run', record);
+      record.set(NODE_SPLIT_BASE_TEXT_FIELD, 'ABCDE');
+      expect(nodeRecordSplitBaseText(record, 4)).toBeNull();
+      expect(nodeRecordSplitBaseText(record, 5)).toBe('ABCDE');
+    } finally {
+      doc.destroy();
     }
   });
 });

--- a/packages/pro/src/collaboration/document-session.ts
+++ b/packages/pro/src/collaboration/document-session.ts
@@ -116,6 +116,7 @@ class DocumentSession implements DocumentCollaborationSession {
     (participants: readonly CollaborationParticipant[]) => void
   >();
   private readonly localOrigin = Object.freeze({ kind: 'docx-document-local' });
+  private readonly splitTextRepairOrigin = Object.freeze({ kind: 'docx-split-text-repair' });
   private readonly undoManager: Y.UndoManager;
   private port: CollaborationDocumentPort | null = null;
   private detachPort: (() => void) | null = null;
@@ -614,6 +615,7 @@ class DocumentSession implements DocumentCollaborationSession {
 
   private readonly onYjsTransaction = (transaction: Y.Transaction): void => {
     if (this.destroyed || !this.port) return;
+    if (transaction.origin === this.splitTextRepairOrigin) return;
     // The canonical store already holds a local commit. Materializing it back would rebuild
     // the package for an edit the store authored — so this normally skips a local transaction.
     // The exception is a concurrent-split tangle the dedup declines (#581): the materialized
@@ -636,6 +638,9 @@ class DocumentSession implements DocumentCollaborationSession {
     // offset or the wrong sibling — inside bounds, so admitted, so agreed on by every replica.
     // Journals reach shared state in the frame that commits them instead, which is why there
     // is nothing left to publish at this point.
+    this.ydoc.transact(() => {
+      this.registry.repairConcurrentSplitText(this.identityMap.replicaId);
+    }, this.splitTextRepairOrigin);
     this.publishSharedToPort();
   };
 

--- a/packages/pro/src/collaboration/document-session.ts
+++ b/packages/pro/src/collaboration/document-session.ts
@@ -116,7 +116,6 @@ class DocumentSession implements DocumentCollaborationSession {
     (participants: readonly CollaborationParticipant[]) => void
   >();
   private readonly localOrigin = Object.freeze({ kind: 'docx-document-local' });
-  private readonly splitTextRepairOrigin = Object.freeze({ kind: 'docx-split-text-repair' });
   private readonly undoManager: Y.UndoManager;
   private port: CollaborationDocumentPort | null = null;
   private detachPort: (() => void) | null = null;
@@ -615,7 +614,6 @@ class DocumentSession implements DocumentCollaborationSession {
 
   private readonly onYjsTransaction = (transaction: Y.Transaction): void => {
     if (this.destroyed || !this.port) return;
-    if (transaction.origin === this.splitTextRepairOrigin) return;
     // The canonical store already holds a local commit. Materializing it back would rebuild
     // the package for an edit the store authored — so this normally skips a local transaction.
     // The exception is a concurrent-split tangle the dedup declines (#581): the materialized
@@ -638,9 +636,6 @@ class DocumentSession implements DocumentCollaborationSession {
     // offset or the wrong sibling — inside bounds, so admitted, so agreed on by every replica.
     // Journals reach shared state in the frame that commits them instead, which is why there
     // is nothing left to publish at this point.
-    this.ydoc.transact(() => {
-      this.registry.repairConcurrentSplitText(this.identityMap.replicaId);
-    }, this.splitTextRepairOrigin);
     this.publishSharedToPort();
   };
 

--- a/packages/pro/src/collaboration/document/journal.ts
+++ b/packages/pro/src/collaboration/document/journal.ts
@@ -500,9 +500,8 @@ function recordSplitProvenance(registry: DocumentRegistry, planned: JournalPlan)
   for (const [removedId, insertedIds] of planned.replacementsByRemoved) {
     if (registry.kindOf(removedId) !== 'run') continue;
     const root = resolveSplitRoot(registry, removedId, planned.reinserted);
-    for (const runId of insertedIds) {
-      if (registry.kindOf(runId) === 'run') registry.recordSplitFrom(root, runId);
-    }
+    const runs = insertedIds.filter((runId) => registry.kindOf(runId) === 'run');
+    registry.recordRunSplit(root, removedId, runs);
   }
 }
 

--- a/packages/pro/src/collaboration/document/materialize-split-projection.ts
+++ b/packages/pro/src/collaboration/document/materialize-split-projection.ts
@@ -1,0 +1,35 @@
+/*
+Copyright (c) 2026 EigenPal, Inc. All rights reserved.
+Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/pro/LICENSE.md.
+Production use requires a commercial agreement: licensing@eigenpal.com
+*/
+
+import type { LogicalId } from './identity.ts';
+import type { DocumentRegistry } from './registry.ts';
+
+export class MaterializeSplitProjection {
+  private lastLosers: ReadonlySet<LogicalId> = new Set();
+  private textOverlays: ReadonlyMap<LogicalId, string> = new Map();
+  losers: ReadonlySet<LogicalId> = new Set();
+
+  update(registry: DocumentRegistry): readonly LogicalId[] {
+    const dirty: LogicalId[] = [];
+    const nextLosers = registry.replacementLoserRuns();
+    const addParent = (runId: LogicalId): void => {
+      const parent = registry.parentOf(runId);
+      if (parent !== null) dirty.push(parent);
+    };
+    for (const id of nextLosers) if (!this.lastLosers.has(id)) addParent(id);
+    for (const id of this.lastLosers) if (!nextLosers.has(id)) addParent(id);
+    this.lastLosers = nextLosers;
+    this.losers = nextLosers;
+    const overlays = registry.concurrentSplitTextOverlays();
+    this.textOverlays = overlays.values;
+    dirty.push(...overlays.changedIds);
+    return dirty;
+  }
+
+  textValue(logicalId: LogicalId, fallback: string): string {
+    return this.textOverlays.get(logicalId) ?? fallback;
+  }
+}

--- a/packages/pro/src/collaboration/document/materialize.ts
+++ b/packages/pro/src/collaboration/document/materialize.ts
@@ -43,6 +43,7 @@ import {
 } from './materialize-custom-xml.ts';
 import { partMemberSpecFor } from './materialize-part-members.ts';
 import { PackageProjectionCache } from './materialize-package-cache.ts';
+import { MaterializeSplitProjection } from './materialize-split-projection.ts';
 import {
   attributesMatch,
   countPass,
@@ -108,10 +109,7 @@ export class PackageMaterializer {
   /** Adoptee signature per survivor at the end of the last pass. */
   private lastAdoption = new Map<LogicalId, string>();
   private placementContested = false;
-  /** Runs a concurrent format split superseded; skipped this pass. Recomputed each rebuild. */
-  private replacementLosers: ReadonlySet<LogicalId> = new Set();
-  /** The loser set the previous pass used, to dirty parents when the verdict flips. */
-  private lastLosers: ReadonlySet<LogicalId> = new Set();
+  private readonly splitProjection = new MaterializeSplitProjection();
   /**
    * What the last full pass decided for each contested id: the parent the registry resolved
    * then, `null` for none. Holds only ids that pass evidenced as contested, so a hostile peer
@@ -220,22 +218,6 @@ export class PackageMaterializer {
     return moved;
   }
 
-  /**
-   * Parents of runs whose format-split loser verdict flipped, so the incremental pass
-   * rebuilds them instead of reusing a cached subtree with the stale verdict (#581).
-   */
-  private loserChanges(losers: ReadonlySet<LogicalId>): readonly LogicalId[] {
-    const parents: LogicalId[] = [];
-    const flipped = (runId: LogicalId): void => {
-      const parent = this.registry.parentOf(runId);
-      if (parent !== null) parents.push(parent);
-    };
-    for (const runId of losers) if (!this.lastLosers.has(runId)) flipped(runId);
-    for (const runId of this.lastLosers) if (!losers.has(runId)) flipped(runId);
-    this.lastLosers = losers;
-    return parents;
-  }
-
   rebuild(): MaterializeResult {
     const rawDirty = new Set(this.pendingDirty);
     const packageChanged = this.pendingPackage;
@@ -254,10 +236,7 @@ export class PackageMaterializer {
     // delivered yet, so it disqualifies the package projections exactly as the flag does.
     if (packageChanged || unobserved) this.packageCache.invalidate();
     for (const survivor of this.adoptionChanges()) rawDirty.add(survivor);
-    // Recompute the split-loser set once here, dirty the parents whose verdict changed, and
-    // reuse it for the pass so incremental and cold agree on which runs to drop (#581).
-    this.replacementLosers = this.registry.replacementLoserRuns();
-    for (const parent of this.loserChanges(this.replacementLosers)) rawDirty.add(parent);
+    for (const id of this.splitProjection.update(this.registry)) rawDirty.add(id);
     const dirty = expandAncestors(this.registry, rawDirty);
     // A relationship-only change dirties no nodes. Reuse the node cache, then project `.rels`.
     //
@@ -342,8 +321,7 @@ export class PackageMaterializer {
     }
     this.customXmlRels = [];
     this.customXmlOverrides.clear();
-    // `this.replacementLosers` was set in `rebuild()`, which also dirtied the parents whose
-    // loser verdict changed so this pass rebuilds them (#581).
+    // The split projection was updated in `rebuild()`, which also dirtied changed products.
     const placed = new Set<LogicalId>();
     const parts = new Map<string, OoxmlPart>();
     for (const entry of this.registry.partEntries()) {
@@ -556,9 +534,10 @@ export class PackageMaterializer {
       return null;
     }
     if (isTextRecord(record)) {
+      const value = this.splitProjection.textValue(logicalId, record.value);
       const previous = this.cache.get(logicalId);
-      if (previous?.kind === 'textValue' && previous.value === record.value) return previous;
-      const next = freezeText(logicalId, record.value);
+      if (previous?.kind === 'textValue' && previous.value === value) return previous;
+      const next = freezeText(logicalId, value);
       this.remember(logicalId, next);
       return next;
     }
@@ -586,7 +565,7 @@ export class PackageMaterializer {
       // A run a concurrent split superseded: drop it, and mark it placed so reachability does
       // not report it as stranded content — its loss is deliberate, the winning split's runs
       // carry the text. Every replica picks the same loser, so this converges.
-      if (this.replacementLosers.has(childId)) {
+      if (this.splitProjection.losers.has(childId)) {
         placed.add(childId);
         continue;
       }

--- a/packages/pro/src/collaboration/document/registry.ts
+++ b/packages/pro/src/collaboration/document/registry.ts
@@ -126,7 +126,7 @@ export class DocumentRegistry {
   ) {
     this.schema = packageSchemaOf(doc);
     this.limits = mergeLimits(limits);
-    this.splitDedup = new SplitDedupIndex(this.schema.nodes);
+    this.splitDedup = new SplitDedupIndex(this.schema.nodes, this.limits);
     this.stopObserving = observeRegistrySchema(this.schema, {
       onNodeEvents: (events) => {
         if (this.bulkLoad > 0) return;
@@ -485,9 +485,8 @@ export class DocumentRegistry {
     if (replacedBy) rec.set(NODE_REPLACED_BY_FIELD, replacedBy);
   }
 
-  /** Stamp a run with the root origin a concurrent split superseded (#581). */
-  recordSplitFrom(root: LogicalId, runId: LogicalId): void {
-    this.splitDedup.record(root, runId);
+  recordRunSplit(root: LogicalId, replaced: LogicalId, runs: readonly LogicalId[]): void {
+    this.splitDedup.record(root, replaced, runs);
   }
 
   /** The run a given run split off from, or null — the caller resolves the chain (#581). */
@@ -498,6 +497,10 @@ export class DocumentRegistry {
   /** Runs a concurrent format split superseded and this replica must not materialize (#581). */
   replacementLoserRuns(): ReadonlySet<LogicalId> {
     return this.splitDedup.loserRuns({ isPresent: (id) => runIsPresent(this, id) });
+  }
+
+  repairConcurrentSplitText(replicaId: string): number {
+    return this.splitDedup.repairConcurrentText(replicaId, (id) => runIsPresent(this, id));
   }
 
   /**
@@ -752,6 +755,7 @@ export class DocumentRegistry {
     this.pendingNodeAdds = 0;
     const changed = new Set<LogicalId>();
     for (const event of events) {
+      if (event.path.length > 0) this.splitDedup.noteChanged(String(event.path[0]));
       // A remote applyUpdate delivers a new element record with its children already filled.
       // Yjs does not emit a child-array event for that initial fill. Skipping it left
       // `parentOf` null, so an attribute-only journal could not dirty the part root and the

--- a/packages/pro/src/collaboration/document/registry.ts
+++ b/packages/pro/src/collaboration/document/registry.ts
@@ -7,7 +7,7 @@ import * as Y from 'yjs';
 import type { CanonicalBinaryDescriptor } from '@docx-editor.dev/core/collaboration/replication';
 import { partNameKey } from '@docx-editor.dev/core/store';
 import { yjsItemKey, type LogicalId, type NodeIdentityMeta, wordFacingIdsOf } from './identity.ts';
-import { SplitDedupIndex } from './split-dedup.ts';
+import { SplitDedupIndex, type SplitTextOverlays } from './split-dedup.ts';
 import { runIsPresent } from './run-text-reads.ts';
 import {
   DEFAULT_DOCUMENT_LIMITS,
@@ -499,8 +499,8 @@ export class DocumentRegistry {
     return this.splitDedup.loserRuns({ isPresent: (id) => runIsPresent(this, id) });
   }
 
-  repairConcurrentSplitText(replicaId: string): number {
-    return this.splitDedup.repairConcurrentText(replicaId, (id) => runIsPresent(this, id));
+  concurrentSplitTextOverlays(): SplitTextOverlays {
+    return this.splitDedup.concurrentTextOverlays((id) => runIsPresent(this, id));
   }
 
   /**

--- a/packages/pro/src/collaboration/document/schema.ts
+++ b/packages/pro/src/collaboration/document/schema.ts
@@ -482,10 +482,10 @@ export function nodeRecordSplitFrom(record: unknown): string | null {
   return typeof value === 'string' && value.length > 0 ? value : null;
 }
 
-export function nodeRecordSplitBaseText(record: unknown): string | null {
+export function nodeRecordSplitBaseText(record: unknown, maxLength: number): string | null {
   if (!isNodeMap(record)) return null;
   const value = record.get(NODE_SPLIT_BASE_TEXT_FIELD);
-  return typeof value === 'string' ? value : null;
+  return typeof value === 'string' && value.length <= maxLength ? value : null;
 }
 
 export function nodeRecordSplitStart(record: unknown): number | null {

--- a/packages/pro/src/collaboration/document/schema.ts
+++ b/packages/pro/src/collaboration/document/schema.ts
@@ -39,6 +39,10 @@ export const NODE_REPLACED_BY_FIELD = 'replacedBy';
  * Internal shared state, never serialized to the `.docx`.
  */
 export const NODE_SPLIT_FROM_FIELD = 'splitFrom';
+/** Source text when a run split, used to rebase a concurrent text edit onto its products. */
+export const NODE_SPLIT_BASE_TEXT_FIELD = 'splitBaseText';
+/** UTF-16 start of one split product in {@link NODE_SPLIT_BASE_TEXT_FIELD}. */
+export const NODE_SPLIT_START_FIELD = 'splitStart';
 
 /** Unit separator. XML names and NCName prefixes cannot hold this character. */
 export const FIELD_SEP = '\u001f';
@@ -476,4 +480,16 @@ export function nodeRecordSplitFrom(record: unknown): string | null {
   if (!isNodeMap(record)) return null;
   const value = record.get(NODE_SPLIT_FROM_FIELD);
   return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+export function nodeRecordSplitBaseText(record: unknown): string | null {
+  if (!isNodeMap(record)) return null;
+  const value = record.get(NODE_SPLIT_BASE_TEXT_FIELD);
+  return typeof value === 'string' ? value : null;
+}
+
+export function nodeRecordSplitStart(record: unknown): number | null {
+  if (!isNodeMap(record)) return null;
+  const value = record.get(NODE_SPLIT_START_FIELD);
+  return Number.isSafeInteger(value) && (value as number) >= 0 ? (value as number) : null;
 }

--- a/packages/pro/src/collaboration/document/split-dedup.ts
+++ b/packages/pro/src/collaboration/document/split-dedup.ts
@@ -51,9 +51,15 @@ export interface SplitTextOverlays {
 }
 
 interface RunText {
-  readonly ids: readonly LogicalId[];
+  readonly parts: readonly { readonly id: LogicalId; readonly value: string }[];
   readonly witnessIds: readonly LogicalId[];
   readonly value: string;
+}
+
+interface SplitProduct {
+  readonly id: LogicalId;
+  readonly start: number | null;
+  readonly text: RunText | null;
 }
 
 /** Cap on the `splitFrom` walk that classifies a re-split; stops a peer-crafted chain or cycle. */
@@ -189,17 +195,15 @@ export class SplitDedupIndex {
         .sort(
           (left, right) => (left.start ?? 0) - (right.start ?? 0) || left.id.localeCompare(right.id)
         );
-      if (!this.productsMatchBaseline(products, base)) continue;
-      const boundaries = products.map((product) => product.start!);
-      boundaries.push(base.length);
-      const mapped = boundaries.map((offset) => mapBaseOffset(base, source.value, offset));
+      if (!this.productsCoverBaseline(products, base)) continue;
+      const merged = mergeSourceEditIntoProducts(base, source.value, products);
       const overlayIds = new Set<LogicalId>();
       for (let index = 0; index < products.length; index += 1) {
         const product = products[index]!;
-        const value = source.value.slice(mapped[index]!, mapped[index + 1]!);
-        for (let textIndex = 0; textIndex < product.text!.ids.length; textIndex += 1) {
-          const id = product.text!.ids[textIndex]!;
-          const overlay = textIndex === 0 ? value : '';
+        const values = partitionRunText(product.text!, merged[index]!);
+        for (let textIndex = 0; textIndex < product.text!.parts.length; textIndex += 1) {
+          const id = product.text!.parts[textIndex]!.id;
+          const overlay = values[textIndex]!;
           if (this.textOverlays.get(id) !== overlay) changedIds.add(id);
           this.textOverlays.set(id, overlay);
           overlayIds.add(id);
@@ -216,27 +220,20 @@ export class SplitDedupIndex {
     }
   }
 
-  private productsMatchBaseline(
-    products: readonly {
-      readonly start: number | null;
-      readonly text: RunText | null;
-    }[],
-    baseline: string
-  ): boolean {
+  private productsCoverBaseline(products: readonly SplitProduct[], baseline: string): boolean {
     if (products.length === 0 || products[0]?.start !== 0) return false;
     for (let index = 0; index < products.length; index += 1) {
       const product = products[index]!;
       if (product.start === null || !product.text) return false;
       const end = products[index + 1]?.start ?? baseline.length;
-      if (end < product.start || product.text.value !== baseline.slice(product.start, end))
-        return false;
+      if (end < product.start || end > baseline.length) return false;
     }
     return true;
   }
 
   private runText(runId: LogicalId): RunText | null {
     if (nodeKindOf(this.nodes, runId) !== 'run') return null;
-    const ids: LogicalId[] = [];
+    const parts: { id: LogicalId; value: string }[] = [];
     const witnessIds: LogicalId[] = [];
     let value = '';
     const seen = new Set<LogicalId>();
@@ -249,9 +246,10 @@ export class SplitDedupIndex {
       if (isTextNodeMap(rec)) {
         const text = rec.get(NODE_TEXT_FIELD);
         if (!(text instanceof Y.Text)) return false;
-        value += text.toString();
+        const part = text.toString();
+        value += part;
         if (value.length > this.limits.maxTextLength) return false;
-        ids.push(id);
+        parts.push({ id, value: part });
         return true;
       }
       const shell = rec.get(NODE_SHELL_FIELD);
@@ -263,7 +261,7 @@ export class SplitDedupIndex {
       }
       return true;
     };
-    return visit(runId, 0) && ids.length > 0 ? { ids, witnessIds, value } : null;
+    return visit(runId, 0) && parts.length > 0 ? { parts, witnessIds, value } : null;
   }
 
   /**
@@ -405,4 +403,73 @@ function mapBaseOffset(base: string, next: string, offset: number): number {
   if (offset <= prefix) return offset;
   if (offset >= baseEnd) return nextEnd + offset - baseEnd;
   return prefix;
+}
+
+function mergeSourceEditIntoProducts(
+  base: string,
+  source: string,
+  products: readonly SplitProduct[]
+): readonly string[] {
+  const edit = textSplice(base, source);
+  const owner = products.findIndex((product, index) => {
+    const end = products[index + 1]?.start ?? base.length;
+    return product.start !== null && edit.start >= product.start && edit.start <= end;
+  });
+  return products.map((product, index) => {
+    const start = product.start!;
+    const end = products[index + 1]?.start ?? base.length;
+    const basePart = base.slice(start, end);
+    const current = product.text!.value;
+    const deleteStart = Math.max(edit.start, start);
+    const deleteEnd = Math.min(edit.end, end);
+    const ownsInsert = index === owner && edit.insert.length > 0;
+    if (deleteStart >= deleteEnd && !ownsInsert) return current;
+    const localStart = Math.max(0, (ownsInsert ? edit.start : deleteStart) - start);
+    const localEnd = Math.max(localStart, deleteEnd - start);
+    const mappedStart = mapBaseOffset(basePart, current, localStart);
+    const mappedEnd = mapBaseOffset(basePart, current, localEnd);
+    if (
+      mappedStart === mappedEnd &&
+      ownsInsert &&
+      current.slice(mappedStart, mappedStart + edit.insert.length) === edit.insert
+    ) {
+      return current;
+    }
+    return (
+      current.slice(0, mappedStart) + (ownsInsert ? edit.insert : '') + current.slice(mappedEnd)
+    );
+  });
+}
+
+function partitionRunText(run: RunText, merged: string): readonly string[] {
+  const boundaries = [0];
+  for (const part of run.parts) boundaries.push(boundaries.at(-1)! + part.value.length);
+  const mapped = boundaries.map((offset) => mapBaseOffset(run.value, merged, offset));
+  return run.parts.map((_, index) => merged.slice(mapped[index]!, mapped[index + 1]!));
+}
+
+function textSplice(
+  base: string,
+  next: string
+): {
+  readonly start: number;
+  readonly end: number;
+  readonly insert: string;
+} {
+  let start = 0;
+  const shared = Math.min(base.length, next.length);
+  while (start < shared && base.charCodeAt(start) === next.charCodeAt(start)) start += 1;
+  let suffix = 0;
+  while (
+    suffix < base.length - start &&
+    suffix < next.length - start &&
+    base.charCodeAt(base.length - suffix - 1) === next.charCodeAt(next.length - suffix - 1)
+  ) {
+    suffix += 1;
+  }
+  return {
+    start,
+    end: base.length - suffix,
+    insert: next.slice(start, next.length - suffix),
+  };
 }

--- a/packages/pro/src/collaboration/document/split-dedup.ts
+++ b/packages/pro/src/collaboration/document/split-dedup.ts
@@ -15,14 +15,25 @@ Production use requires a commercial agreement: licensing@eigenpal.com
  * the same tree with the text intact.
  */
 
-import type * as Y from 'yjs';
+import * as Y from 'yjs';
 import { replicaOfLogicalId, type LogicalId } from './identity.ts';
+import type { DocumentLimits } from './limits.ts';
 import {
+  NODE_SPLIT_BASE_TEXT_FIELD,
   NODE_SPLIT_FROM_FIELD,
+  NODE_SPLIT_START_FIELD,
+  NODE_SHELL_FIELD,
+  NODE_TEXT_FIELD,
+  childArrayOf,
   isNodeMap,
+  isTextNodeMap,
+  nodeRecordSplitBaseText,
   nodeRecordSplitFrom,
+  nodeRecordSplitStart,
   nodeRecordTombstoned,
+  unpackNodeShell,
 } from './schema.ts';
+import { nodeKindOf } from './registry-node-reads.ts';
 
 /**
  * What the dedup reads about the tree it is projecting, injected so the index stays free of the
@@ -32,6 +43,12 @@ import {
  */
 export interface SplitDedupContext {
   readonly isPresent: (id: LogicalId) => boolean;
+}
+
+interface RunText {
+  readonly ids: readonly LogicalId[];
+  readonly witnessIds: readonly LogicalId[];
+  readonly value: string;
 }
 
 /** Cap on the `splitFrom` walk that classifies a re-split; stops a peer-crafted chain or cycle. */
@@ -44,6 +61,10 @@ export class SplitDedupIndex {
   private replicasByOrigin = new Map<LogicalId, Set<string>>();
   /** Origins that more than one replica split — the only ones a dedup pass has to examine. */
   private contestedOrigins = new Set<LogicalId>();
+  /** Source text id → split origins that still use it as their concurrent-edit witness. */
+  private originsBySourceText = new Map<LogicalId, Set<LogicalId>>();
+  /** Split origins whose source text changed since the last repair pass. */
+  private pendingTextRepairOrigins = new Set<LogicalId>();
   /**
    * Origins that are live again while products still point at them — an undo restored the origin.
    * A cold rebuild reads this straight from current state, so a peer joining after the undo drops
@@ -59,13 +80,18 @@ export class SplitDedupIndex {
    */
   private declinedTangleCount = 0;
 
-  constructor(private readonly nodes: Y.Map<Y.Map<unknown>>) {}
+  constructor(
+    private readonly nodes: Y.Map<Y.Map<unknown>>,
+    private readonly limits: Pick<DocumentLimits, 'maxTextLength' | 'maxTreeDepth'>
+  ) {}
 
   reset(): void {
     this.runsBySplitOrigin = new Map();
     this.replicasByOrigin = new Map();
     this.contestedOrigins = new Set();
     this.liveRootedOrigins = new Set();
+    this.originsBySourceText = new Map();
+    this.pendingTextRepairOrigins = new Set();
   }
 
   /**
@@ -76,21 +102,156 @@ export class SplitDedupIndex {
    * Both concurrent splits of one run must reach the SAME root, or their products land in
    * separate groups and both survive.
    */
-  record(root: LogicalId, runId: LogicalId): void {
-    const rec = this.nodes.get(runId);
-    if (!isNodeMap(rec)) return;
-    // A run is not split from itself. Wrapping a run (a TOC bookmark, a hyperlink) removes and
-    // reinserts the SAME node, which looks like a replacement but partitions nothing; stamping it
-    // would let the dedup drop the run as a copy of itself.
-    if (root === runId) return;
-    rec.set(NODE_SPLIT_FROM_FIELD, root);
-    this.index(root, runId);
+  record(root: LogicalId, replacedRunId: LogicalId, runIds: readonly LogicalId[]): void {
+    const rootRecord = this.nodes.get(root);
+    const replacedRecord = this.nodes.get(replacedRunId);
+    if (!isNodeMap(rootRecord) || !isNodeMap(replacedRecord)) return;
+    const baseline = nodeRecordSplitBaseText(rootRecord) ?? this.runText(root)?.value;
+    const start = nodeRecordSplitStart(replacedRecord) ?? 0;
+    const products = runIds.map((id) => ({ id, text: this.runText(id) }));
+    const canRepair =
+      baseline !== undefined &&
+      baseline.length <= this.limits.maxTextLength &&
+      products.every((product) => product.text !== null);
+    if (canRepair) {
+      rootRecord.set(NODE_SPLIT_BASE_TEXT_FIELD, baseline);
+      this.indexSourceText(root);
+    }
+    let cursor = start;
+    for (const product of products) {
+      const rec = this.nodes.get(product.id);
+      if (!isNodeMap(rec)) return;
+      // A run is not split from itself. Wrapping a run (a TOC bookmark, a hyperlink) removes and
+      // reinserts the SAME node, which looks like a replacement but partitions nothing.
+      if (root === product.id) continue;
+      rec.set(NODE_SPLIT_FROM_FIELD, root);
+      if (canRepair) rec.set(NODE_SPLIT_START_FIELD, cursor);
+      this.index(root, product.id);
+      cursor += product.text?.value.length ?? 0;
+    }
     // A later round re-split a run an earlier round produced, and the shared origin was split by
     // two replicas — the tangle the dedup declines. Count it, so the session reconciles the
     // author's store only on the edit that creates the tangle, not on every keystroke while it
     // persists. A single author re-formatting a paragraph re-splits products too, but its origin
     // is never contested, so this ignores it — no wasted reconcile without a real conflict.
-    if (this.reSplitOfContestedOrigin(root)) this.declinedTangleCount += 1;
+    if (this.reSplitOfContestedOrigin(root)) this.declinedTangleCount += products.length;
+  }
+
+  /**
+   * Rebase text written concurrently to a split source onto the winning split products.
+   *
+   * Only the product owner writes the repair. This prevents two peers from inserting the same
+   * correction into one Y.Text. The baseline proves the product text has not changed since the
+   * split, so a later sequential edit is never overwritten.
+   */
+  repairConcurrentText(replicaId: string, isPresent: SplitDedupContext['isPresent']): number {
+    let repaired = 0;
+    const pending = this.pendingTextRepairOrigins;
+    this.pendingTextRepairOrigins = new Set();
+    for (const root of pending) {
+      const runs = this.runsBySplitOrigin.get(root);
+      if (!runs) continue;
+      if (this.isReSplit(root) || isPresent(root)) continue;
+      const base = nodeRecordSplitBaseText(this.nodes.get(root));
+      const source = this.runText(root);
+      if (base === null || !source || source.value === base) continue;
+      const presentReplicas = new Set<string>();
+      for (const runId of runs) {
+        if (isPresent(runId)) presentReplicas.add(replicaOfLogicalId(runId) ?? '');
+      }
+      const winner = [...presentReplicas].sort()[0];
+      if (winner !== replicaId) continue;
+      const products = [...runs]
+        .filter((runId) => isPresent(runId) && replicaOfLogicalId(runId) === winner)
+        .map((runId) => ({
+          id: runId,
+          start: nodeRecordSplitStart(this.nodes.get(runId)),
+          text: this.runText(runId),
+        }))
+        .sort(
+          (left, right) => (left.start ?? 0) - (right.start ?? 0) || left.id.localeCompare(right.id)
+        );
+      if (!this.productsMatchBaseline(products, base)) continue;
+      const boundaries = products.map((product) => product.start!);
+      boundaries.push(base.length);
+      const mapped = boundaries.map((offset) => mapBaseOffset(base, source.value, offset));
+      for (let index = 0; index < products.length; index += 1) {
+        const product = products[index]!;
+        this.replaceText(product.text!, source.value.slice(mapped[index]!, mapped[index + 1]!));
+        const rec = this.nodes.get(product.id);
+        if (isNodeMap(rec)) rec.set(NODE_SPLIT_START_FIELD, mapped[index]!);
+      }
+      const rootRecord = this.nodes.get(root);
+      if (isNodeMap(rootRecord)) rootRecord.set(NODE_SPLIT_BASE_TEXT_FIELD, source.value);
+      repaired += 1;
+    }
+    return repaired;
+  }
+
+  noteChanged(logicalId: LogicalId): void {
+    for (const root of this.originsBySourceText.get(logicalId) ?? []) {
+      this.pendingTextRepairOrigins.add(root);
+    }
+  }
+
+  private productsMatchBaseline(
+    products: readonly {
+      readonly start: number | null;
+      readonly text: RunText | null;
+    }[],
+    baseline: string
+  ): boolean {
+    if (products.length === 0 || products[0]?.start !== 0) return false;
+    for (let index = 0; index < products.length; index += 1) {
+      const product = products[index]!;
+      if (product.start === null || !product.text) return false;
+      const end = products[index + 1]?.start ?? baseline.length;
+      if (end < product.start || product.text.value !== baseline.slice(product.start, end))
+        return false;
+    }
+    return true;
+  }
+
+  private runText(runId: LogicalId): RunText | null {
+    if (nodeKindOf(this.nodes, runId) !== 'run') return null;
+    const ids: LogicalId[] = [];
+    const witnessIds: LogicalId[] = [];
+    let value = '';
+    const seen = new Set<LogicalId>();
+    const visit = (id: LogicalId, depth: number): boolean => {
+      if (depth > this.limits.maxTreeDepth || seen.has(id)) return false;
+      seen.add(id);
+      witnessIds.push(id);
+      const rec = this.nodes.get(id);
+      if (!isNodeMap(rec)) return false;
+      if (isTextNodeMap(rec)) {
+        const text = rec.get(NODE_TEXT_FIELD);
+        if (!(text instanceof Y.Text)) return false;
+        value += text.toString();
+        if (value.length > this.limits.maxTextLength) return false;
+        ids.push(id);
+        return true;
+      }
+      const shell = rec.get(NODE_SHELL_FIELD);
+      const decoded = unpackNodeShell(typeof shell === 'string' ? shell : '');
+      if (depth > 0 && decoded.kind === 'runProperties') return true;
+      if (depth > 0 && decoded.localName !== 't') return false;
+      for (const childId of childArrayOf(rec)?.toArray() ?? []) {
+        if (!visit(childId, depth + 1)) return false;
+      }
+      return true;
+    };
+    return visit(runId, 0) && ids.length > 0 ? { ids, witnessIds, value } : null;
+  }
+
+  private replaceText(run: RunText, value: string): void {
+    for (let index = 0; index < run.ids.length; index += 1) {
+      const rec = this.nodes.get(run.ids[index]!);
+      const text = isNodeMap(rec) ? rec.get(NODE_TEXT_FIELD) : null;
+      if (!(text instanceof Y.Text)) continue;
+      if (text.length > 0) text.delete(0, text.length);
+      if (index === 0 && value.length > 0) text.insert(0, value);
+    }
   }
 
   /**
@@ -114,7 +275,25 @@ export class SplitDedupIndex {
   /** Index a run that already carries a `splitFrom` (a rebuild scan, or a remote arrival). */
   indexExisting(runId: LogicalId): void {
     const root = nodeRecordSplitFrom(this.nodes.get(runId));
-    if (root !== null && root !== runId) this.index(root, runId);
+    if (root !== null && root !== runId) {
+      this.index(root, runId);
+      this.indexSourceText(root);
+      const base = nodeRecordSplitBaseText(this.nodes.get(root));
+      const source = this.runText(root);
+      if (base !== null && source && source.value !== base) {
+        this.pendingTextRepairOrigins.add(root);
+      }
+    }
+  }
+
+  private indexSourceText(root: LogicalId): void {
+    const source = this.runText(root);
+    if (!source) return;
+    for (const witnessId of source.witnessIds) {
+      const origins = this.originsBySourceText.get(witnessId) ?? new Set<LogicalId>();
+      origins.add(root);
+      this.originsBySourceText.set(witnessId, origins);
+    }
   }
 
   private index(root: LogicalId, runId: LogicalId): void {
@@ -195,4 +374,23 @@ export class SplitDedupIndex {
     }
     return losers;
   }
+}
+
+function mapBaseOffset(base: string, next: string, offset: number): number {
+  let prefix = 0;
+  const shared = Math.min(base.length, next.length);
+  while (prefix < shared && base.charCodeAt(prefix) === next.charCodeAt(prefix)) prefix += 1;
+  let suffix = 0;
+  while (
+    suffix < base.length - prefix &&
+    suffix < next.length - prefix &&
+    base.charCodeAt(base.length - suffix - 1) === next.charCodeAt(next.length - suffix - 1)
+  ) {
+    suffix += 1;
+  }
+  const baseEnd = base.length - suffix;
+  const nextEnd = next.length - suffix;
+  if (offset <= prefix) return offset;
+  if (offset >= baseEnd) return nextEnd + offset - baseEnd;
+  return prefix;
 }

--- a/packages/pro/src/collaboration/document/split-dedup.ts
+++ b/packages/pro/src/collaboration/document/split-dedup.ts
@@ -117,7 +117,8 @@ export class SplitDedupIndex {
     const rootRecord = this.nodes.get(root);
     const replacedRecord = this.nodes.get(replacedRunId);
     if (!isNodeMap(rootRecord) || !isNodeMap(replacedRecord)) return;
-    const baseline = nodeRecordSplitBaseText(rootRecord) ?? this.runText(root)?.value;
+    const baseline =
+      nodeRecordSplitBaseText(rootRecord, this.limits.maxTextLength) ?? this.runText(root)?.value;
     const start = nodeRecordSplitStart(replacedRecord) ?? 0;
     const products = runIds.map((id) => ({ id, text: this.runText(id) }));
     const canRepair =
@@ -169,7 +170,7 @@ export class SplitDedupIndex {
       const runs = this.runsBySplitOrigin.get(root);
       if (!runs) continue;
       if (this.isReSplit(root) || isPresent(root)) continue;
-      const base = nodeRecordSplitBaseText(this.nodes.get(root));
+      const base = nodeRecordSplitBaseText(this.nodes.get(root), this.limits.maxTextLength);
       const source = this.runText(root);
       if (base === null || !source || source.value === base) continue;
       const presentReplicas = new Set<string>();
@@ -290,7 +291,7 @@ export class SplitDedupIndex {
       this.index(root, runId);
       this.indexTextWitnesses(root, this.runText(root));
       this.indexTextWitnesses(root, this.runText(runId));
-      const base = nodeRecordSplitBaseText(this.nodes.get(root));
+      const base = nodeRecordSplitBaseText(this.nodes.get(root), this.limits.maxTextLength);
       const source = this.runText(root);
       if (base !== null && source && source.value !== base) {
         this.pendingTextRepairOrigins.add(root);

--- a/packages/pro/src/collaboration/document/split-dedup.ts
+++ b/packages/pro/src/collaboration/document/split-dedup.ts
@@ -45,6 +45,11 @@ export interface SplitDedupContext {
   readonly isPresent: (id: LogicalId) => boolean;
 }
 
+export interface SplitTextOverlays {
+  readonly values: ReadonlyMap<LogicalId, string>;
+  readonly changedIds: ReadonlySet<LogicalId>;
+}
+
 interface RunText {
   readonly ids: readonly LogicalId[];
   readonly witnessIds: readonly LogicalId[];
@@ -61,10 +66,14 @@ export class SplitDedupIndex {
   private replicasByOrigin = new Map<LogicalId, Set<string>>();
   /** Origins that more than one replica split — the only ones a dedup pass has to examine. */
   private contestedOrigins = new Set<LogicalId>();
-  /** Source text id → split origins that still use it as their concurrent-edit witness. */
-  private originsBySourceText = new Map<LogicalId, Set<LogicalId>>();
+  /** Text witness id → split origins whose derived text can change when that record changes. */
+  private originsByTextWitness = new Map<LogicalId, Set<LogicalId>>();
   /** Split origins whose source text changed since the last repair pass. */
   private pendingTextRepairOrigins = new Set<LogicalId>();
+  /** Product text id → derived value that rebases a concurrent edit without shared writes. */
+  private textOverlays = new Map<LogicalId, string>();
+  /** Split origin → product text ids carrying its current derived overlay. */
+  private overlayIdsByOrigin = new Map<LogicalId, Set<LogicalId>>();
   /**
    * Origins that are live again while products still point at them — an undo restored the origin.
    * A cold rebuild reads this straight from current state, so a peer joining after the undo drops
@@ -90,8 +99,10 @@ export class SplitDedupIndex {
     this.replicasByOrigin = new Map();
     this.contestedOrigins = new Set();
     this.liveRootedOrigins = new Set();
-    this.originsBySourceText = new Map();
+    this.originsByTextWitness = new Map();
     this.pendingTextRepairOrigins = new Set();
+    this.textOverlays = new Map();
+    this.overlayIdsByOrigin = new Map();
   }
 
   /**
@@ -115,7 +126,7 @@ export class SplitDedupIndex {
       products.every((product) => product.text !== null);
     if (canRepair) {
       rootRecord.set(NODE_SPLIT_BASE_TEXT_FIELD, baseline);
-      this.indexSourceText(root);
+      this.indexTextWitnesses(root, this.runText(root));
     }
     let cursor = start;
     for (const product of products) {
@@ -127,6 +138,7 @@ export class SplitDedupIndex {
       rec.set(NODE_SPLIT_FROM_FIELD, root);
       if (canRepair) rec.set(NODE_SPLIT_START_FIELD, cursor);
       this.index(root, product.id);
+      if (canRepair) this.indexTextWitnesses(root, product.text);
       cursor += product.text?.value.length ?? 0;
     }
     // A later round re-split a run an earlier round produced, and the shared origin was split by
@@ -140,15 +152,20 @@ export class SplitDedupIndex {
   /**
    * Rebase text written concurrently to a split source onto the winning split products.
    *
-   * Only the product owner writes the repair. This prevents two peers from inserting the same
-   * correction into one Y.Text. The baseline proves the product text has not changed since the
-   * split, so a later sequential edit is never overwritten.
+   * The overlay is derived from shared state and never writes to Yjs. Every live peer and late
+   * joiner therefore computes the same result without requiring the split author to stay online.
+   * The baseline proves the product text has not changed since the split, so a later sequential
+   * edit is never overwritten.
    */
-  repairConcurrentText(replicaId: string, isPresent: SplitDedupContext['isPresent']): number {
-    let repaired = 0;
+  concurrentTextOverlays(isPresent: SplitDedupContext['isPresent']): SplitTextOverlays {
+    const changedIds = new Set<LogicalId>();
     const pending = this.pendingTextRepairOrigins;
     this.pendingTextRepairOrigins = new Set();
     for (const root of pending) {
+      for (const id of this.overlayIdsByOrigin.get(root) ?? []) {
+        if (this.textOverlays.delete(id)) changedIds.add(id);
+      }
+      this.overlayIdsByOrigin.delete(root);
       const runs = this.runsBySplitOrigin.get(root);
       if (!runs) continue;
       if (this.isReSplit(root) || isPresent(root)) continue;
@@ -160,7 +177,7 @@ export class SplitDedupIndex {
         if (isPresent(runId)) presentReplicas.add(replicaOfLogicalId(runId) ?? '');
       }
       const winner = [...presentReplicas].sort()[0];
-      if (winner !== replicaId) continue;
+      if (winner === undefined) continue;
       const products = [...runs]
         .filter((runId) => isPresent(runId) && replicaOfLogicalId(runId) === winner)
         .map((runId) => ({
@@ -175,21 +192,25 @@ export class SplitDedupIndex {
       const boundaries = products.map((product) => product.start!);
       boundaries.push(base.length);
       const mapped = boundaries.map((offset) => mapBaseOffset(base, source.value, offset));
+      const overlayIds = new Set<LogicalId>();
       for (let index = 0; index < products.length; index += 1) {
         const product = products[index]!;
-        this.replaceText(product.text!, source.value.slice(mapped[index]!, mapped[index + 1]!));
-        const rec = this.nodes.get(product.id);
-        if (isNodeMap(rec)) rec.set(NODE_SPLIT_START_FIELD, mapped[index]!);
+        const value = source.value.slice(mapped[index]!, mapped[index + 1]!);
+        for (let textIndex = 0; textIndex < product.text!.ids.length; textIndex += 1) {
+          const id = product.text!.ids[textIndex]!;
+          const overlay = textIndex === 0 ? value : '';
+          if (this.textOverlays.get(id) !== overlay) changedIds.add(id);
+          this.textOverlays.set(id, overlay);
+          overlayIds.add(id);
+        }
       }
-      const rootRecord = this.nodes.get(root);
-      if (isNodeMap(rootRecord)) rootRecord.set(NODE_SPLIT_BASE_TEXT_FIELD, source.value);
-      repaired += 1;
+      this.overlayIdsByOrigin.set(root, overlayIds);
     }
-    return repaired;
+    return { values: this.textOverlays, changedIds };
   }
 
   noteChanged(logicalId: LogicalId): void {
-    for (const root of this.originsBySourceText.get(logicalId) ?? []) {
+    for (const root of this.originsByTextWitness.get(logicalId) ?? []) {
       this.pendingTextRepairOrigins.add(root);
     }
   }
@@ -244,16 +265,6 @@ export class SplitDedupIndex {
     return visit(runId, 0) && ids.length > 0 ? { ids, witnessIds, value } : null;
   }
 
-  private replaceText(run: RunText, value: string): void {
-    for (let index = 0; index < run.ids.length; index += 1) {
-      const rec = this.nodes.get(run.ids[index]!);
-      const text = isNodeMap(rec) ? rec.get(NODE_TEXT_FIELD) : null;
-      if (!(text instanceof Y.Text)) continue;
-      if (text.length > 0) text.delete(0, text.length);
-      if (index === 0 && value.length > 0) text.insert(0, value);
-    }
-  }
-
   /**
    * True if `root` is itself a split product whose shared origin two replicas split.
    *
@@ -277,7 +288,8 @@ export class SplitDedupIndex {
     const root = nodeRecordSplitFrom(this.nodes.get(runId));
     if (root !== null && root !== runId) {
       this.index(root, runId);
-      this.indexSourceText(root);
+      this.indexTextWitnesses(root, this.runText(root));
+      this.indexTextWitnesses(root, this.runText(runId));
       const base = nodeRecordSplitBaseText(this.nodes.get(root));
       const source = this.runText(root);
       if (base !== null && source && source.value !== base) {
@@ -286,13 +298,12 @@ export class SplitDedupIndex {
     }
   }
 
-  private indexSourceText(root: LogicalId): void {
-    const source = this.runText(root);
-    if (!source) return;
-    for (const witnessId of source.witnessIds) {
-      const origins = this.originsBySourceText.get(witnessId) ?? new Set<LogicalId>();
+  private indexTextWitnesses(root: LogicalId, text: RunText | null): void {
+    if (!text) return;
+    for (const witnessId of text.witnessIds) {
+      const origins = this.originsByTextWitness.get(witnessId) ?? new Set<LogicalId>();
       origins.add(root);
-      this.originsBySourceText.set(witnessId, origins);
+      this.originsByTextWitness.set(witnessId, origins);
     }
   }
 


### PR DESCRIPTION
## Summary
- Preserve text inserted or deleted while another peer formats the same run.
- Derive the rebase during materialization so disconnects and late joins remain safe.
- Cover convergence, continued editing, undo, role reversal, disconnects, and fresh joins.

## Test plan
- `bun run typecheck`
- `bun run lint`
- `bun test packages/pro/src/collaboration/__tests__/document-concurrent-run-format.test.ts packages/pro/src/collaboration/__tests__/remote-receive-equivalence.test.ts packages/pro/src/collaboration/__tests__/remote-receive-supersession.test.ts packages/pro/src/collaboration/__tests__/document-session.test.ts packages/pro/src/collaboration/__tests__/document-security.test.ts`
- `bun run test` (10,905 passed; two unrelated heavy tests timed out locally)

Fixes #590