### PR TITLE
fix(core): lock secondary-story hyperlink relationships

### DIFF
--- a/.changeset/fuzzy-secondary-story-links.md
+++ b/.changeset/fuzzy-secondary-story-links.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Hyperlinks in headers, footers, and drawing text boxes now resolve through their owning OOXML part and paint as link anchors. Read-only story links remain inert until those stories become editable.

--- a/.changeset/fuzzy-secondary-story-links.md
+++ b/.changeset/fuzzy-secondary-story-links.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': patch
 ---
 
-Hyperlinks in headers, footers, and drawing text boxes now resolve through their owning OOXML part and paint as link anchors. Read-only story links remain inert until those stories become editable.
+Hyperlinks in headers, footers, and anchored text boxes now resolve through their owning OOXML part and paint as link anchors. You can edit or remove header and footer links with Ctrl+K while editing their story; secondary-story anchors remain inert. Fixes #643.

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -838,7 +838,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'Insert, edit, and remove a link with Ctrl+K, Cmd+K, or the toolbar. Targets are allowlisted: http, https, mailto, tel, and ftp. Any other target renders inert and still round-trips. A HYPERLINK field, complex or w:fldSimple, is a live link too: its target passes the same allowlist, and the link panel shows it read-only. Links in footnote and endnote text work the same way. Opening a document never requests a link target, because activation needs an explicit gesture.',
+      'Insert, edit, and remove a link with Ctrl+K, Cmd+K, or the toolbar. Targets are allowlisted: http, https, mailto, tel, and ftp. Any other target renders inert and still round-trips. A HYPERLINK field, complex or w:fldSimple, is a live link too: its target passes the same allowlist, and the link panel shows it read-only. Links in footnote and endnote text work the same way. Links in headers, footers, and anchored text boxes resolve through their own part. You can edit or remove header and footer links with Ctrl+K while editing their story. Secondary-story anchors remain inert and do not open. Opening a document never requests a link target, because activation needs an explicit gesture.',
   },
   {
     id: 'fields.bookmarks',

--- a/packages/core/src/editor/__tests__/secondary-story-hyperlink-rels.test.ts
+++ b/packages/core/src/editor/__tests__/secondary-story-hyperlink-rels.test.ts
@@ -227,9 +227,9 @@ describe('secondary-story hyperlink relationship scope', () => {
       ]);
       expect(textboxHref(page.footer?.anchoredDrawings)).toBe('https://footer.example/');
 
-      // Text-box stories and page furniture are read-only today, so paint intentionally omits
-      // href while retaining an anchor + link id. The semantic record above remains the target
-      // authority for export and for any future interactive story surface.
+      // Page furniture and text-box paint intentionally omit href while retaining an anchor +
+      // link id. The semantic record above remains the target authority for export and future
+      // interaction paths.
       for (const label of [
         'BodyTextboxLink',
         'HeaderLink',
@@ -264,11 +264,12 @@ describe('secondary-story hyperlink relationship scope', () => {
         relationshipTargetIn(pkg, pkg.mainDocumentPart, relationshipId),
     };
     const links = createDocumentLinkProjectors(view);
+    const cache = createParagraphLayoutCache<readonly PendingLine[]>();
     const furniture = createDocumentFurnitureSource({
       view,
       measurer: createFixedMeasurer(6, 14),
       producer: 'secondary-story-link-rels-only',
-      cache: createParagraphLayoutCache<readonly PendingLine[]>(),
+      cache,
       inlineDrawingLayoutForPart: (partName) => drawingLayoutFor(pkg.parts.get(partName)!),
       linkProjectors: links,
     });
@@ -281,6 +282,7 @@ describe('secondary-story hyperlink relationship scope', () => {
       targetFor('header', 'one'),
       targetFor('header', 'one'),
     ]);
+    const missesAfterFirst = cache.stats.misses;
 
     const relationships = new Map(firstPackage.relationships);
     relationships.set(
@@ -312,6 +314,7 @@ describe('secondary-story hyperlink relationship scope', () => {
     expect(updatedFooter).toBe(firstFooter);
     expect(directHref(updatedFooter)).toBe(targetFor('footer', 'one'));
     expect(textboxHref(updatedFooter?.anchoredDrawings)).toBe(targetFor('footer', 'one'));
+    expect(cache.stats.misses - missesAfterFirst).toBeLessThanOrEqual(5);
   });
 
   test('a rels-only body retarget invalidates its hosted story with one cache and session', () => {
@@ -360,6 +363,7 @@ describe('secondary-story hyperlink relationship scope', () => {
 
     const first = layout();
     expect(textboxHref(first.pages[0]!.anchoredDrawings)).toBe(targetFor('body', 'one'));
+    const missesAfterFirst = cache.stats.misses;
 
     const relationships = new Map(firstPackage.relationships);
     relationships.set(
@@ -391,5 +395,6 @@ describe('secondary-story hyperlink relationship scope', () => {
     expect(textboxHref(updated.pages[0]!.footer?.anchoredDrawings)).toBe(
       targetFor('footer', 'one')
     );
+    expect(cache.stats.misses - missesAfterFirst).toBeLessThanOrEqual(3);
   });
 });

--- a/packages/core/src/editor/__tests__/secondary-story-hyperlink-rels.test.ts
+++ b/packages/core/src/editor/__tests__/secondary-story-hyperlink-rels.test.ts
@@ -1,0 +1,395 @@
+// Hyperlink relationship scope for headers, footers, and hosted text-box stories.
+//
+// Every OOXML part owns its own relationship namespace. Reusing the same r:id in the body,
+// header, and footer is legal, so both direct text and text hosted by a drawing must retain the
+// projector of the part that owns them all the way through layout and paint.
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { strToU8, zipSync } from 'fflate';
+import type {
+  AnchoredDrawingRecord,
+  BlockFragmentRecord,
+  HeaderFooterStoryLayout,
+  InlineDrawingLayoutContext,
+  PendingLine,
+  StyleSpanRecord,
+} from '../../layout/index.ts';
+import {
+  createDocumentFurnitureSource,
+  createDocumentLinkProjectors,
+  createFixedMeasurer,
+  createLayoutSession,
+  createParagraphLayoutCache,
+} from '../../layout/index.ts';
+import { layoutDocumentView } from '../../layout/document-layout-coordinator.ts';
+import {
+  DEFAULT_DRAWING_PROJECTION_LIMITS,
+  indexInlineDrawingProjectionsInPart,
+  projectDrawing,
+} from '../../store/package/drawing-projection.ts';
+import {
+  readOoxmlPackage,
+  relationshipTargetIn,
+  resolveHeaderFooterPartsBySection,
+  type HeadlessDocumentView,
+  type OoxmlPackage,
+  type OoxmlPart,
+} from '../../store/package/index.ts';
+import { createDocxEditor } from '../docx-editor.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
+const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+const WPS = 'http://schemas.microsoft.com/office/word/2010/wordprocessingShape';
+
+function linkedParagraph(label: string): string {
+  return `<w:p><w:hyperlink r:id="rId7"><w:r><w:t>${label}</w:t></w:r></w:hyperlink></w:p>`;
+}
+
+function linkedTextbox(
+  label: string,
+  drawingId: number,
+  yEmu: number,
+  withTableContent = false
+): string {
+  const content = withTableContent
+    ? '<w:tbl><w:tblPr/><w:tblGrid><w:gridCol w:w="2400"/></w:tblGrid>' +
+      '<w:tr><w:tc><w:tcPr><w:tcW w:w="2400" w:type="dxa"/></w:tcPr>' +
+      linkedParagraph(label) +
+      '</w:tc></w:tr></w:tbl>'
+    : linkedParagraph(label);
+  return (
+    '<w:p><w:r><w:drawing>' +
+    '<wp:anchor distT="0" distB="0" distL="0" distR="0" simplePos="0"' +
+    ' relativeHeight="1" behindDoc="0" locked="0" layoutInCell="1" allowOverlap="1">' +
+    '<wp:simplePos x="0" y="0"/>' +
+    '<wp:positionH relativeFrom="page"><wp:posOffset>1800000</wp:posOffset></wp:positionH>' +
+    `<wp:positionV relativeFrom="page"><wp:posOffset>${yEmu}</wp:posOffset></wp:positionV>` +
+    '<wp:extent cx="1800000" cy="500000"/>' +
+    '<wp:effectExtent l="0" t="0" r="0" b="0"/><wp:wrapNone/>' +
+    `<wp:docPr id="${drawingId}" name="Linked textbox ${drawingId}"/>` +
+    `<a:graphic><a:graphicData uri="${WPS}"><wps:wsp>` +
+    '<wps:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="1800000" cy="500000"/></a:xfrm>' +
+    '<a:prstGeom prst="rect"><a:avLst/></a:prstGeom></wps:spPr>' +
+    `<wps:txbx><w:txbxContent>${content}</w:txbxContent></wps:txbx>` +
+    '<wps:bodyPr lIns="0" tIns="0" rIns="0" bIns="0"/>' +
+    '</wps:wsp></a:graphicData></a:graphic></wp:anchor>' +
+    '</w:drawing></w:r></w:p>'
+  );
+}
+
+function textboxInTableCell(label: string, drawingId: number, yEmu: number): string {
+  return (
+    '<w:tbl><w:tblPr/><w:tblGrid><w:gridCol w:w="4000"/></w:tblGrid>' +
+    '<w:tr><w:tc><w:tcPr><w:tcW w:w="4000" w:type="dxa"/></w:tcPr>' +
+    linkedTextbox(label, drawingId, yEmu) +
+    '</w:tc></w:tr></w:tbl>'
+  );
+}
+
+function targetFor(owner: 'body' | 'header' | 'footer', suffix = ''): string {
+  return `https://${owner}${suffix ? `.${suffix}` : ''}.example/`;
+}
+
+/** One rId, three owners: each occurrence must resolve in the part that contains it. */
+function conflictingSecondaryStoryRelsDoc(suffix = ''): Uint8Array {
+  const namespaces = `xmlns:w="${W}" xmlns:r="${R}" xmlns:wp="${WP}" xmlns:a="${A}" xmlns:wps="${WPS}"`;
+  const relationships = (target: string) =>
+    `<Relationships xmlns="${REL}">` +
+    `<Relationship Id="rId7" Type="${R}/hyperlink" Target="${target}" TargetMode="External"/>` +
+    '</Relationships>';
+
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '<Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>' +
+        '<Override PartName="/word/footer1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rDoc" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}">` +
+        `<Relationship Id="rHeader" Type="${R}/header" Target="header1.xml"/>` +
+        `<Relationship Id="rFooter" Type="${R}/footer" Target="footer1.xml"/>` +
+        `<Relationship Id="rId7" Type="${R}/hyperlink" Target="${targetFor('body', suffix)}" TargetMode="External"/>` +
+        '</Relationships>'
+    ),
+    'word/_rels/header1.xml.rels': strToU8(relationships(targetFor('header', suffix))),
+    'word/_rels/footer1.xml.rels': strToU8(relationships(targetFor('footer', suffix))),
+    'word/document.xml': strToU8(
+      `<w:document ${namespaces}><w:body>` +
+        linkedParagraph('BodyLink') +
+        linkedTextbox('BodyTextboxLink', 1, 3_000_000) +
+        '<w:sectPr>' +
+        '<w:headerReference w:type="default" r:id="rHeader"/>' +
+        '<w:footerReference w:type="default" r:id="rFooter"/>' +
+        '<w:pgSz w:w="11906" w:h="16838"/>' +
+        '<w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440" w:header="720" w:footer="720"/>' +
+        '</w:sectPr></w:body></w:document>'
+    ),
+    'word/header1.xml': strToU8(
+      `<w:hdr ${namespaces}>` +
+        linkedParagraph('HeaderLink') +
+        linkedTextbox('HeaderTextboxLink', 2, 500_000, true) +
+        textboxInTableCell('CellHostedTextboxLink', 4, 1_000_000) +
+        '</w:hdr>'
+    ),
+    'word/footer1.xml': strToU8(
+      `<w:ftr ${namespaces}>` +
+        linkedParagraph('FooterLink') +
+        linkedTextbox('FooterTextboxLink', 3, 9_500_000) +
+        '</w:ftr>'
+    ),
+  });
+}
+
+function openPackage(bytes: Uint8Array): OoxmlPackage {
+  const loaded = readOoxmlPackage(bytes);
+  if (!loaded.ok) throw new Error(loaded.reason);
+  return loaded.package;
+}
+
+function drawingLayoutFor(part: OoxmlPart): InlineDrawingLayoutContext {
+  const projections = indexInlineDrawingProjectionsInPart(part);
+  return {
+    ownerPartName: part.name,
+    projectionForAtom: (atomId) => projections.get(atomId) ?? null,
+    project: (node) =>
+      projections.get(node.id) ??
+      projectDrawing(node, {
+        ownerPartName: part.name,
+        limits: DEFAULT_DRAWING_PROJECTION_LIMITS,
+      }),
+    resourceOf: () => ({ kind: 'missing', relationshipId: 'none' }),
+  };
+}
+
+function spansIn(fragments: readonly BlockFragmentRecord[]): StyleSpanRecord[] {
+  const spans: StyleSpanRecord[] = [];
+  for (const fragment of fragments) {
+    if (fragment.kind === 'paragraph') {
+      for (const line of fragment.lines) spans.push(...line.spans);
+      continue;
+    }
+    for (const row of fragment.rows) {
+      for (const cell of row.cells) spans.push(...spansIn(cell.blocks));
+    }
+  }
+  return spans;
+}
+
+function textboxHrefs(drawings: readonly AnchoredDrawingRecord[] | undefined): string[] {
+  return (drawings ?? []).flatMap((drawing) =>
+    spansIn(drawing.textboxStory?.fragments ?? []).flatMap((span) =>
+      span.link ? [span.link.href] : []
+    )
+  );
+}
+
+function textboxHref(drawings: readonly AnchoredDrawingRecord[] | undefined): string | null {
+  return textboxHrefs(drawings)[0] ?? null;
+}
+
+function directHref(story: HeaderFooterStoryLayout | undefined): string | null {
+  return spansIn(story?.fragments ?? []).find((span) => span.link)?.link?.href ?? null;
+}
+
+describe('secondary-story hyperlink relationship scope', () => {
+  test('direct and text-box links resolve against their owning body, header, or footer part', () => {
+    const container = document.createElement('div');
+    document.body.append(container);
+    const editor = createDocxEditor({ container, document: conflictingSecondaryStoryRelsDoc() });
+    try {
+      expect(editor.surface).not.toBeNull();
+
+      const anchors = [...container.querySelectorAll<HTMLElement>('a.docx-hyperlink')];
+      const anchorFor = (text: string): HTMLElement | undefined =>
+        anchors.find((anchor) => anchor.textContent === text);
+      const hrefFor = (text: string): string | null | undefined =>
+        anchorFor(text)?.getAttribute('href');
+      const page = editor.surface!.layout().pages[0]!;
+
+      expect(hrefFor('BodyLink')).toBe('https://body.example/');
+      expect(textboxHref(page.anchoredDrawings)).toBe('https://body.example/');
+      expect(textboxHrefs(page.header?.anchoredDrawings)).toEqual([
+        'https://header.example/',
+        'https://header.example/',
+      ]);
+      expect(textboxHref(page.footer?.anchoredDrawings)).toBe('https://footer.example/');
+
+      // Text-box stories and page furniture are read-only today, so paint intentionally omits
+      // href while retaining an anchor + link id. The semantic record above remains the target
+      // authority for export and for any future interactive story surface.
+      for (const label of [
+        'BodyTextboxLink',
+        'HeaderLink',
+        'HeaderTextboxLink',
+        'FooterLink',
+        'FooterTextboxLink',
+      ]) {
+        expect(anchorFor(label)?.dataset.docxLink).toBeTruthy();
+        expect(hrefFor(label)).toBeNull();
+      }
+    } finally {
+      editor.destroy();
+      container.remove();
+    }
+  });
+
+  test('a rels-only header retarget invalidates direct and hosted story records', () => {
+    const firstPackage = openPackage(conflictingSecondaryStoryRelsDoc('one'));
+    const secondPackage = openPackage(conflictingSecondaryStoryRelsDoc('two'));
+    let pkg = firstPackage;
+    const view: HeadlessDocumentView = {
+      part: () => firstPackage.parts.get(firstPackage.mainDocumentPart)!,
+      currentPackage: () => pkg,
+      packageRevision: () => 1,
+      stylesRoot: () => null,
+      numberingRoot: () => null,
+      settingsRoot: () => null,
+      documentThemeFonts: () => ({ major: null, minor: null }),
+      documentProperties: () => ({}),
+      headerFooterPartsBySection: () => resolveHeaderFooterPartsBySection(pkg),
+      relationshipTarget: (relationshipId) =>
+        relationshipTargetIn(pkg, pkg.mainDocumentPart, relationshipId),
+    };
+    const links = createDocumentLinkProjectors(view);
+    const furniture = createDocumentFurnitureSource({
+      view,
+      measurer: createFixedMeasurer(6, 14),
+      producer: 'secondary-story-link-rels-only',
+      cache: createParagraphLayoutCache<readonly PendingLine[]>(),
+      inlineDrawingLayoutForPart: (partName) => drawingLayoutFor(pkg.parts.get(partName)!),
+      linkProjectors: links,
+    });
+
+    const first = furniture.furniture()!;
+    const firstHeader = first.headers.get('default');
+    const firstFooter = first.footers.get('default');
+    expect(directHref(firstHeader)).toBe(targetFor('header', 'one'));
+    expect(textboxHrefs(firstHeader?.anchoredDrawings)).toEqual([
+      targetFor('header', 'one'),
+      targetFor('header', 'one'),
+    ]);
+
+    const relationships = new Map(firstPackage.relationships);
+    relationships.set(
+      '/word/header1.xml',
+      secondPackage.relationships.get('/word/header1.xml') ?? []
+    );
+    pkg = Object.freeze({
+      ...firstPackage,
+      relationships,
+      externalTargets: Object.freeze([
+        ...firstPackage.externalTargets.filter(
+          (target) => target.ownerPart !== '/word/header1.xml'
+        ),
+        ...secondPackage.externalTargets.filter(
+          (target) => target.ownerPart === '/word/header1.xml'
+        ),
+      ]),
+    });
+
+    const updated = furniture.furniture()!;
+    const updatedHeader = updated.headers.get('default');
+    const updatedFooter = updated.footers.get('default');
+    expect(updatedHeader).not.toBe(firstHeader);
+    expect(directHref(updatedHeader)).toBe(targetFor('header', 'two'));
+    expect(textboxHrefs(updatedHeader?.anchoredDrawings)).toEqual([
+      targetFor('header', 'two'),
+      targetFor('header', 'two'),
+    ]);
+    expect(updatedFooter).toBe(firstFooter);
+    expect(directHref(updatedFooter)).toBe(targetFor('footer', 'one'));
+    expect(textboxHref(updatedFooter?.anchoredDrawings)).toBe(targetFor('footer', 'one'));
+  });
+
+  test('a rels-only body retarget invalidates its hosted story with one cache and session', () => {
+    const firstPackage = openPackage(conflictingSecondaryStoryRelsDoc('one'));
+    const secondPackage = openPackage(conflictingSecondaryStoryRelsDoc('two'));
+    let pkg = firstPackage;
+    let revision = 1;
+    const view: HeadlessDocumentView = {
+      part: () => firstPackage.parts.get(firstPackage.mainDocumentPart)!,
+      currentPackage: () => pkg,
+      packageRevision: () => revision,
+      stylesRoot: () => null,
+      numberingRoot: () => null,
+      settingsRoot: () => null,
+      documentThemeFonts: () => ({ major: null, minor: null }),
+      documentProperties: () => ({}),
+      headerFooterPartsBySection: () => resolveHeaderFooterPartsBySection(pkg),
+      relationshipTarget: (relationshipId) =>
+        relationshipTargetIn(pkg, pkg.mainDocumentPart, relationshipId),
+    };
+    const links = createDocumentLinkProjectors(view);
+    const cache = createParagraphLayoutCache<readonly PendingLine[]>();
+    const session = createLayoutSession();
+    const furniture = createDocumentFurnitureSource({
+      view,
+      measurer: createFixedMeasurer(6, 14),
+      producer: 'body-textbox-link-rels-only',
+      cache,
+      inlineDrawingLayoutForPart: (partName) => drawingLayoutFor(pkg.parts.get(partName)!),
+      linkProjectors: links,
+    });
+    const layout = () =>
+      layoutDocumentView({
+        view,
+        revision,
+        measurer: createFixedMeasurer(6, 14),
+        cache,
+        session,
+        producer: 'body-textbox-link-rels-only',
+        furniture,
+        linkProjectors: links,
+        inlineDrawingLayout: drawingLayoutFor(
+          firstPackage.parts.get(firstPackage.mainDocumentPart)!
+        ),
+      });
+
+    const first = layout();
+    expect(textboxHref(first.pages[0]!.anchoredDrawings)).toBe(targetFor('body', 'one'));
+
+    const relationships = new Map(firstPackage.relationships);
+    relationships.set(
+      firstPackage.mainDocumentPart,
+      secondPackage.relationships.get(secondPackage.mainDocumentPart) ?? []
+    );
+    pkg = Object.freeze({
+      ...firstPackage,
+      relationships,
+      externalTargets: Object.freeze([
+        ...firstPackage.externalTargets.filter(
+          (target) => target.ownerPart !== firstPackage.mainDocumentPart
+        ),
+        ...secondPackage.externalTargets.filter(
+          (target) => target.ownerPart === secondPackage.mainDocumentPart
+        ),
+      ]),
+    });
+    revision += 1;
+
+    const updated = layout();
+    expect(textboxHref(updated.pages[0]!.anchoredDrawings)).toBe(targetFor('body', 'two'));
+    expect(directHref(updated.pages[0]!.header)).toBe(targetFor('header', 'one'));
+    expect(textboxHrefs(updated.pages[0]!.header?.anchoredDrawings)).toEqual([
+      targetFor('header', 'one'),
+      targetFor('header', 'one'),
+    ]);
+    expect(directHref(updated.pages[0]!.footer)).toBe(targetFor('footer', 'one'));
+    expect(textboxHref(updated.pages[0]!.footer?.anchoredDrawings)).toBe(
+      targetFor('footer', 'one')
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- lock end-to-end coverage for hyperlinks resolved in the body, header, footer, and supported anchored text boxes with deliberately colliding relationship ids
- cover both table nesting directions: a table inside a text box and a text box hosted in a header table cell
- prove relationship-only retargets invalidate body and header hosted-story records under one cache/session while unrelated story targets remain unchanged
- document the shipped behavior accurately in the feature matrix and add the missing consumer-facing patch note

## Implementation context

The runtime projector plumbing landed incidentally in #661 after the last release, but that PR did not test or announce #643. This PR completes the fix with the regression contract, cache-locality bounds, documentation, and release note.

## Scope

Closes #643.

Note-hosted text-box layout is a separate capability tracked by #639. Header, footer, and anchored text-box links now retain correctly part-scoped semantic targets; painted secondary-story anchors remain inert. Header and footer links can be edited or removed with Ctrl+K while their story is active.

## Verification

- bun run test — 11,281 passed across 891 files
- bun run typecheck — all workspaces passed
- bun run lint — 0 errors (75 pre-existing warnings)
- focused regression — 3 tests, 31 assertions
- commit hooks — typecheck, parity gates, license checks, API snapshot check, formatting, lint, and lint-staged all passed

## Claude Fable 5.1 review loop

Independent correctness and test/release reviewers examined the diff repeatedly. Medium+ findings fixed during the loop:

- corrected release wording so inert secondary-story anchors are not described as clickable
- documented the precise header/footer edit path without promising an Open action
- added the #643 changeset reference and feature-matrix coverage
- added header and body relationship-only invalidation coverage with cache-miss ceilings
- covered body text boxes, header/footer text boxes, a table inside a text box, and a text box hosted in a header table cell
- verified #639 as the explicit boundary for note-hosted text-box layout

The final two independent Fable 5.1 review passes both returned CLEAN: no Medium, High, or Critical findings remain.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790995349&installation_model_id=422592&pr_number=712&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F712&signature=47117d0e3f7ecb111c39ace6601ab28dcfa13d6e33795bebe04702d3830c89e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->