### PR TITLE
Fix header/footer margin-relative drawing coordinates

### DIFF
--- a/packages/core/src/layout/drawing-layout.ts
+++ b/packages/core/src/layout/drawing-layout.ts
@@ -489,9 +489,7 @@ export interface DrawingAnchorFrameContext {
    * header taller than the top margin pushes the body content box down, and a page-relative
    * anchor resolved against the authored margin then lands that difference too low (#274).
    *
-   * Header and footer stories keep passing their authored margin here — their own origin is
-   * the story box, and `hfAnchorOnPageSheet` cancels whatever this is for page-frame axes.
-   *
+   * HF stories keep authored page/landmark insets; attached pages supply effective margin frames.
    * The horizontal pair stays `marginLeft` / `marginRight` because nothing pushes the content
    * box sideways: `contentBox.x - box.x` is always the authored left margin. A future gutter
    * or binding offset would need its own inset field rather than a change of meaning here.
@@ -499,6 +497,7 @@ export interface DrawingAnchorFrameContext {
   readonly contentInsetTop: number;
   readonly contentInsetBottom: number;
   readonly contentWidth: number;
+  readonly verticalMarginFrame?: { readonly top: number; readonly height: number };
   /** Body flow height on the current page (may shrink for notes/HF reserves). */
   readonly contentHeight: number;
   /** Content band between the insets: pageHeight − contentInsetTop − contentInsetBottom. */
@@ -698,12 +697,14 @@ function verticalEdges(
   const pageBottomSheet = contentBandHeight + ctx.contentInsetBottom;
   const contentTop = 0;
   const contentBottom = ctx.contentHeight;
+  const marginTop = ctx.verticalMarginFrame?.top ?? contentTop;
+  const marginBottom = marginTop + (ctx.verticalMarginFrame?.height ?? ctx.contentHeight);
 
   switch (frame) {
     case 'page':
       return { top: pageTop, bottom: pageBottomSheet, center: (pageTop + pageBottomSheet) / 2 };
     case 'margin':
-      return { top: contentTop, bottom: contentBottom, center: contentTop + ctx.contentHeight / 2 };
+      return { top: marginTop, bottom: marginBottom, center: (marginTop + marginBottom) / 2 };
     case 'paragraph':
       return {
         top: ctx.paragraphBox.y,
@@ -1303,7 +1304,11 @@ export function publishAnchoredDrawingsForParagraph(options: {
       options.cellBox.height > 0 &&
       Number.isFinite(options.cellBox.width) &&
       options.cellBox.width > 0;
-    const clipRegion = clipToCell ? options.cellBox! : pageClipRegion(options.frameBase);
+    const pageClip =
+      projection.position?.vertical.relativeFrom === 'margin'
+        ? options.pageClip
+        : pageClipRegion(options.frameBase);
+    const clipRegion = clipToCell ? options.cellBox! : pageClip;
     const record = buildAnchoredDrawingRecord({
       input: Object.freeze({
         drawingNodeId: atom.atomId,

--- a/packages/core/src/layout/hf-layout.ts
+++ b/packages/core/src/layout/hf-layout.ts
@@ -76,6 +76,16 @@ export interface HeaderFooterPageContext {
   readonly marginBottom: number;
 }
 
+/** Per-sheet geometry needed to resolve header/footer anchors before wrap and clipping. */
+export interface HeaderFooterLayoutPageContext extends FieldPageContext {
+  /** Effective content-box inset after this page's header/footer reserves are applied. */
+  readonly contentInsetTop?: number;
+  /** Effective bottom content-box inset after footer reserve. */
+  readonly contentInsetBottom?: number;
+  /** Story-box top measured from the physical sheet top. */
+  readonly storyTop?: number;
+}
+
 export interface HeaderFooterStoryLayout {
   readonly partName: string;
   /**
@@ -110,12 +120,12 @@ export interface HeaderFooterStoryLayout {
   /** Anchored drawings owned by this story, in story-relative coordinates. */
   readonly anchoredDrawings?: readonly AnchoredDrawingRecord[];
   /**
-   * Re-layout this story under a page-field context.
+   * Re-layout this story under page-field and optional attached-page geometry context.
    *
    * Field-free stories return `this`. Count-only stories cache by the counts they read.
    * PAGE stories cache by the distinct evaluated values (including format) with a bounded LRU.
    */
-  readonly withPageContext: (ctx: FieldPageContext) => HeaderFooterStoryLayout;
+  readonly withPageContext: (ctx: HeaderFooterLayoutPageContext) => HeaderFooterStoryLayout;
 }
 
 /** Memoized per immutable part: the fingerprint+hash walk is pure and parts never mutate. */
@@ -248,11 +258,20 @@ export function layoutHeaderFooterStory(
   );
   let baseline: HeaderFooterStoryLayout | undefined;
 
-  const layoutOnce = (ctx: FieldPageContext | undefined): HeaderFooterStoryLayout => {
+  const layoutOnce = (ctx: HeaderFooterLayoutPageContext | undefined): HeaderFooterStoryLayout => {
     const effectiveCtx = storyNeedsPageFields(needs) || inlineDrawingLayout ? ctx : undefined;
     const pageNumber = effectiveCtx?.pageNumber ?? hfPageContext?.pageNumber ?? 1;
+    const anchorPageToken =
+      inlineDrawingLayout &&
+      effectiveCtx?.contentInsetTop !== undefined &&
+      effectiveCtx.contentInsetBottom !== undefined &&
+      effectiveCtx.storyTop !== undefined
+        ? `|hf:${effectiveCtx.contentInsetTop},${effectiveCtx.contentInsetBottom},${effectiveCtx.storyTop}`
+        : '';
     const token =
-      fieldPageContextToken(effectiveCtx, needs) + (inlineDrawingLayout ? `|pn:${pageNumber}` : '');
+      fieldPageContextToken(effectiveCtx, needs) +
+      (inlineDrawingLayout ? `|pn:${pageNumber}` : '') +
+      anchorPageToken;
 
     if (token === '') {
       if (baseline) return baseline;
@@ -280,6 +299,18 @@ export function layoutHeaderFooterStory(
       const marginTop = hfPageContext?.marginTop ?? 0;
       const marginBottom = hfPageContext?.marginBottom ?? 0;
       const hfContentHeight = Math.max(1, pageHeight - marginTop - marginBottom);
+      const verticalMarginFrame =
+        effectiveCtx?.contentInsetTop !== undefined &&
+        effectiveCtx.contentInsetBottom !== undefined &&
+        effectiveCtx.storyTop !== undefined
+          ? Object.freeze({
+              top: effectiveCtx.contentInsetTop - effectiveCtx.storyTop,
+              height: Math.max(
+                1,
+                pageHeight - effectiveCtx.contentInsetTop - effectiveCtx.contentInsetBottom
+              ),
+            })
+          : undefined;
       return Object.freeze({
         pageNumber,
         pageWidth,
@@ -287,12 +318,14 @@ export function layoutHeaderFooterStory(
         marginLeft,
         marginRight,
         marginBottom,
-        // ON PURPOSE, unlike the body story: a header/footer frame keeps the AUTHORED margin
-        // here. Its origin is the story box, and `hfAnchorOnPageSheet` re-bases page-frame
-        // axes by subtracting `verticalFrameOrigin`, so this value cancels exactly.
+        // ON PURPOSE, unlike the body story: the established page/topMargin/bottomMargin
+        // frames keep the AUTHORED margin here. `hfAnchorOnPageSheet` re-bases page-frame
+        // axes by subtracting `verticalFrameOrigin`, so this value cancels exactly. The
+        // vertical margin frame above carries the effective content-box geometry separately.
         contentInsetTop: marginTop,
         contentInsetBottom: marginBottom,
         contentWidth,
+        ...(verticalMarginFrame ? { verticalMarginFrame } : {}),
         contentHeight: hfContentHeight,
         contentBandHeight: hfContentHeight,
         ownerPartName: part.name,
@@ -329,7 +362,17 @@ export function layoutHeaderFooterStory(
           ...(documentProperties ? { documentProperties } : {}),
           inlineDrawingLayout,
           anchorFrameBase,
-          pageContentClip: () => pageClipRegion(anchorFrameBase()),
+          pageContentClip: () => {
+            const frame = anchorFrameBase();
+            return effectiveCtx?.storyTop !== undefined
+              ? Object.freeze({
+                  x: -frame.marginLeft,
+                  y: -effectiveCtx.storyTop,
+                  width: frame.pageWidth,
+                  height: frame.pageHeight,
+                })
+              : pageClipRegion(frame);
+          },
           // Textbox stories flow with the SAME page-field context as the host story, so a
           // PAGE field inside an anchored footer text box evaluates per page like a direct
           // footer field. The context token already keys this cache entry.

--- a/packages/core/src/layout/section-page-furniture.ts
+++ b/packages/core/src/layout/section-page-furniture.ts
@@ -8,7 +8,7 @@
 
 import type { FieldPageContext } from './field-page-furniture.ts';
 import { storyNeedsPageFields } from './field-projection.ts';
-import type { HeaderFooterStoryLayout } from './hf-layout.ts';
+import type { HeaderFooterLayoutPageContext, HeaderFooterStoryLayout } from './hf-layout.ts';
 import {
   headerFooterVariantFor,
   type HeaderFooterVariantName,
@@ -79,7 +79,7 @@ export function createSectionPageFurniture(
     // An absent variant shows nothing — Word falls back to blank, not to `default`.
     if (!story) return undefined;
     const place = (laid: HeaderFooterStoryLayout): HeaderFooterStoryRecord => {
-      const y =
+      const storyY =
         kind === 'header'
           ? box.y + headerDistance
           : box.y + geometry.height - footerDistance - laid.flowHeight;
@@ -91,7 +91,7 @@ export function createSectionPageFurniture(
         ...(laid.rId ? { rId: laid.rId } : {}),
         box: {
           x: box.x + geometry.margin.left,
-          y,
+          y: storyY,
           width: inputs.contentWidth,
           height: laid.flowHeight,
         },
@@ -105,15 +105,33 @@ export function createSectionPageFurniture(
       pageCount: Math.max(pageNumber, inputs.pageCount() + 1),
       sectionPageCount: index + 1,
     };
+    const insets = inputs.insetsFor(index);
+    const layoutForPage = (fields: FieldPageContext): HeaderFooterStoryLayout => {
+      let laid = story;
+      for (let pass = 0; pass < 8; pass += 1) {
+        const storyTop =
+          kind === 'header' ? headerDistance : geometry.height - footerDistance - laid.flowHeight;
+        const context: HeaderFooterLayoutPageContext = {
+          ...fields,
+          contentInsetTop: insets.top,
+          contentInsetBottom: insets.bottom,
+          storyTop,
+        };
+        const next = story.withPageContext(context);
+        if (Math.abs(next.flowHeight - laid.flowHeight) <= 0.001) return next;
+        laid = next;
+      }
+      throw new Error('header/footer attached-page anchor layout did not converge');
+    };
     const needs = story.pageFieldNeeds;
     const needsPerPageLayout =
       storyNeedsPageFields(needs) || (story.anchoredDrawings?.length ?? 0) > 0;
-    const laid = needsPerPageLayout ? story.withPageContext(pageContext) : story;
+    const laid = needsPerPageLayout ? layoutForPage(pageContext) : story;
     const placed = place(laid);
     if (storyNeedsPageFields(needs)) {
       return {
         ...placed,
-        pageFieldProjector: (context) => place(story.withPageContext(context)),
+        pageFieldProjector: (context) => place(layoutForPage(context)),
       };
     }
     return placed;

--- a/packages/core/src/output/__tests__/header-margin-anchor.test.ts
+++ b/packages/core/src/output/__tests__/header-margin-anchor.test.ts
@@ -1,0 +1,389 @@
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { zipSync, strToU8 } from 'fflate';
+import {
+  createFixedMeasurer,
+  enumerateDocumentSections,
+  geometryOfSection,
+  layoutSemanticDocument,
+  type PageFurniture,
+  type SemanticLayout,
+} from '../../layout/index.ts';
+import { layoutHeaderFooterStory, type HeaderFooterStoryLayout } from '../../layout/hf-layout.ts';
+import type { InlineDrawingLayoutContext } from '../../layout/drawing-layout.ts';
+import {
+  readOoxmlPackage,
+  resolveHeaderFooterPartsBySection,
+  type OoxmlPackage,
+  type OoxmlPart,
+} from '@docx-editor.dev/core/store';
+import {
+  DEFAULT_DRAWING_PROJECTION_LIMITS,
+  indexInlineDrawingProjectionsInPart,
+  projectDrawing,
+} from '../../store/package/drawing-projection.ts';
+import { mockReadyImageResource } from '../../store/__tests__/drawing-ready-fixture.ts';
+import { paintSemanticLayout } from '../semantic-paint.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
+const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+const WPS = 'http://schemas.microsoft.com/office/word/2010/wordprocessingShape';
+
+const measurer = createFixedMeasurer(6, 14);
+
+const OFF_H_EMU = -930_275; // -73.25pt
+const OFF_V_EMU = -989_965; // -77.95pt
+const SIZE_EMU = 809_625; //  63.75pt
+
+type HorizontalFrame = 'character' | 'margin' | 'page';
+type VerticalFrame = 'bottomMargin' | 'line' | 'margin' | 'page' | 'paragraph' | 'topMargin';
+
+interface AnchorOptions {
+  readonly horizontalFrame?: HorizontalFrame;
+  readonly verticalFrame?: VerticalFrame;
+  readonly horizontalOffsetEmu?: number;
+  readonly verticalOffsetEmu?: number;
+  readonly verticalAlign?: 'bottom' | 'center';
+  readonly storyLineCount?: number;
+}
+
+function logoDrawing(options: AnchorOptions = {}): string {
+  const horizontalFrame = options.horizontalFrame ?? 'margin';
+  const verticalFrame = options.verticalFrame ?? 'margin';
+  const horizontalOffsetEmu = options.horizontalOffsetEmu ?? OFF_H_EMU;
+  const verticalOffsetEmu = options.verticalOffsetEmu ?? OFF_V_EMU;
+  const verticalPosition = options.verticalAlign
+    ? `<wp:align>${options.verticalAlign}</wp:align>`
+    : `<wp:posOffset>${verticalOffsetEmu}</wp:posOffset>`;
+  return (
+    '<w:drawing><wp:anchor distT="0" distB="0" distL="114300" distR="114300" simplePos="0"' +
+    ' relativeHeight="251659264" behindDoc="0" locked="0" layoutInCell="1" allowOverlap="1">' +
+    '<wp:simplePos x="0" y="0"/>' +
+    `<wp:positionH relativeFrom="${horizontalFrame}"><wp:posOffset>${horizontalOffsetEmu}</wp:posOffset></wp:positionH>` +
+    `<wp:positionV relativeFrom="${verticalFrame}">${verticalPosition}</wp:positionV>` +
+    `<wp:extent cx="${SIZE_EMU}" cy="${SIZE_EMU}"/>` +
+    '<wp:effectExtent l="0" t="0" r="0" b="0"/><wp:wrapSquare wrapText="bothSides"/>' +
+    '<wp:docPr id="1" name="logo"/>' +
+    `<a:graphic><a:graphicData uri="${WPS}"><wps:wsp>` +
+    `<wps:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="${SIZE_EMU}" cy="${SIZE_EMU}"/></a:xfrm>` +
+    '<a:prstGeom prst="rect"><a:avLst/></a:prstGeom>' +
+    '<a:solidFill><a:srgbClr val="4472C4"/></a:solidFill></wps:spPr>' +
+    '<wps:bodyPr/></wps:wsp></a:graphicData></a:graphic></wp:anchor></w:drawing>'
+  );
+}
+
+function storyDoc(kind: 'header' | 'footer', options: AnchorOptions = {}): Uint8Array {
+  const ns = `xmlns:w="${W}" xmlns:r="${R}" xmlns:wp="${WP}" xmlns:a="${A}" xmlns:wps="${WPS}"`;
+  const lineCount = options.storyLineCount ?? 3;
+  const trailingParagraphs =
+    lineCount === 3
+      ? '<w:p><w:r><w:t>Address line</w:t></w:r></w:p>' +
+        '<w:p><w:r><w:t>Tel line</w:t></w:r></w:p>'
+      : Array.from(
+          { length: Math.max(0, lineCount - 1) },
+          (_, index) => `<w:p><w:r><w:t>Story line ${index + 2}</w:t></w:r></w:p>`
+        ).join('');
+  const storyParagraph =
+    '<w:p><w:r><w:t>Company Name Co., Ltd.</w:t></w:r>' +
+    `<w:r>${logoDrawing(options)}</w:r></w:p>` +
+    trailingParagraphs;
+  const partName = `${kind}1.xml`;
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        `<Override PartName="/word/${partName}" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.${kind}+xml"/>` +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/${kind}" Target="${partName}"/></Relationships>`
+    ),
+    [`word/${partName}`]: strToU8(
+      `<w:${kind === 'header' ? 'hdr' : 'ftr'} ${ns}>${storyParagraph}</w:${kind === 'header' ? 'hdr' : 'ftr'}>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document ${ns}><w:body><w:p><w:r><w:t>body text</w:t></w:r></w:p>` +
+        `<w:sectPr><w:${kind}Reference w:type="default" r:id="rId1"/>` +
+        '<w:pgSz w:w="11906" w:h="16838"/>' +
+        '<w:pgMar w:top="1560" w:right="1700" w:bottom="2694" w:left="1701" w:header="851" w:footer="0"/>' +
+        '</w:sectPr></w:body></w:document>'
+    ),
+  });
+}
+
+function openPackage(bytes: Uint8Array): OoxmlPackage {
+  const result = readOoxmlPackage(bytes);
+  if (!result.ok) throw new Error(result.reason);
+  return result.package;
+}
+
+function drawingLayoutFor(part: OoxmlPart): InlineDrawingLayoutContext {
+  const atomProjections = indexInlineDrawingProjectionsInPart(part);
+  const ready = mockReadyImageResource({
+    bytes: new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]),
+  });
+  return {
+    ownerPartName: part.name,
+    projectionForAtom: (atomId) => atomProjections.get(atomId) ?? null,
+    project: (node) =>
+      atomProjections.get(node.id) ??
+      projectDrawing(node, {
+        ownerPartName: part.name,
+        limits: DEFAULT_DRAWING_PROJECTION_LIMITS,
+      }),
+    resourceOf: () => ready,
+  };
+}
+
+function furnitureWithDrawings(
+  pkg: OoxmlPackage,
+  part: OoxmlPart
+): readonly (PageFurniture | undefined)[] {
+  const sections = enumerateDocumentSections(part);
+  const bySection = resolveHeaderFooterPartsBySection(pkg);
+  return sections.map((section, index) => {
+    const parts = bySection[index];
+    if (!parts || (parts.headers.size === 0 && parts.footers.size === 0)) return undefined;
+    const geometry = geometryOfSection(section.properties);
+    const width = geometry.width - geometry.margin.left - geometry.margin.right;
+    const pageContext = {
+      pageNumber: 1,
+      pageWidth: geometry.width,
+      pageHeight: geometry.height,
+      marginLeft: geometry.margin.left,
+      marginRight: geometry.margin.right,
+      marginTop: geometry.margin.top,
+      marginBottom: geometry.margin.bottom,
+    };
+    const stampRId = (story: HeaderFooterStoryLayout, rId: string): HeaderFooterStoryLayout => ({
+      ...story,
+      rId,
+      withPageContext: (ctx) => stampRId(story.withPageContext(ctx), rId),
+    });
+    const mapStories = (source: typeof parts.headers) => {
+      const laid = new Map();
+      for (const [variant, hfPart] of source)
+        laid.set(
+          variant,
+          stampRId(
+            layoutHeaderFooterStory(
+              hfPart,
+              width,
+              measurer,
+              'test',
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              drawingLayoutFor(hfPart),
+              undefined,
+              undefined,
+              pageContext
+            ),
+            'rId1'
+          )
+        );
+      return laid;
+    };
+    return {
+      titlePage: parts.titlePage,
+      evenAndOddHeaders: parts.evenAndOddHeaders,
+      headers: mapStories(parts.headers),
+      footers: mapStories(parts.footers),
+    };
+  });
+}
+
+function layoutHeaderDoc(options: AnchorOptions = {}): SemanticLayout {
+  return layoutStoryDoc('header', options);
+}
+
+function layoutStoryDoc(kind: 'header' | 'footer', options: AnchorOptions = {}): SemanticLayout {
+  const pkg = openPackage(storyDoc(kind, options));
+  const part = pkg.parts.get(pkg.mainDocumentPart)!;
+  return layoutSemanticDocument(part, 1, {
+    measurer,
+    producer: 'test',
+    sectionFurniture: furnitureWithDrawings(pkg, part),
+  });
+}
+
+function paintedPosition(layout: SemanticLayout): {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+} {
+  const container = document.createElement('div');
+  paintSemanticLayout(container, layout, { scale: 1 });
+  const element = container.querySelector<HTMLElement>('.docx-drawing-layer-front > *');
+  if (!element) throw new Error('expected one painted anchored drawing');
+  const story = element.closest<HTMLElement>('[data-docx-hf]');
+  return {
+    x: parseFloat(element.style.left) + (story ? parseFloat(story.style.left) : 0),
+    y: parseFloat(element.style.top) + (story ? parseFloat(story.style.top) : 0),
+    width: parseFloat(element.style.width),
+    height: parseFloat(element.style.height),
+  };
+}
+
+describe('header anchor relativeFrom="margin"', () => {
+  test('resolves against the content box, not the story box', () => {
+    const layout = layoutHeaderDoc();
+    const page = layout.pages[0]!;
+    const story = page.header!;
+    const drawing = story.anchoredDrawings![0]!;
+    const sheetY = story.box.y + drawing.paintBounds.y;
+    const sheetX = story.box.x + drawing.paintBounds.x;
+
+    expect(sheetY).toBeCloseTo(page.contentBox.y - 77.95, 2);
+    expect(sheetX).toBeCloseTo(page.contentBox.x - 73.25, 2);
+  });
+
+  test('paints the standalone negative-offset reproduction at the content-margin position', () => {
+    const layout = layoutHeaderDoc();
+    const page = layout.pages[0]!;
+    const position = paintedPosition(layout);
+
+    expect(position.y).toBeCloseTo(page.contentBox.y - 77.95, 2);
+    expect(position.x).toBeCloseTo(page.contentBox.x - 73.25, 2);
+  });
+
+  test('rebases only the margin axis when horizontal and vertical frames differ', () => {
+    const horizontalPage = layoutHeaderDoc({
+      horizontalFrame: 'page',
+      horizontalOffsetEmu: 127_000,
+    });
+    const horizontalPagePosition = paintedPosition(horizontalPage);
+    expect(horizontalPagePosition.x).toBeCloseTo(10, 2);
+    expect(horizontalPagePosition.y).toBeCloseTo(horizontalPage.pages[0]!.contentBox.y - 77.95, 2);
+
+    const verticalPage = layoutHeaderDoc({
+      verticalFrame: 'page',
+      verticalOffsetEmu: 127_000,
+    });
+    const verticalPagePosition = paintedPosition(verticalPage);
+    expect(verticalPagePosition.x).toBeCloseTo(verticalPage.pages[0]!.contentBox.x - 73.25, 2);
+    expect(verticalPagePosition.y).toBeCloseTo(10, 2);
+  });
+
+  test('clips a stronger negative offset at the physical sheet edge after rebasing', () => {
+    const layout = layoutHeaderDoc({
+      horizontalOffsetEmu: 0,
+      verticalOffsetEmu: -1_143_000,
+    });
+    const page = layout.pages[0]!;
+    const position = paintedPosition(layout);
+    const unclippedTop = page.contentBox.y - 90;
+
+    expect(unclippedTop).toBeLessThan(0);
+    expect(position.y).toBeCloseTo(0, 5);
+    expect(position.height).toBeCloseTo(63.75 + unclippedTop, 5);
+  });
+
+  test('computes wrap exclusions at the rebased margin position', () => {
+    const layout = layoutHeaderDoc({
+      horizontalOffsetEmu: 0,
+      verticalOffsetEmu: -254_000,
+    });
+    const story = layout.pages[0]!.header!;
+    const drawing = story.anchoredDrawings![0]!;
+    const laterLines = story.fragments
+      .slice(1)
+      .flatMap((fragment) => (fragment.kind === 'paragraph' ? fragment.lines : []));
+    const overlappingLines = laterLines.filter(
+      (line) => line.box.y >= drawing.y && line.box.y < drawing.y + drawing.height
+    );
+
+    expect(drawing.y).toBeGreaterThan(0);
+    expect(overlappingLines.length).toBeGreaterThan(0);
+    for (const line of overlappingLines) expect(line.contentX).toBeGreaterThanOrEqual(63.75);
+  });
+});
+
+describe('margin alignment uses the effective content-box extent', () => {
+  test.each([
+    ['header', 'center', 3],
+    ['header', 'bottom', 3],
+    ['footer', 'center', 12],
+    ['footer', 'bottom', 12],
+  ] as const)('%s margin align="%s" follows expanded content insets', (kind, align, lineCount) => {
+    const layout = layoutStoryDoc(kind, {
+      horizontalOffsetEmu: 0,
+      verticalAlign: align,
+      storyLineCount: lineCount,
+    });
+    const page = layout.pages[0]!;
+    const story = page[kind]!;
+    const drawing = story.anchoredDrawings![0]!;
+    const expectedY =
+      align === 'center'
+        ? page.contentBox.y + (page.contentBox.height - drawing.height) / 2
+        : page.contentBox.y + page.contentBox.height - drawing.height;
+
+    expect(story.box.y + drawing.y).toBeCloseTo(expectedY, 5);
+    if (kind === 'header') expect(page.contentBox.y).toBeGreaterThan(78);
+    else
+      expect(page.box.height - page.contentBox.y - page.contentBox.height).toBeGreaterThan(134.7);
+  });
+});
+
+describe('header non-margin frames', () => {
+  test.each([
+    ['page', -78],
+    ['topMargin', -78],
+    ['bottomMargin', 629.2],
+    ['paragraph', 0],
+    ['line', 0],
+  ] as const)(
+    'preserves the existing %s vertical frame origin and authored offset',
+    (verticalFrame, expectedOrigin) => {
+      const layout = layoutHeaderDoc({ verticalFrame });
+      const drawing = layout.pages[0]!.header!.anchoredDrawings![0]!;
+      expect(drawing.verticalFrameOrigin).toBeCloseTo(expectedOrigin, 5);
+      expect(drawing.y).toBeCloseTo(expectedOrigin - 77.95, 5);
+      expect(drawing.y - drawing.verticalFrameOrigin).toBeCloseTo(-77.95, 5);
+    }
+  );
+
+  test('keeps a page-frame axis painted from the sheet while topMargin stays story-based', () => {
+    const pageFrame = layoutHeaderDoc({ verticalFrame: 'page', verticalOffsetEmu: 127_000 });
+    expect(paintedPosition(pageFrame).y).toBeCloseTo(10, 2);
+
+    const topMargin = layoutHeaderDoc({
+      verticalFrame: 'topMargin',
+      verticalOffsetEmu: 127_000,
+    });
+    expect(paintedPosition(topMargin).y).toBeCloseTo(42.55 - 78 + 10, 2);
+  });
+
+  test('preserves the authored negative offset for the character horizontal frame', () => {
+    const layout = layoutHeaderDoc({ horizontalFrame: 'character' });
+    const drawing = layout.pages[0]!.header!.anchoredDrawings![0]!;
+    expect(drawing.x - drawing.horizontalFrameOrigin).toBeCloseTo(-73.25, 5);
+  });
+});
+
+describe('footer anchor relativeFrom="margin"', () => {
+  test('uses the same page content-box origin despite the footer story being near the bottom', () => {
+    const layout = layoutStoryDoc('footer');
+    const page = layout.pages[0]!;
+    const story = page.footer!;
+    const drawing = story.anchoredDrawings![0]!;
+
+    expect(story.box.y + drawing.paintBounds.y).toBeCloseTo(page.contentBox.y - 77.95, 2);
+    expect(paintedPosition(layout).y).toBeCloseTo(page.contentBox.y - 77.95, 2);
+  });
+});


### PR DESCRIPTION
## Summary

- resolve header/footer vertical anchors with relativeFrom="margin" against the attached page content-box margin frame before wrapping and clipping
- keep page, topMargin, bottomMargin, paragraph, line, and character frame behavior separate and unchanged
- add the standalone issue reproduction plus mixed-axis, negative-offset, clipping, wrapping, alignment, expanded header/footer, and existing-frame regression coverage

Fixes #565

## Before / after coordinates

For the standalone reproduction with content-box origin approximately (85.05 pt, 80.73 pt) and offsets (-73.25 pt, -77.95 pt):

- before: drawing origin approximately (11.80 pt, -35.40 pt), using the header story-box origin vertically
- after: drawing origin approximately (11.80 pt, 2.78 pt), using the page content-box margin frame vertically

The horizontal margin-relative coordinate remains 11.80 pt.

## Verification

- standalone regression: 17 passed
- focused layout and paint suites: 113 passed, 0 failed
- complete core layout and output suites: 2512 passed, 0 failed
- full repository test suite: 10923 passed, 0 failed across 841 files
- bun run typecheck: passed
- bun run lint: passed with 0 errors and 77 pre-existing warnings
- bun run format:check: passed
- bun run check:lane-boundaries: passed
- bun run build: passed; existing bundler warnings only
- repository pre-commit gate including API snapshots, parity, license checks, formatting, lint, and typecheck: passed

## Independent review

An independent reviewer specifically rechecked coordinate-space handling and existing page/topMargin anchor behavior after revisions. The final review explicitly reported no remaining medium-or-higher issues.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790855993&installation_model_id=422592&pr_number=686&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F686&signature=6848c667ed22db12e0a009c8d92045d9aa1e0ea65263843dbfb53c849152e7ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->