### PR TITLE
fix(demo): simplify Markdown loading state

### DIFF
--- a/examples/docx-to-markdown/src/MarkdownExportDemo.tsx
+++ b/examples/docx-to-markdown/src/MarkdownExportDemo.tsx
@@ -94,38 +94,11 @@ function Spinner() {
   return <span className="md-spinner" aria-hidden="true" />;
 }
 
-const MARKDOWN_LOADING_MESSAGES = [
-  'Markdowning with page boundaries intact',
-  'Keeping headers and footers close to their pages',
-  'Giving tables, lists, and review notes careful treatment',
-  'Making the document citation-ready',
-] as const;
-
-function MarkdownLoadingState({ status }: { readonly status: 'queued' | 'exporting' }) {
-  const [messageIndex, setMessageIndex] = useState(0);
-
-  useEffect(() => {
-    setMessageIndex(0);
-    if (status === 'queued') return;
-    const timer = window.setInterval(
-      () => setMessageIndex((current) => (current + 1) % MARKDOWN_LOADING_MESSAGES.length),
-      1_800
-    );
-    return () => window.clearInterval(timer);
-  }, [status]);
-
+function MarkdownLoadingState() {
   return (
-    <div className="md-export-loading" aria-label="Building page-aware Markdown">
-      <div className="md-export-loading__indicator">
-        <Spinner />
-        <span>{status === 'queued' ? 'Catching up with your edits' : 'Building Markdown'}</span>
-      </div>
-      <strong>Preparing a page-aware export</strong>
-      <p aria-hidden="true">
-        {status === 'queued'
-          ? 'Waiting for a quiet moment before the next layout pass'
-          : MARKDOWN_LOADING_MESSAGES[messageIndex]}
-      </p>
+    <div className="md-export-loading" role="status" aria-live="polite">
+      <Spinner />
+      <span className="md-visually-hidden">Building Markdown</span>
     </div>
   );
 }
@@ -913,7 +886,7 @@ export function MarkdownExportDemo() {
                 onTabChange={setDeveloperPanelTab}
               />
             ) : loadingStatus ? (
-              <MarkdownLoadingState status={loadingStatus} />
+              <MarkdownLoadingState />
             ) : (
               <>
                 {busyPresentation === 'overlay' ? (

--- a/examples/docx-to-markdown/src/styles.css
+++ b/examples/docx-to-markdown/src/styles.css
@@ -999,41 +999,13 @@ button {
 .md-export-loading {
   display: grid;
   min-height: 100%;
-  place-content: center;
-  justify-items: center;
+  place-items: center;
   padding: 40px;
-  color: var(--md-ink);
-  text-align: center;
 }
 
-.md-export-loading__indicator {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  margin-bottom: 14px;
-  color: var(--md-accent);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.md-export-loading__indicator .md-spinner {
-  width: 13px;
-  height: 13px;
-}
-
-.md-export-loading > strong {
-  font-size: 15px;
-  letter-spacing: -0.015em;
-}
-
-.md-export-loading > p {
-  min-height: 18px;
-  margin: 7px 0 0;
-  color: var(--md-muted);
-  font-size: 11px;
-  line-height: 1.55;
+.md-export-loading .md-spinner {
+  width: 18px;
+  height: 18px;
 }
 
 .md-live-update {


### PR DESCRIPTION
## Summary

- replace the right-hand Markdown loading screen with one centered spinner
- remove rotating loading copy and its timer state
- retain an accessible live status label for screen readers

## Verification

- `bun run --filter './examples/docx-to-markdown' typecheck`
- `bun test ./examples/docx-to-markdown/src/*.test.ts ./examples/docx-to-markdown/src/*.test.tsx` — 23 pass
- `bunx eslint examples/docx-to-markdown/src/MarkdownExportDemo.tsx`
- `bunx prettier --check examples/docx-to-markdown/src/MarkdownExportDemo.tsx examples/docx-to-markdown/src/styles.css`
- `bun run check:app-build:markdown`
- repository pre-commit gates: typecheck, parity, API snapshots, format, and lint

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/704"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790922262&installation_model_id=422592&pr_number=704&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F704&signature=42d5487e77cedebc0bda35a999fb22ae7dc516b70a3aba98decc54ba567ab9dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->