### PR TITLE
Fix underline-to-margin heading fills

### DIFF
--- a/.changeset/steady-underline-fills.md
+++ b/.changeset/steady-underline-fills.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Keep underlined trailing spaces and underscore tab leaders as single rules that reach the line margin.

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -3185,6 +3185,7 @@ export interface StyleSpanRecord {
     readonly equation?: EquationSpanRecord;
     readonly fieldAtom?: FieldAtomMarker;
     readonly fontSlot?: FontSlot;
+    readonly lineEndWhitespace?: true;
     readonly link?: SpanLinkRecord;
     readonly noteNav?: {
         readonly direction: 'to-note' | 'to-body';

--- a/packages/core/src/layout/__tests__/drawing-align-geometry.test.ts
+++ b/packages/core/src/layout/__tests__/drawing-align-geometry.test.ts
@@ -48,6 +48,9 @@ function inlinePictureRun(): string {
   );
 }
 
+const TEXT_AND_SPACE = '<w:r><w:t>x</w:t></w:r><w:r><w:t xml:space="preserve"> </w:t></w:r>';
+const TERMINAL_FILL = `<w:r><w:t xml:space="preserve">${'\u3000'.repeat(80)}</w:t></w:r>`;
+
 function documentXml(body: string): string {
   return `<w:document xmlns:w="${WML_NAMESPACE_URI}" xmlns:wp="${WP}" xmlns:a="${A}" xmlns:pic="${PIC}" xmlns:r="${R}"><w:body>${body}</w:body></w:document>`;
 }
@@ -104,6 +107,68 @@ describe('inline drawing geometry tracks alignment shifts', () => {
     expect(drawing.paintBounds.x).toBeGreaterThan(50);
     expectGeometryTracksBounds(drawing);
   });
+
+  for (const alignment of ['center', 'right'] as const) {
+    test(`${alignment} alignment counts a drawing after a pure whitespace run`, () => {
+      const body = layoutOf(
+        documentXml(
+          `<w:p><w:pPr><w:jc w:val="${alignment}"/></w:pPr>` +
+            `${TEXT_AND_SPACE}${inlinePictureRun()}</w:p>`
+        )
+      );
+      const table = layoutOf(
+        documentXml(
+          '<w:tbl><w:tblGrid><w:gridCol w:w="4680"/></w:tblGrid><w:tr><w:tc>' +
+            `<w:p><w:pPr><w:jc w:val="${alignment}"/></w:pPr>` +
+            `${TEXT_AND_SPACE}${inlinePictureRun()}</w:p>` +
+            '</w:tc></w:tr></w:tbl><w:p/>'
+        )
+      );
+
+      for (const layout of [body, table]) {
+        const line = linesOf(layout).find((candidate) => candidate.drawings?.length)!;
+        const drawing = line.drawings![0]!;
+        const rightEdge = line.box.x + line.box.width;
+        if (alignment === 'right') expect(drawing.advanceEnd).toBeCloseTo(rightEdge, 5);
+        else {
+          const leading = line.spans[0]!.box.x - line.box.x;
+          expect(leading).toBeCloseTo(rightEdge - drawing.advanceEnd, 5);
+        }
+        expectGeometryTracksBounds(drawing);
+      }
+    });
+
+    test(`${alignment} alignment keeps an interleaved drawing before the terminal fill`, () => {
+      const paragraph =
+        `<w:p><w:pPr><w:jc w:val="${alignment}"/></w:pPr>` +
+        `${TEXT_AND_SPACE}${inlinePictureRun()}${TERMINAL_FILL}</w:p>`;
+      const body = layoutOf(documentXml(paragraph));
+      const table = layoutOf(
+        documentXml(
+          '<w:tbl><w:tblGrid><w:gridCol w:w="4680"/></w:tblGrid><w:tr><w:tc>' +
+            paragraph +
+            '</w:tc></w:tr></w:tbl><w:p/>'
+        )
+      );
+
+      for (const layout of [body, table]) {
+        const line = linesOf(layout).find((candidate) => candidate.drawings?.length)!;
+        const drawing = line.drawings![0]!;
+        const fill = line.spans.find((span) => span.lineEndWhitespace)!;
+        const rightEdge = line.box.x + line.box.width;
+        const visibleWidth = drawing.advanceEnd - line.spans[0]!.box.x;
+        const expectedLeading =
+          alignment === 'center'
+            ? (line.box.width - visibleWidth) / 2
+            : line.box.width - visibleWidth;
+
+        expect(line.spans[0]!.box.x - line.box.x).toBeCloseTo(expectedLeading, 5);
+        expect(fill.box.x).toBeGreaterThanOrEqual(drawing.advanceEnd - 0.001);
+        expect(fill.box.x + fill.box.width).toBeCloseTo(rightEdge, 5);
+        expectGeometryTracksBounds(drawing);
+      }
+    });
+  }
 
   test('centered paragraph inside a table cell keeps geometry in the aligned space', () => {
     const layout = layoutOf(

--- a/packages/core/src/layout/__tests__/underline-to-margin.test.ts
+++ b/packages/core/src/layout/__tests__/underline-to-margin.test.ts
@@ -190,8 +190,32 @@ describe('underline-to-margin headings', () => {
     paintSemanticLayout(container, layout, { scale: 1 });
     const leader = container.querySelector<HTMLElement>('[data-docx-tab-leader]')!;
     const glyphs = leader.firstElementChild as HTMLElement;
+    const tabRun = [...container.querySelectorAll<HTMLElement>('.layout-run-text')].find(
+      (element) => element.textContent === '\t'
+    )!;
     expect(glyphs.style.fontFamily).toContain('SimSun');
     expect(glyphs.style.fontSize).toBe('18px');
     expect(glyphs.style.fontWeight).toBe('bold');
+    expect(tabRun.dataset.docxTabUnderline).toBeUndefined();
+    expect(tabRun.style.borderBottomStyle).toBe('');
+  });
+
+  test('an opaque tab highlight does not hide the underscore leader', () => {
+    const highlightedProps = `${RUN_PROPS}<w:highlight w:val="yellow"/>`;
+    const layout = layoutOf(
+      `<w:p><w:pPr><w:tabs><w:tab w:val="right" w:pos="3600" w:leader="underscore"/></w:tabs></w:pPr>` +
+        `<w:r><w:rPr>${RUN_PROPS}</w:rPr><w:t>${HEADING}</w:t></w:r>` +
+        `<w:r><w:rPr>${highlightedProps}</w:rPr><w:tab/></w:r></w:p>`
+    );
+    const container = document.createElement('div');
+    paintSemanticLayout(container, layout, { scale: 1 });
+    const leader = container.querySelector<HTMLElement>('[data-docx-tab-leader]')!;
+    const tabRun = [...container.querySelectorAll<HTMLElement>('.layout-run-text')].find(
+      (element) => element.textContent === '\t'
+    )!;
+
+    expect(tabRun.style.backgroundColor).not.toBe('');
+    expect(tabRun.style.borderBottomStyle).toBe('');
+    expect(leader.style.zIndex).toBe('1');
   });
 });

--- a/packages/core/src/layout/__tests__/underline-to-margin.test.ts
+++ b/packages/core/src/layout/__tests__/underline-to-margin.test.ts
@@ -1,0 +1,197 @@
+// Underline-to-margin headings authored with trailing spaces or an underscore tab leader.
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, type OoxmlPart } from '@docx-editor.dev/core/store';
+import { paintSemanticLayout } from '../../output/semantic-paint.ts';
+import { createFixedMeasurer } from '../fixed-measurer.ts';
+import { layoutSemanticDocument, linesOf } from '../index.ts';
+import { spanOffsetX } from '../semantic-hit-test.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const HEADING = '二、宣布开庭';
+const FULL_WIDTH_FILL = '\u3000'.repeat(52);
+const RUN_PROPS =
+  '<w:rFonts w:ascii="SimSun" w:eastAsia="SimSun"/><w:sz w:val="36"/><w:b/><w:u w:val="single"/>';
+const GEOMETRY = {
+  width: 200,
+  height: 400,
+  margin: { top: 10, right: 10, bottom: 10, left: 10 },
+};
+const MEASURER = createFixedMeasurer(6, 20);
+
+function load(body: string): OoxmlPart {
+  const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'app/xml',
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+function layoutOf(body: string) {
+  return layoutSemanticDocument(load(body), 1, {
+    measurer: MEASURER,
+    geometry: GEOMETRY,
+  });
+}
+
+describe('underline-to-margin headings', () => {
+  test('trailing full-width spaces fill the remaining width without opening lines', () => {
+    const layout = layoutOf(
+      `<w:p><w:pPr><w:spacing w:line="560" w:lineRule="exact"/></w:pPr>` +
+        `<w:r><w:rPr>${RUN_PROPS}</w:rPr><w:t>${HEADING}</w:t></w:r>` +
+        `<w:r><w:rPr>${RUN_PROPS}</w:rPr><w:t xml:space="preserve">${FULL_WIDTH_FILL}</w:t></w:r>` +
+        '</w:p>'
+    );
+    const lines = linesOf(layout);
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]!.spans.map((span) => span.text).join('')).toBe(HEADING + FULL_WIDTH_FILL);
+    const fill = lines[0]!.spans.at(-1)!;
+    expect(fill.box.x + fill.box.width).toBeCloseTo(180, 5);
+    expect(spanOffsetX(fill, fill.range.end, MEASURER)).toBeCloseTo(180, 5);
+
+    const container = document.createElement('div');
+    paintSemanticLayout(container, layout, { scale: 1 });
+    const paintedFill = [...container.querySelectorAll<HTMLElement>('[data-start]')].at(-1)!;
+    expect(Number.parseFloat(paintedFill.style.width)).toBeCloseTo(fill.box.width, 5);
+    expect(paintedFill.style.clipPath).toContain('-1em');
+  });
+
+  for (const alignment of ['center', 'right'] as const) {
+    test(`${alignment}-aligned heading keeps its visible alignment and fills to the margin`, () => {
+      const layout = layoutOf(
+        `<w:p><w:pPr><w:jc w:val="${alignment}"/></w:pPr>` +
+          `<w:r><w:rPr>${RUN_PROPS}</w:rPr><w:t>${HEADING}</w:t></w:r>` +
+          `<w:r><w:rPr>${RUN_PROPS}</w:rPr><w:t xml:space="preserve">${FULL_WIDTH_FILL}</w:t></w:r>` +
+          '</w:p>'
+      );
+      const line = linesOf(layout)[0]!;
+      const heading = line.spans[0]!;
+      const fill = line.spans.at(-1)!;
+      const expectedX =
+        alignment === 'center' ? (180 - heading.box.width) / 2 : 180 - heading.box.width;
+
+      expect(heading.box.x).toBeCloseTo(expectedX, 5);
+      expect(fill.box.x + fill.box.width).toBeCloseTo(180, 5);
+    });
+
+    test(`${alignment}-aligned fill remains terminal before a hard break`, () => {
+      const paragraph =
+        `<w:p><w:pPr><w:jc w:val="${alignment}"/></w:pPr>` +
+        `<w:r><w:rPr>${RUN_PROPS}</w:rPr><w:t>${HEADING}</w:t></w:r>` +
+        `<w:r><w:rPr>${RUN_PROPS}</w:rPr><w:t xml:space="preserve">${FULL_WIDTH_FILL}</w:t></w:r>` +
+        '<w:r><w:br/></w:r></w:p>';
+      const body = layoutOf(paragraph);
+      const table = layoutOf(
+        '<w:tbl><w:tblGrid><w:gridCol w:w="2880"/></w:tblGrid><w:tr><w:tc>' +
+          paragraph +
+          '</w:tc></w:tr></w:tbl><w:p/>'
+      );
+
+      for (const layout of [body, table]) {
+        const line = linesOf(layout).find((candidate) =>
+          candidate.spans.some((span) => span.text === '\n')
+        )!;
+        const heading = line.spans[0]!;
+        const fill = line.spans.find((span) => span.lineEndWhitespace)!;
+        const lineBreak = line.spans.at(-1)!;
+        const rightEdge = line.box.x + line.box.width;
+        const expectedLeading =
+          alignment === 'center'
+            ? (line.box.width - heading.box.width) / 2
+            : line.box.width - heading.box.width;
+
+        expect(heading.box.x - line.box.x).toBeCloseTo(expectedLeading, 5);
+        expect(fill.box.x + fill.box.width).toBeCloseTo(rightEdge, 5);
+        expect(lineBreak.box.x).toBeCloseTo(rightEdge, 5);
+      }
+    });
+  }
+
+  test('scaled wavy fill clips in an untransformed box without trimming vertical ink', () => {
+    const scaledProps =
+      '<w:rFonts w:ascii="SimSun" w:eastAsia="SimSun"/><w:sz w:val="36"/>' +
+      '<w:b/><w:w w:val="200"/><w:u w:val="wave"/>';
+    const layout = layoutOf(
+      `<w:p><w:pPr><w:spacing w:line="360" w:lineRule="exact"/></w:pPr>` +
+        `<w:r><w:rPr>${scaledProps}</w:rPr><w:t>${HEADING}</w:t></w:r>` +
+        `<w:r><w:rPr>${scaledProps}</w:rPr><w:t xml:space="preserve">${FULL_WIDTH_FILL}</w:t></w:r>` +
+        '</w:p>'
+    );
+    expect(linesOf(layout)).toHaveLength(1);
+
+    const container = document.createElement('div');
+    paintSemanticLayout(container, layout, { scale: 1 });
+    const fill = [...container.querySelectorAll<HTMLElement>('[data-start]')].at(-1)!;
+    const glyph = fill.querySelector<HTMLElement>('[data-docx-clipped-fill]')!;
+    expect(fill.style.transform).toBe('');
+    expect(fill.style.clipPath).toContain('-1em');
+    expect(glyph.style.transform).toBe('scaleX(2)');
+    expect(glyph.style.textDecorationStyle).toBe('wavy');
+  });
+
+  test('a long trailing ASCII-space run is handled in linear time', () => {
+    const spaces = ' '.repeat(50_000);
+    const part = load(
+      `<w:p><w:r><w:t>x</w:t></w:r>` + `<w:r><w:t xml:space="preserve">${spaces}</w:t></w:r></w:p>`
+    );
+    const started = performance.now();
+    const layout = layoutSemanticDocument(part, 1, { measurer: MEASURER, geometry: GEOMETRY });
+    const elapsed = performance.now() - started;
+
+    expect(linesOf(layout)).toHaveLength(1);
+    expect(elapsed).toBeLessThan(2_000);
+  });
+
+  for (const [kind, wrapper, textElement, decoration] of [
+    ['insert', 'ins', 't', 'underline'],
+    ['delete', 'del', 'delText', 'line-through'],
+  ] as const) {
+    test(`scaled clipped ${kind} fill keeps its tracked-change decoration`, () => {
+      const scaledProps =
+        '<w:rFonts w:ascii="SimSun" w:eastAsia="SimSun"/><w:sz w:val="36"/>' + '<w:w w:val="200"/>';
+      const layout = layoutSemanticDocument(
+        load(
+          `<w:p><w:r><w:rPr>${scaledProps}</w:rPr><w:t>${HEADING}</w:t></w:r>` +
+            `<w:${wrapper} w:id="1" w:author="QA"><w:r><w:rPr>${scaledProps}</w:rPr>` +
+            `<w:${textElement} xml:space="preserve">${FULL_WIDTH_FILL}</w:${textElement}>` +
+            `</w:r></w:${wrapper}></w:p>`
+        ),
+        1,
+        { measurer: MEASURER, geometry: GEOMETRY, displayMode: 'all-markup' }
+      );
+      const container = document.createElement('div');
+      paintSemanticLayout(container, layout, { scale: 1 });
+      const tracked = container.querySelector<HTMLElement>(`[data-revision-kind="${kind}"]`)!;
+      const glyph = tracked.querySelector<HTMLElement>('[data-docx-clipped-fill]')!;
+
+      expect(tracked.style.textDecorationLine).toBe('');
+      expect(glyph.style.textDecorationLine).toBe(decoration);
+    });
+  }
+
+  test('underscore tab leaders use the active paragraph font metrics', () => {
+    const layout = layoutOf(
+      `<w:p><w:pPr><w:tabs><w:tab w:val="right" w:pos="3600" w:leader="underscore"/></w:tabs>` +
+        `<w:rPr>${RUN_PROPS}</w:rPr></w:pPr>` +
+        `<w:r><w:rPr>${RUN_PROPS}</w:rPr><w:t>${HEADING}</w:t></w:r>` +
+        `<w:r><w:rPr>${RUN_PROPS}</w:rPr><w:tab/></w:r></w:p>`
+    );
+    const lines = linesOf(layout);
+    expect(lines).toHaveLength(1);
+    const tab = lines[0]!.spans.find((span) => span.text === '\t')!;
+    expect(tab.tabLeader).toBe('underscore');
+    expect(tab.tabLeaderAdvancePt).toBe(MEASURER.measure('_', tab.style));
+
+    const container = document.createElement('div');
+    paintSemanticLayout(container, layout, { scale: 1 });
+    const leader = container.querySelector<HTMLElement>('[data-docx-tab-leader]')!;
+    const glyphs = leader.firstElementChild as HTMLElement;
+    expect(glyphs.style.fontFamily).toContain('SimSun');
+    expect(glyphs.style.fontSize).toBe('18px');
+    expect(glyphs.style.fontWeight).toBe('bold');
+  });
+});

--- a/packages/core/src/layout/line-end-whitespace.ts
+++ b/packages/core/src/layout/line-end-whitespace.ts
@@ -1,0 +1,8 @@
+/** Spaces Word may hang/clip at a line end instead of wrapping onto a new line. */
+export function isCollapsibleLineEndWhitespace(text: string): boolean {
+  if (text.length === 0) return false;
+  for (const char of text) {
+    if (char !== ' ' && char !== '\u3000') return false;
+  }
+  return true;
+}

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -77,6 +77,7 @@ import {
   type ExclusionZone,
 } from './drawing-exclusion.ts';
 import { createEquationLayouter } from './equation-layout.ts';
+import { isCollapsibleLineEndWhitespace } from './line-end-whitespace.ts';
 
 /**
  * How far past the line's right edge a span may reach before it counts as overflow.
@@ -301,22 +302,27 @@ function wordBoundaries(text: string): number[] {
  * page. Stops at a hard break, which ends the line anyway, and skips further tabs and
  * spaces, which are themselves trimmed at the line end.
  */
-function placeableContentFollows(
-  pieces: readonly Piece[],
-  pieceIndex: number,
-  offsetInPiece: number
-): boolean {
-  for (let index = pieceIndex; index < pieces.length; index += 1) {
-    const piece = pieces[index]!;
-    if (piece.inlineDrawing) return true;
-    const from = index === pieceIndex ? offsetInPiece : 0;
-    for (let cursor = from; cursor < piece.text.length; cursor += 1) {
-      const ch = piece.text[cursor]!;
-      if (ch === '\n' || ch === PAGE_BREAK_CHAR) return false;
-      if (ch !== '\t' && ch !== ' ') return true;
+function placeableContentSuffixes(pieces: readonly Piece[]): readonly Uint8Array[] {
+  const suffixes = new Array<Uint8Array>(pieces.length);
+  let follows = false;
+  for (let pieceIndex = pieces.length - 1; pieceIndex >= 0; pieceIndex -= 1) {
+    const piece = pieces[pieceIndex]!;
+    const suffix = new Uint8Array(piece.text.length + 1);
+    suffix[piece.text.length] = follows ? 1 : 0;
+    if (piece.inlineDrawing) {
+      suffix.fill(1);
+    } else {
+      for (let cursor = piece.text.length - 1; cursor >= 0; cursor -= 1) {
+        const ch = piece.text[cursor]!;
+        if (ch === '\n' || ch === PAGE_BREAK_CHAR) suffix[cursor] = 0;
+        else if (ch !== '\t' && !isCollapsibleLineEndWhitespace(ch)) suffix[cursor] = 1;
+        else suffix[cursor] = suffix[cursor + 1]!;
+      }
     }
+    suffixes[pieceIndex] = suffix;
+    follows = suffix[0] === 1;
   }
-  return false;
+  return suffixes;
 }
 
 function measureFollowingTabSegment(
@@ -507,6 +513,45 @@ export function alignSpans(
   if (spans.length === 0) return spans;
   if (alignment === 'left') return spans;
 
+  let trailingEnd = spans.length;
+  while (
+    trailingEnd > 0 &&
+    spans[trailingEnd - 1]!.box.width === 0 &&
+    (spans[trailingEnd - 1]!.text === '\n' || spans[trailingEnd - 1]!.text === PAGE_BREAK_CHAR)
+  ) {
+    trailingEnd -= 1;
+  }
+  let trailingStart = trailingEnd;
+  while (trailingStart > 0 && spans[trailingStart - 1]!.lineEndWhitespace) {
+    trailingStart -= 1;
+  }
+  const lastContentSpan = spans[trailingEnd - 1];
+  const spansReachLineEnd =
+    lineUsedWidth !== undefined &&
+    lastContentSpan !== undefined &&
+    Math.abs(lastContentSpan.box.x + lastContentSpan.box.width - indentLeft - lineUsedWidth) <=
+      OVERFLOW_TOLERANCE_PT;
+  if (
+    trailingStart < trailingEnd &&
+    spansReachLineEnd &&
+    (alignment === 'center' || alignment === 'right')
+  ) {
+    const used = spans[trailingStart]!.box.x - indentLeft;
+    const slack = available - used;
+    if (slack <= 0) return spans;
+    const offset = alignment === 'center' ? slack / 2 : slack;
+    const clipsAtMargin = (lineUsedWidth ?? 0) >= available - OVERFLOW_TOLERANCE_PT;
+    let fillX = spans[trailingStart]!.box.x + offset;
+    return spans.map((span, index) => {
+      if (index < trailingStart) return { ...span, box: { ...span.box, x: span.box.x + offset } };
+      if (!clipsAtMargin) return { ...span, box: { ...span.box, x: span.box.x + offset } };
+      const width = Math.min(span.box.width, Math.max(0, indentLeft + available - fillX));
+      const aligned = { ...span, box: { ...span.box, x: fillX, width } };
+      fillX += width;
+      return aligned;
+    });
+  }
+
   // Trailing whitespace hangs into the margin rather than pushing the text off-centre, which
   // is what Word does and what stops a line ending in a space from looking misaligned.
   const last = spans[spans.length - 1]!;
@@ -623,6 +668,7 @@ export function breakParagraph(
       },
     ];
   });
+  const placeableSuffixes = placeableContentSuffixes(pieces);
   const layoutEquation = createEquationLayouter(measurer, flow?.equationCacheToken);
   const equationLayoutOf = (piece: FieldAwarePiece) =>
     piece.equation ? layoutEquation(piece.equation, piece.style) : null;
@@ -1410,7 +1456,7 @@ export function breakParagraph(
         if (
           (line.spans.length > 0 || line.drawings.length > 0) &&
           line.width >= lineAvailable() &&
-          placeableContentFollows(pieces, pieceIndex, boundary)
+          placeableSuffixes[pieceIndex]![boundary] === 1
         )
           closeLine();
         const currentX = lineOrigin() + line.width;
@@ -1486,7 +1532,7 @@ export function breakParagraph(
       // would size the line for characters the reader never sees. Note marks may reserve
       // a wider measureText (eachPage) while painting the real digits.
       const measureSource = piece.measureText ?? candidate;
-      const width = measurer.measure(displayText(measureSource, faceStyle), faceStyle);
+      let width = measurer.measure(displayText(measureSource, faceStyle), faceStyle);
       // A candidate may open a line only at a real break opportunity. Within a piece,
       // `wordBoundaries` cuts after spaces, dashes and tabs, so every candidate but the
       // first is one. The FIRST candidate of a piece continues whatever the previous piece
@@ -1506,6 +1552,13 @@ export function breakParagraph(
         wordStartEnd = line.end;
       }
       advancePastAnchorExclusionForPlacement(piece.start + consumed);
+      // Word hangs trailing fill spaces at the line edge: they occupy the remaining band
+      // (and keep their underline) but never open continuation lines of their own.
+      const lineEndWhitespace =
+        isCollapsibleLineEndWhitespace(candidate) && placeableSuffixes[pieceIndex]![boundary] !== 1;
+      if (lineEndWhitespace) {
+        width = Math.min(width, Math.max(0, lineAvailable() - line.width));
+      }
       if (
         line.width + width > lineAvailable() + OVERFLOW_TOLERANCE_PT &&
         (line.spans.length > 0 || line.drawings.length > 0)
@@ -1620,6 +1673,7 @@ export function breakParagraph(
         ...(layoutOwned && !piece.positionalTab ? { projected: true as const } : {}),
         ...(piece.noteNav ? { noteNav: piece.noteNav } : {}),
         ...(piece.fontSlot ? { fontSlot: piece.fontSlot } : {}),
+        ...(lineEndWhitespace ? { lineEndWhitespace: true as const } : {}),
         ...revisionsOf(piece),
       });
       line.width += remainingWidth;

--- a/packages/core/src/layout/semantic-hit-test.ts
+++ b/packages/core/src/layout/semantic-hit-test.ts
@@ -926,7 +926,7 @@ function prefixWidth(span: StyleSpanRecord, utf16: number, measurer: TextMeasure
   if (cached !== undefined) return cached;
   // As DRAWN, matching `caretEdges` and the advance `breakParagraph` reserved: a `w:caps`
   // run paints uppercase, and measuring the source text would disagree with both.
-  const width =
+  const measured =
     utf16 <= 0
       ? 0
       : measureDisplayText(
@@ -934,6 +934,7 @@ function prefixWidth(span: StyleSpanRecord, utf16: number, measurer: TextMeasure
           styleForFontSlot(span.style, span.fontSlot),
           measurer
         );
+  const width = span.lineEndWhitespace ? Math.min(measured, span.box.width) : measured;
   widths.set(utf16, width);
   return width;
 }

--- a/packages/core/src/layout/semantic-records.ts
+++ b/packages/core/src/layout/semantic-records.ts
@@ -142,6 +142,8 @@ export interface StyleSpanRecord {
    */
   readonly fontSlot?: FontSlot;
   readonly box: LayoutBox;
+  /** Authored trailing spaces that layout may clip at the line's right edge. */
+  readonly lineEndWhitespace?: true;
   /**
    * Cumulative advances from {@link box}.x to each UTF-16 caret boundary in {@link text}.
    *

--- a/packages/core/src/output/semantic-paint-line-end-whitespace.ts
+++ b/packages/core/src/output/semantic-paint-line-end-whitespace.ts
@@ -1,0 +1,38 @@
+import type { StyleSpanRecord } from '../layout/semantic-records.ts';
+
+/**
+ * Keep clipped fill geometry outside glyph scaling. The expanded vertical clip preserves
+ * underline ink while the zero horizontal inset stops authored spaces at the published edge.
+ */
+export function prepareTextPaintHost(
+  document: Document,
+  element: HTMLElement,
+  span: StyleSpanRecord,
+  scale: number
+): HTMLElement {
+  const clippedLineEndWhitespace = span.lineEndWhitespace === true;
+  if (span.style.horizontalScalePercent !== 100 || span.text === '\t' || clippedLineEndWhitespace) {
+    element.style.width = `${span.box.width * scale}px`;
+  }
+  if (!clippedLineEndWhitespace) return element;
+  element.style.clipPath = 'inset(-1em 0)';
+  if (span.style.horizontalScalePercent === 100) return element;
+
+  const glyph = document.createElement('span');
+  glyph.dataset.docxClippedFill = '';
+  glyph.style.display = 'inline-block';
+  glyph.style.transform = element.style.transform;
+  glyph.style.transformOrigin = element.style.transformOrigin;
+  glyph.style.textDecorationLine = element.style.textDecorationLine;
+  glyph.style.textDecorationStyle = element.style.textDecorationStyle;
+  glyph.style.textDecorationColor = element.style.textDecorationColor;
+  glyph.style.textDecorationThickness = element.style.textDecorationThickness;
+  element.style.removeProperty('transform');
+  element.style.removeProperty('transform-origin');
+  element.style.removeProperty('text-decoration-line');
+  element.style.removeProperty('text-decoration-style');
+  element.style.removeProperty('text-decoration-color');
+  element.style.removeProperty('text-decoration-thickness');
+  element.append(glyph);
+  return glyph;
+}

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -1189,8 +1189,11 @@ function paintSpan(
     // is exactly where a baseline-aligned run of the same band lands anyway.
     element.style.verticalAlign = 'top';
     // Form blanks: `w:u` on `w:tab` underlines the ADVANCE (Word), not the `\t` glyph.
+    // An underscore leader already supplies that rule with repeated glyphs in the active
+    // face. Adding the advance border as well paints two parallel lines; retain the border
+    // for every other leader, where underline remains independent.
     const tabUnderline = underlineDecorationOf(span.style);
-    if (tabUnderline) {
+    if (tabUnderline && span.tabLeader !== 'underscore') {
       element.dataset.docxTabUnderline = '';
       applyTabAdvanceUnderline(element.style, tabUnderline, ctx.scale);
     }
@@ -1648,8 +1651,8 @@ function paintFragment(
   if (fragment.marker) {
     element.append(paintListMarker(document, fragment, ctx));
   }
-  // Tab leaders are furniture too, and they are painted BEFORE the lines so the glyphs sit
-  // behind the text rather than over it.
+  // Punctuation leaders sit behind the text. Underscores rise above the tab's own background
+  // below, or an opaque highlight/shading/revision wash would erase their only visible rule.
   for (const line of fragment.lines) {
     for (const span of line.spans) {
       if (!span.tabLeader) continue;
@@ -1806,6 +1809,7 @@ function paintTabLeader(
   layer.setAttribute('contenteditable', 'false');
   layer.setAttribute('aria-hidden', 'true');
   layer.style.position = 'absolute';
+  if (span.tabLeader === 'underscore') layer.style.zIndex = '1';
   layer.style.left = `${(span.box.x - fragment.box.x) * scale}px`;
   layer.style.top = `${(line.box.y - fragment.box.y) * scale}px`;
   layer.style.width = `${span.box.width * scale}px`;

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -69,6 +69,7 @@ import {
   type PaintImageUrlPort,
 } from './semantic-paint-drawings.ts';
 import { mountEquationGeometry } from './semantic-paint-equation.ts';
+import { prepareTextPaintHost } from './semantic-paint-line-end-whitespace.ts';
 
 /**
  * When a field's result is drawn on its grey block, following Word's own View option.
@@ -1169,13 +1170,7 @@ function paintSpan(
   applyRunFaceStyle(element, faceStyle, ctx);
   applyFieldShading(element, span, ctx);
   applyRevisionPresentation(element, span, ctx);
-  // Layout owns advances that the browser cannot reconstruct: horizontal scaling (transform
-  // does not reserve space) and OOXML tab stops (`\t` would otherwise paint as a narrow
-  // native tab). Both must take the published box width so following runs start where
-  // breakParagraph placed them — body, cells, and headers/footers share this painter.
-  if (span.style.horizontalScalePercent !== 100 || span.text === '\t') {
-    element.style.width = `${span.box.width * ctx.scale}px`;
-  }
+  const textHost = prepareTextPaintHost(document, element, span, ctx.scale);
   if (span.text === '\t') {
     // Keep the model character for range mapping, but clip any native tab ink that would
     // spill past the reserved advance.
@@ -1200,7 +1195,7 @@ function paintSpan(
       applyTabAdvanceUnderline(element.style, tabUnderline, ctx.scale);
     }
   }
-  mountRunText(document, element, span.text, span.style, ctx.scale);
+  mountRunText(document, textHost, span.text, span.style, ctx.scale);
   if (span.projected) {
     element.dataset.docxField = '';
     element.setAttribute('contenteditable', 'false');


### PR DESCRIPTION
Fixes #663

## Root cause

Trailing U+3000 full-width spaces were treated as one oversized wrapping candidate. The normal split path therefore flowed an underline-to-margin run onto continuation lines instead of treating the trailing whitespace as line-end fill. Layout, painting, and caret hit testing also lacked a shared signal for that special geometry.

For the alternate tab-leader form, the underscore glyph leader and the explicit `w:u` tab-advance border were both painted, producing two parallel rules. The leader also sat behind tab backgrounds, so simply removing the border could make highlighted or revised leaders disappear.

## Changes

- Mark terminal U+0020/U+3000 whitespace in layout and cap it to the remaining line width without opening continuation lines.
- Preserve center/right alignment, drawings, hard breaks, scaled text, revision decorations, caret geometry, and note-pagination memoization behavior.
- Keep terminal-whitespace lookup linear for very long fills.
- Use the active run font metrics for underscore leaders without adding a duplicate tab-advance border.
- Keep underscore leaders visible above opaque highlight, shading, and revision backgrounds while clipped to their inert tab geometry.
- Add regression coverage for both authoring forms and their paint/layout edge cases.

## Verification

- Final focused layout/paint suite: 103 passed
- Full repository suite: 10,795 passed across 825 files
- `bun run typecheck`
- `bun run lint` (0 errors; 77 existing warnings)
- Core package build
- Changed-file Prettier and `git diff --check`
- Pre-commit API snapshot, parity, license, formatting, and lint-staged gates
- Independent review loop: no remaining medium-or-higher issues