### PR TITLE
fix: apply author, mode, translate, and locale prop changes without a remount

### DIFF
--- a/.changeset/live-author-props.md
+++ b/.changeset/live-author-props.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': minor
 ---
 
-Apply live author, mode, translation, and locale changes without rebuilding the editor. Keep Vue root and packaged editor props reactive after mount. Fixes #695 and #561.
+Apply live author, mode, translation, and locale changes without rebuilding the editor. Keep Vue root and packaged editor props reactive after mount. A locale catalog change no longer rebuilds the editor. Fixes #695 and #561.

--- a/.changeset/live-author-props.md
+++ b/.changeset/live-author-props.md
@@ -1,5 +1,5 @@
 ---
-'@docx-editor.dev/core': patch
+'@docx-editor.dev/core': minor
 ---
 
-Apply React and Vue author prop changes to later comments, replies, and tracked changes without rebuilding the editor. Keep Vue packaged editor props reactive after mount. Fixes #695 and #561.
+Apply live author, mode, translation, and locale changes without rebuilding the editor. Keep Vue root and packaged editor props reactive after mount. Fixes #695 and #561.

--- a/.changeset/live-author-props.md
+++ b/.changeset/live-author-props.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Apply React and Vue author prop changes to later comments, replies, and tracked changes without rebuilding the editor. Keep Vue packaged editor props reactive after mount. Fixes #695 and #561.

--- a/docs/api/docx-editor-core/editor.api.md
+++ b/docs/api/docx-editor-core/editor.api.md
@@ -857,9 +857,12 @@ export interface DocxEditorInstance extends Editor {
     setAuthor(author: string | undefined): void;
     setEquationChrome(handlers: EquationChromeHandlers): Unsubscribe;
     setHyperlinkChrome(handlers: HyperlinkChromeHandlers): Unsubscribe;
+    setLocale(locale: string | undefined): void;
+    setMode(mode: 'edit' | 'view' | 'suggesting' | undefined): void;
     setRemoteCaretLabelHost(host: RemoteCaretLabelHost | null): void;
     setReviewAuthorVisible(author: string, visible: boolean): void;
     setRevisionStyles(styles: RevisionStyles): void;
+    setTranslate(translate: ((key: string, params?: Record<string, string | number>) => string) | undefined): void;
     showAllReviewAuthors(): void;
     stateVersion(): number;
     readonly surface: PaginatedSurface | null;
@@ -1530,6 +1533,7 @@ export interface PaginatedSurface {
     setAllRevisionAuthorsVisible(visible: boolean): void;
     setAuthor(author: string | undefined): void;
     setCellSelection(next: CellSelection | null): void;
+    setDrawingStrings(strings: DrawingPaintStrings): void;
     setEditable(editable: boolean): void;
     // (undocumented)
     setEditingMode(mode: SurfaceEditingMode): void;
@@ -1577,6 +1581,7 @@ export interface PaginatedSurface {
     }): boolean;
     setSelection(next: SemanticSelection): void;
     setTableInteractionLabel(resolver: (key: 'table.insertRowBelow' | 'table.insertColumnRight') => string): void;
+    setTocLabels(labels: NonNullable<PaginatedSurfaceOptions['tocLabels']>): void;
     setTrackedChangesFilter(predicate: TrackedChangePredicate | null, mode?: TrackedChangeFilterMode): void;
     showAllRevisionAuthors(): void;
     // (undocumented)

--- a/docs/api/docx-editor-core/editor.api.md
+++ b/docs/api/docx-editor-core/editor.api.md
@@ -854,6 +854,7 @@ export interface DocxEditorInstance extends Editor {
     readonly mountGeneration: number;
     presenceColorFor(name: string): string;
     setAllReviewAuthorsVisible(visible: boolean): void;
+    setAuthor(author: string | undefined): void;
     setEquationChrome(handlers: EquationChromeHandlers): Unsubscribe;
     setHyperlinkChrome(handlers: HyperlinkChromeHandlers): Unsubscribe;
     setRemoteCaretLabelHost(host: RemoteCaretLabelHost | null): void;
@@ -1527,6 +1528,7 @@ export interface PaginatedSurface {
     readonly session: TreeDocxSessionView;
     setActiveScope(scope: ViewScope): boolean;
     setAllRevisionAuthorsVisible(visible: boolean): void;
+    setAuthor(author: string | undefined): void;
     setCellSelection(next: CellSelection | null): void;
     setEditable(editable: boolean): void;
     // (undocumented)

--- a/docs/api/docx-editor-core/index.api.md
+++ b/docs/api/docx-editor-core/index.api.md
@@ -1075,9 +1075,12 @@ export interface DocxEditorInstance extends Editor {
     setAuthor(author: string | undefined): void;
     setEquationChrome(handlers: EquationChromeHandlers): Unsubscribe;
     setHyperlinkChrome(handlers: HyperlinkChromeHandlers): Unsubscribe;
+    setLocale(locale: string | undefined): void;
+    setMode(mode: 'edit' | 'view' | 'suggesting' | undefined): void;
     setRemoteCaretLabelHost(host: RemoteCaretLabelHost | null): void;
     setReviewAuthorVisible(author: string, visible: boolean): void;
     setRevisionStyles(styles: RevisionStyles): void;
+    setTranslate(translate: ((key: string, params?: Record<string, string | number>) => string) | undefined): void;
     showAllReviewAuthors(): void;
     stateVersion(): number;
     readonly surface: PaginatedSurface | null;

--- a/docs/api/docx-editor-core/index.api.md
+++ b/docs/api/docx-editor-core/index.api.md
@@ -1072,6 +1072,7 @@ export interface DocxEditorInstance extends Editor {
     readonly mountGeneration: number;
     presenceColorFor(name: string): string;
     setAllReviewAuthorsVisible(visible: boolean): void;
+    setAuthor(author: string | undefined): void;
     setEquationChrome(handlers: EquationChromeHandlers): Unsubscribe;
     setHyperlinkChrome(handlers: HyperlinkChromeHandlers): Unsubscribe;
     setRemoteCaretLabelHost(host: RemoteCaretLabelHost | null): void;

--- a/docs/api/docx-editor-react/index.api.md
+++ b/docs/api/docx-editor-react/index.api.md
@@ -735,7 +735,6 @@ export interface DocxEditorProps {
     fonts?: FontConfiguration | FontConfigurationFragment | FontResolver;
     hyperlinkPopup?: boolean;
     i18n?: Translations;
-    // (undocumented)
     locale?: string;
     menu?: boolean | DocxEditorMenuProps;
     mode?: EditorMode;
@@ -794,7 +793,6 @@ export interface DocxEditorRootProps {
     document?: DocumentSource;
     fonts?: FontConfiguration | FontConfigurationFragment | FontResolver;
     imageDecodePort?: ImageDecodePort;
-    // (undocumented)
     locale?: string;
     mode?: 'edit' | 'view' | 'suggesting';
     modules?: readonly EditorModule[];

--- a/docs/api/docx-editor-react/index.api.md
+++ b/docs/api/docx-editor-react/index.api.md
@@ -788,7 +788,6 @@ export interface DocxEditorRootListeners {
 
 // @public
 export interface DocxEditorRootProps {
-    // (undocumented)
     author?: string;
     // (undocumented)
     children?: DocxEditorChildren;

--- a/docs/api/docx-editor-vue/index.api.md
+++ b/docs/api/docx-editor-vue/index.api.md
@@ -2868,19 +2868,15 @@ export interface DocxEditorProps {
     hyperlinkPopup?: boolean;
     // (undocumented)
     i18n?: Translations;
-    // (undocumented)
     locale?: string;
     // (undocumented)
     menu?: boolean | DocxEditorMenuProps;
-    // (undocumented)
     mode?: EditorMode;
-    // (undocumented)
     modules?: readonly EditorModule[];
     // (undocumented)
     navigation?: boolean;
     // (undocumented)
     rulers?: boolean;
-    // (undocumented)
     t?: (key: string, params?: Record<string, string | number>) => string;
     // (undocumented)
     title?: string;
@@ -3039,7 +3035,6 @@ export interface DocxEditorRootListeners {
 
 // @public (undocumented)
 export interface DocxEditorRootProps {
-    // (undocumented)
     author?: string;
     // (undocumented)
     children?: DocxEditorChildren;
@@ -3049,11 +3044,8 @@ export interface DocxEditorRootProps {
     fonts?: FontConfiguration | FontConfigurationFragment | FontResolver;
     // (undocumented)
     imageDecodePort?: ImageDecodePort;
-    // (undocumented)
     locale?: string;
-    // (undocumented)
     mode?: 'edit' | 'view' | 'suggesting';
-    // (undocumented)
     modules?: readonly EditorModule[];
     // (undocumented)
     onChange?: (change: DocumentChange) => void;
@@ -3063,7 +3055,6 @@ export interface DocxEditorRootProps {
     onReady?: (editor: Editor) => void;
     // (undocumented)
     tableInteractionLabel?: (key: 'table.insertRowBelow' | 'table.insertColumnRight') => string;
-    // (undocumented)
     translate?: (key: string, params?: Record<string, string | number>) => string;
     // (undocumented)
     zoom?: number;

--- a/docs/site/content/react/composition.mdx
+++ b/docs/site/content/react/composition.mdx
@@ -18,7 +18,7 @@ Your controls can use the same command and state APIs.
 | `DocxEditor.Root`        | Every composed editor            | Owns and provides the editor instance                            |
 | `DocxEditor.Viewport`    | Every composed editor            | Supplies the scroll container and page-layout classes            |
 | `DocxEditor.Content`     | Every composed editor            | Mounts the painted document surface                              |
-| Stable `modules` array   | When you register modules        | Prevents unintended module changes during construction           |
+| Remount `key`            | When you change modules          | Registers the new construction-only module set                   |
 | Positioned workspace row | When you use the navigation pane | Anchors the navigation pane                                      |
 | Pro review module        | When you use Pro review chrome   | Enables comments, tracked changes, and custom-node review chrome |
 
@@ -60,26 +60,26 @@ hyperlink popover, and context menu.
 ### Root props
 
 The editor reads construction props when it creates the instance.
-Changes to `document`, `fonts`, `imageDecodePort`, or the locale catalog
-remount the editor.
-Changes to `author`, `zoom`, and `zoomMode` apply without a remount.
+Changes to `document`, `fonts`, or `imageDecodePort` remount the editor.
+Changes to `author`, `locale`, `mode`, `translate`, `zoom`, `zoomMode`, or the locale catalog
+apply without a remount.
 These changes preserve edits, caret position, and undo history.
 
-| Prop                    | Type                                                             | Description                                                                                        |
-| ----------------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `document`              | `DocumentSource`                                                 | Loads DOCX bytes, `'blank'`, or a `DocumentHandle`. An identity change remounts the editor.        |
-| `fonts`                 | `FontConfiguration \| FontConfigurationFragment \| FontResolver` | Supplies font bytes or a resolver. An identity change remounts the editor.                         |
-| `author`                | `string`                                                         | Sets the author for later comments, replies, and tracked changes. Changes apply without a remount. |
-| `locale`                | `string`                                                         | Sets the document locale for the editor engine.                                                    |
-| `mode`                  | `'edit' \| 'view' \| 'suggesting'`                               | Sets the initial mode. When omitted, `w:trackRevisions` can select suggesting mode.                |
-| `modules`               | `readonly EditorModule[]`                                        | Registers capability modules during construction. Keep the array identity stable.                  |
-| `zoom` / `zoomMode`     | `number` / `ZoomMode \| 'auto'`                                  | Sets the display scale and its source. `'auto'` fits the page width.                               |
-| `onReady`               | `(editor: Editor) => void`                                       | Runs once per instance after `Content` attaches.                                                   |
-| `onChange`              | `(change: DocumentChange) => void`                               | Reports revision and identity changes after mutations.                                             |
-| `onFontError`           | `(error: EditorFontError) => void`                               | Reports typed font-resolution failures.                                                            |
-| `translate`             | `(key, params?) => string`                                       | Resolves document-surface labels. It defaults to the active catalog.                               |
-| `tableInteractionLabel` | `(key) => string`                                                | Resolves labels for table insertion controls.                                                      |
-| `imageDecodePort`       | `ImageDecodePort`                                                | Overrides raster decoding for tests or custom hosts.                                               |
+| Prop                    | Type                                                             | Description                                                                                                       |
+| ----------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `document`              | `DocumentSource`                                                 | Loads DOCX bytes, `'blank'`, or a `DocumentHandle`. An identity change remounts the editor.                       |
+| `fonts`                 | `FontConfiguration \| FontConfigurationFragment \| FontResolver` | Supplies font bytes or a resolver. An identity change remounts the editor.                                        |
+| `author`                | `string`                                                         | Sets the author for later comments, replies, and tracked changes. Changes apply without a remount.                |
+| `locale`                | `string`                                                         | Engine locale for engine-generated content, such as the table of contents title. Changes apply without a remount. |
+| `mode`                  | `'edit' \| 'view' \| 'suggesting'`                               | Sets the live host mode. When omitted, `w:trackRevisions` can select suggesting mode.                             |
+| `modules`               | `readonly EditorModule[]`                                        | Registers modules during construction. Remount with a different `key` to change them.                             |
+| `zoom` / `zoomMode`     | `number` / `ZoomMode \| 'auto'`                                  | Sets the display scale and its source. `'auto'` fits the page width.                                              |
+| `onReady`               | `(editor: Editor) => void`                                       | Runs once per instance after `Content` attaches.                                                                  |
+| `onChange`              | `(change: DocumentChange) => void`                               | Reports revision and identity changes after mutations.                                                            |
+| `onFontError`           | `(error: EditorFontError) => void`                               | Reports typed font-resolution failures.                                                                           |
+| `translate`             | `(key, params?) => string`                                       | Resolves live document-surface labels. It defaults to the active catalog.                                         |
+| `tableInteractionLabel` | `(key) => string`                                                | Resolves labels for table insertion controls.                                                                     |
+| `imageDecodePort`       | `ImageDecodePort`                                                | Overrides raster decoding for tests or custom hosts.                                                              |
 
 For exact signatures, see the [React API reference](/docs/2.x/api/react).
 

--- a/docs/site/content/react/composition.mdx
+++ b/docs/site/content/react/composition.mdx
@@ -62,24 +62,24 @@ hyperlink popover, and context menu.
 The editor reads construction props when it creates the instance.
 Changes to `document`, `fonts`, `imageDecodePort`, or the locale catalog
 remount the editor.
-Changes to `zoom` and `zoomMode` apply without a remount.
+Changes to `author`, `zoom`, and `zoomMode` apply without a remount.
 These changes preserve edits, caret position, and undo history.
 
-| Prop                    | Type                                                             | Description                                                                                 |
-| ----------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| `document`              | `DocumentSource`                                                 | Loads DOCX bytes, `'blank'`, or a `DocumentHandle`. An identity change remounts the editor. |
-| `fonts`                 | `FontConfiguration \| FontConfigurationFragment \| FontResolver` | Supplies font bytes or a resolver. An identity change remounts the editor.                  |
-| `author`                | `string`                                                         | Sets the author for comments and tracked changes. Suggesting mode requires it.              |
-| `locale`                | `string`                                                         | Sets the document locale for the editor engine.                                             |
-| `mode`                  | `'edit' \| 'view' \| 'suggesting'`                               | Sets the initial mode. When omitted, `w:trackRevisions` can select suggesting mode.         |
-| `modules`               | `readonly EditorModule[]`                                        | Registers capability modules during construction. Keep the array identity stable.           |
-| `zoom` / `zoomMode`     | `number` / `ZoomMode \| 'auto'`                                  | Sets the display scale and its source. `'auto'` fits the page width.                        |
-| `onReady`               | `(editor: Editor) => void`                                       | Runs once per instance after `Content` attaches.                                            |
-| `onChange`              | `(change: DocumentChange) => void`                               | Reports revision and identity changes after mutations.                                      |
-| `onFontError`           | `(error: EditorFontError) => void`                               | Reports typed font-resolution failures.                                                     |
-| `translate`             | `(key, params?) => string`                                       | Resolves document-surface labels. It defaults to the active catalog.                        |
-| `tableInteractionLabel` | `(key) => string`                                                | Resolves labels for table insertion controls.                                               |
-| `imageDecodePort`       | `ImageDecodePort`                                                | Overrides raster decoding for tests or custom hosts.                                        |
+| Prop                    | Type                                                             | Description                                                                                        |
+| ----------------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `document`              | `DocumentSource`                                                 | Loads DOCX bytes, `'blank'`, or a `DocumentHandle`. An identity change remounts the editor.        |
+| `fonts`                 | `FontConfiguration \| FontConfigurationFragment \| FontResolver` | Supplies font bytes or a resolver. An identity change remounts the editor.                         |
+| `author`                | `string`                                                         | Sets the author for later comments, replies, and tracked changes. Changes apply without a remount. |
+| `locale`                | `string`                                                         | Sets the document locale for the editor engine.                                                    |
+| `mode`                  | `'edit' \| 'view' \| 'suggesting'`                               | Sets the initial mode. When omitted, `w:trackRevisions` can select suggesting mode.                |
+| `modules`               | `readonly EditorModule[]`                                        | Registers capability modules during construction. Keep the array identity stable.                  |
+| `zoom` / `zoomMode`     | `number` / `ZoomMode \| 'auto'`                                  | Sets the display scale and its source. `'auto'` fits the page width.                               |
+| `onReady`               | `(editor: Editor) => void`                                       | Runs once per instance after `Content` attaches.                                                   |
+| `onChange`              | `(change: DocumentChange) => void`                               | Reports revision and identity changes after mutations.                                             |
+| `onFontError`           | `(error: EditorFontError) => void`                               | Reports typed font-resolution failures.                                                            |
+| `translate`             | `(key, params?) => string`                                       | Resolves document-surface labels. It defaults to the active catalog.                               |
+| `tableInteractionLabel` | `(key) => string`                                                | Resolves labels for table insertion controls.                                                      |
+| `imageDecodePort`       | `ImageDecodePort`                                                | Overrides raster decoding for tests or custom hosts.                                               |
 
 For exact signatures, see the [React API reference](/docs/2.x/api/react).
 

--- a/docs/site/content/react/props.mdx
+++ b/docs/site/content/react/props.mdx
@@ -14,15 +14,15 @@ For all signatures, see the [React API reference](/docs/2.x/api/react).
 Use `document` for the document source.
 Use `fonts` to supply font metrics for measurement.
 
-| Prop       | Type                                                             | Description                                                                               |
-| ---------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `document` | `DocumentSource`                                                 | DOCX bytes, `'blank'`, or an existing `DocumentHandle`.                                   |
-| `fonts`    | `FontConfiguration \| FontConfigurationFragment \| FontResolver` | Font bytes or a resolver for text shaping and pagination.                                 |
-| `author`   | `string`                                                         | Author for later comments, replies, and tracked changes. Changes apply without a remount. |
-| `locale`   | `string`                                                         | Document locale passed to the editor engine.                                              |
-| `mode`     | `'edit' \| 'view' \| 'suggesting'`                               | Initial editing mode. The default is `'edit'`. Remount the editor to change it.           |
-| `zoom`     | `number`                                                         | Fixed display scale. Changes apply without a remount.                                     |
-| `zoomMode` | `ZoomMode \| 'auto'`                                             | Scale source. The default `'auto'` fits the page width.                                   |
+| Prop       | Type                                                             | Description                                                                                                       |
+| ---------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `document` | `DocumentSource`                                                 | DOCX bytes, `'blank'`, or an existing `DocumentHandle`.                                                           |
+| `fonts`    | `FontConfiguration \| FontConfigurationFragment \| FontResolver` | Font bytes or a resolver for text shaping and pagination.                                                         |
+| `author`   | `string`                                                         | Author for later comments, replies, and tracked changes. Changes apply without a remount.                         |
+| `locale`   | `string`                                                         | Engine locale for engine-generated content, such as the table of contents title. Changes apply without a remount. |
+| `mode`     | `'edit' \| 'view' \| 'suggesting'`                               | Host editing mode. Changes apply without a remount.                                                               |
+| `zoom`     | `number`                                                         | Fixed display scale. Changes apply without a remount.                                                             |
+| `zoomMode` | `ZoomMode \| 'auto'`                                             | Scale source. The default `'auto'` fits the page width.                                                           |
 
 The editor colors tracked changes by author.
 Changing `author` preserves the editor instance and all existing revisions.
@@ -50,9 +50,9 @@ comments, and custom nodes.
 | --------- | ------------------------- | ------------------------------------------------------------- |
 | `modules` | `readonly EditorModule[]` | Capability modules that the editor loads during construction. |
 
-Keep the array identity stable.
-A new array causes the editor to rebuild.
-Define the array outside your component or memoize it:
+The editor reads `modules` only during construction.
+A later array change has no effect.
+To change modules, remount the editor with a different React `key`:
 
 ```tsx
 import { DocxEditor } from '@docx-editor.dev/react';
@@ -60,7 +60,7 @@ import { reviewModule } from '@docx-editor.dev/pro/react';
 
 const MODULES = [reviewModule()];
 
-<DocxEditor document={bytes} modules={MODULES} author="Jess Lin" />;
+<DocxEditor key={moduleSet} document={bytes} modules={MODULES} author="Jess Lin" />;
 ```
 
 Without a module, the editor preserves revisions and comments during save.
@@ -85,8 +85,8 @@ These props control the packaged frame around the document.
 | `hyperlinkPopup`                             | `boolean`                               | Shows or hides the packaged hyperlink popover.                                  |
 | `contextMenu`                                | `boolean \| DocxEditorContextMenuProps` | Shows, hides, or configures the packaged context menu.                          |
 | `children`                                   | `DocxEditorChildren`                    | Renders extra chrome inside the viewport after the document pages.              |
-| `t`                                          | `(key, params?) => string`              | Resolves chrome labels and interpolation parameters.                            |
-| `i18n`                                       | `Translations`                          | Sets the chrome language for this editor.                                       |
+| `t`                                          | `(key, params?) => string`              | Resolves live chrome and drawing labels.                                        |
+| `i18n`                                       | `Translations`                          | Sets live chrome and drawing labels for this editor.                            |
 
 ## Dark mode
 

--- a/docs/site/content/react/props.mdx
+++ b/docs/site/content/react/props.mdx
@@ -14,17 +14,18 @@ For all signatures, see the [React API reference](/docs/2.x/api/react).
 Use `document` for the document source.
 Use `fonts` to supply font metrics for measurement.
 
-| Prop       | Type                                                             | Description                                                                     |
-| ---------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| `document` | `DocumentSource`                                                 | DOCX bytes, `'blank'`, or an existing `DocumentHandle`.                         |
-| `fonts`    | `FontConfiguration \| FontConfigurationFragment \| FontResolver` | Font bytes or a resolver for text shaping and pagination.                       |
-| `author`   | `string`                                                         | Author for comments, tracked changes, and other authored commands.              |
-| `locale`   | `string`                                                         | Document locale passed to the editor engine.                                    |
-| `mode`     | `'edit' \| 'view' \| 'suggesting'`                               | Initial editing mode. The default is `'edit'`. Remount the editor to change it. |
-| `zoom`     | `number`                                                         | Fixed display scale. Changes apply without a remount.                           |
-| `zoomMode` | `ZoomMode \| 'auto'`                                             | Scale source. The default `'auto'` fits the page width.                         |
+| Prop       | Type                                                             | Description                                                                               |
+| ---------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `document` | `DocumentSource`                                                 | DOCX bytes, `'blank'`, or an existing `DocumentHandle`.                                   |
+| `fonts`    | `FontConfiguration \| FontConfigurationFragment \| FontResolver` | Font bytes or a resolver for text shaping and pagination.                                 |
+| `author`   | `string`                                                         | Author for later comments, replies, and tracked changes. Changes apply without a remount. |
+| `locale`   | `string`                                                         | Document locale passed to the editor engine.                                              |
+| `mode`     | `'edit' \| 'view' \| 'suggesting'`                               | Initial editing mode. The default is `'edit'`. Remount the editor to change it.           |
+| `zoom`     | `number`                                                         | Fixed display scale. Changes apply without a remount.                                     |
+| `zoomMode` | `ZoomMode \| 'auto'`                                             | Scale source. The default `'auto'` fits the page width.                                   |
 
 The editor colors tracked changes by author.
+Changing `author` preserves the editor instance and all existing revisions.
 Mount `<DocxEditor.AuthorStyle />` to override one author's style.
 Mount `<DocxEditor.ColorByChangeType />` to color changes by type.
 These settings do not have equivalent props.

--- a/docs/site/content/vue/composition.mdx
+++ b/docs/site/content/vue/composition.mdx
@@ -15,7 +15,7 @@ need a different interface.
 | `DocxEditorRoot`         | Every composed editor            | Owns and provides the editor instance                            |
 | `DocxEditorViewport`     | Every composed editor            | Supplies the scroll container and page-layout classes            |
 | `DocxEditorContent`      | Every composed editor            | Mounts the painted document surface                              |
-| Stable `modules` array   | When you register modules        | Prevents unintended module changes during construction           |
+| Remount `:key`           | When you change modules          | Registers the new construction-only module set                   |
 | Positioned workspace row | When you use the navigation pane | Anchors the navigation pane                                      |
 | Pro review module        | When you use Pro review chrome   | Enables comments, tracked changes, and custom-node review chrome |
 
@@ -54,10 +54,13 @@ You can place all optional chrome inside `DocxEditorRoot`.
 
 Listen for `@ready`, `@change`, and `@font-error` on the root.
 
-The root samples `document`, `fonts`, `translate`, and `imageDecodePort` when it
-creates the editor. An identity change rebuilds the editor. Changes to `zoom`
-and `zoomMode` apply without a rebuild. Changes to `author` also apply without a
-rebuild, and existing revisions keep their authors.
+The root rebuilds for `document`, `fonts`, and `imageDecodePort` identity changes.
+Changes to `author`, `locale`, `mode`, `translate`, `zoom`, `zoomMode`, and the locale catalog
+apply without a rebuild. Existing revisions keep their authors.
+The root ignores a later `modules` array change until you remount it with a different `:key`.
+
+The engine uses `locale` for engine-generated content, such as the table of contents title.
+Changes apply without a remount.
 
 For full prop types, see the
 [Vue API reference](/docs/2.x/api/vue).

--- a/docs/site/content/vue/composition.mdx
+++ b/docs/site/content/vue/composition.mdx
@@ -56,7 +56,8 @@ Listen for `@ready`, `@change`, and `@font-error` on the root.
 
 The root samples `document`, `fonts`, `translate`, and `imageDecodePort` when it
 creates the editor. An identity change rebuilds the editor. Changes to `zoom`
-and `zoomMode` apply without a rebuild.
+and `zoomMode` apply without a rebuild. Changes to `author` also apply without a
+rebuild, and existing revisions keep their authors.
 
 For full prop types, see the
 [Vue API reference](/docs/2.x/api/vue).

--- a/docs/site/content/vue/props.mdx
+++ b/docs/site/content/vue/props.mdx
@@ -15,7 +15,7 @@ Use `document` for the document source.
 | Prop       | Type                               | Description                                                     |
 | ---------- | ---------------------------------- | --------------------------------------------------------------- |
 | `document` | `DocumentSource`                   | DOCX bytes, `'blank'`, or a `DocumentHandle`.                   |
-| `author`   | `string`                           | Author for comments and review commands.                        |
+| `author`   | `string`                           | Author for later comments, replies, and tracked changes.        |
 | `locale`   | `string`                           | Locale passed to the editor.                                    |
 | `mode`     | `'edit' \| 'view' \| 'suggesting'` | Opening mode. The packaged `<DocxEditor>` defaults to `'edit'`. |
 | `zoom`     | `number`                           | Numeric display scale.                                          |
@@ -36,7 +36,8 @@ import { DocxEditor } from '@docx-editor.dev/vue';
 ```
 
 `<DocxEditor>` rebuilds when the `document` identity changes. It applies later
-`zoom` and `zoomMode` changes through the editor facade.
+`author`, `zoom`, and `zoomMode` changes through the editor facade without a rebuild.
+Existing revisions keep their authors.
 
 ## Modules
 

--- a/docs/site/content/vue/props.mdx
+++ b/docs/site/content/vue/props.mdx
@@ -12,14 +12,14 @@ use. See the [Vue API reference](/docs/2.x/api/vue) for generated signatures.
 
 Use `document` for the document source.
 
-| Prop       | Type                               | Description                                                     |
-| ---------- | ---------------------------------- | --------------------------------------------------------------- |
-| `document` | `DocumentSource`                   | DOCX bytes, `'blank'`, or a `DocumentHandle`.                   |
-| `author`   | `string`                           | Author for later comments, replies, and tracked changes.        |
-| `locale`   | `string`                           | Locale passed to the editor.                                    |
-| `mode`     | `'edit' \| 'view' \| 'suggesting'` | Opening mode. The packaged `<DocxEditor>` defaults to `'edit'`. |
-| `zoom`     | `number`                           | Numeric display scale.                                          |
-| `zoomMode` | `ZoomMode \| 'auto'`               | Zoom source. `'auto'` fits the page width.                      |
+| Prop       | Type                               | Description                                                                                                       |
+| ---------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `document` | `DocumentSource`                   | DOCX bytes, `'blank'`, or a `DocumentHandle`.                                                                     |
+| `author`   | `string`                           | Author for later comments, replies, and tracked changes.                                                          |
+| `locale`   | `string`                           | Engine locale for engine-generated content, such as the table of contents title. Changes apply without a remount. |
+| `mode`     | `'edit' \| 'view' \| 'suggesting'` | Live host mode. The packaged `<DocxEditor>` defaults to `'edit'`.                                                 |
+| `zoom`     | `number`                           | Numeric display scale.                                                                                            |
+| `zoomMode` | `ZoomMode \| 'auto'`               | Zoom source. `'auto'` fits the page width.                                                                        |
 
 `DocumentSource` accepts `Uint8Array`, `ArrayBuffer`, `'blank'`, or an existing
 `DocumentHandle`. Resolve URLs and paths with
@@ -36,7 +36,7 @@ import { DocxEditor } from '@docx-editor.dev/vue';
 ```
 
 `<DocxEditor>` rebuilds when the `document` identity changes. It applies later
-`author`, `zoom`, and `zoomMode` changes through the editor facade without a rebuild.
+`author`, `locale`, `mode`, `translate`, `zoom`, `zoomMode`, and catalog changes without a rebuild.
 Existing revisions keep their authors.
 
 ## Modules
@@ -47,7 +47,8 @@ Existing revisions keep their authors.
 | --------- | ------------------------- | ----------------------------------- |
 | `modules` | `readonly EditorModule[]` | Modules registered at construction. |
 
-Keep the array identity stable.
+The editor ignores later `modules` array changes.
+Change the Vue `:key` to remount the editor with another module set.
 
 ```vue
 <script setup lang="ts">
@@ -58,7 +59,7 @@ const modules = [reviewModule()];
 </script>
 
 <template>
-  <DocxEditor :document="bytes" :modules="modules" author="Jess Lin" />
+  <DocxEditor :key="moduleSet" :document="bytes" :modules="modules" author="Jess Lin" />
 </template>
 ```
 
@@ -69,16 +70,16 @@ Pro entry also exports custom-node chip and context-menu chrome.
 
 These props control the packaged frame:
 
-| Prop             | Type                                    | Description                               |
-| ---------------- | --------------------------------------- | ----------------------------------------- |
-| `chrome`         | `boolean`                               | Toggles the packaged frame.               |
-| `menu`           | `boolean \| DocxEditorMenuProps`        | Toggles or configures the menu bar.       |
-| `navigation`     | `boolean`                               | Toggles the navigation pane.              |
-| `rulers`         | `boolean`                               | Toggles both packaged rulers.             |
-| `hyperlinkPopup` | `boolean`                               | Toggles the hyperlink popover.            |
-| `contextMenu`    | `boolean \| DocxEditorContextMenuProps` | Toggles or configures the context menu.   |
-| `t`              | `(key, params?) => string`              | Resolves packaged chrome labels.          |
-| `i18n`           | `Translations`                          | Supplies a locale catalog to this editor. |
+| Prop             | Type                                    | Description                              |
+| ---------------- | --------------------------------------- | ---------------------------------------- |
+| `chrome`         | `boolean`                               | Toggles the packaged frame.              |
+| `menu`           | `boolean \| DocxEditorMenuProps`        | Toggles or configures the menu bar.      |
+| `navigation`     | `boolean`                               | Toggles the navigation pane.             |
+| `rulers`         | `boolean`                               | Toggles both packaged rulers.            |
+| `hyperlinkPopup` | `boolean`                               | Toggles the hyperlink popover.           |
+| `contextMenu`    | `boolean \| DocxEditorContextMenuProps` | Toggles or configures the context menu.  |
+| `t`              | `(key, params?) => string`              | Resolves live chrome and drawing labels. |
+| `i18n`           | `Translations`                          | Supplies a live catalog to this editor.  |
 
 Set `chrome` to `false` for the document surface without packaged chrome. You can
 then build the frame from the [composition primitives](/docs/2.x/vue/composition).

--- a/packages/core/src/editor/__tests__/live-author.test.ts
+++ b/packages/core/src/editor/__tests__/live-author.test.ts
@@ -2,8 +2,76 @@ import { GlobalRegistrator } from '@happy-dom/global-registrator';
 if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
 
 import { describe, expect, test } from 'bun:test';
+import { strToU8, zipSync } from 'fflate';
 import { serializeOoxmlPart } from '@docx-editor.dev/core/store';
 import { createDocxEditor, type DocxEditorInstance } from '../docx-editor.ts';
+import { stubReviewModule } from './review-test-module.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+
+function packageDocx(parts: Record<string, string>): Uint8Array {
+  return zipSync(
+    Object.fromEntries(Object.entries(parts).map(([name, xml]) => [name, strToU8(xml)]))
+  );
+}
+
+function trackedDocx(): Uint8Array {
+  return packageDocx({
+    '[Content_Types].xml':
+      `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+      '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+      '<Override PartName="/word/settings.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.settings+xml"/></Types>',
+    '_rels/.rels': `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`,
+    'word/_rels/document.xml.rels': `<Relationships xmlns="${REL}"><Relationship Id="rIdSettings" Type="${R}/settings" Target="settings.xml"/></Relationships>`,
+    'word/settings.xml': `<w:settings xmlns:w="${W}"><w:trackRevisions/></w:settings>`,
+    'word/document.xml': `<w:document xmlns:w="${W}"><w:body><w:p><w:r><w:t>tracked</w:t></w:r></w:p></w:body></w:document>`,
+  });
+}
+
+function drawingDocx(): Uint8Array {
+  const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
+  const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+  const PIC = 'http://schemas.openxmlformats.org/drawingml/2006/picture';
+  const drawing =
+    '<w:r><w:drawing><wp:inline><wp:extent cx="228600" cy="114300"/>' +
+    '<wp:docPr id="1" name="picture"/><a:graphic><a:graphicData ' +
+    `uri="${PIC}"><pic:pic><pic:nvPicPr><pic:cNvPr id="1" name=""/>` +
+    '<pic:cNvPicPr/></pic:nvPicPr><pic:blipFill><a:blip r:embed="rIdImg"/>' +
+    '<a:stretch><a:fillRect/></a:stretch></pic:blipFill><pic:spPr><a:xfrm>' +
+    '<a:ext cx="228600" cy="114300"/></a:xfrm><a:prstGeom prst="rect"/>' +
+    '</pic:spPr></pic:pic></a:graphicData></a:graphic></wp:inline></w:drawing></w:r>';
+  return packageDocx({
+    '[Content_Types].xml':
+      `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+      '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>',
+    '_rels/.rels': `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`,
+    'word/_rels/document.xml.rels': `<Relationships xmlns="${REL}"><Relationship Id="rIdImg" Type="${R}/image" Target="https://example.com/image.png" TargetMode="External"/></Relationships>`,
+    'word/document.xml': `<w:document xmlns:w="${W}" xmlns:wp="${WP}" xmlns:a="${A}" xmlns:pic="${PIC}" xmlns:r="${R}"><w:body><w:p>${drawing}</w:p></w:body></w:document>`,
+  });
+}
+
+function tocDocx(): Uint8Array {
+  const stylesRel = `${R}/styles`;
+  const heading =
+    '<w:p><w:pPr><w:pStyle w:val="Heading1"/></w:pPr><w:r><w:t>Introduction</w:t></w:r></w:p>';
+  return packageDocx({
+    '[Content_Types].xml':
+      `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+      '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+      '<Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/></Types>',
+    '_rels/.rels': `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`,
+    'word/_rels/document.xml.rels': `<Relationships xmlns="${REL}"><Relationship Id="rIdStyles" Type="${stylesRel}" Target="styles.xml"/></Relationships>`,
+    'word/styles.xml':
+      `<w:styles xmlns:w="${W}"><w:style w:type="paragraph" w:styleId="Normal" w:default="1"><w:name w:val="Normal"/></w:style>` +
+      '<w:style w:type="paragraph" w:styleId="Heading1"><w:name w:val="heading 1"/></w:style>' +
+      '<w:style w:type="paragraph" w:styleId="TOC1"><w:name w:val="toc 1"/></w:style></w:styles>',
+    'word/document.xml': `<w:document xmlns:w="${W}"><w:body>${heading}</w:body></w:document>`,
+  });
+}
 
 function mounted(author: string) {
   const container = document.createElement('div');
@@ -113,6 +181,127 @@ describe('live author state', () => {
       off();
     } finally {
       dispose();
+    }
+  });
+});
+
+describe('live host configuration', () => {
+  test('mode changes enforce and lift the host view lock', () => {
+    const { editor, dispose } = mounted('Author A');
+    try {
+      let changes = 0;
+      editor.on('selectionChange', () => changes++);
+      editor.setMode('view');
+      expect(changes).toBe(1);
+      editor.setMode('view');
+      expect(changes).toBe(1);
+      expect(editor.getEditingMode()).toBe('viewing');
+      expect(editor.exec({ type: 'insertText', text: 'x' })).toMatchObject({
+        ok: false,
+        code: 'locked',
+      });
+      expect(editor.can({ type: 'setEditingMode', mode: 'editing' })).toMatchObject({
+        ok: false,
+        code: 'locked',
+      });
+
+      editor.setMode('edit');
+      expect(editor.getEditingMode()).toBe('editing');
+      expect(editor.exec({ type: 'insertText', text: 'x' })).toMatchObject({ ok: true });
+    } finally {
+      dispose();
+    }
+  });
+
+  test('an editor constructed for viewing can become editable', () => {
+    const container = document.createElement('div');
+    document.body.append(container);
+    const editor = createDocxEditor({ container, document: 'blank', mode: 'view' });
+    try {
+      expect(editor.getEditingMode()).toBe('viewing');
+      editor.setMode('edit');
+      expect(editor.getEditingMode()).toBe('editing');
+      expect(editor.exec({ type: 'insertText', text: 'x' })).toMatchObject({ ok: true });
+    } finally {
+      editor.destroy();
+      container.remove();
+    }
+  });
+
+  test('mode changes resolve suggesting and let document tracking decide again', () => {
+    const { editor, dispose } = mounted('Author A');
+    try {
+      editor.setMode('suggesting');
+      expect(editor.getEditingMode()).toBe('editing');
+      expect(editor.snapshot().lastRejection).toContain('pro review module');
+    } finally {
+      dispose();
+    }
+
+    const container = document.createElement('div');
+    document.body.append(container);
+    const tracked = createDocxEditor({
+      container,
+      author: 'Author A',
+      mode: 'edit',
+      modules: [stubReviewModule()],
+    });
+    try {
+      tracked.load(trackedDocx());
+      expect(tracked.snapshot().parseError).toBeNull();
+      expect(tracked.getEditingMode()).toBe('editing');
+      tracked.setMode(undefined);
+      expect(tracked.getEditingMode()).toBe('suggesting');
+    } finally {
+      tracked.destroy();
+      container.remove();
+    }
+  });
+
+  test('translation changes repaint drawing placeholder labels', () => {
+    const container = document.createElement('div');
+    document.body.append(container);
+    const editor = createDocxEditor({ container });
+    try {
+      editor.load(drawingDocx());
+      expect(editor.snapshot().parseError).toBeNull();
+      expect(container.querySelector('.docx-drawing-placeholder')?.textContent).toBe(
+        'Loading image'
+      );
+      let changes = 0;
+      editor.on('selectionChange', () => changes++);
+      const translate = (key: string) => (key === 'image.pendingResource' ? 'REMOTE IMAGE' : key);
+      editor.setTranslate(translate);
+      expect(changes).toBe(1);
+      expect(container.querySelector('.docx-drawing-placeholder')?.textContent).toBe(
+        'REMOTE IMAGE'
+      );
+      editor.setTranslate(translate);
+      expect(changes).toBe(1);
+    } finally {
+      editor.destroy();
+      container.remove();
+    }
+  });
+
+  test('locale changes apply to later TOC insertions', () => {
+    const container = document.createElement('div');
+    document.body.append(container);
+    const editor = createDocxEditor({ container });
+    try {
+      editor.load(tocDocx());
+      expect(editor.snapshot().parseError).toBeNull();
+      let changes = 0;
+      editor.on('selectionChange', () => changes++);
+      editor.setLocale('de');
+      expect(changes).toBe(1);
+      editor.setLocale('de');
+      expect(changes).toBe(1);
+      expect(editor.exec({ type: 'insertToc' })).toMatchObject({ ok: true, changed: true });
+      expect(xmlOf(editor)).toContain('w:alias w:val="Inhaltsverzeichnis"');
+    } finally {
+      editor.destroy();
+      container.remove();
     }
   });
 });

--- a/packages/core/src/editor/__tests__/live-author.test.ts
+++ b/packages/core/src/editor/__tests__/live-author.test.ts
@@ -261,23 +261,24 @@ describe('live host configuration', () => {
   test('translation changes repaint drawing placeholder labels', () => {
     const container = document.createElement('div');
     document.body.append(container);
-    const editor = createDocxEditor({ container });
+    const translate = (key: string) => `initial:${key}`;
+    const editor = createDocxEditor({ container, translate });
     try {
       editor.load(drawingDocx());
       expect(editor.snapshot().parseError).toBeNull();
-      expect(container.querySelector('.docx-drawing-placeholder')?.textContent).toBe(
-        'Loading image'
-      );
+      const placeholder = container.querySelector('.docx-drawing-placeholder');
+      expect(placeholder?.textContent).toBe('initial:image.pendingResource');
       let changes = 0;
       editor.on('selectionChange', () => changes++);
-      const translate = (key: string) => (key === 'image.pendingResource' ? 'REMOTE IMAGE' : key);
-      editor.setTranslate(translate);
+      editor.setTranslate((key) => `initial:${key}`);
+      expect(changes).toBe(0);
+      expect(container.querySelector('.docx-drawing-placeholder')).toBe(placeholder);
+
+      editor.setTranslate((key) => `updated:${key}`);
       expect(changes).toBe(1);
       expect(container.querySelector('.docx-drawing-placeholder')?.textContent).toBe(
-        'REMOTE IMAGE'
+        'updated:image.pendingResource'
       );
-      editor.setTranslate(translate);
-      expect(changes).toBe(1);
     } finally {
       editor.destroy();
       container.remove();

--- a/packages/core/src/editor/__tests__/live-author.test.ts
+++ b/packages/core/src/editor/__tests__/live-author.test.ts
@@ -1,0 +1,118 @@
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { serializeOoxmlPart } from '@docx-editor.dev/core/store';
+import { createDocxEditor, type DocxEditorInstance } from '../docx-editor.ts';
+
+function mounted(author: string) {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const editor = createDocxEditor({ container, document: 'blank', author });
+  editor.exec({ type: 'insertText', text: 'abcd' });
+  return {
+    editor,
+    dispose() {
+      editor.destroy();
+      container.remove();
+    },
+  };
+}
+
+function select(editor: DocxEditorInstance, start: number, end: number): void {
+  const paragraphId = editor.surface!.session.paragraphIds()[0]!;
+  editor.surface!.setSelection({
+    anchor: { paragraphId, offset: start },
+    head: { paragraphId, offset: end },
+  });
+}
+
+function xmlOf(editor: DocxEditorInstance): string {
+  return serializeOoxmlPart(editor.surface!.session.part());
+}
+
+describe('live author state', () => {
+  test('commits buffered text under the author active when it was typed', () => {
+    const { editor, dispose } = mounted('Author A');
+    try {
+      editor.surface!.setEditingMode('suggest');
+      editor.surface!.enqueueType('X');
+
+      editor.setAuthor('Author B');
+      editor.surface!.enqueueType('Y');
+      editor.surface!.flushPendingInput();
+
+      const xml = xmlOf(editor);
+      expect(xml).toMatch(/<w:ins\b[^>]*w:author="Author A"[^>]*>.*?<w:t>X<\/w:t>.*?<\/w:ins>/);
+      expect(xml).toMatch(/<w:ins\b[^>]*w:author="Author B"[^>]*>.*?<w:t>Y<\/w:t>.*?<\/w:ins>/);
+    } finally {
+      dispose();
+    }
+  });
+
+  test('attributes later replacements without rewriting an existing revision', () => {
+    const { editor, dispose } = mounted('Author A');
+    try {
+      select(editor, 0, 1);
+      expect(editor.exec({ type: 'proposeReplacement', replaceWith: 'X' })).toMatchObject({
+        ok: true,
+        changed: true,
+      });
+
+      editor.setAuthor('  Author B  ');
+      expect(editor.getConfiguredAuthor()).toBe('Author B');
+      select(editor, 1, 2);
+      expect(editor.exec({ type: 'proposeReplacement', replaceWith: 'Y' })).toMatchObject({
+        ok: true,
+        changed: true,
+      });
+
+      const xml = xmlOf(editor);
+      expect(xml.match(/w:author="Author A"/g)).toHaveLength(2);
+      expect(xml.match(/w:author="Author B"/g)).toHaveLength(2);
+    } finally {
+      dispose();
+    }
+  });
+
+  test('publishes author changes, clears whitespace, and keeps the value across reloads', () => {
+    const { editor, dispose } = mounted('Author A');
+    try {
+      let selectionChanges = 0;
+      const off = editor.on('selectionChange', () => {
+        selectionChanges += 1;
+      });
+
+      editor.setAuthor('Author B');
+      expect(selectionChanges).toBe(1);
+      editor.setAuthor(' Author B ');
+      expect(selectionChanges).toBe(1);
+
+      editor.load('blank');
+      expect(editor.getConfiguredAuthor()).toBe('Author B');
+      editor.exec({ type: 'insertText', text: 'ab' });
+      select(editor, 0, 1);
+      expect(editor.exec({ type: 'proposeReplacement', replaceWith: 'X' })).toMatchObject({
+        ok: true,
+        changed: true,
+      });
+      expect(xmlOf(editor)).toContain('w:author="Author B"');
+
+      editor.setAuthor('  ');
+      expect(editor.getConfiguredAuthor()).toBeNull();
+      editor.surface!.setEditingMode('suggest');
+      editor.surface!.insertPlainText('z');
+      expect(editor.surface!.state().lastRejection).toBe(
+        'suggesting needs an author before it can propose a change'
+      );
+      expect(editor.exec({ type: 'proposeInsertion', text: 'z' })).toMatchObject({
+        ok: false,
+        code: 'invalidArgs',
+        reason: 'tracked changes need a non-empty author',
+      });
+      off();
+    } finally {
+      dispose();
+    }
+  });
+});

--- a/packages/core/src/editor/docx-editor-author.ts
+++ b/packages/core/src/editor/docx-editor-author.ts
@@ -1,0 +1,14 @@
+/** Normalize an editor author for storage and comparison. */
+export function normalizeEditorAuthor(author: string | undefined): string | undefined {
+  return author?.trim() || undefined;
+}
+
+/** Initials from a name, for a revision — `CT_TrackChange` carries no `@w:initials`. */
+export function initialsOfAuthor(author: string): string {
+  const words = author.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return '?';
+  return words
+    .slice(0, 2)
+    .map((word) => word[0]!.toUpperCase())
+    .join('');
+}

--- a/packages/core/src/editor/docx-editor-host-config.ts
+++ b/packages/core/src/editor/docx-editor-host-config.ts
@@ -1,0 +1,88 @@
+/** Live host configuration for the editor facade. */
+
+import {
+  createT,
+  deepMerge,
+  en,
+  locales,
+  type LocaleCode,
+  type LocaleStrings,
+} from '@docx-editor.dev/i18n';
+import {
+  DEFAULT_DRAWING_PAINT_STRINGS,
+  drawingPaintStringsFromTranslate,
+  type DrawingPaintStrings,
+} from '../output/semantic-paint-drawings.ts';
+import {
+  resolveOpeningEditingMode,
+  type OpeningModeDecision,
+  type OpeningModeGuards,
+} from './opening-editing-mode.ts';
+
+export type HostEditingMode = 'edit' | 'view' | 'suggesting';
+export type EditorTranslate = (key: string, params?: Record<string, string | number>) => string;
+export interface TocLabels {
+  readonly title: string;
+}
+
+function localeState(locale: string | undefined): { code: LocaleCode; labels: TocLabels } {
+  const code = locale && locale in locales ? (locale as LocaleCode) : ('en' as const);
+  const t = createT(
+    deepMerge(en, code === 'en' ? undefined : locales[code]) as LocaleStrings,
+    code
+  );
+  return { code, labels: { title: t('toolbar.tableOfContents') } };
+}
+
+/** State that construction config and later instance setters share. */
+export interface DocxEditorHostConfigState {
+  mode(): HostEditingMode | undefined;
+  modeForGate(): HostEditingMode;
+  openingModeDecision(guards: OpeningModeGuards): OpeningModeDecision;
+  setMode(mode: HostEditingMode | undefined): boolean;
+  drawingStrings(): DrawingPaintStrings;
+  setTranslate(translate: EditorTranslate | undefined): DrawingPaintStrings | null;
+  tocLabels(): TocLabels;
+  setLocale(locale: string | undefined): TocLabels | null;
+}
+
+/** Create mutable host state while module registration stays construction-only. */
+export function createDocxEditorHostConfigState(initial: {
+  readonly mode?: HostEditingMode;
+  readonly translate?: EditorTranslate;
+  readonly locale?: string;
+}): DocxEditorHostConfigState {
+  let mode = initial.mode;
+  let translate = initial.translate;
+  let drawingStrings = translate
+    ? drawingPaintStringsFromTranslate(translate)
+    : DEFAULT_DRAWING_PAINT_STRINGS;
+  let locale = localeState(initial.locale);
+
+  return {
+    mode: () => mode,
+    modeForGate: () => mode ?? 'edit',
+    openingModeDecision: (guards) => resolveOpeningEditingMode(mode, guards),
+    setMode(next) {
+      if (mode === next) return false;
+      mode = next;
+      return true;
+    },
+    drawingStrings: () => drawingStrings,
+    setTranslate(next) {
+      if (translate === next) return null;
+      translate = next;
+      drawingStrings = next
+        ? drawingPaintStringsFromTranslate(next)
+        : DEFAULT_DRAWING_PAINT_STRINGS;
+      return drawingStrings;
+    },
+    tocLabels: () => locale.labels,
+    setLocale(next) {
+      const resolved = localeState(next);
+      if (locale.code === resolved.code) return null;
+      locale = resolved;
+      return locale.labels;
+    },
+  };
+}

--- a/packages/core/src/editor/docx-editor-host-config.ts
+++ b/packages/core/src/editor/docx-editor-host-config.ts
@@ -10,6 +10,7 @@ import {
 } from '@docx-editor.dev/i18n';
 import {
   DEFAULT_DRAWING_PAINT_STRINGS,
+  drawingPaintStringsCacheToken,
   drawingPaintStringsFromTranslate,
   type DrawingPaintStrings,
 } from '../output/semantic-paint-drawings.ts';
@@ -72,9 +73,17 @@ export function createDocxEditorHostConfigState(initial: {
     setTranslate(next) {
       if (translate === next) return null;
       translate = next;
-      drawingStrings = next
+      const nextDrawingStrings = next
         ? drawingPaintStringsFromTranslate(next)
         : DEFAULT_DRAWING_PAINT_STRINGS;
+      if (
+        drawingPaintStringsCacheToken(drawingStrings) ===
+        drawingPaintStringsCacheToken(nextDrawingStrings)
+      ) {
+        drawingStrings = nextDrawingStrings;
+        return null;
+      }
+      drawingStrings = nextDrawingStrings;
       return drawingStrings;
     },
     tocLabels: () => locale.labels,

--- a/packages/core/src/editor/docx-editor-types.ts
+++ b/packages/core/src/editor/docx-editor-types.ts
@@ -290,6 +290,32 @@ export interface DocxEditorInstance extends Editor {
    */
   setAuthor(author: string | undefined): void;
   /**
+   * Set the host editing mode without rebuilding the editor.
+   *
+   * This has the same meaning as {@link DocxEditorConfig.mode}. Passing `undefined` lets the
+   * document's tracking settings select the mode again. Host changes do not count as a reader
+   * toolbar choice.
+   *
+   * @public
+   */
+  setMode(mode: 'edit' | 'view' | 'suggesting' | undefined): void;
+  /**
+   * Set the drawing-label resolver without rebuilding the editor. Painted placeholders update
+   * immediately, and later surface mounts use the same resolver.
+   *
+   * @public
+   */
+  setTranslate(
+    translate: ((key: string, params?: Record<string, string | number>) => string) | undefined
+  ): void;
+  /**
+   * Set the engine locale without rebuilding the editor. Later table-of-contents insertions use
+   * the resolved locale label. Unsupported and omitted locales resolve to English.
+   *
+   * @public
+   */
+  setLocale(locale: string | undefined): void;
+  /**
    * The style declared for one author, whether or not the SURFACE has published them yet —
    * so review chrome can draw a card the rail is holding before the roster catches up.
    *

--- a/packages/core/src/editor/docx-editor-types.ts
+++ b/packages/core/src/editor/docx-editor-types.ts
@@ -279,6 +279,17 @@ export interface DocxEditorInstance extends Editor {
    */
   getConfiguredAuthor(): string | null;
   /**
+   * Set the author for runtime editor state.
+   *
+   * Unlike the construction-time {@link DocxEditorConfig.author}, this value applies to every
+   * later comment, reply, and tracked change. It does not rewrite existing revisions. The value
+   * survives document reloads and font remounts. An empty or whitespace value clears the author,
+   * after which suggesting refuses writes with its existing reason.
+   *
+   * @public
+   */
+  setAuthor(author: string | undefined): void;
+  /**
    * The style declared for one author, whether or not the SURFACE has published them yet —
    * so review chrome can draw a card the rail is holding before the roster catches up.
    *

--- a/packages/core/src/editor/docx-editor-types.ts
+++ b/packages/core/src/editor/docx-editor-types.ts
@@ -293,8 +293,8 @@ export interface DocxEditorInstance extends Editor {
    * Set the host editing mode without rebuilding the editor.
    *
    * This has the same meaning as {@link DocxEditorConfig.mode}. Passing `undefined` lets the
-   * document's tracking settings select the mode again. Host changes do not count as a reader
-   * toolbar choice.
+   * document's tracking settings select the mode again. A host change clears the reader's
+   * toolbar choice, so a later document reload can adopt `w:trackRevisions` again.
    *
    * @public
    */

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -216,6 +216,7 @@ import {
 } from './opening-editing-mode.ts';
 import { createRevisionStyleState, EMPTY_AUTHOR_SLOTS } from './revision-style-state.ts';
 import { createChromeHandlerStack } from './chrome-handler-stack.ts';
+import { initialsOfAuthor, normalizeEditorAuthor } from './docx-editor-author.ts';
 import type {
   DocxEditorConfig,
   DocxEditorInstance,
@@ -314,6 +315,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
   let readerChoseMode = false;
   /** A refusal this facade made before the surface could see the request; see `snapshot`. */
   let facadeRejection: string | null = null;
+  let author = normalizeEditorAuthor(config.author);
   const mode = config.mode ?? 'edit';
 
   // The HOST's opening mode, when `config.mode` is explicit — precedence and reasons live
@@ -504,7 +506,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
         : {}),
       // Suggesting needs both: an author to attribute a proposal to, and the mode itself,
       // which survives a document reload because the reader chose it, not the file.
-      ...(config.author ? { author: config.author } : {}),
+      ...(author ? { author } : {}),
       // Presentation policy for tracked changes, applied wherever revision markup paints.
       // The facade's state, not `config`: a reload keeps a live `setRevisionStyles`.
       ...(revisionStyleState.current() !== undefined
@@ -1633,7 +1635,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
     const decision = documentTrackingAdoption({
       viewOnly: mode === 'view',
       reviewEnabled,
-      hasAuthor: Boolean(config.author),
+      hasAuthor: Boolean(author),
       hostChoseMode: config.mode !== undefined,
       readerChoseMode,
       currentMode: editingMode,
@@ -1669,16 +1671,6 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
   function dateOfItem(item: ReviewItem): string | undefined {
     if (item.kind === 'comment') return item.comment.date;
     return item.kind === 'revision' ? item.date : undefined;
-  }
-
-  /** Initials from a name, for a revision — `CT_TrackChange` carries no `@w:initials`. */
-  function initialsOfAuthor(author: string): string {
-    const words = author.trim().split(/\s+/).filter(Boolean);
-    if (words.length === 0) return '?';
-    return words
-      .slice(0, 2)
-      .map((word) => word[0]!.toUpperCase())
-      .join('');
   }
 
   function resolveReviewItem(key: string, action: 'accept' | 'reject'): ExecResult {
@@ -1968,7 +1960,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
         command.type === 'proposeDeletion' ||
         command.type === 'proposeReplacement'
       ) {
-        const writer = (command.author ?? config.author ?? '').trim();
+        const writer = (command.author ?? author ?? '').trim();
         if (!writer) {
           return {
             ok: false,
@@ -2163,7 +2155,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
     getCustomNodeDefinitions: () => modules.customNodes,
     reportCustomNodeDiagnostic: reportDiagnostic,
 
-    addComment(text: string, author?: string): ExecResult {
+    addComment(text: string, authorOverride?: string): ExecResult {
       // Comment AUTHORING is the review module's capability, like every other
       // review write above. Missed in the first gating pass — caught by review.
       if (!reviewEnabled) {
@@ -2177,7 +2169,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
       if (!range || !surface) {
         return { ok: false, code: 'invalidArgs', reason: 'a comment needs a selected range' };
       }
-      const writer = (author ?? config.author ?? '').trim();
+      const writer = (authorOverride ?? author ?? '').trim();
       if (writer.length === 0 || text.trim().length === 0) {
         return {
           ok: false,
@@ -2235,7 +2227,15 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
       bump();
       emitSelectionChange();
     },
-    getConfiguredAuthor: () => config.author?.trim() || null,
+    getConfiguredAuthor: () => author ?? null,
+    setAuthor(nextAuthor) {
+      const normalized = normalizeEditorAuthor(nextAuthor);
+      if (author === normalized) return;
+      author = normalized;
+      surface?.setAuthor(author);
+      bump();
+      emitSelectionChange();
+    },
     presenceColorFor: (name) => surface?.remotePresenceColor(name) ?? 'var(--doc-accent)',
     collaborationSession: () => surface?.collaborationSession() ?? null,
     getReviewAuthorStyle: (author) => revisionStyleState.styleFor(author),
@@ -2454,7 +2454,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
       return { ok: true, changed: true };
     },
 
-    replyToReviewItem(key: string, text: string, author?: string): ExecResult {
+    replyToReviewItem(key: string, text: string, authorOverride?: string): ExecResult {
       if (!reviewEnabled) {
         return { ok: false, code: 'unsupported', reason: PRO_REVIEW_REASON };
       }
@@ -2471,7 +2471,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
       if (!range) {
         return { ok: false, code: 'invalidArgs', reason: 'the item has no anchorable range' };
       }
-      const writer = (author ?? config.author ?? '').trim();
+      const writer = (authorOverride ?? author ?? '').trim();
       const refusal = reviewReplyRefusal(item, text, writer);
       if (refusal) return refusal;
       // Against a REVISION this is a comment over that revision's range: OOXML gives `w:ins`

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -116,14 +116,6 @@ import {
   snapshotsEqual,
   unloadableSourceReason,
 } from './docx-editor-support.ts';
-import {
-  createT,
-  deepMerge,
-  en,
-  locales,
-  type LocaleCode,
-  type LocaleStrings,
-} from '@docx-editor.dev/i18n';
 import { execEditorCommand } from './docx-editor-exec.ts';
 import { createPublishSignal } from './surface-publish-signal.ts';
 import { FORMAT_PAINTER_OFF } from './surface-format-painter-contract.ts';
@@ -206,17 +198,17 @@ import {
   type PaginatedSurfaceOptions,
   type RemoteCaretLabelHost,
 } from './paginated-surface.ts';
-import { drawingPaintStringsFromTranslate } from '../output/semantic-paint-drawings.ts';
 import { surfaceScroller } from './surface-pages.ts';
 import { createZoomLane, zoomFacadeMembers } from './docx-editor-zoom.ts';
 import {
+  documentEditingModeRestriction,
   documentTrackingAdoption,
   PRO_REVIEW_REASON,
-  resolveOpeningEditingMode,
 } from './opening-editing-mode.ts';
 import { createRevisionStyleState, EMPTY_AUTHOR_SLOTS } from './revision-style-state.ts';
 import { createChromeHandlerStack } from './chrome-handler-stack.ts';
 import { initialsOfAuthor, normalizeEditorAuthor } from './docx-editor-author.ts';
+import { createDocxEditorHostConfigState } from './docx-editor-host-config.ts';
 import type {
   DocxEditorConfig,
   DocxEditorInstance,
@@ -257,13 +249,8 @@ const EMPTY_FONT_SUBSTITUTIONS: readonly string[] = Object.freeze([]);
  * @public
  */
 export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
-  const localeCode =
-    config.locale && config.locale in locales ? (config.locale as LocaleCode) : ('en' as const);
-  const t = createT(
-    deepMerge(en, localeCode === 'en' ? undefined : locales[localeCode]) as LocaleStrings,
-    localeCode
-  );
-  const tocLabels = { title: t('toolbar.tableOfContents') };
+  const hostConfig = createDocxEditorHostConfigState(config);
+  let author = normalizeEditorAuthor(config.author);
   let container: HTMLElement | null = config.container ?? null;
   /**
    * The capability registry, resolved once — module registration is
@@ -288,7 +275,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
    * and the opening-mode decision below may move it. Declared here because the surface is
    * handed it at mount, and a document reload keeps the reader's choice.
    */
-  let editingMode: DocumentEditingMode = config.mode === 'view' ? 'viewing' : 'editing';
+  let editingMode: DocumentEditingMode = hostConfig.mode() === 'view' ? 'viewing' : 'editing';
 
   /**
    * The host rail's activation filter, held here so a surface rebuilt on load or font
@@ -315,14 +302,12 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
   let readerChoseMode = false;
   /** A refusal this facade made before the surface could see the request; see `snapshot`. */
   let facadeRejection: string | null = null;
-  let author = normalizeEditorAuthor(config.author);
-  const mode = config.mode ?? 'edit';
 
   // The HOST's opening mode, when `config.mode` is explicit — precedence and reasons live
   // in `opening-editing-mode.ts`. Applied before the first mount reads `editingMode`.
-  const openingModeDecision = resolveOpeningEditingMode(config.mode, {
+  const openingModeDecision = hostConfig.openingModeDecision({
     reviewEnabled,
-    hasAuthor: Boolean(config.author),
+    hasAuthor: Boolean(author),
   });
   if (openingModeDecision.mode !== null) editingMode = openingModeDecision.mode;
   if (openingModeDecision.rejection !== null) facadeRejection = openingModeDecision.rejection;
@@ -501,9 +486,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
       // as (`resolveFont`'s fallback below) — so a blank document's font box reads
       // "Calibri", not an em-dash.
       defaultFontFamily: configuredDefaultFontFamily(fontConfiguration()),
-      ...(config.translate
-        ? { drawingStrings: drawingPaintStringsFromTranslate(config.translate) }
-        : {}),
+      drawingStrings: hostConfig.drawingStrings(),
       // Suggesting needs both: an author to attribute a proposal to, and the mode itself,
       // which survives a document reload because the reader chose it, not the file.
       ...(author ? { author } : {}),
@@ -566,7 +549,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
         bump();
         emitSelectionChange();
       },
-      tocLabels,
+      tocLabels: hostConfig.tocLabels(),
       onChange: (state) => {
         // The mount-time render reports before `surface` is assigned; nothing observable
         // has changed at that point, so it is not a selection change.
@@ -1080,7 +1063,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
       editable:
         surface !== null &&
         surface.session.editable &&
-        mode !== 'view' &&
+        hostConfig.mode() !== 'view' &&
         editingMode !== 'viewing',
       zoom: zoomLane.zoom(),
       zoomMode: zoomLane.mode(),
@@ -1630,42 +1613,33 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
    * is published, lives with the decision: `documentTrackingAdoption` in
    * `opening-editing-mode.ts`.
    */
-  function adoptDocumentTracking(): void {
+  function documentTrackingDecision(currentMode = editingMode, readerChoice = readerChoseMode) {
     const tracking = documentTracking();
-    const decision = documentTrackingAdoption({
-      viewOnly: mode === 'view',
+    return documentTrackingAdoption({
+      viewOnly: hostConfig.mode() === 'view',
       reviewEnabled,
       hasAuthor: Boolean(author),
-      hostChoseMode: config.mode !== undefined,
-      readerChoseMode,
-      currentMode: editingMode,
+      hostChoseMode: hostConfig.mode() !== undefined,
+      readerChoseMode: readerChoice,
+      currentMode,
       trackRevisions: tracking.trackRevisions,
       restrictedToTrackedChanges: tracking.restrictedToTrackedChanges,
     });
-    if (decision.rejection !== null) facadeRejection = decision.rejection;
-    if (decision.mode !== 'suggesting') return;
-    editingMode = 'suggesting';
-    surface?.setEditingMode('suggest');
   }
 
-  /**
-   * The document's own refusal of a mode change, or null.
-   *
-   * `w:documentProtection/@w:edit="trackedChanges"` says the document permits editing ONLY as
-   * tracked changes, so leaving suggesting is refused. It is ADVISORY and never presented as
-   * enforcement — the password hash is not verified and the file is editable by anyone
-   * holding it — but ignoring it silently produces exactly the untracked edits its author
-   * asked not to have. Viewing is always reachable: reading less than the document permits
-   * is not something a protection setting has an interest in.
-   */
-  function modeRestriction(next: DocumentEditingMode): ExecResult | null {
-    if (next !== 'editing') return null;
-    if (!documentTracking().restrictedToTrackedChanges) return null;
-    return {
-      ok: false,
-      code: 'locked',
-      reason: 'this document permits editing only as tracked changes',
-    };
+  function applyEditingMode(next: DocumentEditingMode): void {
+    editingMode = next;
+    surface?.setEditingMode(
+      next === 'suggesting' ? 'suggest' : next === 'viewing' ? 'view' : 'edit'
+    );
+    surface?.setEditable(next !== 'viewing');
+  }
+
+  function adoptDocumentTracking(): void {
+    const decision = documentTrackingDecision();
+    if (decision.rejection !== null) facadeRejection = decision.rejection;
+    if (decision.mode !== 'suggesting') return;
+    applyEditingMode('suggesting');
   }
 
   function dateOfItem(item: ReviewItem): string | undefined {
@@ -1843,25 +1817,18 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
         // A document opened with `mode: 'view'` is read-only for the session. Letting the
         // control move off Viewing put "Editing" on the pill of a document where every
         // command was still refused.
-        if (mode === 'view' && command.mode !== 'viewing') {
+        if (hostConfig.mode() === 'view' && command.mode !== 'viewing') {
           return { ok: false, code: 'locked', reason: 'this document was opened for viewing' };
         }
         if (command.mode === 'suggesting' && !reviewEnabled) {
           return { ok: false, code: 'unsupported', reason: PRO_REVIEW_REASON };
         }
-        const restriction = modeRestriction(command.mode);
+        const restriction = documentEditingModeRestriction(documentTracking(), command.mode);
         if (restriction) return restriction;
         readerChoseMode = true;
         facadeRejection = null;
-        editingMode = command.mode;
-        // The SURFACE decides what an op becomes, so it has to hear about this; `viewing`
-        // additionally gates every command below through `gateCommand`.
-        surface?.setEditingMode(
-          command.mode === 'suggesting' ? 'suggest' : command.mode === 'viewing' ? 'view' : 'edit'
-        );
-        // The DOM affordance is separate from the op gate: `setEditingMode` decides what a
-        // write becomes, this decides whether the browser offers one at all.
-        surface?.setEditable(command.mode !== 'viewing');
+        // The surface decides what an op becomes and whether the browser offers edits.
+        applyEditingMode(command.mode);
         bump();
         emitSelectionChange();
         return { ok: true, changed: false };
@@ -1891,7 +1858,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
       if (editingMode === 'viewing' && viewingGate.supported && viewingGate.mutating) {
         return { ok: false, code: 'locked', reason: 'the document is open for viewing' };
       }
-      const gated = gateCommand(command, surface, mode, options);
+      const gated = gateCommand(command, surface, hostConfig.modeForGate(), options);
       if (!gated.ok) return gated.refusal;
       const mounted = surface!;
       // Package revision covers body, furniture stories, and lifecycle ops; body-only
@@ -1916,7 +1883,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
       if (command.type === 'insertImage' || command.type === 'replaceImage') {
         if (destroyed) return { ok: false, code: 'notFound', reason: 'the editor was destroyed' };
         if (options?.scope) {
-          const scoped = gateCommand(command, surface, mode, options);
+          const scoped = gateCommand(command, surface, hostConfig.modeForGate(), options);
           if (!scoped.ok) return scoped.refusal;
         }
         return canAsyncImageCommandOf(command, surface);
@@ -1931,14 +1898,18 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
         if (command.type === 'toggleReviewPane' && !reviewEnabled) {
           return { ok: false, code: 'unsupported', reason: PRO_REVIEW_REASON };
         }
-        if (command.type === 'setEditingMode' && mode === 'view' && command.mode !== 'viewing') {
+        if (
+          command.type === 'setEditingMode' &&
+          hostConfig.mode() === 'view' &&
+          command.mode !== 'viewing'
+        ) {
           return { ok: false, code: 'locked', reason: 'this document was opened for viewing' };
         }
         if (command.type === 'setEditingMode') {
           if (command.mode === 'suggesting' && !reviewEnabled) {
             return { ok: false, code: 'unsupported', reason: PRO_REVIEW_REASON };
           }
-          const restriction = modeRestriction(command.mode);
+          const restriction = documentEditingModeRestriction(documentTracking(), command.mode);
           if (restriction) return restriction;
         }
         return { ok: true };
@@ -1953,7 +1924,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
       if (editingMode === 'viewing' && viewingSupport.supported && viewingSupport.mutating) {
         return { ok: false, code: 'locked', reason: 'the document is open for viewing' };
       }
-      const gated = gateCommand(command, surface, mode, options);
+      const gated = gateCommand(command, surface, hostConfig.modeForGate(), options);
       if (!gated.ok) return gated.refusal;
       if (
         command.type === 'proposeInsertion' ||
@@ -2121,7 +2092,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
     canExecuteImageCommand(command, options) {
       if (destroyed) return { ok: false, code: 'notFound', reason: 'the editor was destroyed' };
       if (options?.scope) {
-        const gated = gateCommand(command, surface, mode, options);
+        const gated = gateCommand(command, surface, hostConfig.modeForGate(), options);
         if (!gated.ok) return gated.refusal;
       }
       return canExecuteImageCommandOf(command, surface);
@@ -2233,6 +2204,36 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
       if (author === normalized) return;
       author = normalized;
       surface?.setAuthor(author);
+      bump();
+      emitSelectionChange();
+    },
+    setMode(nextMode) {
+      if (!hostConfig.setMode(nextMode)) return;
+      readerChoseMode = false;
+      const hostDecision = hostConfig.openingModeDecision({
+        reviewEnabled,
+        hasAuthor: Boolean(author),
+      });
+      let next: DocumentEditingMode =
+        nextMode === 'view' ? 'viewing' : (hostDecision.mode ?? 'editing');
+      const documentDecision = documentTrackingDecision(next, false);
+      if (documentDecision.mode !== null) next = documentDecision.mode;
+      facadeRejection = documentDecision.rejection ?? hostDecision.rejection;
+      applyEditingMode(next);
+      bump();
+      emitSelectionChange();
+    },
+    setTranslate(nextTranslate) {
+      const drawingStrings = hostConfig.setTranslate(nextTranslate);
+      if (drawingStrings === null) return;
+      surface?.setDrawingStrings(drawingStrings);
+      bump();
+      emitSelectionChange();
+    },
+    setLocale(nextLocale) {
+      const labels = hostConfig.setLocale(nextLocale);
+      if (labels === null) return;
+      surface?.setTocLabels(labels);
       bump();
       emitSelectionChange();
     },

--- a/packages/core/src/editor/opening-editing-mode.ts
+++ b/packages/core/src/editor/opening-editing-mode.ts
@@ -25,7 +25,8 @@
  * request being dropped in silence.
  */
 
-import type { DocumentEditingMode } from '../contracts/editor.ts';
+import type { DocumentEditingMode, ExecResult } from '../contracts/editor.ts';
+import type { DocumentTrackingSettings } from '../store/package/tracking-settings.ts';
 
 /**
  * The refusal every review write gets when no review module is registered.
@@ -110,4 +111,17 @@ export function documentTrackingAdoption(
     };
   }
   return { mode: 'suggesting', rejection: null };
+}
+
+/** Refuse editing when document protection permits tracked changes only. */
+export function documentEditingModeRestriction(
+  tracking: DocumentTrackingSettings,
+  next: DocumentEditingMode
+): ExecResult | null {
+  if (next !== 'editing' || !tracking.restrictedToTrackedChanges) return null;
+  return {
+    ok: false,
+    code: 'locked',
+    reason: 'this document permits editing only as tracked changes',
+  };
 }

--- a/packages/core/src/editor/paginated-surface-contract.ts
+++ b/packages/core/src/editor/paginated-surface-contract.ts
@@ -764,6 +764,8 @@ export interface PaginatedSurface {
    */
   editingMode(): SurfaceEditingMode;
   setEditingMode(mode: SurfaceEditingMode): void;
+  /** Set the ambient author after buffered text commits under the previous author. */
+  setAuthor(author: string | undefined): void;
   /**
    * Every author with a revision in the CURRENT layout, mapped to Word's colour slot by
    * order of first appearance. One map instance per layout, so a caller can key caches on

--- a/packages/core/src/editor/paginated-surface-contract.ts
+++ b/packages/core/src/editor/paginated-surface-contract.ts
@@ -184,9 +184,7 @@ export interface PaginatedSurfaceOptions {
    * The update ACTIONS are not here: they are rows in the host's context menu, which owns
    * its own labels. The engine paints no menu of its own.
    */
-  readonly tocLabels?: {
-    readonly title: string;
-  };
+  readonly tocLabels?: { readonly title: string };
 }
 
 /**
@@ -766,6 +764,12 @@ export interface PaginatedSurface {
   setEditingMode(mode: SurfaceEditingMode): void;
   /** Set the ambient author after buffered text commits under the previous author. */
   setAuthor(author: string | undefined): void;
+  /** Replace localized drawing labels and repaint materialized pages. */
+  setDrawingStrings(
+    strings: import('../output/semantic-paint-drawings.ts').DrawingPaintStrings
+  ): void;
+  /** Replace the localized title used by later TOC insertions. */
+  setTocLabels(labels: NonNullable<PaginatedSurfaceOptions['tocLabels']>): void;
   /**
    * Every author with a revision in the CURRENT layout, mapped to Word's colour slot by
    * order of first appearance. One map instance per layout, so a caller can key caches on

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -780,8 +780,8 @@ export function mountPaginatedSurface(
     decodePort,
     onResourcesChanged: () => onDrawingResourcesChanged?.(),
   });
-  const drawingStrings: DrawingPaintStrings =
-    options.drawingStrings ?? DEFAULT_DRAWING_PAINT_STRINGS;
+  let drawingStrings: DrawingPaintStrings = options.drawingStrings ?? DEFAULT_DRAWING_PAINT_STRINGS;
+  let tocLabels = options.tocLabels;
   /**
    * The insertion point, or null when the selection is not collapsed — a range has two ends
    * and is not "inside" anything, and a second background under one of them would read as a
@@ -4371,7 +4371,7 @@ export function mountPaginatedSurface(
       op: 'insertToc' as const,
       beforeParagraphId: selection.head.paragraphId,
       instruction: INSERT_TOC_INSTRUCTION,
-      alias: options.tocLabels?.title ?? 'TOC',
+      alias: tocLabels?.title ?? 'TOC',
       entries: plan.entries,
       bookmarksToCreate: plan.bookmarksToCreate,
     };
@@ -5352,6 +5352,15 @@ export function mountPaginatedSurface(
       if (author === nextAuthor) return;
       flushTypeBuffer();
       author = nextAuthor;
+    },
+    setDrawingStrings: (strings) => {
+      if (drawingStrings === strings) return;
+      drawingStrings = strings;
+      flushPendingInputAndLayout();
+      render(false);
+    },
+    setTocLabels: (labels) => {
+      tocLabels = labels;
     },
     setEditingMode: (mode) => {
       // Text typed under the OLD mode commits under it — a buffered edit must

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -104,6 +104,7 @@ import { createPresenceColors } from './surface-presence-color.ts';
 import {
   DEFAULT_DRAWING_PAINT_STRINGS,
   detachDrawingUrlRegistry,
+  drawingPaintStringsCacheToken,
   type DrawingPaintStrings,
 } from '../output/semantic-paint-drawings.ts';
 import { tryCreateBrowserCanvasContext } from './browser-canvas-context.ts';
@@ -5355,6 +5356,8 @@ export function mountPaginatedSurface(
     },
     setDrawingStrings: (strings) => {
       if (drawingStrings === strings) return;
+      if (drawingPaintStringsCacheToken(drawingStrings) === drawingPaintStringsCacheToken(strings))
+        return;
       drawingStrings = strings;
       flushPendingInputAndLayout();
       render(false);

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -315,6 +315,7 @@ export function mountPaginatedSurface(
   }
   const session = opened.session;
   const collaborationSession = options.collaborationModel?.session;
+  let author = options.author;
   let scale = options.scale ?? 96 / 72;
   const tableLabelState = {
     resolve:
@@ -1395,8 +1396,8 @@ export function mountPaginatedSurface(
     authorOverride?: string
   ): boolean {
     flushTypeBuffer();
-    const author = authorOverride?.trim() || options.author?.trim();
-    if (!author) {
+    const writer = authorOverride?.trim() || author?.trim();
+    if (!writer) {
       lastRejection = 'tracked changes need a non-empty author';
       options.onChange?.(currentState());
       return false;
@@ -1417,7 +1418,7 @@ export function mountPaginatedSurface(
       options.onChange?.(currentState());
       return false;
     }
-    const revision = { author, date: trackedDate() };
+    const revision = { author: writer, date: trackedDate() };
     const range = orderedRange();
     const collapsed =
       range.from.paragraphId === range.to.paragraphId && range.from.offset === range.to.offset;
@@ -1440,7 +1441,7 @@ export function mountPaginatedSurface(
             ops: [] as readonly TreeDocOp[],
             collapseTo: positionPastDeletion(currentLayout, range.from),
           }
-        : deleteSelectionPlan(author);
+        : deleteSelectionPlan(writer);
     const ops = attributeTrackedOps(plan.ops, revision, formattingTracked());
     let caret = plan.collapseTo;
     if (kind === 'insertion' || kind === 'replacement') {
@@ -3026,7 +3027,7 @@ export function mountPaginatedSurface(
     // EVERY edit, not just the destructive ones. Letting insertions through wrote permanent
     // changes to someone else's document while the pill said Suggesting and the review pane
     // stayed empty — half the keyboard proposing and half editing outright.
-    if (editingMode === 'suggest' && !options.author?.trim() && edits) {
+    if (editingMode === 'suggest' && !author?.trim() && edits) {
       return 'suggesting needs an author before it can propose a change';
     }
     // Deleting a note is a package-level removal with no tracked form: the reference and
@@ -3212,8 +3213,8 @@ export function mountPaginatedSurface(
    * that decides how to attribute it.
    */
   function trackedAuthorOrNone(): string | undefined {
-    const author = options.author?.trim();
-    return editingMode === 'suggest' && author ? author : undefined;
+    const writer = author?.trim();
+    return editingMode === 'suggest' && writer ? writer : undefined;
   }
 
   /** Suggesting attributes text and structural row edits as Word tracked changes. */
@@ -4525,7 +4526,7 @@ export function mountPaginatedSurface(
     selection: () => selection,
     cellSelection: () => cellSelection,
     editingMode: () => editingMode,
-    author: () => options.author,
+    author: () => author,
     storyScope,
     paragraphOrder,
     flushPendingInputAndLayout,
@@ -5347,6 +5348,11 @@ export function mountPaginatedSurface(
     },
 
     editingMode: () => editingMode,
+    setAuthor: (nextAuthor) => {
+      if (author === nextAuthor) return;
+      flushTypeBuffer();
+      author = nextAuthor;
+    },
     setEditingMode: (mode) => {
       // Text typed under the OLD mode commits under it — a buffered edit must
       // not silently become a suggestion (or a viewing-mode refusal). The layout
@@ -5705,7 +5711,7 @@ export function mountPaginatedSurface(
       storyScope,
       selectionMark,
       editingMode: () => editingMode,
-      author: () => options.author,
+      author: () => author,
       trackedDate,
       decodePort: () => decodePort,
       actorId: () => collaborationSession?.identity.actorId,

--- a/packages/pro/src/__tests__/review-draft-live-author.test.tsx
+++ b/packages/pro/src/__tests__/review-draft-live-author.test.tsx
@@ -1,0 +1,85 @@
+/*
+Copyright (c) 2026 EigenPal, Inc. All rights reserved.
+Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/pro/LICENSE.md.
+Production use requires a commercial agreement: licensing@eigenpal.com
+*/
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { act, cleanup, fireEvent, render } from '@testing-library/react';
+import { strToU8, zipSync } from 'fflate';
+import type { DocxEditorInstance } from '@docx-editor.dev/core/editor';
+import {
+  DocxEditorAuthorStyle,
+  DocxEditorContent,
+  DocxEditorRoot,
+  DocxEditorViewport,
+} from '@docx-editor.dev/react';
+import { DocxEditorReview } from '../react/index.ts';
+import { reviewModule } from '../index.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+
+function docx(body: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
+    ),
+  });
+}
+
+const SOURCE = docx('<w:p><w:r><w:t>hello world</w:t></w:r></w:p>');
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('the live review draft author', () => {
+  test('updates the open draft author and color', () => {
+    let instance: DocxEditorInstance | null = null;
+    const view = render(
+      <DocxEditorRoot
+        document={SOURCE}
+        author="Demo Reviewer"
+        modules={[reviewModule()]}
+        onReady={(editor) => {
+          instance = editor as DocxEditorInstance;
+        }}
+      >
+        <DocxEditorAuthorStyle author="Demo Reviewer" color="#b42318" />
+        <DocxEditorAuthorStyle author="Updated Reviewer" color="#0b7285" />
+        <DocxEditorViewport>
+          <DocxEditorContent />
+          <DocxEditorReview />
+        </DocxEditorViewport>
+      </DocxEditorRoot>
+    );
+
+    act(() => instance!.surface!.selectAll());
+    act(() => fireEvent.click(view.getByTestId('review-add-comment')));
+    const draft = view.getByTestId('review-draft');
+    expect(draft.dataset.reviewAuthor).toBe('Demo Reviewer');
+    expect(draft.style.getPropertyValue('--doc-review-author-current')).toBe('#b42318');
+
+    act(() => instance!.setAuthor('Updated Reviewer'));
+    const updatedDraft = view.getByTestId('review-draft');
+    expect(updatedDraft.dataset.reviewAuthor).toBe('Updated Reviewer');
+    expect(updatedDraft.style.getPropertyValue('--doc-review-author-current')).toBe('#0b7285');
+  });
+});

--- a/packages/pro/src/__tests__/review-sidebar-vue.test.ts
+++ b/packages/pro/src/__tests__/review-sidebar-vue.test.ts
@@ -167,6 +167,7 @@ describe('DocxEditorReview (Vue)', () => {
           author: 'Demo Reviewer',
           color: '#b42318',
         }),
+        h(DocxEditorAuthorStyle, { author: 'Updated Reviewer', color: '#0b7285' }),
       ],
       SOURCE,
       () => [h(DocxEditorReview)],
@@ -183,6 +184,13 @@ describe('DocxEditorReview (Vue)', () => {
       const draft = mounted.container.querySelector('[data-testid="review-draft"]') as HTMLElement;
       expect(draft.dataset.reviewAuthor).toBe('Demo Reviewer');
       expect(draft.style.getPropertyValue('--doc-review-author-current')).toBe('#b42318');
+      mounted.editor().setAuthor('Updated Reviewer');
+      await flushMount();
+      const updatedDraft = mounted.container.querySelector(
+        '[data-testid="review-draft"]'
+      ) as HTMLElement;
+      expect(updatedDraft.dataset.reviewAuthor).toBe('Updated Reviewer');
+      expect(updatedDraft.style.getPropertyValue('--doc-review-author-current')).toBe('#0b7285');
     } finally {
       mounted.unmount();
     }

--- a/packages/pro/src/react/DocxEditorReview.tsx
+++ b/packages/pro/src/react/DocxEditorReview.tsx
@@ -43,6 +43,7 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
 } from 'react';
 import type { CSSProperties, ReactNode } from 'react';
 import type {
@@ -471,10 +472,11 @@ function ReviewRoot({
   const items = useMemo(() => {
     return filter ? review.items.filter((entry) => filter(entry)) : review.items;
   }, [review.items, filter]);
-  // Word's rule: a colour per author by ORDER OF FIRST APPEARANCE. A hash of the name is
-  // stable but collides, and two reviewers drawn in one colour tells the reader the wrong
-  // thing about who proposed what.
-  const configuredAuthor = editor?.getConfiguredAuthor() ?? null;
+  const configuredAuthor = useSyncExternalStore(
+    useCallback((notify) => editor?.on('selectionChange', notify) ?? (() => {}), [editor]),
+    () => editor?.getConfiguredAuthor() ?? null,
+    () => null
+  );
   const authorSlots = useMemo(() => {
     const slots = new Map<string, number>();
     for (const entry of items) {

--- a/packages/pro/src/vue/DocxEditorReview.tsx
+++ b/packages/pro/src/vue/DocxEditorReview.tsx
@@ -243,7 +243,7 @@ const ReviewRoot = defineComponent({
       },
       { flush: 'sync' }
     );
-    const configuredAuthor = computed(() => editorRef.value?.getConfiguredAuthor() ?? null);
+    const configuredAuthor = useEditorState(() => editorRef.value?.getConfiguredAuthor() ?? null);
     const authorSlots = computed(() => {
       const slotsMap = new Map<string, number>();
       for (const entry of items.value) {

--- a/packages/react/src/editor/DocxEditorRoot.tsx
+++ b/packages/react/src/editor/DocxEditorRoot.tsx
@@ -52,10 +52,10 @@ import {
 } from './revision-style-registry';
 
 /**
- * Props for `DocxEditor.Root`. Creation parameters (`document`, `fonts`, `author`,
- * `locale`, and the initial `mode`/`zoom`) are sampled when the instance is created;
- * only `document` and `fonts` identity remount it. Later `mode` and `zoom` changes flow through
- * `Editor.setZoom` so edits, the caret, and the undo history survive.
+ * Props for `DocxEditor.Root`. Creation parameters (`document`, `fonts`, `locale`, and the
+ * initial `mode`/`zoom`) are sampled when the instance is created. Only `document` and `fonts`
+ * identity remount it. Later `author`, `zoom`, and `zoomMode` changes use instance setters, so
+ * edits, the caret, and the undo history survive. `mode` and `modules` are sampled at mount only.
  *
  * @public
  */
@@ -73,6 +73,7 @@ export interface DocxEditorRootProps {
    * failures degrade to the fixed measurer and report through `onFontError`.
    */
   fonts?: FontConfiguration | FontConfigurationFragment | FontResolver;
+  /** Author for later comments, replies, and tracked changes. Changes apply without a remount. */
   author?: string;
   locale?: string;
   /** Drawing refusal labels for painted placeholders; defaults to the active locale catalogue. */
@@ -203,6 +204,7 @@ export function DocxEditorRoot(props: DocxEditorRootProps) {
   const {
     document: doc,
     fonts,
+    author,
     zoom,
     zoomMode,
     tableInteractionLabel,
@@ -333,6 +335,12 @@ export function DocxEditorRoot(props: DocxEditorRootProps) {
       editor.setZoomMode(zoomMode!);
     }
   }, [editor, zoom, zoomMode]);
+
+  // Author is runtime state. Prop changes preserve the editor instance and existing revisions.
+  useEffect(() => {
+    if (!editor) return;
+    editor.setAuthor(author);
+  }, [editor, author]);
 
   // Table furniture labels follow the live locale resolver without remounting the editor.
   useEffect(() => {

--- a/packages/react/src/editor/DocxEditorRoot.tsx
+++ b/packages/react/src/editor/DocxEditorRoot.tsx
@@ -52,10 +52,9 @@ import {
 } from './revision-style-registry';
 
 /**
- * Props for `DocxEditor.Root`. Creation parameters (`document`, `fonts`, `locale`, and the
- * initial `mode`/`zoom`) are sampled when the instance is created. Only `document` and `fonts`
- * identity remount it. Later `author`, `zoom`, and `zoomMode` changes use instance setters, so
- * edits, the caret, and the undo history survive. `mode` and `modules` are sampled at mount only.
+ * Props for `DocxEditor.Root`. Only `document`, `fonts`, and `imageDecodePort` identity remounts
+ * the editor. Later `author`, `locale`, `mode`, `translate`, `zoom`, and `zoomMode` changes use
+ * instance setters. `modules` is sampled at mount only.
  *
  * @public
  */
@@ -75,18 +74,20 @@ export interface DocxEditorRootProps {
   fonts?: FontConfiguration | FontConfigurationFragment | FontResolver;
   /** Author for later comments, replies, and tracked changes. Changes apply without a remount. */
   author?: string;
+  /**
+   * Engine locale for engine-generated content, such as the table of contents title.
+   * Changes apply without a remount.
+   */
   locale?: string;
-  /** Drawing refusal labels for painted placeholders; defaults to the active locale catalogue. */
+  /** Live drawing labels for painted placeholders; defaults to the active locale catalogue. */
   translate?: (key: string, params?: Record<string, string | number>) => string;
   /**
-   * Capability modules to register (`@docx-editor.dev/pro`'s review module,
-   * custom nodes, collaboration). Sampled at mount only, like `mode`: module registration is
-   * construction-time in the engine.
+   * Capability modules to register (`@docx-editor.dev/pro`'s review module, custom nodes,
+   * collaboration). Sampled at mount only because registration is construction-time.
    */
   modules?: readonly EditorModule[];
   /**
-   * The mode the editor opens in, matching the toolbar's three-state pill. Sampled at
-   * mount only.
+   * The host mode, matching the toolbar's three-state pill. Changes apply without a remount.
    *
    * `'edit'` opens in editing even when the document's `w:trackRevisions` asks for
    * tracked changes; `'suggesting'` opens in suggesting (needs a review module and an
@@ -205,6 +206,9 @@ export function DocxEditorRoot(props: DocxEditorRootProps) {
     document: doc,
     fonts,
     author,
+    locale,
+    translate,
+    mode,
     zoom,
     zoomMode,
     tableInteractionLabel,
@@ -217,6 +221,8 @@ export function DocxEditorRoot(props: DocxEditorRootProps) {
       catalogT(key as TranslationKey, params),
     [catalogT]
   );
+  const defaultTranslateRef = useRef(defaultTranslate);
+  defaultTranslateRef.current = defaultTranslate;
 
   // Latest props, read inside effects without retriggering them.
   const propsRef = useRef(props);
@@ -240,7 +246,7 @@ export function DocxEditorRoot(props: DocxEditorRootProps) {
   // terminal, so a StrictMode re-run must build anew rather than resurrect.
   useEffect(() => {
     const p = propsRef.current;
-    const translate = p.translate ?? defaultTranslate;
+    const translate = p.translate ?? defaultTranslateRef.current;
     // Declarations mounted in this same commit registered BEFORE this effect (child
     // effects run bottom-up), so they reach the engine as construction config and the
     // FIRST paint is already styled — no kind-coloured frame.
@@ -268,7 +274,7 @@ export function DocxEditorRoot(props: DocxEditorRootProps) {
       // Functional update: a StrictMode re-run's second instance must not be clobbered.
       setEditor((current) => (current === instance ? null : current));
     };
-  }, [doc, fonts, defaultTranslate, imageDecodePort, revisionStyleRegistry]);
+  }, [doc, fonts, imageDecodePort, revisionStyleRegistry]);
 
   // Fired AFTER the instance is published: this effect runs in the commit that rendered
   // the new editor, after child layout effects — so a `DocxEditor.Content` in the tree
@@ -341,6 +347,31 @@ export function DocxEditorRoot(props: DocxEditorRootProps) {
     if (!editor) return;
     editor.setAuthor(author);
   }, [editor, author]);
+
+  const appliedMode = useRef<{
+    editor: DocxEditorInstance | null;
+    value: 'edit' | 'view' | 'suggesting' | undefined;
+  }>({ editor: null, value: undefined });
+  useEffect(() => {
+    if (!editor) return;
+    if (appliedMode.current.editor !== editor) {
+      appliedMode.current = { editor, value: mode };
+      return;
+    }
+    if (appliedMode.current.value === mode) return;
+    appliedMode.current.value = mode;
+    editor.setMode(mode);
+  }, [editor, mode]);
+
+  useEffect(() => {
+    if (!editor) return;
+    editor.setTranslate(translate ?? defaultTranslate);
+  }, [editor, translate, defaultTranslate]);
+
+  useEffect(() => {
+    if (!editor) return;
+    editor.setLocale(locale);
+  }, [editor, locale]);
 
   // Table furniture labels follow the live locale resolver without remounting the editor.
   useEffect(() => {

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -185,8 +185,7 @@ export interface DocxEditorProps {
    * Omitting it mounts NO document, which is not the same as an empty one. */
   document?: DocumentSource;
   /**
-   * The mode the editor opens in, matching the toolbar's three-state pill. Applied at
-   * mount only — not reactive; remount to change.
+   * The host mode, matching the toolbar's three-state pill. Changes apply without a remount.
    *
    * Defaults to `'edit'`: the packaged editor opens every document ready to type, even
    * one whose `w:trackRevisions` asks for tracked changes. Pass `'suggesting'` (needs
@@ -205,11 +204,15 @@ export interface DocxEditorProps {
    * `{ type: 'fixed' }` opts out.
    */
   zoomMode?: ZoomMode | 'auto';
+  /**
+   * Engine locale for engine-generated content, such as the table of contents title.
+   * Changes apply without a remount.
+   */
   locale?: string;
   author?: string;
   /**
-   * Capability modules to register (`@docx-editor.dev/pro`'s review module,
-   * custom nodes). Applied at mount only, like `mode`.
+   * Capability modules to register (`@docx-editor.dev/pro`'s review module, custom nodes).
+   * Applied at mount only.
    */
   modules?: readonly EditorModule[];
   /**

--- a/packages/react/test/live-author-prop.test.tsx
+++ b/packages/react/test/live-author-prop.test.tsx
@@ -1,0 +1,80 @@
+import './dom-setup.ts';
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { act, cleanup, render } from '@testing-library/react';
+import { zipSync, strToU8 } from 'fflate';
+import { serializeOoxmlPart } from '@docx-editor.dev/core/store';
+import type { DocxEditorInstance } from '@docx-editor.dev/core/editor';
+import { DocxEditorRoot } from '../src/editor/DocxEditorRoot.tsx';
+import { DocxEditorViewport } from '../src/editor/DocxEditorViewport.tsx';
+import { DocxEditorContent } from '../src/editor/DocxEditorContent.tsx';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+
+const SOURCE = zipSync({
+  '[Content_Types].xml': strToU8(
+    `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+      '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>'
+  ),
+  '_rels/.rels': strToU8(
+    `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+  ),
+  'word/document.xml': strToU8(
+    `<w:document xmlns:w="${W}"><w:body><w:p><w:r><w:t>abcd</w:t></w:r></w:p></w:body></w:document>`
+  ),
+});
+
+function select(editor: DocxEditorInstance, start: number, end: number): void {
+  const paragraphId = editor.surface!.session.paragraphIds()[0]!;
+  editor.surface!.setSelection({
+    anchor: { paragraphId, offset: start },
+    head: { paragraphId, offset: end },
+  });
+}
+
+afterEach(cleanup);
+
+describe('DocxEditor.Root author prop', () => {
+  test('applies a changed author without replacing the editor', async () => {
+    let instance: DocxEditorInstance | null = null;
+    const tree = (author: string) => (
+      <DocxEditorRoot
+        document={SOURCE}
+        author={author}
+        onReady={(editor) => {
+          instance = editor as DocxEditorInstance;
+        }}
+      >
+        <DocxEditorViewport>
+          <DocxEditorContent />
+        </DocxEditorViewport>
+      </DocxEditorRoot>
+    );
+    const view = render(tree('Initial Author'));
+    const firstInstance = instance!;
+
+    await act(async () => {
+      select(firstInstance, 0, 1);
+      firstInstance.exec({ type: 'proposeReplacement', replaceWith: 'X' });
+    });
+    await act(async () => {
+      view.rerender(tree('Updated Author'));
+    });
+    expect(instance).toBe(firstInstance);
+    expect(firstInstance.getConfiguredAuthor()).toBe('Updated Author');
+
+    await act(async () => {
+      select(firstInstance, 1, 2);
+      firstInstance.exec({ type: 'proposeReplacement', replaceWith: 'Y' });
+      await firstInstance.save();
+    });
+    const xml = serializeOoxmlPart(firstInstance.surface!.session.part());
+    expect(xml.match(/w:author="Initial Author"/g)).toHaveLength(2);
+    expect(xml.match(/w:author="Updated Author"/g)).toHaveLength(2);
+  });
+});

--- a/packages/react/test/live-author-prop.test.tsx
+++ b/packages/react/test/live-author-prop.test.tsx
@@ -10,6 +10,7 @@ import type { DocxEditorInstance } from '@docx-editor.dev/core/editor';
 import { DocxEditorRoot } from '../src/editor/DocxEditorRoot.tsx';
 import { DocxEditorViewport } from '../src/editor/DocxEditorViewport.tsx';
 import { DocxEditorContent } from '../src/editor/DocxEditorContent.tsx';
+import { LocaleProvider } from '../src/i18n/LocaleContext.tsx';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
@@ -76,5 +77,107 @@ describe('DocxEditor.Root author prop', () => {
     const xml = serializeOoxmlPart(firstInstance.surface!.session.part());
     expect(xml.match(/w:author="Initial Author"/g)).toHaveLength(2);
     expect(xml.match(/w:author="Updated Author"/g)).toHaveLength(2);
+  });
+
+  test('applies mode, translate, and locale changes without replacing the editor', async () => {
+    let instance: DocxEditorInstance | null = null;
+    const initialTranslate = (key: string) => `initial:${key}`;
+    const updatedTranslate = (key: string) => `updated:${key}`;
+    const tree = (mode: 'edit' | 'view', translate: (key: string) => string, locale: string) => (
+      <DocxEditorRoot
+        document={SOURCE}
+        mode={mode}
+        translate={translate}
+        locale={locale}
+        onReady={(editor) => {
+          instance = editor as DocxEditorInstance;
+        }}
+      >
+        <DocxEditorViewport>
+          <DocxEditorContent />
+        </DocxEditorViewport>
+      </DocxEditorRoot>
+    );
+    const view = render(tree('edit', initialTranslate, 'en'));
+    const firstInstance = instance!;
+    let receivedTranslate: typeof updatedTranslate | undefined;
+    let receivedLocale: string | undefined;
+    const setTranslate = firstInstance.setTranslate.bind(firstInstance);
+    const setLocale = firstInstance.setLocale.bind(firstInstance);
+    firstInstance.setTranslate = (value) => {
+      receivedTranslate = value as typeof updatedTranslate;
+      setTranslate(value);
+    };
+    firstInstance.setLocale = (value) => {
+      receivedLocale = value;
+      setLocale(value);
+    };
+
+    await act(async () => {
+      view.rerender(tree('view', updatedTranslate, 'de'));
+    });
+    expect(instance).toBe(firstInstance);
+    expect(firstInstance.getEditingMode()).toBe('viewing');
+    expect(receivedTranslate?.('probe')).toBe('updated:probe');
+    expect(receivedLocale).toBe('de');
+  });
+
+  test('an unrelated rerender does not restore a host mode after a reader change', async () => {
+    let instance: DocxEditorInstance | null = null;
+    const tree = (marker: string) => (
+      <DocxEditorRoot
+        document={SOURCE}
+        mode="edit"
+        onReady={(editor) => {
+          instance = editor as DocxEditorInstance;
+        }}
+      >
+        <span>{marker}</span>
+        <DocxEditorViewport>
+          <DocxEditorContent />
+        </DocxEditorViewport>
+      </DocxEditorRoot>
+    );
+    const view = render(tree('first'));
+    const firstInstance = instance!;
+    await act(async () => {
+      firstInstance.exec({ type: 'setEditingMode', mode: 'viewing' });
+      view.rerender(tree('second'));
+    });
+    expect(instance).toBe(firstInstance);
+    expect(firstInstance.getEditingMode()).toBe('viewing');
+  });
+
+  test('a locale catalog change updates translation without replacing the editor', async () => {
+    let instance: DocxEditorInstance | null = null;
+    const catalog = (label: string) => ({ image: { pendingResource: label } });
+    const tree = (label: string) => (
+      <LocaleProvider i18n={catalog(label)}>
+        <DocxEditorRoot
+          document={SOURCE}
+          onReady={(editor) => {
+            instance = editor as DocxEditorInstance;
+          }}
+        >
+          <DocxEditorViewport>
+            <DocxEditorContent />
+          </DocxEditorViewport>
+        </DocxEditorRoot>
+      </LocaleProvider>
+    );
+    const view = render(tree('First loading label'));
+    const firstInstance = instance!;
+    let resolver: ((key: string) => string) | undefined;
+    const setTranslate = firstInstance.setTranslate.bind(firstInstance);
+    firstInstance.setTranslate = (value) => {
+      resolver = value;
+      setTranslate(value);
+    };
+
+    await act(async () => {
+      view.rerender(tree('Second loading label'));
+    });
+    expect(instance).toBe(firstInstance);
+    expect(resolver?.('image.pendingResource')).toBe('Second loading label');
   });
 });

--- a/packages/react/test/live-author-prop.test.tsx
+++ b/packages/react/test/live-author-prop.test.tsx
@@ -180,4 +180,32 @@ describe('DocxEditor.Root author prop', () => {
     expect(instance).toBe(firstInstance);
     expect(resolver?.('image.pendingResource')).toBe('Second loading label');
   });
+
+  test('a fresh equivalent inline translation does not publish a selection change', async () => {
+    let instance: DocxEditorInstance | null = null;
+    const tree = (marker: string) => (
+      <DocxEditorRoot
+        document={SOURCE}
+        translate={(key) => `same:${key}`}
+        onReady={(editor) => {
+          instance = editor as DocxEditorInstance;
+        }}
+      >
+        <span>{marker}</span>
+        <DocxEditorViewport>
+          <DocxEditorContent />
+        </DocxEditorViewport>
+      </DocxEditorRoot>
+    );
+    const view = render(tree('first'));
+    const firstInstance = instance!;
+    let changes = 0;
+    firstInstance.on('selectionChange', () => changes++);
+
+    await act(async () => {
+      view.rerender(tree('second'));
+    });
+    expect(instance).toBe(firstInstance);
+    expect(changes).toBe(0);
+  });
 });

--- a/packages/vue/src/components/DocxEditor.tsx
+++ b/packages/vue/src/components/DocxEditor.tsx
@@ -469,9 +469,9 @@ const DocxEditorImpl = defineComponent({
         api.value?.snapshot(options) ?? createDocxEditorRefApi(() => null).snapshot(options),
     } satisfies DocxEditorRef);
 
-    const { i18n, ...frameProps } = props;
-    return () =>
-      h(LocaleProvider, i18n !== undefined ? { i18n } : {}, {
+    return () => {
+      const { i18n, ...frameProps } = props;
+      return h(LocaleProvider, i18n !== undefined ? { i18n } : {}, {
         default: () =>
           h(
             DocxEditorFrame,
@@ -515,6 +515,7 @@ const DocxEditorImpl = defineComponent({
             }
           ),
       });
+    };
   },
 });
 

--- a/packages/vue/src/components/DocxEditor.tsx
+++ b/packages/vue/src/components/DocxEditor.tsx
@@ -276,14 +276,18 @@ const DocxEditorFrame = defineComponent({
     );
 
     const isDark = computed(() => resolveIsDark(props.colorMode, systemDark.value));
-    const { t: catalogT } = useTranslation();
-    const translate = (key: string, params?: Record<string, string | number>) =>
-      props.t ? props.t(key, params) : catalogT(key as TranslationKey, params);
+    const translation = useTranslation();
+    const translate = computed(() => {
+      const custom = props.t;
+      const catalogT = translation.t;
+      return (key: string, params?: Record<string, string | number>) =>
+        custom ? custom(key, params) : catalogT(key as TranslationKey, params);
+    });
 
     const tableInteractionLabel = (key: 'table.insertRowBelow' | 'table.insertColumnRight') =>
-      translate(key);
+      translate.value(key);
 
-    provide(PageNumberTranslationContext, translate);
+    provide(PageNumberTranslationContext, (key) => translate.value(key));
 
     const handleRef = shallowRef<DocxEditorRef | null>(null);
     expose({
@@ -312,6 +316,7 @@ const DocxEditorFrame = defineComponent({
     });
 
     return () => {
+      const t = translate.value;
       const viewportClass =
         chrome.value && isDark.value ? 'dark' : chrome.value ? undefined : props.class;
       const viewport = h(
@@ -331,7 +336,7 @@ const DocxEditorFrame = defineComponent({
             contextMenu.value === false
               ? null
               : h(DocxEditorContextMenu, {
-                  t: translate,
+                  t,
                   ...(typeof contextMenu.value === 'object' ? contextMenu.value : {}),
                 }),
             h(DocxEditorContentControl),
@@ -361,9 +366,9 @@ const DocxEditorFrame = defineComponent({
                   h('div', { style: TITLE_BLOCK_STYLE }, [
                     hostTitleChange.value !== undefined
                       ? h('input', {
-                          'aria-label': translate('titleBar.documentNameAriaLabel'),
+                          'aria-label': t('titleBar.documentNameAriaLabel'),
                           value: props.title ?? '',
-                          placeholder: translate('titleBar.untitled'),
+                          placeholder: t('titleBar.untitled'),
                           style: TITLE_INPUT_STYLE,
                           onInput: (event: Event) => {
                             const value = (event.target as HTMLInputElement).value;
@@ -374,11 +379,11 @@ const DocxEditorFrame = defineComponent({
                       : h(
                           'span',
                           { style: { minWidth: 0, padding: '2px 6px' } },
-                          props.title ?? translate('titleBar.untitled')
+                          props.title ?? t('titleBar.untitled')
                         ),
                     menu.value !== false
                       ? h(DocxEditorMenu, {
-                          t: translate,
+                          t,
                           ...(props.title !== undefined ? { fileName: props.title } : {}),
                           ...(hostOpen.value !== undefined ? { openHandler: hostOpen.value } : {}),
                           ...(hostSave.value !== undefined ? { saveHandler: hostSave.value } : {}),
@@ -388,16 +393,16 @@ const DocxEditorFrame = defineComponent({
                   ]),
                   slots.titleBarRight?.(),
                 ]),
-                h('div', { style: TOOLBAR_ROW_STYLE }, [h(DocxEditorToolbar, { t: translate })]),
+                h('div', { style: TOOLBAR_ROW_STYLE }, [h(DocxEditorToolbar, { t })]),
               ]),
               rulers.value
                 ? h('div', { style: RULER_ROW_STYLE, 'data-testid': 'docx-editor-ruler-row' }, [
                     h(DocxEditorHorizontalRuler),
                   ])
                 : null,
-              h(DocxEditorFontNotice, { t: translate }),
+              h(DocxEditorFontNotice, { t }),
               h('div', { style: WORKSPACE_STYLE }, [
-                navigation.value ? h(DocxEditorNavigation, { t: translate }) : null,
+                navigation.value ? h(DocxEditorNavigation, { t }) : null,
                 viewport,
                 h(DocxEditorPageNumber),
                 h(DocxEditorLoading, { overlay: true }),
@@ -413,7 +418,7 @@ const DocxEditorFrame = defineComponent({
           ...(props.fonts ? { fonts: props.fonts } : {}),
           ...(props.author !== undefined ? { author: props.author } : {}),
           ...(props.locale !== undefined ? { locale: props.locale } : {}),
-          translate,
+          translate: t,
           ...(props.mode !== undefined ? { mode: props.mode } : { mode: 'edit' }),
           ...(props.modules !== undefined ? { modules: props.modules } : {}),
           ...(props.zoom !== undefined ? { zoom: props.zoom } : {}),

--- a/packages/vue/src/editor/useDocxEditorRoot.ts
+++ b/packages/vue/src/editor/useDocxEditorRoot.ts
@@ -291,6 +291,14 @@ export function useDocxEditorRootOwner(
   );
 
   watch(
+    () => [editorRef.value, toValue(props).author] as const,
+    ([editor, author]) => {
+      if (editor) editor.setAuthor(author);
+    },
+    { flush: 'post' }
+  );
+
+  watch(
     () => [editorRef.value, toValue(props).tableInteractionLabel] as const,
     ([editor, label]) => {
       if (editor) editor.setTableInteractionLabel(label ?? defaultTableLabel);

--- a/packages/vue/src/editor/useDocxEditorRoot.ts
+++ b/packages/vue/src/editor/useDocxEditorRoot.ts
@@ -50,10 +50,18 @@ import {
 export interface DocxEditorRootProps {
   document?: DocumentSource;
   fonts?: FontConfiguration | FontConfigurationFragment | FontResolver;
+  /** Author for later comments, replies, and tracked changes. Changes apply without a remount. */
   author?: string;
+  /**
+   * Engine locale for engine-generated content, such as the table of contents title.
+   * Changes apply without a remount.
+   */
   locale?: string;
+  /** Live drawing labels. Defaults to the active locale catalog. */
   translate?: (key: string, params?: Record<string, string | number>) => string;
+  /** Construction-time capability modules. Later array changes need a remount. */
   modules?: readonly EditorModule[];
+  /** Live host mode. Omit it to let document tracking settings select the mode. */
   mode?: 'edit' | 'view' | 'suggesting';
   zoom?: number;
   zoomMode?: ZoomMode | 'auto';
@@ -109,14 +117,12 @@ export function useDocxEditorRootOwner(
   const revisionStyleRegistry = createRevisionStyleRegistry();
   provide(RevisionStyleRegistryContext, revisionStyleRegistry);
 
-  const { t: catalogT, catalogue } = useTranslation();
+  const translation = useTranslation();
   const translateResolver = computed(() => {
-    catalogue.value;
+    translation.catalogue.value;
     const custom = toValue(props).translate;
-    if (custom) return custom;
-    const t = catalogT;
     return (key: string, params?: Record<string, string | number>) =>
-      t(key as TranslationKey, params);
+      custom ? custom(key, params) : translation.t(key as TranslationKey, params);
   });
 
   const railCount = shallowRef(0);
@@ -247,12 +253,7 @@ export function useDocxEditorRootOwner(
   if (typeof window !== 'undefined') {
     watch(
       () =>
-        [
-          toValue(props).document,
-          toValue(props).fonts,
-          catalogue.value,
-          toValue(props).imageDecodePort,
-        ] as const,
+        [toValue(props).document, toValue(props).fonts, toValue(props).imageDecodePort] as const,
       createEditor,
       { immediate: true, flush: 'post' }
     );
@@ -294,6 +295,42 @@ export function useDocxEditorRootOwner(
     () => [editorRef.value, toValue(props).author] as const,
     ([editor, author]) => {
       if (editor) editor.setAuthor(author);
+    },
+    { flush: 'post' }
+  );
+
+  const appliedHostMode = {
+    editor: null as DocxEditorInstance | null,
+    value: undefined as 'edit' | 'view' | 'suggesting' | undefined,
+  };
+  watch(
+    () => [editorRef.value, toValue(props).mode] as const,
+    ([editor, mode]) => {
+      if (!editor) return;
+      if (appliedHostMode.editor !== editor) {
+        appliedHostMode.editor = editor;
+        appliedHostMode.value = mode;
+        return;
+      }
+      if (appliedHostMode.value === mode) return;
+      appliedHostMode.value = mode;
+      editor.setMode(mode);
+    },
+    { flush: 'post', immediate: true }
+  );
+
+  watch(
+    () => [editorRef.value, translateResolver.value] as const,
+    ([editor, translate]) => {
+      if (editor) editor.setTranslate(translate);
+    },
+    { flush: 'post' }
+  );
+
+  watch(
+    () => [editorRef.value, toValue(props).locale] as const,
+    ([editor, locale]) => {
+      if (editor) editor.setLocale(locale);
     },
     { flush: 'post' }
   );

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -33,6 +33,7 @@ export type EditorMode = 'edit' | 'view' | 'suggesting';
 export interface DocxEditorProps {
   fonts?: FontConfiguration | FontConfigurationFragment | FontResolver;
   colorMode?: 'light' | 'dark' | 'system';
+  /** Live resolver for chrome and drawing labels. */
   t?: (key: string, params?: Record<string, string | number>) => string;
   i18n?: Translations;
   chrome?: boolean;
@@ -43,11 +44,17 @@ export interface DocxEditorProps {
   navigation?: boolean;
   rulers?: boolean;
   document?: DocumentSource;
+  /** Live host mode. */
   mode?: EditorMode;
   zoom?: number;
   zoomMode?: ZoomMode | 'auto';
+  /**
+   * Engine locale for engine-generated content, such as the table of contents title.
+   * Changes apply without a remount.
+   */
   locale?: string;
   author?: string;
+  /** Construction-time capability modules. Later array changes need a remount. */
   modules?: readonly EditorModule[];
   class?: string;
 }

--- a/packages/vue/test/lifecycle-regression.test.ts
+++ b/packages/vue/test/lifecycle-regression.test.ts
@@ -127,7 +127,7 @@ describe('DocxEditorRoot lifecycle regressions', () => {
     }
   });
 
-  test('nested LocaleProvider catalogue change rebuilds exactly once', async () => {
+  test('nested LocaleProvider catalogue change preserves the editor instance', async () => {
     const instances: DocxEditorInstance[] = [];
     const outer = { _lang: 'en', toolbar: { file: 'File' } } as Translations;
     const inner = ref({ _lang: 'de', toolbar: { file: 'Datei' } } as Translations);
@@ -170,8 +170,7 @@ describe('DocxEditorRoot lifecycle regressions', () => {
       await flush();
       inner.value = { _lang: 'fr', toolbar: { file: 'Fichier' } };
       await flush();
-      expect(instances.length).toBe(2);
-      expect(instances[0]).not.toBe(instances[1]);
+      expect(instances).toHaveLength(1);
     } finally {
       app.unmount();
       container.remove();

--- a/packages/vue/test/live-props.test.ts
+++ b/packages/vue/test/live-props.test.ts
@@ -1,0 +1,119 @@
+import './dom-setup.ts';
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { createApp, h, reactive, type Component } from 'vue';
+import { serializeOoxmlPart } from '@docx-editor.dev/core/store';
+import type { DocxEditorInstance } from '@docx-editor.dev/core/editor';
+import { DocxEditor } from '../src/components/DocxEditor';
+import { DocxEditorRoot } from '../src/editor/DocxEditorRoot';
+import { DocxEditorViewport } from '../src/editor/DocxEditorViewport';
+import { DocxEditorContent } from '../src/editor/DocxEditorContent';
+import { flush, SOURCE } from './helpers/mount';
+
+function mountWithProps(component: Component, initialProps: Record<string, unknown>) {
+  const props = reactive({ ...initialProps });
+  const container = document.createElement('div');
+  document.body.append(container);
+  const ready: DocxEditorInstance[] = [];
+  const app = createApp({
+    render: () =>
+      h(
+        component,
+        {
+          document: SOURCE,
+          ...props,
+          onReady: (editor: unknown) => ready.push(editor as DocxEditorInstance),
+        },
+        component === DocxEditorRoot
+          ? {
+              default: () => h(DocxEditorViewport, null, { default: () => h(DocxEditorContent) }),
+            }
+          : undefined
+      ),
+  });
+  app.mount(container);
+  return {
+    container,
+    editor: () => ready.at(-1)!,
+    async setProps(nextProps: Record<string, unknown>) {
+      Object.assign(props, nextProps);
+      await flush();
+    },
+    unmount() {
+      app.unmount();
+      container.remove();
+    },
+  };
+}
+
+function select(editor: DocxEditorInstance, start: number, end: number): void {
+  const paragraphId = editor.surface!.session.paragraphIds()[0]!;
+  editor.surface!.setSelection({
+    anchor: { paragraphId, offset: start },
+    head: { paragraphId, offset: end },
+  });
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('live Vue props', () => {
+  test('DocxEditorRoot applies a changed author without replacing the editor', async () => {
+    const wrapper = mountWithProps(DocxEditorRoot, { author: 'Initial Author' });
+    try {
+      await flush();
+      const editor = wrapper.editor();
+      select(editor, 0, 1);
+      expect(editor.exec({ type: 'proposeReplacement', replaceWith: 'X' })).toMatchObject({
+        ok: true,
+        changed: true,
+      });
+
+      await wrapper.setProps({ author: 'Updated Author' });
+      expect(wrapper.editor()).toBe(editor);
+      expect(editor.getConfiguredAuthor()).toBe('Updated Author');
+      select(editor, 1, 2);
+      expect(editor.exec({ type: 'proposeReplacement', replaceWith: 'Y' })).toMatchObject({
+        ok: true,
+        changed: true,
+      });
+
+      const xml = serializeOoxmlPart(editor.surface!.session.part());
+      expect(xml.match(/w:author="Initial Author"/g)).toHaveLength(2);
+      expect(xml.match(/w:author="Updated Author"/g)).toHaveLength(2);
+    } finally {
+      wrapper.unmount();
+    }
+  });
+
+  test('DocxEditor sugar applies frame prop changes', async () => {
+    const wrapper = mountWithProps(DocxEditor, {
+      rulers: true,
+      navigation: true,
+      colorMode: 'light',
+      title: 'First title',
+    });
+    try {
+      await flush();
+      expect(
+        wrapper.container.querySelector('[data-testid="docx-editor-ruler-row"]')
+      ).not.toBeNull();
+      expect(wrapper.container.querySelector('.docx-nav')).not.toBeNull();
+      expect(wrapper.container.querySelector('.docx-editor.dark')).toBeNull();
+      expect(wrapper.container.textContent).toContain('First title');
+
+      await wrapper.setProps({ rulers: false });
+      expect(wrapper.container.querySelector('[data-testid="docx-editor-ruler-row"]')).toBeNull();
+      await wrapper.setProps({ navigation: false });
+      expect(wrapper.container.querySelector('.docx-nav')).toBeNull();
+      await wrapper.setProps({ colorMode: 'dark' });
+      expect(wrapper.container.querySelector('.docx-editor.dark')).not.toBeNull();
+      await wrapper.setProps({ title: 'Second title' });
+      expect(wrapper.container.textContent).toContain('Second title');
+      expect(wrapper.container.textContent).not.toContain('First title');
+    } finally {
+      wrapper.unmount();
+    }
+  });
+});

--- a/packages/vue/test/live-props.test.ts
+++ b/packages/vue/test/live-props.test.ts
@@ -1,13 +1,14 @@
 import './dom-setup.ts';
 
 import { afterEach, describe, expect, test } from 'bun:test';
-import { createApp, h, reactive, type Component } from 'vue';
+import { createApp, h, reactive, ref, type Component } from 'vue';
 import { serializeOoxmlPart } from '@docx-editor.dev/core/store';
 import type { DocxEditorInstance } from '@docx-editor.dev/core/editor';
 import { DocxEditor } from '../src/components/DocxEditor';
 import { DocxEditorRoot } from '../src/editor/DocxEditorRoot';
 import { DocxEditorViewport } from '../src/editor/DocxEditorViewport';
 import { DocxEditorContent } from '../src/editor/DocxEditorContent';
+import { LocaleProvider } from '../src/i18n/LocaleContext';
 import { flush, SOURCE } from './helpers/mount';
 
 function mountWithProps(component: Component, initialProps: Record<string, unknown>) {
@@ -84,6 +85,129 @@ describe('live Vue props', () => {
       expect(xml.match(/w:author="Updated Author"/g)).toHaveLength(2);
     } finally {
       wrapper.unmount();
+    }
+  });
+
+  test('DocxEditorRoot applies mode, translate, and locale changes in place', async () => {
+    const initialTranslate = (key: string) => `initial:${key}`;
+    const updatedTranslate = (key: string) => `updated:${key}`;
+    const wrapper = mountWithProps(DocxEditorRoot, {
+      mode: 'edit',
+      translate: initialTranslate,
+      locale: 'en',
+    });
+    try {
+      await flush();
+      const editor = wrapper.editor();
+      let receivedTranslate: typeof updatedTranslate | undefined;
+      let receivedLocale: string | undefined;
+      const setTranslate = editor.setTranslate.bind(editor);
+      const setLocale = editor.setLocale.bind(editor);
+      editor.setTranslate = (value) => {
+        receivedTranslate = value as typeof updatedTranslate;
+        setTranslate(value);
+      };
+      editor.setLocale = (value) => {
+        receivedLocale = value;
+        setLocale(value);
+      };
+
+      await wrapper.setProps({ mode: 'view', translate: updatedTranslate, locale: 'de' });
+      expect(wrapper.editor()).toBe(editor);
+      expect(editor.getEditingMode()).toBe('viewing');
+      expect(receivedTranslate?.('probe')).toBe('updated:probe');
+      expect(receivedLocale).toBe('de');
+    } finally {
+      wrapper.unmount();
+    }
+  });
+
+  test('an unrelated prop change does not restore a host mode after a reader change', async () => {
+    const wrapper = mountWithProps(DocxEditorRoot, { mode: 'edit', author: 'First Author' });
+    try {
+      await flush();
+      const editor = wrapper.editor();
+      expect(editor.exec({ type: 'setEditingMode', mode: 'viewing' })).toMatchObject({ ok: true });
+      await wrapper.setProps({ author: 'Second Author' });
+      expect(wrapper.editor()).toBe(editor);
+      expect(editor.getEditingMode()).toBe('viewing');
+    } finally {
+      wrapper.unmount();
+    }
+  });
+
+  test('a locale catalog change updates translation without replacing the editor', async () => {
+    const catalog = (label: string) => ({ image: { pendingResource: label } });
+    const wrapper = mountWithProps(DocxEditor, { i18n: catalog('First loading label') });
+    try {
+      await flush();
+      const editor = wrapper.editor();
+      let resolver: ((key: string) => string) | undefined;
+      const setTranslate = editor.setTranslate.bind(editor);
+      editor.setTranslate = (value) => {
+        resolver = value;
+        setTranslate(value);
+      };
+
+      await wrapper.setProps({ i18n: catalog('Second loading label') });
+      expect(wrapper.editor()).toBe(editor);
+      expect(resolver?.('image.pendingResource')).toBe('Second loading label');
+
+      const catalogResolver = resolver;
+      await wrapper.setProps({ t: (key: string) => `custom:${key}` });
+      expect(wrapper.editor()).toBe(editor);
+      expect(resolver).not.toBe(catalogResolver);
+      expect(resolver?.('image.pendingResource')).toBe('custom:image.pendingResource');
+    } finally {
+      wrapper.unmount();
+    }
+  });
+
+  test('a bare root reads a changed locale catalog without replacing the editor', async () => {
+    const catalog = (label: string) => ({ image: { pendingResource: label } });
+    const i18n = ref(catalog('First loading label'));
+    const container = document.createElement('div');
+    document.body.append(container);
+    const ready: DocxEditorInstance[] = [];
+    const app = createApp({
+      render: () =>
+        h(
+          LocaleProvider,
+          { i18n: i18n.value },
+          {
+            default: () =>
+              h(
+                DocxEditorRoot,
+                {
+                  document: SOURCE,
+                  onReady: (editor: unknown) => ready.push(editor as DocxEditorInstance),
+                },
+                {
+                  default: () =>
+                    h(DocxEditorViewport, null, { default: () => h(DocxEditorContent) }),
+                }
+              ),
+          }
+        ),
+    });
+    app.mount(container);
+    try {
+      await flush();
+      const editor = ready.at(-1)!;
+      let resolver: ((key: string) => string) | undefined;
+      const setTranslate = editor.setTranslate.bind(editor);
+      editor.setTranslate = (value) => {
+        resolver = value;
+        setTranslate(value);
+      };
+
+      i18n.value = catalog('Second loading label');
+      await flush();
+      expect(ready.at(-1)).toBe(editor);
+      expect(resolver?.('image.pendingResource')).toBe('Second loading label');
+    } finally {
+      app.unmount();
+      container.remove();
     }
   });
 

--- a/packages/vue/test/live-props.test.ts
+++ b/packages/vue/test/live-props.test.ts
@@ -211,6 +211,22 @@ describe('live Vue props', () => {
     }
   });
 
+  test('a fresh equivalent inline translation does not publish a selection change', async () => {
+    const wrapper = mountWithProps(DocxEditor, { t: (key: string) => `same:${key}` });
+    try {
+      await flush();
+      const editor = wrapper.editor();
+      let changes = 0;
+      editor.on('selectionChange', () => changes++);
+
+      await wrapper.setProps({ t: (key: string) => `same:${key}` });
+      expect(wrapper.editor()).toBe(editor);
+      expect(changes).toBe(0);
+    } finally {
+      wrapper.unmount();
+    }
+  });
+
   test('DocxEditor sugar applies frame prop changes', async () => {
     const wrapper = mountWithProps(DocxEditor, {
       rulers: true,


### PR DESCRIPTION
The `author` prop on `DocxEditor.Root` and `DocxEditorRoot` applied only when the instance was created. The engine had no author setter, so a later prop change could not reach it, and every revision kept the mount-time author. The Vue packaged `<DocxEditor>` also read its props once in `setup`, which froze `rulers`, `navigation`, `colorMode`, `title`, and the other frame props after the first render. An audit found the same mount-only behavior for `mode`, `translate`, and `locale`, and a docs claim that a new `modules` array rebuilds the editor, which it does not.

## What changes

- `DocxEditorInstance` gains `setAuthor`, `setMode`, `setTranslate`, and `setLocale`. Each applies without rebuilding the editor, so edits, the caret, and the undo history survive. Existing revisions keep their author. Buffered typed text commits under the author that was active when it was typed.
- Both adapter roots forward `author`, `mode`, `translate`, and `locale` prop changes through those setters. A `mode` change applies only when the prop itself moves, so an unrelated parent render never undoes a toolbar-picked mode. A locale catalog change no longer remounts the editor.
- The Vue packaged `<DocxEditor>` reads its props inside the render function, so every frame prop is reactive after mount.
- The review pane in both adapters refreshes the configured author for an open comment draft.
- Docs describe which props apply live and state that `modules` is read only at construction.

## Tests

Core, React, Vue, and Pro tests cover a tracked change before and after an author change, the reload case, the cleared-author refusal, buffered typing across the switch, the live view lock, suggesting fallback, document tracking adoption after `setMode(undefined)`, drawing placeholder repaint after `setTranslate`, the table of contents title after `setLocale`, Vue frame prop reactivity, catalog changes without a remount, and the review draft author.

Fixes #695
Fixes #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SJFYMH5YMkrRjerKFYhQo
