### PR TITLE
fix: restore issue #662 document fidelity

### DIFF
--- a/.changeset/calm-tables-float.md
+++ b/.changeset/calm-tables-float.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': patch
 ---
 
-Position page- and margin-anchored floating tables at `tblpY` without advancing body flow. Fixes #662.
+Position page- and margin-anchored floating tables at `tblpY` without advancing body flow. Preserve `btLr` cell text, built-up bar fractions, and inline pictures in later columns. Fixes #662.

--- a/.changeset/calm-tables-float.md
+++ b/.changeset/calm-tables-float.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': patch
 ---
 
-Position page- and margin-anchored floating tables at `tblpY` without advancing body flow. Preserve `btLr` cell text, built-up bar fractions, and inline pictures in later columns. Fixes #662.
+Position page- and margin-anchored floating tables at `tblpY` without advancing body flow. Preserve `btLr` cell text, built-up bar fractions, and inline pictures in later columns. Keep automatic line spacing from scaling built-up equations and changing pagination. Fixes #662.

--- a/.changeset/calm-tables-float.md
+++ b/.changeset/calm-tables-float.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Position page- and margin-anchored floating tables at `tblpY` without advancing body flow. Fixes #662.

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -2852,6 +2852,7 @@ export interface SemanticTableCell {
     readonly preferredWidth: PreferredWidth;
     readonly shading?: string;
     readonly styleFormatting: TableCellStyleFormatting;
+    readonly textDirection: 'horizontal' | 'btLr';
     readonly vAlign: CellVerticalAlign;
     readonly vMergeContinue: boolean;
 }
@@ -3323,6 +3324,7 @@ export interface TableCellFragmentRecord {
     readonly paintInert?: boolean;
     readonly rowSpan?: number;
     readonly shading?: string;
+    readonly textDirection?: 'btLr';
     readonly vMergeContinue: boolean;
 }
 

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -443,7 +443,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'An anchored table lands where Word puts it across the page: tblpXSpec or tblpX against the text, margin, or page box, plus a tblpY offset from the text anchor. Text does not wrap beside it yet. Page-anchored and margin-anchored vertical positions keep their place in the flow.',
+      'An anchored table uses tblpXSpec or tblpX across the text, margin, or page box. It uses tblpY or tblpYSpec against the selected vertical anchor. Page-anchored and margin-anchored tables do not advance body flow. Text does not wrap beside them yet.',
   },
   {
     id: 'tables.text-direction',

--- a/packages/core/src/editor/surface-caret.ts
+++ b/packages/core/src/editor/surface-caret.ts
@@ -34,6 +34,7 @@ import {
   type SemanticSelection,
   type TextMeasurer,
 } from '@docx-editor.dev/core/layout';
+import { isBottomToTopCaret } from '../layout/table-cell-text-direction.ts';
 
 /** What the caret reads at paint time. Both move independently of the caret itself. */
 export interface SurfaceCaretInput {
@@ -199,6 +200,9 @@ export function createSurfaceCaret(
     element.style.left = `${geometry.x * currentScale}px`;
     element.style.top = `${geometry.y * currentScale}px`;
     element.style.height = `${geometry.height * currentScale}px`;
+    const bottomToTop = isBottomToTopCaret(geometry);
+    element.style.transformOrigin = bottomToTop ? '0 0' : '';
+    element.style.transform = bottomToTop ? 'rotate(-90deg)' : '';
     if (element.parentNode !== host) host.append(element);
     // Suppress the native caret only while ours is up, and inline so it beats the
     // `[contenteditable='true']` rule in the stylesheet — pages layer AND scoped story.

--- a/packages/core/src/layout/__tests__/drawing-align-geometry.test.ts
+++ b/packages/core/src/layout/__tests__/drawing-align-geometry.test.ts
@@ -89,6 +89,39 @@ function expectGeometryTracksBounds(drawing: InlineDrawingRecord): void {
 }
 
 describe('inline drawing geometry tracks alignment shifts', () => {
+  test('a drawing moved into the second body column keeps non-empty paint bounds', () => {
+    const preceding = Array.from(
+      { length: 60 },
+      (_, index) => `<w:p><w:r><w:t>line ${index}</w:t></w:r></w:p>`
+    ).join('');
+    const layout = layoutOf(
+      documentXml(
+        preceding +
+          `<w:p>${inlinePictureRun()}</w:p>` +
+          '<w:sectPr><w:cols w:num="2" w:space="720"/></w:sectPr>'
+      )
+    );
+    const drawing = firstDrawing(layout);
+    expect(drawing.x).toBeGreaterThan(200);
+    expect(drawing.paintBounds.width).toBeCloseTo(drawing.width, 3);
+    expect(drawing.paintBounds.height).toBeCloseTo(drawing.height, 3);
+    expectGeometryTracksBounds(drawing);
+  });
+
+  test('a drawing in a later table cell keeps geometry translated with its record', () => {
+    const layout = layoutOf(
+      documentXml(
+        '<w:tbl><w:tblGrid><w:gridCol w:w="2340"/><w:gridCol w:w="2340"/></w:tblGrid>' +
+          '<w:tr><w:tc><w:p><w:r><w:t>left</w:t></w:r></w:p></w:tc>' +
+          `<w:tc><w:p>${inlinePictureRun()}</w:p></w:tc></w:tr></w:tbl>`
+      )
+    );
+    const drawing = firstDrawing(layout);
+    expect(drawing.x).toBeGreaterThan(100);
+    expect(drawing.paintBounds.width).toBeCloseTo(drawing.width, 3);
+    expectGeometryTracksBounds(drawing);
+  });
+
   test('centered body paragraph keeps geometry in the aligned space', () => {
     const layout = layoutOf(
       documentXml(`<w:p><w:pPr><w:jc w:val="center"/></w:pPr>${inlinePictureRun()}</w:p>`)

--- a/packages/core/src/layout/__tests__/drawing-layout.test.ts
+++ b/packages/core/src/layout/__tests__/drawing-layout.test.ts
@@ -19,6 +19,7 @@ import {
   measureInlineDrawing,
   pageClipRegion,
   resolveAnchoredDrawingPosition,
+  shiftAnchoredDrawingRecords,
   type InlineDrawingLayoutContext,
 } from '../drawing-layout.ts';
 import { breakParagraph } from '../paragraph-flow.ts';
@@ -800,6 +801,9 @@ describe('places anchors in story and cell context', () => {
     const drawing = layout.pages[0]!.anchoredDrawings![0]!;
     expect(drawing.layoutInCell).toBe(false);
     expect(drawing.x).toBeCloseTo(-72, 2);
+    const shifted = [drawing];
+    shiftAnchoredDrawingRecords(shifted, drawing.anchorParagraphId, 100);
+    expect(shifted[0]!.y).toBe(drawing.y);
   });
 });
 

--- a/packages/core/src/layout/__tests__/equation-layout.test.ts
+++ b/packages/core/src/layout/__tests__/equation-layout.test.ts
@@ -154,6 +154,31 @@ describe('atomic equation paragraph layout', () => {
     expect(equations[0]!.range.end - equations[0]!.range.start).toBe(1);
   });
 
+  test('auto line spacing scales the text band instead of the built-up fraction', () => {
+    const fraction =
+      '<m:oMath><m:f><m:fPr><m:type m:val="bar"/></m:fPr>' +
+      '<m:num><m:r><m:t>1</m:t></m:r></m:num>' +
+      '<m:den><m:r><m:t>2</m:t></m:r></m:den></m:f></m:oMath>';
+    const single = linesOf(layout(`<w:p>${fraction}</w:p>`))[0]!;
+    const multiple = linesOf(
+      layout(
+        '<w:p><w:pPr><w:spacing w:line="360" w:lineRule="auto"/></w:pPr>' + `${fraction}</w:p>`
+      )
+    )[0]!;
+    const plainMultiple = linesOf(
+      layout(
+        '<w:p><w:pPr><w:spacing w:line="360" w:lineRule="auto"/></w:pPr>' +
+          '<w:r><w:t>x</w:t></w:r></w:p>'
+      )
+    )[0]!;
+
+    expect(multiple.box.height).toBeCloseTo(
+      Math.max(single.box.height, plainMultiple.box.height),
+      5
+    );
+    expect(multiple.box.height).toBeLessThan(single.box.height * 1.5);
+  });
+
   test('publishes bounded fallback text geometry for unsupported OMML', () => {
     const span = equationSpan(
       '<w:p><m:oMath><m:bar><m:e><m:r><m:t>safe fallback</m:t></m:r>' +

--- a/packages/core/src/layout/__tests__/semantic-table-layout.test.ts
+++ b/packages/core/src/layout/__tests__/semantic-table-layout.test.ts
@@ -9,7 +9,16 @@ import { readOoxmlPart, type OoxmlPart } from '../../store/package/ooxml-tree.ts
 import { applyTreeOp } from '../../store/store/tree-ops.ts';
 import { createParagraphLayoutCache } from '../layout-cache.ts';
 import type { PendingLine } from '../paragraph-flow.ts';
-import { caretStops, documentOrder, paragraphTextFromLayout } from '../semantic-interaction.ts';
+import {
+  caretAt,
+  caretStopsForBlocks,
+  caretStops,
+  documentOrder,
+  paragraphTextFromLayout,
+  selectionRects,
+} from '../semantic-interaction.ts';
+import { hitTestFragments, hitTestPage } from '../semantic-hit-test.ts';
+import { isBottomToTopCaret } from '../table-cell-text-direction.ts';
 import {
   createFixedMeasurer,
   createLayoutSession,
@@ -300,7 +309,8 @@ describe('semantic table layout', () => {
         ) +
         '</w:tbl>'
     );
-    const cell = allTableFragments(layout(part))[0]!.rows[0]!.cells[0]!;
+    const result = layout(part);
+    const cell = allTableFragments(result)[0]!.rows[0]!.cells[0]!;
     const para = cell.blocks[0]!;
     // left 6pt, top 4pt from tcMar (120/80 twips).
     expect(para.box.x).toBe(cell.box.x + 6);
@@ -411,6 +421,113 @@ describe('semantic table layout', () => {
     const shortTop = short.blocks[0]!.box.y;
     // Centered content sits below the top pad of a top-aligned cell.
     expect(shortTop).toBeGreaterThan(short.box.y + 3);
+  });
+
+  test('btLr cells lay text along the row height instead of the narrow column width', () => {
+    const part = loadPart(
+      '<w:tbl><w:tblGrid><w:gridCol w:w="510"/></w:tblGrid>' +
+        '<w:tr><w:trPr><w:trHeight w:val="2000" w:hRule="exact"/></w:trPr>' +
+        '<w:tc><w:tcPr><w:textDirection w:val="btLr"/><w:vAlign w:val="center"/></w:tcPr>' +
+        p('vertical label') +
+        '</w:tc></w:tr></w:tbl>'
+    );
+    const result = layout(part);
+    const cell = allTableFragments(result)[0]!.rows[0]!.cells[0]!;
+    const paragraph = cell.blocks[0]!;
+    if (paragraph.kind !== 'paragraph') throw new Error('expected paragraph');
+    expect(cell.textDirection).toBe('btLr');
+    expect(cell.box).toMatchObject({ width: 25.5, height: 100 });
+    expect(paragraph.lines).toHaveLength(1);
+    expect(paragraph.lines[0]!.spans.map((span) => span.text).join('')).toBe('vertical label');
+
+    const span = paragraph.lines[0]!.spans[0]!;
+    const paintedPoint = {
+      x: cell.box.x + (span.box.y - cell.box.y) + span.box.height / 2,
+      y: cell.box.y + cell.box.height - (span.box.x - cell.box.x) - span.box.width / 2,
+    };
+    const hit = hitTestPage(result, 0, paintedPoint)!;
+    expect(hit.position.paragraphId).toBe(paragraph.paragraphId);
+    expect(isBottomToTopCaret(hit.caret)).toBe(true);
+    const caret = caretAt(result, { paragraphId: paragraph.paragraphId, offset: 0 })!;
+    expect(isBottomToTopCaret(caret)).toBe(true);
+    expect(hit.caret).toEqual(caretAt(result, hit.position, { preferredPageIndex: 0 }));
+    expect(hit.caret.x).toBeGreaterThanOrEqual(cell.box.x);
+    expect(hit.caret.x).toBeLessThanOrEqual(cell.box.x + cell.box.width);
+    expect(caret.x).toBeGreaterThanOrEqual(cell.box.x);
+    expect(caret.x).toBeLessThanOrEqual(cell.box.x + cell.box.width);
+    const selection = {
+      anchor: { paragraphId: paragraph.paragraphId, offset: 0 },
+      head: { paragraphId: paragraph.paragraphId, offset: 'vertical label'.length },
+    };
+    const [rect] = selectionRects(result, selection, documentOrder(result));
+    expect(rect!.width).toBeCloseTo(paragraph.lines[0]!.box.height, 3);
+    expect(rect!.height).toBeGreaterThan(rect!.width);
+  });
+
+  test('btLr caret geometry is available in furniture and note stories', () => {
+    const part = loadPart(
+      '<w:tbl><w:tblGrid><w:gridCol w:w="510"/></w:tblGrid>' +
+        '<w:tr><w:trPr><w:trHeight w:val="2000" w:hRule="exact"/></w:trPr>' +
+        '<w:tc><w:tcPr><w:textDirection w:val="btLr"/></w:tcPr>' +
+        p('story label') +
+        '</w:tc></w:tr></w:tbl>'
+    );
+    const bodyLayout = layout(part);
+    const page = bodyLayout.pages[0]!;
+    const fragments = page.fragments;
+    const storyLayouts: SemanticLayout[] = [
+      {
+        ...bodyLayout,
+        pages: [
+          {
+            ...page,
+            fragments: [],
+            header: {
+              kind: 'header',
+              variant: 'default',
+              partName: '/word/header1.xml',
+              box: page.contentBox,
+              fragments,
+            },
+          },
+        ],
+      },
+      {
+        ...bodyLayout,
+        pages: [
+          {
+            ...page,
+            fragments: [],
+            footnotes: {
+              kind: 'footnotes',
+              placement: 'pageBottom',
+              box: page.contentBox,
+              notes: [
+                {
+                  noteKind: 'footnote',
+                  noteId: 1,
+                  scopeId: 'footnote:1',
+                  mark: '1',
+                  box: page.contentBox,
+                  fragments,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ];
+    const table = fragments[0]!;
+    if (table.kind !== 'table') throw new Error('expected table');
+    const cell = table.rows[0]!.cells[0]!;
+    const point = { x: cell.box.x + cell.box.width / 2, y: cell.box.y + cell.box.height / 2 };
+    for (const storyLayout of storyLayouts) {
+      const hit = hitTestFragments(storyLayout, 0, fragments, point)!;
+      expect(isBottomToTopCaret(hit.caret)).toBe(true);
+      const stops = caretStopsForBlocks(storyLayout, 0, fragments);
+      expect(stops.length).toBeGreaterThan(1);
+      expect(stops.every(isBottomToTopCaret)).toBe(true);
+    }
   });
 
   test('column widths come from the grid when present', () => {

--- a/packages/core/src/layout/__tests__/table-float-position.test.ts
+++ b/packages/core/src/layout/__tests__/table-float-position.test.ts
@@ -1,10 +1,8 @@
 // `w:tblpPr` (17.4.57): a table positioned against an anchor box rather than at the point
 // in the text where it was authored.
 //
-// Word's floating table is also pulled out of the flow so text wraps beside it. That part
-// is not modelled — the table keeps its place in the flow and only its position within the
-// line of the page moves. A centred callout table therefore lands where Word draws it,
-// while the paragraphs around it still clear it top-to-bottom.
+// A page- or margin-relative table is a sheet object anchored logically to the next regular
+// paragraph. A text-relative table remains in body flow.
 
 import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
@@ -15,8 +13,18 @@ import {
   type OoxmlPart,
 } from '../../store/package/ooxml-tree.ts';
 import { readTableStructure, tableFloatOriginX } from '../semantic-table.ts';
+import {
+  bodyTableVerticalAnchorFrames,
+  isOutOfFlowTableFragment,
+  tableFloatOriginY,
+} from '../table-float-position.ts';
+import { createLayoutSession } from '../layout-session.ts';
 import { createFixedMeasurer, layoutSemanticDocument } from '../semantic-layout.ts';
-import type { TableFragmentRecord } from '../semantic-records.ts';
+import type {
+  ParagraphFragmentRecord,
+  SemanticLayout,
+  TableFragmentRecord,
+} from '../semantic-records.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
@@ -44,6 +52,11 @@ const FRAMES = {
   margin: { left: 0, width: CONTENT_WIDTH_PT },
   page: { left: -72, width: 612 },
 } as const;
+const VERTICAL_FRAMES = {
+  text: { top: 20, height: 628 },
+  margin: { top: 0, height: 648 },
+  page: { top: -72, height: 792 },
+} as const;
 
 const cell = () => `<w:tc><w:p><w:r><w:t>x</w:t></w:r></w:p></w:tc>`;
 /** 144pt wide, leaving 324pt of slack in the text column. */
@@ -53,16 +66,32 @@ const TABLE_WIDTH_PT = 144;
 const structureOf = (bodyXml: string, depth = 0) =>
   readTableStructure(tableNode(bodyXml), CONTENT_WIDTH_PT, depth)!;
 
-const floatingTable = (tblpPr: string) =>
-  `<w:tbl><w:tblPr>${tblpPr}<w:tblW w:type="dxa" w:w="2880"/></w:tblPr>${narrow}</w:tbl>`;
+const floatingTable = (tblpPr: string, rows = narrow) =>
+  `<w:tbl><w:tblPr>${tblpPr}<w:tblW w:type="dxa" w:w="2880"/></w:tblPr>${rows}</w:tbl>`;
+
+const layoutOf = (bodyXml: string): SemanticLayout =>
+  layoutSemanticDocument(documentOf(bodyXml), 0, { measurer: createFixedMeasurer() });
 
 function firstTable(bodyXml: string): TableFragmentRecord {
-  const fragment = layoutSemanticDocument(documentOf(bodyXml), 0, {
-    measurer: createFixedMeasurer(),
-  })
+  const fragment = layoutOf(bodyXml)
     .pages.flatMap((page) => page.fragments)
     .find((item): item is TableFragmentRecord => item.kind === 'table');
   if (!fragment) throw new Error('no table fragment');
+  return fragment;
+}
+
+function paragraphNamed(layout: SemanticLayout, text: string): ParagraphFragmentRecord {
+  const fragment = layout.pages
+    .flatMap((page) => page.fragments)
+    .find(
+      (item): item is ParagraphFragmentRecord =>
+        item.kind === 'paragraph' &&
+        item.lines
+          .flatMap((line) => line.spans.map((span) => span.text))
+          .join('')
+          .includes(text)
+    );
+  if (!fragment) throw new Error(`no paragraph containing ${text}`);
   return fragment;
 }
 
@@ -131,6 +160,41 @@ describe('tableFloatOriginX places the table against its anchor', () => {
   });
 });
 
+describe('tableFloatOriginY places the table against its anchor', () => {
+  const originOf = (tblpPr: string, tableHeightPt = 100) => {
+    const structure = structureOf(floatingTable(tblpPr));
+    return tableFloatOriginY(structure.float!, tableHeightPt, VERTICAL_FRAMES);
+  };
+
+  test('tblpY is measured from the physical sheet for a page anchor', () => {
+    expect(originOf('<w:tblpPr w:vertAnchor="page" w:tblpY="1700"/>')).toBe(13);
+  });
+
+  test('tblpY is measured from the body margin for a margin anchor', () => {
+    expect(originOf('<w:tblpPr w:vertAnchor="margin" w:tblpY="200"/>')).toBe(10);
+  });
+
+  test('tblpYSpec supersedes tblpY and uses the resolved table height', () => {
+    expect(originOf('<w:tblpPr w:vertAnchor="margin" w:tblpYSpec="bottom" w:tblpY="200"/>')).toBe(
+      548
+    );
+  });
+
+  test('the margin frame ignores transient note reserves and follows authored margins', () => {
+    const frames = bodyTableVerticalAnchorFrames(
+      {
+        pageHeight: 792,
+        contentInsetTop: 130,
+        contentHeight: 400,
+        marginBottom: 72,
+      },
+      20,
+      72
+    );
+    expect(frames.margin).toEqual({ top: -58, height: 648 });
+  });
+});
+
 describe('a floated table lays out at its anchored position', () => {
   const paragraph = '<w:p><w:r><w:t>lead</w:t></w:r></w:p>';
 
@@ -186,11 +250,250 @@ describe('a floated table lays out at its anchored position', () => {
     expect(table.box.x).toBeGreaterThan(1);
   });
 
-  test('a page-anchored tblpY is not applied — the table stays in flow', () => {
-    const inFlow = firstTable(paragraph + floatingTable('')).box.y;
-    const floated = firstTable(
-      paragraph + floatingTable('<w:tblpPr w:vertAnchor="page" w:tblpY="2880"/>')
-    ).box.y;
-    expect(floated).toBeCloseTo(inFlow, 3);
+  test('a page-anchored tblpY pins the table without advancing body flow', () => {
+    const tail = '<w:p><w:r><w:t>tail</w:t></w:r></w:p>';
+    const bare = layoutOf(paragraph + tail);
+    const positioned = layoutOf(
+      paragraph + floatingTable('<w:tblpPr w:vertAnchor="page" w:tblpY="2880"/>') + tail
+    );
+    const table = positioned.pages[0]!.fragments.find(
+      (fragment): fragment is TableFragmentRecord => fragment.kind === 'table'
+    )!;
+    expect(table.box.y).toBeCloseTo(72, 3);
+    expect(isOutOfFlowTableFragment(table)).toBe(true);
+    expect(paragraphNamed(positioned, 'tail').box.y).toBeCloseTo(
+      paragraphNamed(bare, 'tail').box.y,
+      3
+    );
+  });
+
+  test('tblpYSpec="inline" keeps a page-anchored table in body flow', () => {
+    const tail = '<w:p><w:r><w:t>inline tail</w:t></w:r></w:p>';
+    const bare = layoutOf(paragraph + tail);
+    const layout = layoutOf(
+      paragraph + floatingTable('<w:tblpPr w:vertAnchor="page" w:tblpYSpec="inline"/>') + tail
+    );
+    const table = firstTable(
+      paragraph + floatingTable('<w:tblpPr w:vertAnchor="page" w:tblpYSpec="inline"/>') + tail
+    );
+    expect(isOutOfFlowTableFragment(table)).toBe(false);
+    expect(paragraphNamed(layout, 'inline tail').box.y).toBeGreaterThan(
+      paragraphNamed(bare, 'inline tail').box.y
+    );
+  });
+
+  test('a page break on the logical anchor carries the table to that paragraph sheet', () => {
+    const anchor =
+      '<w:p><w:pPr><w:pageBreakBefore/></w:pPr><w:r><w:t>sheet anchor</w:t></w:r></w:p>';
+    const layout = layoutOf(
+      paragraph + floatingTable('<w:tblpPr w:vertAnchor="page" w:tblpY="1440"/>') + anchor
+    );
+    const tablePage = layout.pages.findIndex((page) =>
+      page.fragments.some((fragment) => fragment.kind === 'table')
+    );
+    const anchorPage = layout.pages.findIndex((page) =>
+      page.fragments.some(
+        (fragment) =>
+          fragment.kind === 'paragraph' &&
+          fragment.paragraphId === paragraphNamed(layout, 'sheet anchor').paragraphId
+      )
+    );
+    expect(tablePage).toBe(1);
+    expect(tablePage).toBe(anchorPage);
+  });
+
+  test('a logical anchor that does not fit the remaining body band carries its table', () => {
+    const lines = Array.from(
+      { length: 52 },
+      (_, index) => `<w:r><w:t>${index}</w:t><w:br/></w:r>`
+    ).join('');
+    const anchor =
+      '<w:p><w:pPr><w:spacing w:before="480"/></w:pPr><w:r><w:t>full-page anchor</w:t></w:r></w:p>';
+    const layout = layoutOf(
+      `<w:p>${lines}</w:p>` +
+        floatingTable('<w:tblpPr w:vertAnchor="page" w:tblpY="1440"/>') +
+        anchor
+    );
+    const pageOf = (kind: 'table' | 'paragraph') =>
+      layout.pages.findIndex((page) =>
+        page.fragments.some(
+          (fragment) =>
+            fragment.kind === kind &&
+            (kind === 'table' ||
+              (fragment.kind === 'paragraph' &&
+                fragment.paragraphId === paragraphNamed(layout, 'full-page anchor').paragraphId))
+        )
+      );
+    expect(pageOf('table')).toBe(1);
+    expect(pageOf('table')).toBe(pageOf('paragraph'));
+  });
+
+  test('consecutive sheet-positioned tables share the next regular paragraph sheet', () => {
+    const anchor =
+      '<w:p><w:pPr><w:pageBreakBefore/></w:pPr><w:r><w:t>shared anchor</w:t></w:r></w:p>';
+    const layout = layoutOf(
+      paragraph +
+        floatingTable('<w:tblpPr w:vertAnchor="page" w:tblpY="1440"/>') +
+        floatingTable('<w:tblpPr w:vertAnchor="page" w:tblpY="2880"/>') +
+        anchor
+    );
+    expect(layout.pages[0]!.fragments.filter((fragment) => fragment.kind === 'table')).toHaveLength(
+      0
+    );
+    expect(layout.pages[1]!.fragments.filter((fragment) => fragment.kind === 'table')).toHaveLength(
+      2
+    );
+  });
+
+  test('a framed paragraph is not the table logical anchor', () => {
+    const framed = '<w:p><w:pPr><w:framePr/></w:pPr><w:r><w:t>frame text</w:t></w:r></w:p>';
+    const anchor =
+      '<w:p><w:pPr><w:pageBreakBefore/></w:pPr><w:r><w:t>regular anchor</w:t></w:r></w:p>';
+    const layout = layoutOf(
+      paragraph + floatingTable('<w:tblpPr w:vertAnchor="page" w:tblpY="1440"/>') + framed + anchor
+    );
+    expect(layout.pages[0]!.fragments.some((fragment) => fragment.kind === 'table')).toBe(false);
+    expect(layout.pages[1]!.fragments.some((fragment) => fragment.kind === 'table')).toBe(true);
+  });
+
+  test('a continuous section boundary keeps its logical table on the shared sheet', () => {
+    const sectionMark =
+      '<w:p><w:pPr><w:sectPr><w:type w:val="continuous"/></w:sectPr></w:pPr></w:p>';
+    const tail = '<w:p><w:r><w:t>continuous tail</w:t></w:r></w:p>';
+    const end = '<w:sectPr><w:type w:val="continuous"/></w:sectPr>';
+    const bare = layoutOf(paragraph + sectionMark + tail + end);
+    const layout = layoutOf(
+      paragraph +
+        floatingTable('<w:tblpPr w:vertAnchor="page" w:tblpY="1440"/>') +
+        sectionMark +
+        tail +
+        end
+    );
+    expect(layout.pages).toHaveLength(1);
+    expect(layout.pages[0]!.fragments.some((fragment) => fragment.kind === 'table')).toBe(true);
+    expect(paragraphNamed(layout, 'continuous tail').box.y).toBeCloseTo(
+      paragraphNamed(bare, 'continuous tail').box.y,
+      3
+    );
+  });
+
+  test('a terminal suppressed anchor still opens its resolved sheet for the table', () => {
+    const source = documentOf(
+      paragraph +
+        floatingTable('<w:tblpPr w:vertAnchor="page" w:tblpY="1440"/>') +
+        '<w:p><w:pPr><w:pageBreakBefore/></w:pPr></w:p>'
+    );
+    const anchor = source.root.children
+      .flatMap((node) => (node.kind === 'textValue' ? [] : node.children))
+      .find((node) => node.kind === 'paragraph')!;
+    const layout = layoutSemanticDocument(source, 0, {
+      measurer: createFixedMeasurer(),
+      tocFieldChromeParagraphIds: new Set([anchor.id]),
+    });
+    expect(layout.pages).toHaveLength(2);
+    expect(layout.pages[1]!.fragments.some((fragment) => fragment.kind === 'table')).toBe(true);
+  });
+
+  test('bottom margin alignment is stable when footnotes reserve body flow', () => {
+    const body =
+      floatingTable('<w:tblpPr w:vertAnchor="margin" w:tblpYSpec="bottom"/>') +
+      '<w:p><w:r><w:t>margin anchor</w:t></w:r></w:p>';
+    const normal = layoutOf(body);
+    const reserved = layoutSemanticDocument(documentOf(body), 0, {
+      measurer: createFixedMeasurer(),
+      pageBottomReserves: new Map([[0, 180]]),
+    });
+    const tableY = (layout: SemanticLayout) =>
+      layout.pages[0]!.fragments.find(
+        (fragment): fragment is TableFragmentRecord => fragment.kind === 'table'
+      )!.box.y;
+    expect(tableY(reserved)).toBeCloseTo(tableY(normal), 3);
+  });
+
+  test('incremental convergence cannot reuse stale deferred table content', () => {
+    const table = (text: string) =>
+      floatingTable(
+        '<w:tblpPr w:vertAnchor="page" w:tblpY="1440"/>',
+        narrow.replaceAll('>x<', `>${text}<`)
+      );
+    const tail =
+      '<w:p><w:r><w:t>logical anchor</w:t></w:r></w:p><w:p><w:r><w:t>unchanged tail</w:t></w:r></w:p>';
+    const session = createLayoutSession();
+    layoutSemanticDocument(documentOf(table('old') + tail), 0, {
+      measurer: createFixedMeasurer(),
+      session,
+    });
+    const warm = layoutSemanticDocument(documentOf(table('new') + tail), 1, {
+      measurer: createFixedMeasurer(),
+      session,
+    });
+    const cold = layoutSemanticDocument(documentOf(table('new') + tail), 1, {
+      measurer: createFixedMeasurer(),
+    });
+    const tableText = (layout: SemanticLayout) =>
+      layout.pages
+        .flatMap((page) => page.fragments)
+        .filter((fragment): fragment is TableFragmentRecord => fragment.kind === 'table')
+        .flatMap((fragment) => fragment.rows)
+        .flatMap((row) => row.cells)
+        .flatMap((cellRecord) => cellRecord.blocks)
+        .flatMap((block) => (block.kind === 'paragraph' ? block.lines : []))
+        .flatMap((line) => line.spans)
+        .map((span) => span.text)
+        .join('');
+    expect(tableText(warm)).toBe('newnew');
+    expect(tableText(warm)).toBe(tableText(cold));
+  });
+
+  test('incremental deletion cannot resurrect a deferred table from the reused tail', () => {
+    const anchor =
+      '<w:p><w:r><w:t>stable anchor</w:t></w:r></w:p><w:p><w:r><w:t>stable tail</w:t></w:r></w:p>';
+    const oldPart = documentOf(
+      floatingTable('<w:tblpPr w:vertAnchor="page" w:tblpY="1440"/>') + anchor
+    );
+    const body = oldPart.root.children.find(
+      (node): node is OoxmlElement =>
+        node.kind !== 'textValue' && node.children.some((child) => child.kind === 'table')
+    )!;
+    const newBody = Object.freeze({
+      ...body,
+      children: body.children.filter((node) => node.kind !== 'table'),
+    }) as OoxmlElement;
+    const newPart = Object.freeze({
+      ...oldPart,
+      root: Object.freeze({
+        ...oldPart.root,
+        children: oldPart.root.children.map((node) => (node === body ? newBody : node)),
+      }) as OoxmlElement,
+    });
+    const session = createLayoutSession();
+    layoutSemanticDocument(oldPart, 0, { measurer: createFixedMeasurer(), session });
+    const warm = layoutSemanticDocument(newPart, 1, { measurer: createFixedMeasurer(), session });
+    const cold = layoutSemanticDocument(newPart, 1, { measurer: createFixedMeasurer() });
+    const tableCount = (layout: SemanticLayout) =>
+      layout.pages.flatMap((page) => page.fragments).filter((item) => item.kind === 'table').length;
+    expect(tableCount(warm)).toBe(0);
+    expect(tableCount(warm)).toBe(tableCount(cold));
+  });
+
+  test('the issue fixture shape stays on page one and leaves the title at the flow start', () => {
+    const exactRow = narrow.replace(
+      '<w:tr>',
+      '<w:tr><w:trPr><w:trHeight w:val="10771" w:hRule="exact"/></w:trPr>'
+    );
+    const title = '<w:p><w:r><w:t>exam title</w:t></w:r></w:p>';
+    const layout = layoutOf(
+      floatingTable(
+        '<w:tblpPr w:tblpX="340" w:tblpY="1700" w:horzAnchor="page" w:vertAnchor="page"/>',
+        exactRow
+      ) + title
+    );
+    const table = layout.pages[0]!.fragments.find(
+      (fragment): fragment is TableFragmentRecord => fragment.kind === 'table'
+    )!;
+    expect(layout.pages).toHaveLength(1);
+    expect(table.box.y).toBeCloseTo(13, 3);
+    expect(table.box.height).toBeCloseTo(538.55, 2);
+    expect(paragraphNamed(layout, 'exam title').box.y).toBeCloseTo(0, 3);
   });
 });

--- a/packages/core/src/layout/body-flow-helpers.ts
+++ b/packages/core/src/layout/body-flow-helpers.ts
@@ -1,0 +1,82 @@
+// Small body-flow policies extracted from the story loop.
+
+import type { OoxmlElement } from '@docx-editor.dev/core/store';
+import {
+  anchoredDrawingAtomsInParagraph,
+  type DrawingAnchorFrameContext,
+} from './drawing-layout.ts';
+import type { InlineDrawingLayoutContext } from './drawing-layout.ts';
+import type { PendingLine } from './paragraph-flow.ts';
+import type { ParagraphBorders } from './paragraph-style.ts';
+
+type BodyAnchorFrameBase = Omit<
+  DrawingAnchorFrameContext,
+  'paragraphBox' | 'anchorLineBox' | 'anchorCharacterX' | 'columnBox' | 'cellBox' | 'layoutInCell'
+>;
+
+interface BodyAnchorFrameInput {
+  readonly pageNumber: number;
+  readonly onPageParityRead: () => void;
+  readonly geometry: {
+    readonly width: number;
+    readonly height: number;
+    readonly margin: { readonly left: number; readonly right: number; readonly bottom: number };
+  };
+  readonly insets: { readonly top: number; readonly bottom: number; readonly height: number };
+  readonly contentWidth: number;
+  readonly contentHeight: number;
+  readonly ownerPartName: string;
+}
+
+/** Build the drawing/table anchor facts for the current body sheet. */
+export function bodyAnchorFrameBase(input: BodyAnchorFrameInput): BodyAnchorFrameBase {
+  const { geometry, insets } = input;
+  return Object.freeze({
+    pageNumber: input.pageNumber,
+    onPageParityRead: input.onPageParityRead,
+    pageWidth: geometry.width,
+    pageHeight: geometry.height,
+    marginLeft: geometry.margin.left,
+    marginRight: geometry.margin.right,
+    marginBottom: geometry.margin.bottom,
+    // Effective insets keep page-relative anchors stable when tall furniture moves body text.
+    contentInsetTop: insets.top,
+    contentInsetBottom: insets.bottom,
+    contentWidth: input.contentWidth,
+    contentHeight: input.contentHeight,
+    contentBandHeight: insets.height,
+    ownerPartName: input.ownerPartName,
+    storyKind: 'body',
+  });
+}
+
+interface PaintableParagraph {
+  readonly paragraph: OoxmlElement;
+  readonly listItem?: unknown;
+  readonly shading: string | undefined;
+  readonly borders: ParagraphBorders;
+}
+
+/** Whether a section-mark paragraph contributes no visible sheet content. */
+export function paragraphPaintsNothing(
+  entry: PaintableParagraph,
+  lines: readonly PendingLine[],
+  drawingContext: InlineDrawingLayoutContext | undefined
+): boolean {
+  if (entry.listItem !== undefined || entry.shading !== undefined) return false;
+  const { top, bottom, left, right, between } = entry.borders;
+  if (top ?? bottom ?? left ?? right ?? between) return false;
+  if (
+    drawingContext &&
+    anchoredDrawingAtomsInParagraph(entry.paragraph, drawingContext).length > 0
+  ) {
+    return false;
+  }
+  return lines.every(
+    (line) =>
+      line.drawings.length === 0 &&
+      !line.pageBreakAfter &&
+      !line.columnBreakAfter &&
+      line.spans.every((span) => span.text.length === 0)
+  );
+}

--- a/packages/core/src/layout/drawing-layout.ts
+++ b/packages/core/src/layout/drawing-layout.ts
@@ -1201,7 +1201,6 @@ export function columnBoxForSection(options: {
     height: options.paragraphHeight,
   });
 }
-
 export function shiftAnchoredDrawingRecords(
   drawings: AnchoredDrawingRecord[],
   paragraphId: string,
@@ -1211,6 +1210,7 @@ export function shiftAnchoredDrawingRecords(
   for (let index = 0; index < drawings.length; index += 1) {
     const drawing = drawings[index]!;
     if (drawing.anchorParagraphId !== paragraphId) continue;
+    if (!drawing.layoutInCell && !['paragraph', 'line'].includes(drawing.verticalFrame)) continue;
     drawings[index] = Object.freeze({
       ...drawing,
       y: drawing.y + dy,

--- a/packages/core/src/layout/field-page-furniture.ts
+++ b/packages/core/src/layout/field-page-furniture.ts
@@ -23,6 +23,7 @@ import type {
   SemanticLayout,
   StyleSpanRecord,
 } from './semantic-records.ts';
+import { isOutOfFlowTableFragment } from './table-float-position.ts';
 
 /**
  * Placeholder a body PAGE/NUMPAGES/SECTIONPAGES atom paints during measurement.
@@ -289,7 +290,9 @@ export function summarizeFlushedPage(
   let usedBottom = regionTop;
   let hasBodyPageFields = false;
   for (const fragment of fragments) {
-    usedBottom = Math.max(usedBottom, fragment.box.y + fragment.box.height);
+    if (!isOutOfFlowTableFragment(fragment)) {
+      usedBottom = Math.max(usedBottom, fragment.box.y + fragment.box.height);
+    }
     if (!hasBodyPageFields && blockHasBodyPageField(fragment)) hasBodyPageFields = true;
   }
   return { usedBottom, hasBodyPageFields };

--- a/packages/core/src/layout/flow-checkpoint-guards.ts
+++ b/packages/core/src/layout/flow-checkpoint-guards.ts
@@ -39,6 +39,8 @@ export const FLOW_CHECKPOINT_GUARDS = {
   // A flow that still owes the next page a drawing is not one that owes it nothing.
   deferredAnchoredDrawings: 'compared', // sameAnchoredDrawings
   anchorPageDeferCounts: 'compared', // sameDeferCounts
+  pendingPositionedTableTokens: 'compared',
+  positionedTableAnchorSignals: 'compared',
   cursorY: 'compared',
   lineCounter: 'restore-only',
   previousSpaceAfter: 'compared',

--- a/packages/core/src/layout/layout-session.ts
+++ b/packages/core/src/layout/layout-session.ts
@@ -5,6 +5,7 @@
 
 import type { AnchoredDrawingRecord } from './drawing-layout.ts';
 import type { PageRecord, SemanticLayout } from './semantic-records.ts';
+import type { PositionedTableAnchorSignal } from './table-float-position.ts';
 
 /** The flow state as it stood immediately before one block was placed. */
 export interface FlowCheckpoint {
@@ -25,6 +26,9 @@ export interface FlowCheckpoint {
    */
   readonly deferredAnchoredDrawings: readonly AnchoredDrawingRecord[];
   readonly anchorPageDeferCounts: ReadonlyMap<string, number>;
+  /** Sheet-positioned tables and zero-line anchors still owed by the open page. */
+  readonly pendingPositionedTableTokens?: readonly string[];
+  readonly positionedTableAnchorSignals?: readonly PositionedTableAnchorSignal[];
   readonly cursorY: number;
   readonly lineCounter: number;
   /** Trailing paragraph spacing participating in adjacent-spacing collapse. */

--- a/packages/core/src/layout/note-fragment-geometry.ts
+++ b/packages/core/src/layout/note-fragment-geometry.ts
@@ -7,6 +7,7 @@ import type {
   PageRecord,
   ParagraphFragmentRecord,
 } from './semantic-records.ts';
+import { isOutOfFlowTableFragment } from './table-float-position.ts';
 
 /** Translate one paragraph fragment (and every box inside it) by `dy`. */
 export function shiftParagraphFragment(
@@ -74,6 +75,7 @@ export function shiftFragments(
 export function fragmentFlowBottom(fragments: readonly BlockFragmentRecord[]): number {
   let bottom = 0;
   for (const fragment of fragments) {
+    if (isOutOfFlowTableFragment(fragment)) continue;
     bottom = Math.max(bottom, fragment.box.y + fragment.box.height);
   }
   return bottom;
@@ -100,6 +102,7 @@ export function bodyFitBottomPt(page: PageRecord): number {
 
 /** One fragment's fit-rule bottom — its box minus a paragraph's trailing after-spacing. */
 export function fragmentFitBottomPt(fragment: BlockFragmentRecord): number {
+  if (isOutOfFlowTableFragment(fragment)) return 0;
   const trailingAfter = fragment.kind === 'paragraph' ? fragment.spacing.after : 0;
   return fragment.box.y + fragment.box.height - trailingAfter;
 }
@@ -115,6 +118,7 @@ export function fragmentFitBottomPt(fragment: BlockFragmentRecord): number {
 export function firstBodyContentTopPt(page: PageRecord): number {
   let top = Number.POSITIVE_INFINITY;
   for (const fragment of page.fragments) {
+    if (isOutOfFlowTableFragment(fragment)) continue;
     const fragmentTop =
       fragment.kind === 'paragraph' ? (fragment.lines[0]?.box.y ?? fragment.box.y) : fragment.box.y;
     top = Math.min(top, fragmentTop);

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -1357,8 +1357,8 @@ export function breakParagraph(
           slotX,
           y: extentTopY,
           baseline: line.baseline,
-          contentLeft,
-          contentRight,
+          contentLeft: contentOriginX,
+          contentRight: contentOriginX + rightEdge,
           ...(piece.revisions ? { revisions: piece.revisions } : {}),
         })
       );

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -1138,7 +1138,7 @@ export function breakParagraph(
    * Height of the line's text band alone — the span an `auto` multiple scales.
    *
    * Recomputed from the spans rather than tracked alongside `line.height`, because it is only
-   * ever read on a line that also carries an inline drawing.
+   * read on a line that also carries a drawing or equation with its own physical extent.
    */
   const textBandHeight = (fallback: number): number => {
     let height = 0;
@@ -1208,20 +1208,17 @@ export function breakParagraph(
     // Line spacing applies to the finished box, once, so a paragraph's rule governs every
     // line it produced regardless of which run happened to be tallest.
     const naturalHeight = line.height;
-    // `w:lineRule="auto"` is a multiple of the TEXT line (17.3.1.33), not of whatever height
-    // an inline drawing gave the box. Word grows an image line to contain the image and stops
-    // there; scaling the image's own extent by the multiple leaves a band of dead space under
-    // it — a content-width picture under the 279/240 Word writes by default picks up most of
-    // an inch. `growLineHeightForDrawingExtent` below is what re-imposes the drawing as a
-    // floor, so a multiple tall enough to exceed the image still wins, and the baseline is
-    // left alone because it is already the drawing's bottom rather than a text baseline.
-    const scalesTextBandOnly = lineSpacing.rule === 'auto' && line.drawings.length > 0;
+    // `auto` scales the TEXT band, not a tall inline drawing or equation. The atom remains
+    // a floor, while a larger text multiple can still win (ECMA-376 17.3.1.33).
+    const hasUnscaledInlineExtent =
+      line.drawings.length > 0 || line.spans.some((span) => span.equation !== undefined);
+    const scalesTextBandOnly = lineSpacing.rule === 'auto' && hasUnscaledInlineExtent;
     const spacingBase = scalesTextBandOnly ? textBandHeight(metrics.height) : naturalHeight;
     const spaced = applyLineSpacing(lineSpacing, spacingBase, line.baseline);
     if (!scalesTextBandOnly) line.baseline = spaced.baseline;
     // Space ABOVE the glyph band only (exact centering, not auto/atLeast). Never negative.
     line.leading = Math.max(0, line.baseline - glyphBaseline);
-    line.height = spaced.height;
+    line.height = scalesTextBandOnly ? Math.max(spaced.height, naturalHeight) : spaced.height;
     // Baseline shifts from line spacing must move inline drawings too, or authored distT/distB
     // and the text baseline drift apart. For `exact`, keep the authored box — tall drawings
     // clip/overflow per content-clip policy; auto/atLeast still grow to contain distB.

--- a/packages/core/src/layout/selection-rects.ts
+++ b/packages/core/src/layout/selection-rects.ts
@@ -11,6 +11,7 @@ import type { BlockFragmentRecord, SemanticLayout, TextMeasurer } from './semant
 import { documentOrderIndex } from './document-order.ts';
 import { orderPositions } from './semantic-interaction.ts';
 import type { SemanticPosition, SemanticSelection, SelectionRect } from './semantic-interaction.ts';
+import { bottomToTopRectInLayout } from './table-cell-text-direction.ts';
 
 /**
  * The rectangles covering a selection, one per line it spans.
@@ -162,13 +163,15 @@ function rangeRects(
           );
           const startX = Math.min(...edges);
           const endX = Math.max(...edges);
-          rects.push({
-            pageIndex: page.index,
-            x: startX,
-            y: line.box.y,
-            width: endX - startX,
-            height: line.box.height,
-          });
+          rects.push(
+            bottomToTopRectInLayout(layout, segment.paragraphId, {
+              pageIndex: page.index,
+              x: startX,
+              y: line.box.y,
+              width: endX - startX,
+              height: line.box.height,
+            })
+          );
         }
       }
     }
@@ -219,13 +222,15 @@ export function keyedRangeRects(
             const startX = xWithinLine(line, overlap.start, measurer, segment);
             const endX = xWithinLine(line, overlap.end, measurer, segment);
             const rects = found.get(range.key) ?? [];
-            rects.push({
-              pageIndex: page.index,
-              x: Math.min(startX, endX),
-              y: line.box.y,
-              width: Math.abs(endX - startX),
-              height: line.box.height,
-            });
+            rects.push(
+              bottomToTopRectInLayout(layout, segment.paragraphId, {
+                pageIndex: page.index,
+                x: Math.min(startX, endX),
+                y: line.box.y,
+                width: Math.abs(endX - startX),
+                height: line.box.height,
+              })
+            );
             found.set(range.key, rects);
           }
       }

--- a/packages/core/src/layout/semantic-fragment-signature.ts
+++ b/packages/core/src/layout/semantic-fragment-signature.ts
@@ -8,6 +8,7 @@ import type {
   ParagraphFragmentRecord,
   TableFragmentRecord,
 } from './semantic-records.ts';
+import { isOutOfFlowTableFragment } from './table-float-position.ts';
 
 /**
  * What one field of a fragment record does in the signature.
@@ -121,7 +122,10 @@ export function fragmentSignature(fragment: BlockFragmentRecord): string {
   // values stay positionally aligned with the key list that produced them.
   const signature =
     fragment.kind === 'table'
-      ? JSON.stringify(TABLE_KEYS.map((key) => fragment[key]))
+      ? JSON.stringify([
+          isOutOfFlowTableFragment(fragment),
+          ...TABLE_KEYS.map((key) => fragment[key]),
+        ])
       : JSON.stringify(PARAGRAPH_KEYS.map((key) => fragment[key]));
   signatures.set(fragment, signature);
   return signature;

--- a/packages/core/src/layout/semantic-hit-test.ts
+++ b/packages/core/src/layout/semantic-hit-test.ts
@@ -42,6 +42,7 @@ import type {
 } from './semantic-records.ts';
 import type { InlineDrawingRecord, AnchoredDrawingRecord } from './drawing-layout.ts';
 import { pointInDrawingClip } from './drawing-wrap.ts';
+import { bottomToTopCaretInLayout, pointInBottomToTopCell } from './table-cell-text-direction.ts';
 
 /** A point in the coordinate space named by the function taking it. */
 export interface HitPoint {
@@ -130,6 +131,10 @@ interface HitContext {
   readonly pageIndex: number;
   readonly verticalWeight: number;
   readonly measurer: TextMeasurer | undefined;
+}
+
+function bottomToTopHit(layout: SemanticLayout, hit: SemanticHit | null): SemanticHit | null {
+  return hit ? { ...hit, caret: bottomToTopCaretInLayout(layout, hit.caret) } : null;
 }
 
 // ---------------------------------------------------------------------------------------
@@ -341,7 +346,7 @@ export function hitTestPage(
   const behindDrawings = (page.anchoredDrawings ?? []).filter((drawing) => drawing.behindDocument);
   const frontHit = hitAnchoredDrawingAtPoint(frontDrawings, point, context.pageIndex);
   if (frontHit) return { ...frontHit, contentControlId };
-  const textHit = resolveBlocks(page.fragments, point, context, null);
+  const textHit = bottomToTopHit(layout, resolveBlocks(page.fragments, point, context, null));
   if (textHit?.onGlyphs) return { ...textHit, contentControlId };
   const behindHit = hitAnchoredDrawingAtPoint(behindDrawings, point, context.pageIndex);
   if (behindHit) return { ...behindHit, contentControlId };
@@ -355,11 +360,9 @@ export function hitTestPage(
     for (const index of [pageIndex - distance, pageIndex + distance]) {
       const neighbour = layout.pages[index];
       if (!neighbour) continue;
-      const found = resolveBlocks(
-        neighbour.fragments,
-        point,
-        { ...context, pageIndex: neighbour.index },
-        null
+      const found = bottomToTopHit(
+        layout,
+        resolveBlocks(neighbour.fragments, point, { ...context, pageIndex: neighbour.index }, null)
       );
       if (found) {
         return {
@@ -393,7 +396,7 @@ export function hitTestFragments(
     verticalWeight: options.verticalWeight ?? DEFAULT_VERTICAL_WEIGHT,
     measurer: options.measurer,
   };
-  return resolveBlocks(fragments, point, context, null);
+  return bottomToTopHit(layout, resolveBlocks(fragments, point, context, null));
 }
 
 /**
@@ -1272,7 +1275,9 @@ function resolveTable(
     // the padding is outside every block box, so the nearest-block rule picks the block beside
     // it and the line clamp finishes the job — bottom padding lands at the end of the last
     // block.
-    const hit = resolveBlocks(cell.blocks, point, context, address);
+    const cellPoint =
+      cell.textDirection === 'btLr' ? pointInBottomToTopCell(point, cell.box) : point;
+    const hit = resolveBlocks(cell.blocks, cellPoint, context, address);
     if (hit) return hit;
   }
   // This fragment paints no text at all. The caller keeps looking.

--- a/packages/core/src/layout/semantic-interaction.ts
+++ b/packages/core/src/layout/semantic-interaction.ts
@@ -43,6 +43,7 @@ import {
 } from './paragraph-lines.ts';
 import { wordBoundary } from './semantic-word-navigation.ts';
 import { PAGE_BREAK_CHAR } from '../store/package/hard-break.ts';
+import { bottomToTopCaretInLayout } from './table-cell-text-direction.ts';
 
 export { wordBoundary } from './semantic-word-navigation.ts';
 export { positionPastDeletion } from './paragraph-lines.ts';
@@ -241,14 +242,16 @@ function pushSegmentCaretStops(
     // at invisible positions. Derived from the spans rather than from the mode, so the rule
     // holds in any mode that suppresses them.
     if (insideDeletedContent(deleted, offset) && !painted(offset)) continue;
-    stops.push({
-      position: { paragraphId: segment.paragraphId, offset },
-      x: xWithinLine(line, offset, measurer, segment),
-      y: line.box.y,
-      height: line.box.height,
-      lineId: line.id,
-      pageIndex,
-    });
+    stops.push(
+      bottomToTopCaretInLayout(layout, {
+        position: { paragraphId: segment.paragraphId, offset },
+        x: xWithinLine(line, offset, measurer, segment),
+        y: line.box.y,
+        height: line.box.height,
+        lineId: line.id,
+        pageIndex,
+      })
+    );
   }
 }
 
@@ -452,7 +455,14 @@ export function caretAt(
       continue;
     }
     const box = caretBoxOnLine(line, position.offset, options.measurer, segment);
-    return { position, x: box.x, y: box.y, height: box.height, lineId: line.id, pageIndex };
+    return bottomToTopCaretInLayout(layout, {
+      position,
+      x: box.x,
+      y: box.y,
+      height: box.height,
+      lineId: line.id,
+      pageIndex,
+    });
   }
   if (afterBreak) {
     const box = caretBoxOnLine(
@@ -461,14 +471,14 @@ export function caretAt(
       options.measurer,
       lineSegmentFor(afterBreak.line, position.paragraphId)
     );
-    return {
+    return bottomToTopCaretInLayout(layout, {
       position,
       x: box.x,
       y: box.y,
       height: box.height,
       lineId: afterBreak.line.id,
       pageIndex: afterBreak.pageIndex,
-    };
+    });
   }
   return null;
 }

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -99,6 +99,7 @@ import {
   anchoredDrawingAtomsInParagraph,
   pageClipRegion,
   shiftAnchoredDrawingRecords,
+  shiftInlineDrawingRecord,
   type AnchoredDrawingRecord,
 } from './drawing-layout.ts';
 import {
@@ -2729,27 +2730,15 @@ function layoutBlocksPass(
       const pageClip = Object.freeze({
         x: 0,
         y: 0,
-        width: contentWidth,
+        // Inline records are already placed in page-content coordinates. In a multi-column
+        // section `contentWidth` is only column zero; clipping to it erases later columns.
+        width: contentWidthForReflow,
         height: contentHeight(),
       });
       const placedDrawings = pendingLine.drawings.map((drawing) => {
         const placed = Object.freeze({
-          ...drawing,
+          ...shiftInlineDrawingRecord(drawing, columnX, cursorY),
           paragraphId,
-          x: columnX + drawing.x,
-          y: cursorY + drawing.y,
-          advanceStart: drawing.advanceStart + columnX,
-          advanceEnd: drawing.advanceEnd + columnX,
-          paintBounds: Object.freeze({
-            ...drawing.paintBounds,
-            x: columnX + drawing.paintBounds.x,
-            y: cursorY + drawing.paintBounds.y,
-          }),
-          hitBounds: Object.freeze({
-            ...drawing.hitBounds,
-            x: columnX + drawing.hitBounds.x,
-            y: cursorY + drawing.hitBounds.y,
-          }),
         });
         return clipInlineDrawingRecordToRegion(placed, pageClip);
       });

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -81,6 +81,8 @@ import {
 import { paragraphBorderGroupKey } from './cell-border-groups.ts';
 import { paragraphShadingBox } from './ooxml-shading.ts';
 import { type TableAnchorFrames } from './semantic-table.ts';
+import * as tableFloat from './table-float-position.ts';
+import { bodyAnchorFrameBase, paragraphPaintsNothing } from './body-flow-helpers.ts';
 import {
   createTableBorderOwnershipBudget,
   createTableVMergeResolveBudget,
@@ -98,7 +100,6 @@ import {
   pageClipRegion,
   shiftAnchoredDrawingRecords,
   type AnchoredDrawingRecord,
-  type DrawingAnchorFrameContext,
 } from './drawing-layout.ts';
 import {
   collectExclusionZonesByPage,
@@ -1465,24 +1466,32 @@ function layoutBlocksPass(
     };
   }
 
+  const positionedTables = tableFloat.positionedTableAnchors(
+    prepared,
+    contentWidth,
+    styleCascade,
+    displayMode,
+    authorFilter
+  );
+  const positionedTableIds = new Set(positionedTables.map(({ table }) => table.id));
+  const positionedFlow = tableFloat.positionedTableFlow(positionedTables, flowKeys);
   let pageFragments: BlockFragmentRecord[] = [];
   let columnIndex = 0;
   let regionFragmentStart = 0;
   const columnLeft = (): number => columns.lefts[columnIndex]!;
   const columnWidth = (): number => columns.widths[columnIndex]!;
-  /**
-   * The boxes `w:horzAnchor` can name, in the content-box coordinates every fragment box is
-   * reported in: x=0 is the left margin, so the sheet starts one left margin before it.
-   */
   const anchorFrames = (): TableAnchorFrames => ({
     text: { left: columnLeft(), width: columnWidth() },
     margin: { left: 0, width: contentWidthForReflow },
     page: { left: -geometry.margin.left, width: geometry.width },
   });
-  const regionHasFragments = (): boolean => pageFragments.length > regionFragmentStart;
+  const regionHasFragments = (): boolean =>
+    tableFloat.hasFlowFragments(pageFragments, regionFragmentStart);
   let pendingAnchoredDrawings: AnchoredDrawingRecord[] = [];
   let deferredAnchoredDrawings: AnchoredDrawingRecord[] = [];
   const anchorPageDeferCounts = new Map<string, number>();
+  const pendingFloatIds = new Set<string>();
+  const floatSignals: tableFloat.PositionedTableAnchorSignal[] = [];
   // A continuous section resumes the previous section's column rather than opening a
   // sheet, so its first block starts at that column's used height and its first paragraph
   // is NOT at a page top — page-top space-before suppression must not apply to it, and the
@@ -1504,6 +1513,7 @@ function layoutBlocksPass(
       deferredAnchoredDrawings.length > 0 ? [...deferredAnchoredDrawings] : NO_DEFERRED_DRAWINGS,
     anchorPageDeferCounts:
       anchorPageDeferCounts.size > 0 ? new Map(anchorPageDeferCounts) : NO_DEFER_COUNTS,
+    ...positionedFlow.checkpoint(pendingFloatIds, floatSignals),
     cursorY,
     lineCounter,
     previousSpaceAfter,
@@ -1531,6 +1541,7 @@ function layoutBlocksPass(
     columnIndex = checkpoint.flowColumnIndex;
     lineCounter = checkpoint.lineCounter;
     previousSpaceAfter = checkpoint.previousSpaceAfter;
+    positionedFlow.restore(checkpoint, pendingFloatIds, floatSignals);
     startIndex = firstChanged;
     firstParagraphOfSection = false;
     reusedPages = pages.length;
@@ -1548,33 +1559,16 @@ function layoutBlocksPass(
       height: _paragraphBox.height,
     });
 
-  const anchorFrameBase = (): Omit<
-    DrawingAnchorFrameContext,
-    'paragraphBox' | 'anchorLineBox' | 'anchorCharacterX' | 'columnBox' | 'cellBox' | 'layoutInCell'
-  > => {
-    const insets = insetsFor(pages.length);
-    return Object.freeze({
+  const anchorFrameBase = () =>
+    bodyAnchorFrameBase({
       pageNumber: pageIndexStart + pages.length + 1,
       onPageParityRead: markPageParityRead,
-      pageWidth: geometry.width,
-      pageHeight: geometry.height,
-      marginLeft: geometry.margin.left,
-      marginRight: geometry.margin.right,
-      marginBottom: geometry.margin.bottom,
-      // THE INSETS, NOT `w:pgMar`. The page content box starts at this page's own top inset,
-      // which a header taller than the top margin pushes past `w:pgMar`, and paint places every
-      // anchored drawing relative to that box. Handing the authored margin here made a
-      // `relativeFrom="page"` anchor land `inset − margin.top` too low — the whole header
-      // height for a `w:posOffset` of 0 (#274).
-      contentInsetTop: insets.top,
-      contentInsetBottom: insets.bottom,
+      geometry,
+      insets: insetsFor(pages.length),
       contentWidth,
       contentHeight: contentHeight(),
-      contentBandHeight: insets.height,
       ownerPartName: options.inlineDrawingLayout?.ownerPartName ?? WML_MAIN_DOCUMENT_PART,
-      storyKind: 'body',
     });
-  };
 
   const pageContentClip = (): LayoutBox => pageClipRegion(anchorFrameBase());
 
@@ -1624,7 +1618,9 @@ function layoutBlocksPass(
     collectAnchoredDrawings(carried);
   };
 
+  let publishPositionedTablesForPage = (): void => undefined;
   const flushPage = (): void => {
+    publishPositionedTablesForPage();
     const index = pages.length;
     const box = pageBox(index);
     const header = furnitureFor('header', index, box);
@@ -1668,33 +1664,8 @@ function layoutBlocksPass(
     regionFragmentStart = 0;
   };
 
-  /**
-   * Whether a laid-out paragraph would put nothing on the sheet.
-   *
-   * Asked of a section break mark before letting it skip pagination, so the exemption covers
-   * only a mark with nothing to show: any glyph, marker, drawing, rule or shading makes the
-   * paragraph content, and content paginates.
-   */
-  const paintsNothing = (entry: PreparedBlock, lines: readonly PendingLine[]): boolean => {
-    if (entry.kind !== 'paragraph') return false;
-    if (entry.listItem !== undefined || entry.shading !== undefined) return false;
-    const { top, bottom, left, right, between } = entry.borders;
-    if (top ?? bottom ?? left ?? right ?? between) return false;
-    const drawingContext = options.inlineDrawingLayout;
-    if (
-      drawingContext &&
-      anchoredDrawingAtomsInParagraph(entry.paragraph, drawingContext).length > 0
-    ) {
-      return false;
-    }
-    return lines.every(
-      (line) =>
-        line.drawings.length === 0 &&
-        !line.pageBreakAfter &&
-        !line.columnBreakAfter &&
-        line.spans.every((span) => span.text.length === 0)
-    );
-  };
+  const paintsNothing = (entry: PreparedBlock, lines: readonly PendingLine[]): boolean =>
+    entry.kind === 'paragraph' && paragraphPaintsNothing(entry, lines, options.inlineDrawingLayout);
 
   const advanceColumn = (): void => {
     if (columnIndex + 1 < columns.count) {
@@ -2021,10 +1992,8 @@ function layoutBlocksPass(
     return live > 0.001 ? live : breakSkip;
   };
 
-  const layoutTableInFlow = (table: OoxmlElement): void => {
-    // The paginator owns the cursor while it runs. `advanceColumn` is the one call that
-    // hands it back — it belongs to the story flow and moves the cursor itself — so the
-    // adapter syncs across it in both directions rather than letting the two drift.
+  const layoutTableInFlow = (table: OoxmlElement): boolean => {
+    // The paginator owns the cursor. The adapter syncs it around each story-flow advance.
     const flow: TableFlowCursor = {
       cursorY,
       columnWidth,
@@ -2037,6 +2006,8 @@ function layoutBlocksPass(
         flow.cursorY = cursorY;
       },
       anchorFrames,
+      verticalAnchorFrames: () =>
+        tableFloat.bodyTableVerticalAnchorFrames(anchorFrameBase(), cursorY, geometry.margin.top),
       styleCascade,
       displayMode,
       ...(authorFilter ? { revisionAuthorFilter: authorFilter } : {}),
@@ -2047,10 +2018,33 @@ function layoutBlocksPass(
       // taken when the table started would collect its later fragments into a dead array.
       publishFragment: (fragment) => pageFragments.push(fragment),
     };
-    paginateTableInFlow(table, flow);
+    const result = paginateTableInFlow(table, flow);
     cursorY = flow.cursorY;
+    return result.outOfFlow;
   };
 
+  publishPositionedTablesForPage = (): void =>
+    tableFloat.publishPositionedTablesOnPage(
+      positionedTables,
+      pendingFloatIds,
+      pageFragments,
+      floatSignals,
+      (table, anchorColumn) => {
+        const savedColumn = columnIndex;
+        const savedFlowColumn = flowColumnIndex;
+        columnIndex = anchorColumn;
+        flowColumnIndex = anchorColumn;
+        collectingCellBreakKeys = [];
+        try {
+          layoutTableInFlow(table);
+          registerTableCellBreakKeys(table, collectingCellBreakKeys);
+        } finally {
+          collectingCellBreakKeys = null;
+          columnIndex = savedColumn;
+          flowColumnIndex = savedFlowColumn;
+        }
+      }
+    );
   let converged = false;
   let convergedAt = prepared.length;
   /** Whole pages the convergence tail moved by; reused checkpoints shift with it. */
@@ -2081,7 +2075,13 @@ function layoutBlocksPass(
         sameAnchoredDrawings(mark.pendingAnchoredDrawings, pendingAnchoredDrawings) &&
         // A flow that still owes the next page a drawing is not one that owes it nothing.
         sameAnchoredDrawings(mark.deferredAnchoredDrawings, deferredAnchoredDrawings) &&
-        sameDeferCounts(mark.anchorPageDeferCounts, anchorPageDeferCounts)
+        sameDeferCounts(mark.anchorPageDeferCounts, anchorPageDeferCounts) &&
+        positionedFlow.same(
+          mark.pendingPositionedTableTokens,
+          mark.positionedTableAnchorSignals,
+          pendingFloatIds,
+          floatSignals
+        )
       ) {
         // The in-page flow matches. At delta 0 the previous pages are appended by identity;
         // at a nonzero delta the tail is identical content `delta` sheets away and is reused
@@ -2124,10 +2124,14 @@ function layoutBlocksPass(
     placed += 1;
 
     if (entry.kind === 'table') {
-      previousSpaceAfter = 0;
+      if (positionedTableIds.has(entry.table.id)) {
+        pendingFloatIds.add(entry.table.id);
+        continue;
+      }
       collectingCellBreakKeys = [];
       try {
-        layoutTableInFlow(entry.table);
+        const outOfFlow = layoutTableInFlow(entry.table);
+        if (!outOfFlow) previousSpaceAfter = 0;
         registerTableCellBreakKeys(entry.table, collectingCellBreakKeys);
       } finally {
         collectingCellBreakKeys = null;
@@ -2194,21 +2198,11 @@ function layoutBlocksPass(
 
     let lines = breakBlock(entry, index);
     if (lines.length === 0) {
-      // Cross-paragraph TOC field chrome: tree preserved, no painted row or flow height.
+      positionedFlow.note(floatSignals, paragraph.id, flowColumnIndex, pageFragments.length);
       continue;
     }
-    // A SECTION BREAK IS NOT CONTENT. The paragraph mark that carries a paragraph-level
-    // `w:sectPr` (ECMA-376 §17.6.18) IS the section break; `w:type` (§17.6.22) says where the
-    // NEXT section starts, never that the mark itself claims a sheet. So a mark that paints
-    // nothing may not OPEN A SHEET: it rides out the bottom of the page its section already
-    // ended on. Without this a mark missing the bottom margin by a point flushed a sheet, the
-    // following `nextPage` section started after it, and the document rendered a wholly blank
-    // page between two sections Word sets adjacent.
-    //
-    // Only the sheet. Moving into the next COLUMN of the same sheet manufactures nothing, and
-    // the mark is part of what a balanced multi-column section distributes (§17.6.4) — so a
-    // balance trial, which asks how short the region can be while still holding one sheet,
-    // has to see the mark's own demand for room or it converges on a band too tight for it.
+    // A blank paragraph-level `w:sectPr` is the section break, not content. It cannot open a
+    // sheet merely because its line misses the bottom; the next section's break owns that.
     const marksSectionBreak =
       paragraphSectionNode(paragraph) !== undefined && paintsNothing(entry, lines);
     const holdsSheet = (): boolean =>
@@ -2454,6 +2448,9 @@ function layoutBlocksPass(
       const marker = rawMarker
         ? { ...rawMarker, box: { ...rawMarker.box, x: rawMarker.box.x + regionX } }
         : undefined;
+      if (fragmentIndex === 0) {
+        positionedFlow.note(floatSignals, paragraphId, flowColumnIndex, pageFragments.length);
+      }
       pageFragments.push({
         kind: 'paragraph',
         id: `${paragraphId}#f${fragmentIndex}`,
@@ -2823,7 +2820,8 @@ function layoutBlocksPass(
   // The terminal flush closes the page the flow was still filling. When it does NOT run,
   // the last page was already closed by a page break and the cursor sits at the top of a
   // sheet that was never opened — nothing may be appended to what is in `pages`.
-  const flushesOpenPage = !converged && (pageFragments.length > 0 || pages.length === 0);
+  const flushesOpenPage =
+    !converged && (pageFragments.length > 0 || floatSignals.length > 0 || pages.length === 0);
   const endsOpenPage = converged && session ? session.endsOpenPage : flushesOpenPage;
 
   if (flushesOpenPage) flushPage();
@@ -2924,6 +2922,7 @@ function columnBottomsOf(
 ): number[] {
   const bottoms = columns.lefts.map(() => regionTop);
   for (const fragment of page.fragments) {
+    if (tableFloat.isOutOfFlowTableFragment(fragment)) continue;
     let column = 0;
     // A fragment starts at its column's left edge plus indents; assign it to the LAST
     // column whose origin it does not precede (half-point slack for table indents).

--- a/packages/core/src/layout/semantic-records.ts
+++ b/packages/core/src/layout/semantic-records.ts
@@ -571,6 +571,8 @@ export interface TableCellFragmentRecord {
   readonly rowSpan?: number;
   /** Validated 6-hex cell shading fill, absent for none/auto. */
   readonly shading?: string;
+  /** Bottom-to-top cell content uses a rotated local inline axis. */
+  readonly textDirection?: 'btLr';
   /**
    * Layout-owned resolved borders after collapsed conflict resolution.
    *

--- a/packages/core/src/layout/semantic-table-layout.ts
+++ b/packages/core/src/layout/semantic-table-layout.ts
@@ -22,6 +22,7 @@ import type { OoxmlElement, OoxmlNode } from '@docx-editor.dev/core/store';
 import {
   clipInlineDrawingRecordToRegion,
   publishAnchoredDrawingsForParagraph,
+  shiftInlineDrawingRecord,
   type AnchoredDrawingRecord,
   type DrawingAnchorFrameContext,
 } from './drawing-layout.ts';
@@ -103,6 +104,7 @@ import { borderExtentPt, type TableBorderOwnershipBudget } from './table-borders
 import { type TableVMergeResolveBudget } from './table-vmerge.ts';
 import { acceptVMergeSpansAt, planTableVMergeHeights } from './table-vmerge-heights.ts';
 import { contentInsets } from './table-cell-geometry.ts';
+import { blockInlineRight } from './table-cell-text-direction.ts';
 import { finalizeTableRows, shiftBlocks } from './table-fragment-finalize.ts';
 export { finalizeTableRows } from './table-fragment-finalize.ts';
 export { rowWithSplitBorders } from './table-cell-geometry.ts';
@@ -686,22 +688,8 @@ function placeCellParagraph(
       pendingLine.drawings.map((drawing) =>
         clipInlineDrawingRecordToRegion(
           Object.freeze({
-            ...drawing,
+            ...shiftInlineDrawingRecord(drawing, originX, y),
             paragraphId,
-            x: originX + drawing.x,
-            advanceStart: originX + drawing.advanceStart,
-            advanceEnd: originX + drawing.advanceEnd,
-            y: y + drawing.y,
-            paintBounds: Object.freeze({
-              ...drawing.paintBounds,
-              x: originX + drawing.paintBounds.x,
-              y: y + drawing.paintBounds.y,
-            }),
-            hitBounds: Object.freeze({
-              ...drawing.hitBounds,
-              x: originX + drawing.hitBounds.x,
-              y: y + drawing.hitBounds.y,
-            }),
           }),
           cellClip
         )
@@ -1277,6 +1265,7 @@ export function layoutRowFragmentBounded(
     readonly blocks: readonly BlockFragmentRecord[];
     readonly contentTop: number;
     readonly contentBottom: number;
+    readonly physicalBottom: number;
     readonly insets: { top: number; right: number; bottom: number; left: number };
     readonly nextCursor: CellPlaceCursor;
     readonly complete: boolean;
@@ -1294,9 +1283,7 @@ export function layoutRowFragmentBounded(
 
   for (let cellIndex = 0; cellIndex < row.cells.length; cellIndex += 1) {
     const cell = row.cells[cellIndex]!;
-    // Typed, not inferred: without `noUncheckedIndexedAccess` the indexed read is already
-    // non-nullable, so TypeScript discards the right operand's type and a member missing
-    // from it goes unreported — `precededByEmittedTable` would arrive as `undefined` wearing
+    // Keep this typed: otherwise TypeScript can hide a missing cursor member.
     // a `boolean`, and the collapse would silently never fire for that cell.
     const cursor: CellPlaceCursor = cursors[cellIndex] ?? {
       blockIndex: 0,
@@ -1318,7 +1305,6 @@ export function layoutRowFragmentBounded(
     const cellW = Math.max(slotW - 2 * inset, MIN_CELL_BOX_PT);
     const insets = contentInsets(cell.margins, cell.borders);
     const topInset = isContinuation ? borderExtentPt(cell.borders.top) : insets.top;
-    const contentTop = rowTop + topInset;
     // Always reserve bottom inset so the fragment never paints into the margin/border band.
     // A detached head answers to the page and to its own SPAN, and to nothing about this
     // row: `hRule="exact"` fixes the height of the ROW (17.18.37) while the merged content
@@ -1330,7 +1316,15 @@ export function layoutRowFragmentBounded(
     const cellMaxBottom = isDetached
       ? Math.min(detachedBottomPt, rowTop + spanHeightPt)
       : flowMaxBottom;
-    const contentMaxBottom = cellMaxBottom - insets.bottom;
+    const vertical = cell.textDirection === 'btLr';
+    const flowLeft = vertical ? cellX + insets.bottom : cellX + insets.left;
+    const flowRight = vertical
+      ? cellX + Math.max(0, cellMaxBottom - rowTop) - topInset
+      : cellX + cellW - insets.right;
+    const contentTop = vertical ? rowTop + insets.left : rowTop + topInset;
+    const contentMaxBottom = vertical
+      ? rowTop + cellW - insets.right
+      : cellMaxBottom - insets.bottom;
 
     let blocks: readonly BlockFragmentRecord[] = [];
     let contentBottom = contentTop;
@@ -1345,8 +1339,8 @@ export function layoutRowFragmentBounded(
       } else {
         const flow = flowBlocksInBoxBounded(
           cell.blocks,
-          cellX + insets.left,
-          cellX + cellW - insets.right,
+          flowLeft,
+          flowRight,
           contentTop,
           contentMaxBottom,
           depth,
@@ -1371,7 +1365,11 @@ export function layoutRowFragmentBounded(
     // shorter than the DEFAULT_RUN_STYLE line. Empty / continue cells still need one line.
     const cellBottom = Math.min(
       cellMaxBottom,
-      fitted ? contentBottom + insets.bottom : rowTop + topInset + defaultLineHeight + insets.bottom
+      vertical && fitted
+        ? rowTop + topInset + (blockInlineRight(blocks, flowLeft) - flowLeft) + insets.bottom
+        : fitted
+          ? contentBottom + insets.bottom
+          : rowTop + topInset + defaultLineHeight + insets.bottom
     );
     if (cellBottom > rowBottom && !isDetached) rowBottom = cellBottom;
 
@@ -1383,6 +1381,7 @@ export function layoutRowFragmentBounded(
       blocks,
       contentTop,
       contentBottom,
+      physicalBottom: cellBottom,
       insets: { ...insets, top: topInset },
       nextCursor,
       complete: cell.vMergeContinue ? true : complete,
@@ -1391,13 +1390,10 @@ export function layoutRowFragmentBounded(
     });
   }
 
-  // Coordinate fragment height: tallest placed content, never past the flow budget.
   rowBottom = Math.min(flowMaxBottom, Math.max(rowBottom, rowTop));
   for (const entry of flowed) {
     if (detachedSpans?.has(entry.cell.id) === true) continue;
-    const needed = entry.fitted
-      ? entry.contentBottom + entry.insets.bottom
-      : rowTop + entry.insets.top + defaultLineHeight + entry.insets.bottom;
+    const needed = entry.physicalBottom;
     if (needed > rowBottom && needed <= flowMaxBottom + 0.001) {
       rowBottom = needed;
     }
@@ -1451,7 +1447,10 @@ export function layoutRowFragmentBounded(
       blocks.length > 0
     ) {
       const contentHeight = entry.contentBottom - entry.contentTop;
-      const available = rowHeight - entry.insets.top - entry.insets.bottom - contentHeight;
+      const available =
+        entry.cell.textDirection === 'btLr'
+          ? entry.width - entry.insets.left - entry.insets.right - contentHeight
+          : rowHeight - entry.insets.top - entry.insets.bottom - contentHeight;
       if (available > 0) {
         const dy = entry.cell.vAlign === 'center' ? available / 2 : available;
         blocks = shiftBlocks(blocks, dy);
@@ -1466,6 +1465,7 @@ export function layoutRowFragmentBounded(
       ...(entry.cell.vMergeContinue ? { paintInert: true as const } : {}),
       rowSpan: 1,
       ...(entry.cell.shading === undefined ? {} : { shading: entry.cell.shading }),
+      ...(entry.cell.textDirection === 'btLr' ? { textDirection: 'btLr' as const } : {}),
       blocks,
       box: { x: entry.x, y: rowTop, width: entry.width, height: rowHeight },
     };

--- a/packages/core/src/layout/semantic-table.ts
+++ b/packages/core/src/layout/semantic-table.ts
@@ -64,6 +64,7 @@ import {
   readMarginSides,
   type CellMarginsPt,
 } from './table-cell-margins.ts';
+import { readCellTextDirection } from './table-cell-text-direction.ts';
 
 // Cell padding is its own unit (`table-cell-margins.ts`); re-exported here because this is
 // where the published table surface lives.
@@ -222,6 +223,8 @@ export interface SemanticTableCell {
   readonly vMergeContinue: boolean;
   /** `w:vAlign` — defaults to top when omitted/unrecognised. */
   readonly vAlign: CellVerticalAlign;
+  /** `w:textDirection`; unsupported values keep horizontal layout. */
+  readonly textDirection: 'horizontal' | 'btLr';
   /** Resolved per-side margins (tcMar over tblCellMar over the table style over Word's default). */
   readonly margins: CellMarginsPt;
   /** Three-state authored `tcBorders` (omitted / none / edge). */
@@ -999,6 +1002,7 @@ function readTableStructureUncached(
         ...(gridCols[gridColumn]?.id ? { gridColumnId: gridCols[gridColumn]!.id } : {}),
         vMergeContinue: readVMergeContinue(cellProperties),
         vAlign: readVAlign(cellProperties),
+        textDirection: readCellTextDirection(cellProperties),
         margins: cellMargins,
         borders: mergeCellBorders(
           conditionalBorders,

--- a/packages/core/src/layout/table-cell-text-direction.ts
+++ b/packages/core/src/layout/table-cell-text-direction.ts
@@ -1,0 +1,152 @@
+import { paragraphFragmentsOfBlocks } from './semantic-records.ts';
+import type {
+  BlockFragmentRecord,
+  LayoutBox,
+  SemanticLayout,
+  TableCellFragmentRecord,
+} from './semantic-records.ts';
+import type { CaretGeometry } from './semantic-interaction.ts';
+import type { OoxmlElement } from '../store/package/ooxml-tree.ts';
+
+/** Supported `w:textDirection` value, with horizontal layout as the safe default. */
+export function readCellTextDirection(
+  cellProperties: OoxmlElement | undefined
+): 'horizontal' | 'btLr' {
+  const node = cellProperties?.children.find(
+    (child) => child.kind !== 'textValue' && child.localName === 'textDirection'
+  );
+  if (!node || node.kind === 'textValue') return 'horizontal';
+  const value = node?.attributes.find((attribute) => attribute.localName === 'val')?.value;
+  return value === 'btLr' ? 'btLr' : 'horizontal';
+}
+
+/** Furthest laid inline edge, excluding the unused width of paragraph line bands. */
+export function blockInlineRight(blocks: readonly BlockFragmentRecord[], fallback: number): number {
+  let right = fallback;
+  for (const block of blocks) {
+    if (block.kind === 'table') {
+      right = Math.max(right, block.box.x + block.box.width);
+      continue;
+    }
+    for (const line of block.lines) {
+      right = Math.max(right, line.contentX);
+      for (const span of line.spans) right = Math.max(right, span.box.x + span.box.width);
+      for (const drawing of line.drawings ?? []) right = Math.max(right, drawing.advanceEnd);
+    }
+  }
+  return right;
+}
+
+/** Map a sheet point into the horizontal local plane used to lay out `btLr` content. */
+export function pointInBottomToTopCell(point: LayoutBoxPoint, cell: LayoutBox): LayoutBoxPoint {
+  return {
+    x: cell.x + cell.height - (point.y - cell.y),
+    y: cell.y + (point.x - cell.x),
+  };
+}
+
+interface BottomToTopCellLocation {
+  readonly pageIndex: number;
+  readonly cell: TableCellFragmentRecord;
+}
+
+const locationsByLayout = new WeakMap<
+  SemanticLayout,
+  ReadonlyMap<string, readonly BottomToTopCellLocation[]>
+>();
+const bottomToTopCarets = new WeakSet<CaretGeometry>();
+
+function bottomToTopLocations(
+  layout: SemanticLayout
+): ReadonlyMap<string, readonly BottomToTopCellLocation[]> {
+  const cached = locationsByLayout.get(layout);
+  if (cached) return cached;
+  const found = new Map<string, BottomToTopCellLocation[]>();
+  const visit = (blocks: readonly BlockFragmentRecord[], pageIndex: number): void => {
+    for (const block of blocks) {
+      if (block.kind !== 'table') continue;
+      for (const row of block.rows) {
+        for (const cell of row.cells) {
+          if (cell.textDirection === 'btLr') {
+            for (const paragraph of paragraphFragmentsOfBlocks(cell.blocks)) {
+              const locations = found.get(paragraph.paragraphId) ?? [];
+              locations.push({ pageIndex, cell });
+              found.set(paragraph.paragraphId, locations);
+            }
+          } else {
+            visit(cell.blocks, pageIndex);
+          }
+        }
+      }
+    }
+  };
+  for (const page of layout.pages) {
+    visit(page.fragments, page.index);
+    if (page.header) visit(page.header.fragments, page.index);
+    if (page.footer) visit(page.footer.fragments, page.index);
+    for (const area of [page.footnotes, page.endnotes]) {
+      if (!area) continue;
+      if (area.separator) visit(area.separator.fragments, page.index);
+      for (const note of area.notes) visit(note.fragments, page.index);
+    }
+  }
+  locationsByLayout.set(layout, found);
+  return found;
+}
+
+function locationFor(
+  layout: SemanticLayout,
+  pageIndex: number,
+  paragraphId: string
+): BottomToTopCellLocation | undefined {
+  const locations = bottomToTopLocations(layout).get(paragraphId) ?? [];
+  return locations.find((location) => location.pageIndex === pageIndex) ?? locations[0];
+}
+
+/** Rotate virtual horizontal caret geometry into its painted table-cell plane. */
+export function bottomToTopCaretInLayout(
+  layout: SemanticLayout,
+  caret: CaretGeometry
+): CaretGeometry {
+  const location = locationFor(layout, caret.pageIndex, caret.position.paragraphId);
+  if (!location) return caret;
+  const point = pointFromBottomToTopCell(caret, location.cell.box);
+  const transformed = { ...caret, ...point };
+  bottomToTopCarets.add(transformed);
+  return transformed;
+}
+
+/** Whether caret paint must follow the `btLr` plane used for its geometry. */
+export function isBottomToTopCaret(caret: CaretGeometry): boolean {
+  return bottomToTopCarets.has(caret);
+}
+
+/** Rotate one virtual selection band into page-content coordinates. */
+export function bottomToTopRectInLayout<T extends LayoutBox & { readonly pageIndex: number }>(
+  layout: SemanticLayout,
+  paragraphId: string,
+  rect: T
+): T {
+  const location = locationFor(layout, rect.pageIndex, paragraphId);
+  if (!location) return rect;
+  const cell = location.cell.box;
+  return {
+    ...rect,
+    x: cell.x + (rect.y - cell.y),
+    y: cell.y + cell.height - (rect.x - cell.x) - rect.width,
+    width: rect.height,
+    height: rect.width,
+  };
+}
+
+function pointFromBottomToTopCell(point: LayoutBoxPoint, cell: LayoutBox): LayoutBoxPoint {
+  return {
+    x: cell.x + (point.y - cell.y),
+    y: cell.y + cell.height - (point.x - cell.x),
+  };
+}
+
+export interface LayoutBoxPoint {
+  readonly x: number;
+  readonly y: number;
+}

--- a/packages/core/src/layout/table-float-position.ts
+++ b/packages/core/src/layout/table-float-position.ts
@@ -1,0 +1,278 @@
+// Vertical placement for top-level `w:tblpPr` tables.
+
+import type { OoxmlElement, OoxmlProperty } from '@docx-editor.dev/core/store';
+import type { RevisionAuthorFilter, RevisionDisplayMode } from './revision-projection.ts';
+import type { BlockFragmentRecord, TableFragmentRecord } from './semantic-records.ts';
+import { readTableStructure, type TableFloatPosition } from './semantic-table.ts';
+import type { StyleCascadeTable } from './style-cascade.ts';
+
+type PositionedTableFragment = TableFragmentRecord & { readonly outOfFlow: true };
+
+type PositionableBlock =
+  | { readonly kind: 'table'; readonly table: OoxmlElement }
+  | {
+      readonly kind: 'paragraph';
+      readonly paragraph: OoxmlElement;
+      readonly props: readonly OoxmlProperty[];
+    };
+
+export interface PositionedTableAnchor {
+  readonly table: OoxmlElement;
+  readonly sourceIndex: number;
+  readonly anchorId: string;
+}
+
+export interface PositionedTableAnchorSignal {
+  readonly anchorId: string;
+  readonly column: number;
+  readonly fragmentIndex: number;
+}
+
+const anchorsByParagraphMemo = new WeakMap<
+  readonly PositionedTableAnchor[],
+  ReadonlyMap<string, readonly PositionedTableAnchor[]>
+>();
+
+function anchorsByParagraph(
+  positionedTables: readonly PositionedTableAnchor[]
+): ReadonlyMap<string, readonly PositionedTableAnchor[]> {
+  const memo = anchorsByParagraphMemo.get(positionedTables);
+  if (memo) return memo;
+  const mutable = new Map<string, PositionedTableAnchor[]>();
+  for (const positioned of positionedTables) {
+    const entries = mutable.get(positioned.anchorId) ?? [];
+    entries.push(positioned);
+    mutable.set(positioned.anchorId, entries);
+  }
+  anchorsByParagraphMemo.set(positionedTables, mutable);
+  return mutable;
+}
+
+/** Resolve each sheet-positioned table to the next regular paragraph in document order. */
+export function positionedTableAnchors(
+  blocks: readonly PositionableBlock[],
+  contentWidth: number,
+  styleCascade: StyleCascadeTable | undefined,
+  displayMode: RevisionDisplayMode,
+  authorFilter: RevisionAuthorFilter | undefined
+): PositionedTableAnchor[] {
+  const result: PositionedTableAnchor[] = [];
+  let nextParagraphId: string | undefined;
+  for (let sourceIndex = blocks.length - 1; sourceIndex >= 0; sourceIndex -= 1) {
+    const block = blocks[sourceIndex]!;
+    if (
+      block.kind === 'paragraph' &&
+      !block.props.some((property) => property.localName === 'framePr')
+    ) {
+      nextParagraphId = block.paragraph.id;
+      continue;
+    }
+    if (block.kind !== 'table') continue;
+    const float = readTableStructure(
+      block.table,
+      contentWidth,
+      0,
+      styleCascade,
+      displayMode,
+      authorFilter
+    )?.float;
+    if (!float || float.vertAnchor === 'text' || float.ySpec === 'inline') continue;
+    if (!nextParagraphId) continue;
+    result.push({
+      table: block.table,
+      sourceIndex,
+      anchorId: nextParagraphId,
+    });
+  }
+  return result.reverse();
+}
+
+function sameStrings(left: readonly string[] | undefined, right: readonly string[]): boolean {
+  const values = left ?? [];
+  return values.length === right.length && values.every((value, index) => value === right[index]);
+}
+
+function sameAnchorSignals(
+  left: readonly PositionedTableAnchorSignal[] | undefined,
+  right: readonly PositionedTableAnchorSignal[]
+): boolean {
+  const values = left ?? [];
+  return (
+    values.length === right.length &&
+    values.every(
+      (value, index) =>
+        value.anchorId === right[index]!.anchorId &&
+        value.column === right[index]!.column &&
+        value.fragmentIndex === right[index]!.fragmentIndex
+    )
+  );
+}
+
+interface PositionedTableCheckpointState {
+  readonly pendingPositionedTableTokens?: readonly string[];
+  readonly positionedTableAnchorSignals?: readonly PositionedTableAnchorSignal[];
+}
+
+/** Capture, restore, and compare the deferred-table portion of a flow checkpoint. */
+export function positionedTableFlow(
+  positionedTables: readonly PositionedTableAnchor[],
+  flowKeys: readonly string[]
+) {
+  const tokenById = new Map<string, string>();
+  const idByToken = new Map<string, string>();
+  const anchorIds = new Set<string>();
+  for (const positioned of positionedTables) {
+    const token = JSON.stringify([positioned.table.id, flowKeys[positioned.sourceIndex]]);
+    tokenById.set(positioned.table.id, token);
+    idByToken.set(token, positioned.table.id);
+    anchorIds.add(positioned.anchorId);
+  }
+  const tokensOf = (pendingIds: ReadonlySet<string>): string[] =>
+    [...pendingIds].flatMap((id) => {
+      const token = tokenById.get(id);
+      return token ? [token] : [];
+    });
+  return {
+    note(
+      signals: PositionedTableAnchorSignal[],
+      anchorId: string,
+      column: number,
+      fragmentIndex: number
+    ): void {
+      if (anchorIds.has(anchorId)) signals.push({ anchorId, column, fragmentIndex });
+    },
+    checkpoint(pendingIds: ReadonlySet<string>, signals: readonly PositionedTableAnchorSignal[]) {
+      return {
+        pendingPositionedTableTokens: tokensOf(pendingIds),
+        positionedTableAnchorSignals: [...signals],
+      };
+    },
+    restore(
+      checkpoint: PositionedTableCheckpointState,
+      pendingIds: Set<string>,
+      signals: PositionedTableAnchorSignal[]
+    ): void {
+      pendingIds.clear();
+      for (const token of checkpoint.pendingPositionedTableTokens ?? []) {
+        const id = idByToken.get(token);
+        if (id) pendingIds.add(id);
+      }
+      signals.splice(0, signals.length, ...(checkpoint.positionedTableAnchorSignals ?? []));
+    },
+    same(
+      priorTokens: readonly string[] | undefined,
+      priorSignals: readonly PositionedTableAnchorSignal[] | undefined,
+      pendingIds: ReadonlySet<string>,
+      signals: readonly PositionedTableAnchorSignal[]
+    ): boolean {
+      return (
+        sameStrings(priorTokens, tokensOf(pendingIds)) && sameAnchorSignals(priorSignals, signals)
+      );
+    },
+  };
+}
+
+/** Paint tables whose logical anchor paragraph has reached the page being closed. */
+export function publishPositionedTablesOnPage(
+  positionedTables: readonly PositionedTableAnchor[],
+  outstandingIds: Set<string>,
+  pageFragments: BlockFragmentRecord[],
+  anchorSignals: PositionedTableAnchorSignal[],
+  placeTable: (table: OoxmlElement, column: number) => void
+): void {
+  const byParagraph = anchorsByParagraph(positionedTables);
+  let insertedFragments = 0;
+  for (const signal of anchorSignals) {
+    const positionedForAnchor = byParagraph.get(signal.anchorId);
+    if (!positionedForAnchor) continue;
+    const insertionIndex = signal.fragmentIndex + insertedFragments;
+    const publishedAt = pageFragments.length;
+    for (const positioned of positionedForAnchor) {
+      if (!outstandingIds.has(positioned.table.id)) continue;
+      placeTable(positioned.table, signal.column);
+      outstandingIds.delete(positioned.table.id);
+    }
+    const fragments = pageFragments.splice(publishedAt);
+    pageFragments.splice(insertionIndex, 0, ...fragments);
+    insertedFragments += fragments.length;
+  }
+  anchorSignals.length = 0;
+}
+
+/** True when a table paints on its anchor sheet without consuming body flow. */
+export function isOutOfFlowTableFragment(
+  fragment: BlockFragmentRecord
+): fragment is PositionedTableFragment {
+  return fragment.kind === 'table' && (fragment as PositionedTableFragment).outOfFlow === true;
+}
+
+/** One vertical anchor box, in page-content coordinates. */
+export interface TableVerticalAnchorFrame {
+  readonly top: number;
+  readonly height: number;
+}
+
+/** The three boxes `w:vertAnchor` can name, resolved for the page being laid out. */
+export interface TableVerticalAnchorFrames {
+  readonly text: TableVerticalAnchorFrame;
+  readonly margin: TableVerticalAnchorFrame;
+  readonly page: TableVerticalAnchorFrame;
+}
+
+/** The page facts needed to resolve table vertical anchor frames. */
+export interface BodyTableVerticalFrameInput {
+  readonly pageHeight: number;
+  readonly contentInsetTop: number;
+  readonly contentHeight: number;
+  readonly marginBottom: number;
+}
+
+export function bodyTableVerticalAnchorFrames(
+  input: BodyTableVerticalFrameInput,
+  cursorY: number,
+  marginTop: number
+): TableVerticalAnchorFrames {
+  return {
+    text: { top: cursorY, height: Math.max(0, input.contentHeight - cursorY) },
+    margin: {
+      top: marginTop - input.contentInsetTop,
+      height: Math.max(0, input.pageHeight - marginTop - input.marginBottom),
+    },
+    page: { top: -input.contentInsetTop, height: input.pageHeight },
+  };
+}
+
+/** True when the current region holds body-flow content. */
+export function hasFlowFragments(
+  fragments: readonly BlockFragmentRecord[],
+  start: number
+): boolean {
+  for (let index = start; index < fragments.length; index += 1) {
+    const fragment = fragments[index]!;
+    if (!isOutOfFlowTableFragment(fragment)) return true;
+  }
+  return false;
+}
+
+/**
+ * Resolve a floated table's top edge in page-content coordinates.
+ *
+ * A vertical alignment supersedes `w:tblpY`. `inside` and `outside` use top and bottom until
+ * mirrored page margins are modelled. The clamp keeps the leading edge on the sheet.
+ */
+export function tableFloatOriginY(
+  float: TableFloatPosition,
+  tableHeightPt: number,
+  frames: TableVerticalAnchorFrames
+): number {
+  const frame = frames[float.vertAnchor];
+  const slack = frame.height - tableHeightPt;
+  let y: number;
+  if (float.ySpec === 'center') y = frame.top + slack / 2;
+  else if (float.ySpec === 'bottom' || float.ySpec === 'outside') y = frame.top + slack;
+  else if (float.ySpec) y = frame.top;
+  else y = frame.top + float.yPt;
+  if (!Number.isFinite(y)) return frame.top;
+  const pageBottom = frames.page.top + frames.page.height;
+  return Math.max(frames.page.top, Math.min(y, pageBottom));
+}

--- a/packages/core/src/layout/table-flow-pagination.ts
+++ b/packages/core/src/layout/table-flow-pagination.ts
@@ -33,9 +33,15 @@ import {
   type SemanticTableRow,
   type TableAnchorFrames,
 } from './semantic-table.ts';
+import { tableFloatOriginY, type TableVerticalAnchorFrames } from './table-float-position.ts';
+import { shiftBlocks } from './table-fragment-finalize.ts';
 import type { StyleCascadeTable } from './style-cascade.ts';
 import type { RevisionAuthorFilter, RevisionDisplayMode } from './revision-projection.ts';
-import type { BlockFragmentRecord, TableRowFragmentRecord } from './semantic-records.ts';
+import type {
+  BlockFragmentRecord,
+  TableFragmentRecord,
+  TableRowFragmentRecord,
+} from './semantic-records.ts';
 
 /** The body flow a table is placed into: the cursor it moves, and what it publishes to. */
 export interface TableFlowCursor {
@@ -59,6 +65,8 @@ export interface TableFlowCursor {
   readonly advanceColumn: () => void;
   /** Frames a `w:tblpPr` table positions against. */
   readonly anchorFrames: () => TableAnchorFrames;
+  /** Vertical frames a `w:tblpPr` table positions against. */
+  readonly verticalAnchorFrames: () => TableVerticalAnchorFrames;
   readonly styleCascade: StyleCascadeTable | undefined;
   readonly displayMode: RevisionDisplayMode;
   readonly revisionAuthorFilter?: RevisionAuthorFilter;
@@ -79,6 +87,14 @@ export interface TableFlowCursor {
   readonly publishFragment: (fragment: BlockFragmentRecord) => void;
 }
 
+export interface TableFlowPlacementResult {
+  /** True when the table paints on the anchor sheet without advancing the body cursor. */
+  readonly outOfFlow: boolean;
+}
+
+/** Enough vertical room to lay a positioned table as one visual object on its anchor sheet. */
+const POSITIONED_TABLE_LAYOUT_BOTTOM_PT = Number.MAX_SAFE_INTEGER / 1024;
+
 /**
  * Lay out one top-level table with OOXML-aligned row pagination.
  *
@@ -90,13 +106,17 @@ export interface TableFlowCursor {
  * placed together, moved whole when the remainder is too short, re-emitted complete atop
  * each continuation page, and rejected when the group itself exceeds a fresh content page.
  */
-export function paginateTableInFlow(table: OoxmlElement, flow: TableFlowCursor): void {
+export function paginateTableInFlow(
+  table: OoxmlElement,
+  flow: TableFlowCursor
+): TableFlowPlacementResult {
   const {
     columnWidth,
     columnLeft,
-    contentHeight,
+    contentHeight: flowContentHeight,
     advanceColumn,
     anchorFrames,
+    verticalAnchorFrames,
     styleCascade,
     displayMode,
     revisionAuthorFilter,
@@ -113,7 +133,16 @@ export function paginateTableInFlow(table: OoxmlElement, flow: TableFlowCursor):
     displayMode,
     revisionAuthorFilter
   );
-  if (!structure || structure.rows.length === 0) return;
+  if (!structure || structure.rows.length === 0) return { outOfFlow: false };
+  const outOfFlow =
+    structure.float !== undefined &&
+    structure.float.vertAnchor !== 'text' &&
+    structure.float.ySpec !== 'inline';
+  const bodyCursorY = flow.cursorY;
+  const verticalFrames = outOfFlow ? verticalAnchorFrames() : undefined;
+  const contentHeight = outOfFlow
+    ? (): number => POSITIONED_TABLE_LAYOUT_BOTTOM_PT
+    : flowContentHeight;
   // `w:tblInd` / `w:jc` place the table inside the text column, `w:tblpPr` against a wider
   // anchor box; every row and the fragment box share the one origin so cell geometry and
   // the reported box cannot drift apart.
@@ -123,11 +152,14 @@ export function paginateTableInFlow(table: OoxmlElement, flow: TableFlowCursor):
       ? tableFloatOriginX(structure.float, tableWidthPt, anchorFrames())
       : columnLeft() + tableOriginX(structure, columnWidth());
   let tableLeft = originX();
-  // `w:tblpY` against the text anchor is an offset from where the table would otherwise
-  // sit, so it moves the table within the flow. The page and margin anchors state an
-  // absolute position on the sheet, which this layout does not model — those stay in flow.
+  // A text anchor offsets the current body position. Page and margin anchors are sheet
+  // positions, so the table uses a private cursor and the body cursor is restored below.
   if (structure.float && structure.float.vertAnchor === 'text' && !structure.float.ySpec) {
     flow.cursorY = Math.max(0, Math.min(flow.cursorY + structure.float.yPt, contentHeight()));
+  } else if (outOfFlow && structure.float && verticalFrames) {
+    // Alignment needs the final table height. Start at the frame origin, then shift the
+    // complete fragment in closeTableFragment once that height is known.
+    flow.cursorY = tableFloatOriginY(structure.float, 0, verticalFrames);
   }
   /** One row's natural height where the table stands now. `tableLeft` moves; this reads it. */
   const rowHeightOf = (probeRow: SemanticTableRow): number =>
@@ -163,26 +195,47 @@ export function paginateTableInFlow(table: OoxmlElement, flow: TableFlowCursor):
       tableDeps
     );
     const last = finalized[finalized.length - 1]!;
-    publishFragment(
-      annotateTableFragmentGeometry(
-        {
-          kind: 'table',
-          id: `${table.id}#f${fragmentIndex}`,
-          tableId: table.id,
-          fragmentIndex,
-          rows: finalized,
-          box: {
-            x: tableLeft,
-            y: fragmentTop,
-            width: structure.columnWidthsPt.reduce((sum, columnWidth) => sum + columnWidth, 0),
-            height: last.box.y + last.box.height - fragmentTop,
-          },
+    const fragment = annotateTableFragmentGeometry(
+      {
+        kind: 'table',
+        ...(outOfFlow ? { outOfFlow: true as const } : {}),
+        id: `${table.id}#f${fragmentIndex}`,
+        tableId: table.id,
+        fragmentIndex,
+        rows: finalized,
+        box: {
+          x: tableLeft,
+          y: fragmentTop,
+          width: structure.columnWidthsPt.reduce((sum, columnWidth) => sum + columnWidth, 0),
+          height: last.box.y + last.box.height - fragmentTop,
         },
-        structure.columnWidthsPt,
-        0,
-        rowOrdinals
-      )
+      },
+      structure.columnWidthsPt,
+      0,
+      rowOrdinals
     );
+    let positionedFragment: TableFragmentRecord = fragment;
+    if (outOfFlow && structure.float && verticalFrames) {
+      const top = tableFloatOriginY(structure.float, fragment.box.height, verticalFrames);
+      const dy = top - fragment.box.y;
+      positionedFragment = shiftBlocks([fragment], dy)[0] as TableFragmentRecord;
+      if (Math.abs(dy) > 0.001) {
+        const shiftParagraphAnchors = (blocks: readonly BlockFragmentRecord[]): void => {
+          for (const block of blocks) {
+            if (block.kind === 'paragraph') shiftAnchor(block.paragraphId, dy);
+            else {
+              for (const row of block.rows) {
+                for (const cell of row.cells) shiftParagraphAnchors(cell.blocks);
+              }
+            }
+          }
+        };
+        for (const row of fragment.rows) {
+          for (const cell of row.cells) shiftParagraphAnchors(cell.blocks);
+        }
+      }
+    }
+    publishFragment(positionedFragment);
     fragmentIndex += 1;
     rows = [];
     sourceRows = [];
@@ -461,4 +514,6 @@ export function paginateTableInFlow(table: OoxmlElement, flow: TableFlowCursor):
     }
   }
   closeTableFragment();
+  if (outOfFlow) flow.cursorY = bodyCursorY;
+  return { outOfFlow };
 }

--- a/packages/core/src/layout/table-fragment-finalize.ts
+++ b/packages/core/src/layout/table-fragment-finalize.ts
@@ -205,11 +205,16 @@ export function finalizeTableRows(
           contentBottom = Math.max(contentBottom, block.box.y + block.box.height);
         }
         if (Number.isFinite(contentTop) && Number.isFinite(contentBottom)) {
-          const available = height - insets.top - insets.bottom - (contentBottom - contentTop);
+          const vertical = authored.textDirection === 'btLr';
+          const available =
+            (vertical
+              ? cell.box.width - insets.left - insets.right
+              : height - insets.top - insets.bottom) -
+            (contentBottom - contentTop);
           // Reset any per-row shift by measuring from cell top + inset.
           const desiredTop =
             cell.box.y +
-            insets.top +
+            (vertical ? insets.left : insets.top) +
             (available > 0 ? (authored.vAlign === 'center' ? available / 2 : available) : 0);
           const dy = desiredTop - contentTop;
           if (Math.abs(dy) > 0.001) {

--- a/packages/core/src/output/__tests__/semantic-paint-table-text-direction.test.ts
+++ b/packages/core/src/output/__tests__/semantic-paint-table-text-direction.test.ts
@@ -1,0 +1,32 @@
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { expect, test } from 'bun:test';
+import { readOoxmlPart } from '@docx-editor.dev/core/store';
+import { createFixedMeasurer, layoutSemanticDocument } from '@docx-editor.dev/core/layout';
+import { paintSemanticLayout } from '../semantic-paint.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+test('paint rotates btLr table-cell content as one layout-owned plane', () => {
+  const body =
+    '<w:tbl><w:tblGrid><w:gridCol w:w="510"/></w:tblGrid>' +
+    '<w:tr><w:trPr><w:trHeight w:val="2000" w:hRule="exact"/></w:trPr>' +
+    '<w:tc><w:tcPr><w:textDirection w:val="btLr"/></w:tcPr>' +
+    '<w:p><w:r><w:t>vertical label</w:t></w:r></w:p>' +
+    '</w:tc></w:tr></w:tbl>';
+  const read = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'app/xml',
+  });
+  if (!read.ok) throw new Error(read.reason);
+  const layout = layoutSemanticDocument(read.part, 0, { measurer: createFixedMeasurer(6, 14) });
+  const container = document.createElement('div');
+  paintSemanticLayout(container, layout, { scale: 1 });
+
+  const content = container.querySelector<HTMLElement>('.docx-table-cell-content-btlr')!;
+  expect(content.style.width).toBe('100px');
+  expect(content.style.height).toBe('25.5px');
+  expect(content.style.transform).toBe('translateY(100px) rotate(-90deg)');
+  expect(content.textContent).toBe('vertical label');
+});

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -2068,6 +2068,7 @@ function applyParagraphBorderStyle(
 }
 
 import { applyCellBorders } from './semantic-paint-table-borders.ts';
+import { tableCellContentHost } from './table-cell-text-direction-paint.ts';
 
 function paintTableCell(
   document: Document,
@@ -2102,10 +2103,10 @@ function paintTableCell(
   cellElement.style.border = 'none';
   applyCellBorders(document, cellElement, cell.borders, scale);
 
-  // Re-validated at the sink, like every other file-derived style value here.
   if (cell.shading && HEX.test(cell.shading)) {
     cellElement.style.backgroundColor = `#${cell.shading}`;
   }
+  const contentElement = tableCellContentHost(document, cell, scale, cellElement);
   for (const block of cell.blocks) {
     const painted =
       block.kind === 'table'
@@ -2113,7 +2114,7 @@ function paintTableCell(
         : paintFragment(document, block, ctx);
     painted.style.left = `${(block.box.x - cell.box.x) * scale}px`;
     painted.style.top = `${(block.box.y - cell.box.y) * scale}px`;
-    cellElement.append(painted);
+    contentElement.append(painted);
   }
   return cellElement;
 }

--- a/packages/core/src/output/table-cell-text-direction-paint.ts
+++ b/packages/core/src/output/table-cell-text-direction-paint.ts
@@ -1,0 +1,22 @@
+import type { TableCellFragmentRecord } from '../layout/semantic-records.ts';
+
+/** Content host for a table cell, rotated only when layout published a `btLr` plane. */
+export function tableCellContentHost(
+  document: Document,
+  cell: TableCellFragmentRecord,
+  scale: number,
+  cellElement: HTMLElement
+): HTMLElement {
+  if (cell.textDirection !== 'btLr') return cellElement;
+  const content = document.createElement('div');
+  content.className = 'docx-table-cell-content-btlr';
+  content.style.position = 'absolute';
+  content.style.left = '0';
+  content.style.top = '0';
+  content.style.width = `${cell.box.height * scale}px`;
+  content.style.height = `${cell.box.width * scale}px`;
+  content.style.transformOrigin = '0 0';
+  content.style.transform = `translateY(${cell.box.height * scale}px) rotate(-90deg)`;
+  cellElement.append(content);
+  return content;
+}

--- a/packages/core/src/store/__tests__/omml-equation.test.ts
+++ b/packages/core/src/store/__tests__/omml-equation.test.ts
@@ -90,7 +90,8 @@ describe('bounded OMML equation projection', () => {
         '<m:r><m:t>E=mc</m:t></m:r>' +
         '<m:sSup><m:e><m:r><m:t>2</m:t></m:r></m:e>' +
         '<m:sup><m:r><m:t>2</m:t></m:r></m:sup></m:sSup>' +
-        '<m:f><m:num><m:r><m:t>a+b</m:t></m:r></m:num>' +
+        '<m:f><m:fPr><m:type m:val="bar"/></m:fPr>' +
+        '<m:num><m:r><m:t>a+b</m:t></m:r></m:num>' +
         '<m:den><m:r><m:t>2</m:t></m:r></m:den></m:f>' +
         '<m:rad><m:deg/><m:e><m:r><m:t>x</m:t></m:r></m:e></m:rad>' +
         '<m:nary><m:naryPr><m:chr m:val="∑"/></m:naryPr>' +

--- a/packages/core/src/store/package/omml-equation.ts
+++ b/packages/core/src/store/package/omml-equation.ts
@@ -274,8 +274,13 @@ function isSupportedExpressionNode(node: OoxmlNode): boolean {
       return false;
     }
     const property = namedChild(node, 'fPr');
+    const propertySupported =
+      !property ||
+      isEmptyProperty(property) ||
+      (hasOnlyMathChildren(property, { type: { min: 1, max: 1 } }) &&
+        hasOnlyMathVal(namedChildren(property, 'type')[0]!, new Set(['bar'])));
     return (
-      (!property || isEmptyProperty(property)) &&
+      propertySupported &&
       childrenOf(namedChildren(node, 'num')[0]!).every(isSupportedExpressionNode) &&
       childrenOf(namedChildren(node, 'den')[0]!).every(isSupportedExpressionNode)
     );


### PR DESCRIPTION
## Summary

- keep page- and margin-anchored floating tables on their logical anchor sheet
- preserve `btLr` bottom-to-top table-cell text in layout, paint, hit testing, carets, and selections
- retain inline images in later section columns with consistent drawing geometry and clipping
- render explicit OMML `bar` fractions as built-up fractions
- keep automatic line spacing from scaling built-up equations and changing column pagination
- add regression coverage for body, furniture, note, drawing, equation, and spacing paths

## Validation

- Fable 5 review completed with no medium-or-higher findings remaining
- repository suite: 10,970 passed, 0 failed
- typecheck, lint, format, parity, API, i18n, OpenSpec, and diff checks pass
- the exact issue document keeps question 4 in column one
- the document still mounts two ready images, two rotated cell hosts, and six built-up fractions

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790876616&installation_model_id=422592&pr_number=690&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F690&signature=79cd77c2e7b07f577086a1cdd8caff16a72493795f90a0392260a9e4f1b41dc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

Fixes #662
