### PR TITLE
fix(core): ignore empty font resolver fragments

### DIFF
--- a/.changeset/quiet-empty-font-resolvers.md
+++ b/.changeset/quiet-empty-font-resolvers.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Treat empty on-demand font resolver fragments like an undefined result instead of reporting a missing-font configuration.

--- a/packages/core/src/editor/__tests__/embedded-font-autowire.test.ts
+++ b/packages/core/src/editor/__tests__/embedded-font-autowire.test.ts
@@ -398,6 +398,33 @@ describe('embedded fonts auto-wire into shaped measurement', () => {
     editor.destroy();
   });
 
+  test('undefined and empty resolver answers stay equivalent when embedded faces are dropped', async () => {
+    const errorCodes: string[][] = [];
+    const resolvers = [
+      () => undefined,
+      () => ({ sources: [], substitutions: [], failures: [] }),
+    ] as const;
+
+    for (const fonts of resolvers) {
+      const errors: EditorFontError[] = [];
+      const editor = createDocxEditor({
+        container: document.createElement('div'),
+        document: docxWithEmbeds(p('still resilient'), [
+          { family: '   ', slot: 'embedRegular', bytes: boldBytes },
+        ]),
+        fonts,
+        onFontError: (error) => errors.push(error),
+      });
+      await fontsSettled(editor);
+      errorCodes.push(errors.map((error) => error.code));
+      editor.destroy();
+    }
+
+    expect(errorCodes[0]).toEqual(errorCodes[1]);
+    expect(errorCodes[0]).not.toContain('missing');
+    expect(errorCodes[0]!.length).toBeGreaterThan(0);
+  });
+
   test('explicit config sources beat embedded faces on the same request', async () => {
     const container = document.createElement('div');
     const editor = createDocxEditor({

--- a/packages/core/src/editor/__tests__/on-demand-fonts.test.ts
+++ b/packages/core/src/editor/__tests__/on-demand-fonts.test.ts
@@ -22,6 +22,7 @@ import type { EditorFontError } from '../../contracts/editor.ts';
 import { sha256FontBytes } from '../../layout/index.ts';
 import { createDocxEditor, type DocxEditorInstance } from '../docx-editor.ts';
 import { MAX_RESOLVER_FAMILIES, type FontResolutionRequest } from '../font-composition.ts';
+import { composeFontOrigins, defineFontResolver } from '../font-resolver.ts';
 import { docx } from './paginated-surface-fixtures.ts';
 
 const regularBytes = new Uint8Array(
@@ -85,6 +86,69 @@ describe('on-demand font resolution', () => {
     expect(editor.fontMeasurement()).toEqual({ measurer: 'fixed', resolving: false });
     expect(errors).toHaveLength(0);
     expect(editor.exec({ type: 'insertText', text: 'X' })).toEqual({ ok: true, changed: true });
+    editor.destroy();
+  });
+
+  test('a completely empty fragment is the same normal answer as undefined', async () => {
+    const errors: EditorFontError[] = [];
+    const editor = createDocxEditor({
+      container: document.createElement('div'),
+      document: docx(runIn('Garamond', 'nothing covered')),
+      fonts: () => ({ sources: [], substitutions: [], failures: [] }),
+      onFontError: (error) => errors.push(error),
+    });
+    await fontsSettled(editor);
+    expect(editor.fontMeasurement()).toEqual({ measurer: 'fixed', resolving: false });
+    expect(errors).toHaveLength(0);
+    editor.destroy();
+  });
+
+  test('a fragment with failures still reports that no usable source survived', async () => {
+    const errors: EditorFontError[] = [];
+    const editor = createDocxEditor({
+      container: document.createElement('div'),
+      document: docx(runIn('Garamond', 'failed source')),
+      fonts: (request) =>
+        composeFontOrigins(
+          [
+            defineFontResolver(async () => ({
+              sources: [],
+              substitutions: [],
+              failures: [{ family: 'Garamond', diagnostic: 'offline' }],
+            })),
+          ],
+          request
+        ),
+      onFontError: (error) => errors.push(error),
+    });
+    await fontsSettled(editor);
+    expect(editor.fontMeasurement()).toEqual({ measurer: 'fixed', resolving: false });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.code).toBe('missing');
+    editor.destroy();
+  });
+
+  test('substitutions without usable sources still report missing', async () => {
+    const errors: EditorFontError[] = [];
+    const editor = createDocxEditor({
+      container: document.createElement('div'),
+      document: docx(runIn('Garamond', 'unusable substitution')),
+      fonts: () => ({
+        sources: [],
+        substitutions: [
+          {
+            from: { family: 'Garamond', weight: 400, style: 'normal' },
+            to: { family: 'Unavailable Substitute', weight: 400, style: 'normal' },
+          },
+        ],
+        failures: [],
+      }),
+      onFontError: (error) => errors.push(error),
+    });
+    await fontsSettled(editor);
+    expect(editor.fontMeasurement()).toEqual({ measurer: 'fixed', resolving: false });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.code).toBe('missing');
     editor.destroy();
   });
 

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -180,6 +180,7 @@ import {
 import {
   MAX_RESOLVER_FAMILIES,
   composeFontConfiguration,
+  normalizeFontResolverResult,
   type FontConfigurationBase,
 } from './font-composition.ts';
 import { availableFontFamilies, configuredDefaultFontFamily } from './font-catalog.ts';
@@ -758,10 +759,12 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
       // fixed measurer, exactly like a failed byte source.
       const explicit: FontConfigurationBase | undefined =
         typeof configured === 'function'
-          ? await configured({
-              families: mounted.session.documentFonts().slice(0, MAX_RESOLVER_FAMILIES),
-              defaultFamily: configuredDefaultFontFamily(fontConfiguration()),
-            })
+          ? normalizeFontResolverResult(
+              await configured({
+                families: mounted.session.documentFonts().slice(0, MAX_RESOLVER_FAMILIES),
+                defaultFamily: configuredDefaultFontFamily(fontConfiguration()),
+              })
+            )
           : configured;
       // Awaiting handed control back: this load may have been superseded (or the editor
       // destroyed) while the resolver ran, and installing its answer would overwrite a
@@ -771,8 +774,8 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
         return;
       }
       resolvedFontConfiguration = explicit;
-      // A resolver covering none of this document's families is a normal answer, not a
-      // failure — and with nothing embedded there is no font work left to do.
+      // An empty resolver result is normal whether spelled `undefined` or as a fragment;
+      // sources, substitutions, or populated failures retain the genuine error path below.
       if (!explicit && embedded.length === 0) {
         fontsResolving = false;
         bump();

--- a/packages/core/src/editor/font-composition.ts
+++ b/packages/core/src/editor/font-composition.ts
@@ -109,6 +109,19 @@ export type FontResolver = (
   | undefined
   | Promise<FontConfiguration | FontConfigurationFragment | undefined>;
 
+/** Normalize an on-demand resolver answer that covers none of the requested families. */
+export function normalizeFontResolverResult(
+  result: FontConfigurationBase | null | undefined
+): FontConfigurationBase | undefined {
+  const failures = result && 'failures' in result ? result.failures : undefined;
+  const empty =
+    result == null ||
+    ((result.sources?.length ?? 0) === 0 &&
+      (result.substitutions?.length ?? 0) === 0 &&
+      (failures === undefined || (Array.isArray(failures) && failures.length === 0)));
+  return empty ? undefined : result;
+}
+
 /**
  * Ceiling on the families one document can put in front of a resolver.
  *

--- a/packages/core/src/editor/font-resolver.ts
+++ b/packages/core/src/editor/font-resolver.ts
@@ -261,6 +261,7 @@ export async function composeFontOrigins(
   const present: (FontConfiguration | FontConfigurationFragment)[] = [];
   const sourceFaces = new Map<string, FontFaceRequest>();
   const substitutions: FontSourceSubstitution[] = [];
+  const failures: unknown[] = [];
   const inherited = request.resolvedFaces ?? [];
 
   for (const origin of origins) {
@@ -295,9 +296,15 @@ export async function composeFontOrigins(
         (source) => [faceKey(source.request), source.request] as const
       );
       const answerSubstitutions = [...(answer.substitutions ?? [])];
+      const answerFailures = 'failures' in answer ? answer.failures : undefined;
       present.push(answer);
       for (const [key, face] of faces) sourceFaces.set(key, face);
       for (const substitution of answerSubstitutions) substitutions.push(substitution);
+      if (Array.isArray(answerFailures)) {
+        for (const failure of answerFailures) failures.push(failure);
+      } else if (answerFailures !== undefined) {
+        failures.push(answerFailures);
+      }
     } catch (cause) {
       // Reported, never swallowed: a font origin that throws is a host bug (an unmarked
       // resolver called as a loader is the common one) and it degrades the document
@@ -309,5 +316,7 @@ export async function composeFontOrigins(
 
   if (present.length === 0) return undefined;
   const { epoch: _perLoad, ...merged } = composeFontConfiguration(present[0]!, ...present.slice(1));
-  return merged;
+  return failures.length === 0
+    ? merged
+    : ({ ...merged, failures: Object.freeze(failures) } as FontConfigurationFragment);
 }


### PR DESCRIPTION
## Summary

- normalize resolver results with no sources, substitutions, or failures to `undefined` for the full font-resolution flow
- preserve populated failure metadata through `composeFontOrigins`, so all-failed configured sources still reach the genuine `missing` error path
- cover undefined, completely empty, populated-failure, unusable-substitution, composed-failure, and dropped-embedded-face cases

## Behavior distinction

A resolver that covers none of the document families may return either `undefined` or an empty `{ sources: [], substitutions: [], failures: [] }` fragment. Both now leave the fixed measurer active without reporting a font error. Fragments with populated failures or substitutions without usable sources remain configured attempts and still report `missing`.

## Verification

- `bun test packages/core/src/editor/__tests__/on-demand-fonts.test.ts packages/core/src/editor/__tests__/embedded-font-autowire.test.ts` — 39 passed
- `bun run test` — 10,910 passed across 840 files
- `bun run typecheck`
- `bun run lint` — 0 errors (repository baseline warnings only)
- `bun run format:check`
- `bun run check:parity`
- `bun run build:packages` and final `bun run --filter @docx-editor.dev/core build`
- `bun run api:check`
- `bun run i18n:validate`
- independent review/repair loop completed; final review reports no medium-or-higher correctness, regression, or test-coverage issues

Fixes #587

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790855350&installation_model_id=422592&pr_number=685&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F685&signature=5fe1d7bf69a7fd26d41b70eae423e3ed2aacf84406e67cdf97b98332375a6b25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->