### PR TITLE
Fix footnote reserves across continuous sections

### DIFF
--- a/packages/core/src/layout/__tests__/footnote-reserves.test.ts
+++ b/packages/core/src/layout/__tests__/footnote-reserves.test.ts
@@ -17,6 +17,7 @@ import { createLayoutSession } from '../layout-session.ts';
 import { layoutSemanticDocument } from '../semantic-layout.ts';
 import { enumerateDocumentSections } from '../section-properties.ts';
 import {
+  attachNotesToLayout,
   buildPageRefHits,
   computeFootnoteReserves,
   layoutSemanticDocumentWithNotes,
@@ -109,8 +110,8 @@ function loadNotesDoc(bytes: Uint8Array): {
   return { part, notes };
 }
 
-/** Single-paragraph body with one footnote ref — enough for a controlled mock reflow. */
-function singleRefFootnoteDoc(): Uint8Array {
+/** Small footnote body — enough for controlled mock reflow and reserve tests. */
+function singleRefFootnoteDoc(withSecondRef = false): Uint8Array {
   return zipSync({
     '[Content_Types].xml': strToU8(
       `<Types xmlns="${CT}">` +
@@ -128,6 +129,9 @@ function singleRefFootnoteDoc(): Uint8Array {
     'word/document.xml': strToU8(
       `<w:document xmlns:w="${W}" xmlns:r="${R}"><w:body>` +
         '<w:p><w:r><w:t>Body with footnote</w:t><w:footnoteReference w:id="1"/></w:r></w:p>' +
+        (withSecondRef
+          ? '<w:p><w:r><w:t>Second footnote</w:t><w:footnoteReference w:id="2"/></w:r></w:p>'
+          : '') +
         '<w:sectPr><w:pgSz w:w="12240" w:h="15840"/><w:pgMar w:top="720" w:right="720" w:bottom="720" w:left="720"/></w:sectPr>' +
         '</w:body></w:document>'
     ),
@@ -136,6 +140,9 @@ function singleRefFootnoteDoc(): Uint8Array {
         `<w:footnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:footnote>` +
         `<w:footnote w:type="continuationSeparator" w:id="0"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:footnote>` +
         `<w:footnote w:id="1"><w:p><w:r><w:t>Note ${'line '.repeat(12)}</w:t></w:r></w:p></w:footnote>` +
+        (withSecondRef
+          ? '<w:footnote w:id="2"><w:p><w:r><w:t>Section-end note</w:t></w:r></w:p></w:footnote>'
+          : '') +
         '</w:footnotes>'
     ),
   });
@@ -265,6 +272,57 @@ describe('footnote bottom reservation', () => {
       const b = again.pages[i]!.footnotes?.box.height ?? 0;
       expect(b).toBeCloseTo(a, 3);
       expect(bodyUsedHeight(again.pages[i]!)).toBeCloseTo(bodyUsedHeight(layout.pages[i]!), 3);
+    }
+  });
+
+  test('sectEnd refs do not affect pageBottom notes on the same page in either order', () => {
+    const { part, notes } = loadNotesDoc(singleRefFootnoteDoc(true));
+    const refs = collectNoteReferences(part);
+    expect(refs).toHaveLength(2);
+    const contentHeight = 400;
+    const bodyLayout: SemanticLayout = {
+      revision: 1,
+      pages: [
+        mockPage(
+          0,
+          refs.map((ref, index) =>
+            paraFrag(ref.paragraphId, {
+              atomEnd: ref.atomOffset + 1,
+              y: index * 20,
+              height: 14,
+            })
+          ),
+          contentHeight
+        ),
+      ],
+    };
+    for (const pageBottomIndex of [0, 1]) {
+      const sectionByParagraph = new Map(
+        refs.map((ref, index) => [ref.paragraphId, index === pageBottomIndex ? 0 : 1])
+      );
+      const allHits = buildPageRefHits(refs, sectionByParagraph);
+      const mixedNotes: NotesLayoutInput = {
+        ...notes,
+        footnotePropsBySection: [
+          resolveFootnoteProperties({ pos: 'pageBottom' }),
+          resolveFootnoteProperties({ pos: 'sectEnd' }),
+        ],
+      };
+      const noteMarks = provisionalNoteMarks(allHits, mixedNotes);
+      const pageBottomOnly = computeFootnoteReserves(
+        bodyLayout,
+        [allHits[pageBottomIndex]!],
+        mixedNotes,
+        noteMarks
+      );
+      const mixed = computeFootnoteReserves(bodyLayout, allHits, mixedNotes, noteMarks);
+      const attached = attachNotesToLayout(bodyLayout, allHits, mixedNotes);
+
+      expect(pageBottomOnly.reserves.get(0)).toBeGreaterThan(0);
+      expect(mixed.reserves.get(0)).toBe(pageBottomOnly.reserves.get(0));
+      expect(attached.layout.pages[0]!.footnotes?.notes.map((note) => note.noteId)).toEqual([
+        allHits[pageBottomIndex]!.noteId,
+      ]);
     }
   });
 

--- a/packages/core/src/layout/note-pagination.ts
+++ b/packages/core/src/layout/note-pagination.ts
@@ -2139,8 +2139,9 @@ export function computeFootnoteReserves(
     const bodyPage = bodyOnlyPage(page);
     const pageRefs = filterRefsOnPage(bodyPage, allRefs, refIndex);
     const fnRefs = pageRefs.filter((r) => r.noteKind === 'footnote');
-    // Position from first ref's section (Word uses section of the page).
-    const sectionIndex = fnRefs[0]?.sectionIndex ?? 0;
+    const pageBottomRefs = fnRefs.filter(isPageBottomFootnoteRef);
+    // Position from the first page-local ref's section; sect/doc-end refs do not govern it.
+    const sectionIndex = pageBottomRefs[0]?.sectionIndex ?? 0;
     const props = footnotePropsFor(input, sectionIndex);
     const nextPage = layout.pages[pageAt + 1];
     const usedReservePt = previousReserves ? (previousReserves.get(page.index) ?? 0) : undefined;
@@ -2172,7 +2173,7 @@ export function computeFootnoteReserves(
             noteLayoutCache,
           })
         : 0;
-    if (collectsAtEnd(props.pos)) {
+    if (pageBottomRefs.length === 0 && carry.size === 0) {
       // No per-page reservation for THIS page's refs — collected later. The hold-out
       // still runs: a ref-free page in a mixed-position document (or one whose only
       // reference was evicted) answers section 0 here, and skipping it would let the
@@ -2205,7 +2206,7 @@ export function computeFootnoteReserves(
     const reasonsBefore = reasons.length;
     const { area, nextCarry, evictionTopPt } = buildFootnoteArea(
       bodyPage,
-      fnRefs,
+      pageBottomRefs,
       input,
       noteMarks,
       props.pos,
@@ -2373,16 +2374,20 @@ export function attachNotesToLayout(
     }
 
     const bodyPage = bodyOnlyPage(page);
-    const sectionIndex = fnRefs[0]?.sectionIndex ?? 0;
+    const pageBottomRefs = fnRefs.filter((ref) => {
+      const pos = footnotePropsFor(input, ref.sectionIndex).pos;
+      return pos === 'pageBottom' || pos === 'beneathText';
+    });
+    const sectionIndex = pageBottomRefs[0]?.sectionIndex ?? 0;
     const props = footnotePropsFor(input, sectionIndex);
     let footnotes: NoteAreaRecord | undefined;
     const carryWasEmpty = carry.size === 0;
     const reasonsBefore = reasons.length;
-    if (props.pos === 'pageBottom' || props.pos === 'beneathText') {
-      const pageBottomRefs = fnRefs.filter((ref) => {
-        const pos = footnotePropsFor(input, ref.sectionIndex).pos;
-        return pos === 'pageBottom' || pos === 'beneathText';
-      });
+    if (
+      pageBottomRefs.length > 0 ||
+      carry.size > 0 ||
+      (fnRefs.length === 0 && !collectsAtEnd(props.pos))
+    ) {
       const built = buildFootnoteArea(
         bodyPage,
         pageBottomRefs,


### PR DESCRIPTION
Fixes #640

Root cause: computeFootnoteReserves chose placement from the first footnote reference on a page and passed every footnote reference into the page-bottom area builder. On pages spanning continuous sections, sectEnd and docEnd references therefore inflated the bottom reserve. The same first-reference gate in attachment could also suppress a later pageBottom or beneathText note.

This change filters page-local footnotes by each reference section in both reserve and attachment passes, while preserving incoming carry handling, empty-page fail-closed checks, and existing memo cache keys. The regression covers pageBottom and sectEnd references on the same page in both source orders.

Verification:
- Focused note pagination tests: 34 passed
- Full repository suite: 10,907 passed, 0 failed across 840 files
- Workspace typecheck: passed
- Repository lint: passed with 77 pre-existing warnings
- Prettier and git diff checks: passed
- Independent reviewer loop: no remaining medium-or-higher issues

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790855063&installation_model_id=422592&pr_number=683&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F683&signature=4cafb696db271c18de634c1b445d96ea07953fd2c8a20bb2a3887e80119a73e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->