### PR TITLE
fix(core): preserve unrelated drawing diagnostics

### DIFF
--- a/packages/core/src/store/__tests__/drawing-vector-shape.test.ts
+++ b/packages/core/src/store/__tests__/drawing-vector-shape.test.ts
@@ -4,11 +4,21 @@
 // (2) type solid-fill polygon geometry so paint can draw the shape instead of a card.
 
 import { describe, expect, test } from 'bun:test';
-import { readOoxmlPart, WML_NAMESPACE_URI, type OoxmlPackage } from '../index.ts';
+import {
+  readOoxmlPart,
+  WML_NAMESPACE_URI,
+  type OoxmlDrawingNode,
+  type OoxmlElement,
+  type OoxmlPackage,
+  type OoxmlPart,
+} from '../index.ts';
 import {
   indexInlineDrawingProjectionsInPart,
   DEFAULT_DRAWING_PROJECTION_LIMITS,
+  DEFAULT_SUPPORTED_MC_REQUIRES,
+  projectDrawingWithState,
 } from '../package/drawing-projection.ts';
+import { createWalkState, type DrawingDiagnostic } from '../package/drawing-projection-walk.ts';
 import { createPackageShapeThemeResolvers } from '../package/theme-color-resolution.ts';
 
 const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
@@ -32,6 +42,32 @@ function parsePart(body: string) {
   expect(parsed.ok).toBe(true);
   if (!parsed.ok) throw new Error(parsed.reason);
   return parsed.part;
+}
+
+function drawingOf(part: OoxmlPart): OoxmlDrawingNode {
+  const stack: OoxmlElement[] = [part.root];
+  while (stack.length > 0) {
+    const node = stack.pop()!;
+    if (node.kind === 'drawing') return node;
+    for (const child of node.children) {
+      if (child.kind !== 'textValue') stack.push(child);
+    }
+  }
+  throw new Error('missing drawing');
+}
+
+function projectWithDiagnostics(part: OoxmlPart, diagnostics: DrawingDiagnostic[]) {
+  const state = createWalkState();
+  state.diagnostics.push(...diagnostics);
+  return projectDrawingWithState(
+    drawingOf(part),
+    {
+      ownerPartName: part.name,
+      supportedMcRequires: DEFAULT_SUPPORTED_MC_REQUIRES,
+      limits: DEFAULT_DRAWING_PROJECTION_LIMITS,
+    },
+    state
+  );
 }
 
 /** Double-rule custGeom shape, verbatim structure from Word's cover-page separator. */
@@ -84,6 +120,10 @@ function mcWrapped(drawing: string): string {
 /** Attribute-escape a raw value so a hostile spelling reaches the parser intact. */
 function escapeAttribute(value: string): string {
   return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
+}
+
+function unsupportedGraphic(nodeId: string, detail: string): DrawingDiagnostic {
+  return { code: 'unsupported-graphic', nodeId, detail };
 }
 
 /** A `wpg:wgp` group of two independently filled children, with a group `a:xfrm`. */
@@ -233,6 +273,74 @@ describe('wps vector shape projection', () => {
     // Points land in extent-EMU space (path w/h equals the extent here).
     expect(shape!.subpathsEmu[0]![0]).toEqual({ x: 6696075, y: 38100 });
     expect(shape!.subpathsEmu[1]![2]).toEqual({ x: 0, y: 9525 });
+  });
+
+  test('a supported vector shape removes its own provisional unsupported diagnostic', () => {
+    const part = parsePart(`<w:p><w:r>${doubleRuleShapeDrawing()}</w:r></w:p>`);
+    const projection = [...indexInlineDrawingProjectionsInPart(part).values()][0]!;
+
+    expect(projection.vectorShape).not.toBeNull();
+    expect(projection.diagnostics.filter(({ code }) => code === 'unsupported-graphic')).toEqual([]);
+  });
+
+  test('a supported vector shape leaves an unsupported sibling diagnostic intact', () => {
+    const part = parsePart(`<w:p><w:r>${doubleRuleShapeDrawing()}</w:r></w:p>`);
+    const sibling = unsupportedGraphic('unsupported-sibling', 'diagram');
+    const projection = projectWithDiagnostics(part, [sibling])!;
+    const unsupported = projection.diagnostics.filter(({ code }) => code === 'unsupported-graphic');
+
+    expect(projection.vectorShape).not.toBeNull();
+    expect(unsupported).toHaveLength(1);
+    expect(unsupported).toEqual(expect.arrayContaining([sibling]));
+  });
+
+  test('removing a vector provisional leaves multiple unrelated diagnostics intact', () => {
+    const part = parsePart(`<w:p><w:r>${doubleRuleShapeDrawing()}</w:r></w:p>`);
+    const firstUnsupported = unsupportedGraphic('unsupported-chart', 'chart');
+    const malformed: DrawingDiagnostic = {
+      code: 'wrap-polygon-malformed',
+      nodeId: 'malformed-wrap',
+      detail: 'invalid-coordinate',
+    };
+    const secondUnsupported = unsupportedGraphic('unsupported-diagram', 'diagram');
+    const projection = projectWithDiagnostics(part, [
+      firstUnsupported,
+      malformed,
+      secondUnsupported,
+    ])!;
+
+    expect(projection.vectorShape).not.toBeNull();
+    expect(projection.diagnostics).toHaveLength(3);
+    expect(projection.diagnostics).toEqual(
+      expect.arrayContaining([firstUnsupported, malformed, secondUnsupported])
+    );
+  });
+
+  test('diagnostic replacement does not change the rendered vector projection', () => {
+    const part = parsePart(`<w:p><w:r>${doubleRuleShapeDrawing()}</w:r></w:p>`);
+    const shape = [...indexInlineDrawingProjectionsInPart(part).values()][0]!.vectorShape;
+
+    expect(shape).toMatchObject({
+      extentEmu: { cx: 6696075, cy: 47625 },
+      fillHex: '000000',
+      strokeHex: null,
+      subpathsEmu: [
+        [
+          { x: 6696075, y: 38100 },
+          { x: 0, y: 38100 },
+          { x: 0, y: 47625 },
+          { x: 6696075, y: 47625 },
+          { x: 6696075, y: 38100 },
+        ],
+        [
+          { x: 6696075, y: 0 },
+          { x: 0, y: 0 },
+          { x: 0, y: 9525 },
+          { x: 6696075, y: 9525 },
+          { x: 6696075, y: 0 },
+        ],
+      ],
+    });
   });
 
   test('direct (unwrapped) wps shape also carries vector geometry', () => {

--- a/packages/core/src/store/package/drawing-projection.ts
+++ b/packages/core/src/store/package/drawing-projection.ts
@@ -62,6 +62,14 @@ export type { TextboxStoryProjection, VectorShapeProjection } from './drawing-sh
 
 export type { DrawingDiagnostic, DrawingProjectionLimits };
 
+function removeSupersededDrawingDiagnostic(
+  diagnostics: DrawingDiagnostic[],
+  superseded: DrawingDiagnostic
+): void {
+  const index = diagnostics.indexOf(superseded);
+  if (index !== -1) diagnostics.splice(index, 1);
+}
+
 /**
  * Whether a drawing sits in the text flow or is positioned against a frame.
  *
@@ -1403,6 +1411,16 @@ export function drawingAccessibility(projection: DrawingProjection): DrawingAcce
   });
 }
 
+type DrawingProjectionContext = Readonly<{
+  ownerPartName: string;
+  supportedMcRequires: ReadonlySet<string>;
+  limits: DrawingProjectionLimits;
+  namespaceScope?: ReadonlyMap<string, string>;
+  resolveRelationship?: RelationshipTargetResolver;
+  resolveSchemeColor?: ShapeSchemeColorResolver;
+  resolveStyleMatrixReference?: ShapeStyleMatrixResolver;
+}>;
+
 /**
  * Project one `w:drawing` into the resolved shape layout and chrome read.
  *
@@ -1422,6 +1440,15 @@ export function projectDrawing(
     resolveStyleMatrixReference?: ShapeStyleMatrixResolver;
   }>
 ): DrawingProjection | null {
+  return projectDrawingWithState(drawing, context, createWalkState());
+}
+
+/** @internal Projection seam for diagnostic-association tests. */
+export function projectDrawingWithState(
+  drawing: OoxmlDrawingNode,
+  context: DrawingProjectionContext,
+  state: WalkState
+): DrawingProjection | null {
   const ctx: ProjectionContext = {
     ownerPartName: context.ownerPartName,
     supportedMcRequires: context.supportedMcRequires,
@@ -1432,7 +1459,6 @@ export function projectDrawing(
   };
   const namespaceScope = context.namespaceScope ?? emptyNamespaceScope();
   const compatibilityMode = isCompatibilityDrawing(drawing);
-  const state = createWalkState();
   if (state.depth >= ctx.limits.maxDrawingDepth) {
     state.refused = true;
   }
@@ -1531,12 +1557,8 @@ export function projectDrawing(
   const textboxStory = pictureResult.picture
     ? null
     : projectTextboxStory(anchor, extent, ctx.resolveSchemeColor, ctx.resolveStyleMatrixReference);
-  if (vectorShape) {
-    for (let index = state.diagnostics.length - 1; index >= 0; index -= 1) {
-      if (state.diagnostics[index]?.code === 'unsupported-graphic') {
-        state.diagnostics.splice(index, 1);
-      }
-    }
+  if (vectorShape && pictureResult.diagnostic) {
+    removeSupersededDrawingDiagnostic(state.diagnostics, pictureResult.diagnostic);
   }
   return freezeDrawingProjection(
     Object.freeze({


### PR DESCRIPTION
## Summary

- associate the provisional `unsupported-graphic` diagnostic with the exact object returned by `projectPicture`
- when vector projection succeeds, remove only that diagnostic by object identity and preserve unsupported siblings and unrelated diagnostics
- keep rendered vector geometry unchanged and avoid any diagnostic-ordering contract
- add full projection-path coverage for own-diagnostic replacement, unsupported siblings, multiple unrelated diagnostics, and vector output stability

Fixes #577

## Verification

- `bun test packages/core/src/store/__tests__/drawing-vector-shape.test.ts packages/core/src/store/__tests__/drawing-projection.test.ts` — 61 passed
- `bun test packages/core/src/store` — 2,554 passed
- `bun run typecheck` — passed for all workspaces
- `bun run lint` — passed with 0 errors (77 existing warnings)
- `bun run build:packages` — passed
- `bun run api:check` — passed with no API surface drift
- Prettier and `git diff --check` — passed
- pre-commit parity, license, API, formatting, and lint gates — passed
- independent reviewer final verdict — no medium-or-higher correctness, diagnostic-association, API, or test-gap issues remain

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790855129&installation_model_id=422592&pr_number=684&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F684&signature=5af698f7b088b3c0e08d31c8a779a08efda4a92e0bf0a1efb1b5bafe85ab22ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->