### PR TITLE
fix: search tables, field results, and every story

### DIFF
--- a/.changeset/bright-fields-search.md
+++ b/.changeset/bright-fields-search.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Search headers, footers, footnotes, endnotes, table cells, and saved field results. Fixes #703, fixes #694

--- a/docs/api/docx-editor-core/automation.api.md
+++ b/docs/api/docx-editor-core/automation.api.md
@@ -215,14 +215,18 @@ export type AutomationOperation =
 * Text of a body or a paragraph.
 *
 * A story reads as its paragraphs joined by a carriage return — one paragraph mark, one
-* `\r` — which is the separator Word's own text property uses.
+* `\r` — which is the separator Word's own text property uses. Display projections expand
+* fields, so clients must not derive model offsets from this text.
 */
 | {
     readonly op: 'getText';
     readonly projection?: AutomationTextProjection;
     readonly target: AutomationHandle;
 }
-/** Text between two endpoints, with a carriage return at every paragraph mark crossed. */
+/**
+* Display text between two endpoints, with a carriage return at each paragraph boundary.
+* Use the `model` projection when a client needs text in the endpoint offset vocabulary.
+*/
 | {
     readonly op: 'getSpanText';
     readonly projection?: AutomationTextProjection;
@@ -1132,7 +1136,7 @@ export type AutomationStoryId = {
 };
 
 // @public
-export type AutomationTextProjection = 'allMarkup' | 'original';
+export type AutomationTextProjection = 'allMarkup' | 'original' | 'model';
 
 // @public
 export type AutomationUnsubscribe = () => void;

--- a/docs/api/docx-editor-core/contracts-editor.api.md
+++ b/docs/api/docx-editor-core/contracts-editor.api.md
@@ -2013,6 +2013,7 @@ export interface TextMatch {
     readonly runIndex: number;
     // (undocumented)
     readonly runOffset: number;
+    readonly scope?: ViewScope;
     readonly start: number;
     readonly text: string;
 }

--- a/docs/api/docx-editor-core/index.api.md
+++ b/docs/api/docx-editor-core/index.api.md
@@ -2876,6 +2876,7 @@ export interface TextMatch {
     readonly runIndex: number;
     // (undocumented)
     readonly runOffset: number;
+    readonly scope?: ViewScope;
     readonly start: number;
     readonly text: string;
 }

--- a/docs/api/docx-editor-core/store.api.md
+++ b/docs/api/docx-editor-core/store.api.md
@@ -4949,7 +4949,9 @@ export const W15_NAMESPACE_URI = "http://schemas.microsoft.com/office/word/2012/
 export function walkAllStoryParagraphs(children: readonly OoxmlNode[], sdtDepth: number, visit: (paragraph: OoxmlElement) => void): void;
 
 // @public
-export function walkParagraphInline(children: readonly OoxmlNode[], depth: number, visit: (child: OoxmlNode) => void): void;
+export function walkParagraphInline(children: readonly OoxmlNode[], depth: number, visit: (child: OoxmlNode) => void, options?: {
+    readonly descendRevisions?: boolean;
+}): void;
 
 // @public
 export function walkStoryBlocks(children: readonly OoxmlNode[], depth: number, visit: (block: OoxmlElement) => void): void;

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -1035,7 +1035,7 @@ export const wordFeatures: WordFeature[] = [
     rendering: 'full',
     roundTrip: 'full',
     tier: 'community',
-    notes: 'Searches the body story. Text in headers, footers and notes is not matched.',
+    notes: 'Searches headers, footers, footnotes, endnotes, table cells, and saved field results.',
   },
   {
     id: 'collab.clipboard',

--- a/packages/core/src/automation/__tests__/automation-content-control-text.test.ts
+++ b/packages/core/src/automation/__tests__/automation-content-control-text.test.ts
@@ -2,15 +2,22 @@
 
 import { describe, expect, test } from 'bun:test';
 import { docx, handlesAt, open, roots, textAt } from './support/protocol.ts';
+import type { AutomationTextProjection } from '../operations.ts';
 import type { AutomationHandle, AutomationHost } from '../protocol.ts';
 
 function controlsOf(host: AutomationHost, scope: { readonly body: AutomationHandle }) {
   return handlesAt(host.execute({ operations: [{ op: 'getContentControls', scope }] }), 0);
 }
 
-function controlText(host: AutomationHost, control: AutomationHandle): string {
+function controlText(
+  host: AutomationHost,
+  control: AutomationHandle,
+  projection?: AutomationTextProjection
+): string {
   return textAt(
-    host.execute({ operations: [{ op: 'getContentControlText', contentControl: control }] }),
+    host.execute({
+      operations: [{ op: 'getContentControlText', contentControl: control, projection }],
+    }),
     0
   );
 }
@@ -48,6 +55,42 @@ describe('content-control value text', () => {
     const found = controlsOf(host, { body: roots(host).body })[0]!;
 
     expect(controlText(host, found)).toBe('inside');
+  });
+
+  test.each([
+    ['hyperlink', '<w:hyperlink w:anchor="target">', '</w:hyperlink>'],
+    ['insertion', '<w:ins w:id="1" w:author="Ada">', '</w:ins>'],
+  ] as const)('projects a control inside a %s from its own subtree', (_name, openTag, closeTag) => {
+    const control =
+      '<w:sdt><w:sdtPr><w:tag w:val="wrapped"/></w:sdtPr>' +
+      '<w:sdtContent><w:r><w:t>inside</w:t></w:r></w:sdtContent></w:sdt>';
+    const host = open(docx(`<w:p>${openTag}${control}${closeTag}</w:p>`));
+    const found = controlsOf(host, { body: roots(host).body })[0]!;
+
+    expect(controlText(host, found, 'model')).toBe('inside');
+    expect(controlText(host, found, 'original')).toBe('inside');
+  });
+
+  test('projects a nested control from its own subtree', () => {
+    const inner =
+      '<w:sdt><w:sdtPr><w:tag w:val="inner"/></w:sdtPr>' +
+      '<w:sdtContent><w:r><w:t>deep</w:t></w:r></w:sdtContent></w:sdt>';
+    const host = open(
+      docx(
+        '<w:p><w:sdt><w:sdtPr><w:tag w:val="outer"/></w:sdtPr>' +
+          `<w:sdtContent>${inner}</w:sdtContent></w:sdt></w:p>`
+      )
+    );
+    const outer = controlsOf(host, { body: roots(host).body })[0]!;
+    const nested = handlesAt(
+      host.execute({
+        operations: [{ op: 'getContentControls', scope: { contentControl: outer } }],
+      }),
+      0
+    )[0]!;
+
+    expect(controlText(host, nested, 'model')).toBe('deep');
+    expect(controlText(host, nested, 'original')).toBe('deep');
   });
 
   test('omits struck text and paragraph marks from a block control', () => {

--- a/packages/core/src/automation/__tests__/automation-content-control-text.test.ts
+++ b/packages/core/src/automation/__tests__/automation-content-control-text.test.ts
@@ -1,0 +1,66 @@
+// Established content-control value reads over wrappers and struck text.
+
+import { describe, expect, test } from 'bun:test';
+import { docx, handlesAt, open, roots, textAt } from './support/protocol.ts';
+import type { AutomationHandle, AutomationHost } from '../protocol.ts';
+
+function controlsOf(host: AutomationHost, scope: { readonly body: AutomationHandle }) {
+  return handlesAt(host.execute({ operations: [{ op: 'getContentControls', scope }] }), 0);
+}
+
+function controlText(host: AutomationHost, control: AutomationHandle): string {
+  return textAt(
+    host.execute({ operations: [{ op: 'getContentControlText', contentControl: control }] }),
+    0
+  );
+}
+
+describe('content-control value text', () => {
+  test('reads a nested inline control', () => {
+    const inner =
+      '<w:sdt><w:sdtPr><w:tag w:val="inner"/></w:sdtPr>' +
+      '<w:sdtContent><w:r><w:t>deep</w:t></w:r></w:sdtContent></w:sdt>';
+    const host = open(
+      docx(
+        '<w:p><w:sdt><w:sdtPr><w:tag w:val="outer"/></w:sdtPr>' +
+          `<w:sdtContent>${inner}</w:sdtContent></w:sdt></w:p>`
+      )
+    );
+    const outer = controlsOf(host, { body: roots(host).body })[0]!;
+    const nested = handlesAt(
+      host.execute({
+        operations: [{ op: 'getContentControls', scope: { contentControl: outer } }],
+      }),
+      0
+    )[0]!;
+
+    expect(controlText(host, nested)).toBe('deep');
+  });
+
+  test.each([
+    ['hyperlink', '<w:hyperlink w:anchor="target">', '</w:hyperlink>'],
+    ['insertion', '<w:ins w:id="1" w:author="Ada">', '</w:ins>'],
+  ] as const)('reads a control inside a %s', (_name, openTag, closeTag) => {
+    const control =
+      '<w:sdt><w:sdtPr><w:tag w:val="wrapped"/></w:sdtPr>' +
+      '<w:sdtContent><w:r><w:t>inside</w:t></w:r></w:sdtContent></w:sdt>';
+    const host = open(docx(`<w:p>${openTag}${control}${closeTag}</w:p>`));
+    const found = controlsOf(host, { body: roots(host).body })[0]!;
+
+    expect(controlText(host, found)).toBe('inside');
+  });
+
+  test('omits struck text and paragraph marks from a block control', () => {
+    const host = open(
+      docx(
+        '<w:sdt><w:sdtPr><w:tag w:val="block"/></w:sdtPr><w:sdtContent>' +
+          '<w:p><w:r><w:t>one</w:t></w:r><w:del w:id="1" w:author="Ada">' +
+          '<w:r><w:delText>GONE</w:delText></w:r></w:del></w:p>' +
+          '<w:p><w:r><w:t>two</w:t></w:r></w:p></w:sdtContent></w:sdt>'
+      )
+    );
+    const control = controlsOf(host, { body: roots(host).body })[0]!;
+
+    expect(controlText(host, control)).toBe('onetwo');
+  });
+});

--- a/packages/core/src/automation/__tests__/automation-story-reads.test.ts
+++ b/packages/core/src/automation/__tests__/automation-story-reads.test.ts
@@ -5,6 +5,9 @@
 // an object model would otherwise have to guess and get subtly wrong.
 
 import { describe, expect, test } from 'bun:test';
+import { readOoxmlPackage } from '../../store/package/ooxml-package.ts';
+import { documentReads } from '../reads.ts';
+import { spanOffsets } from '../spans.ts';
 import {
   cell,
   docx,
@@ -527,6 +530,143 @@ describe('searching a story', () => {
     );
     const response = host.execute({ operations: [{ op: 'getSpanText', span: found[0]! }] });
     expect(textAt(response, 0)).toBe('me');
+  });
+
+  test('maps a cached field result search to its one editable atom', () => {
+    const field =
+      '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+      '<w:r><w:instrText xml:space="preserve"> DATE \\@ "d MMMM yyyy" </w:instrText></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+      '<w:r><w:t>1 January 2030</w:t></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="end"/></w:r>';
+    const host = open(
+      docx(
+        `<w:p><w:r><w:t xml:space="preserve">Renewal date: </w:t></w:r>${field}<w:r><w:t xml:space="preserve"> is synthetic.</w:t></w:r></w:p>`
+      )
+    );
+    const { body } = roots(host);
+    const [paragraph] = paragraphsOf(host, body);
+    expect(paragraphTexts(host, body)).toEqual(['Renewal date: 1 January 2030 is synthetic.']);
+    expect(storyText(host, body)).toBe('Renewal date: 1 January 2030 is synthetic.');
+    const found = spansAt(
+      host.execute({
+        operations: [
+          {
+            op: 'search',
+            scope: { body },
+            text: '1 January 2030',
+            options: { matchCase: true },
+          },
+        ],
+      }),
+      0
+    );
+
+    expect(found).toEqual([
+      {
+        start: { paragraph: paragraph!, offset: 'Renewal date: '.length },
+        end: { paragraph: paragraph!, offset: 'Renewal date: '.length + 1 },
+      },
+    ]);
+    expect(textAt(host.execute({ operations: [{ op: 'getSpanText', span: found[0]! }] }), 0)).toBe(
+      '1 January 2030'
+    );
+  });
+
+  test('reports repeated result text once for its one editable atom', () => {
+    const field =
+      '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+      '<w:r><w:instrText> PAGE </w:instrText></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+      '<w:r><w:t>aa aa</w:t></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="end"/></w:r>';
+    const host = open(docx(`<w:p>${field}</w:p>`));
+    const { body } = roots(host);
+    const [paragraph] = paragraphsOf(host, body);
+    const found = spansAt(
+      host.execute({ operations: [{ op: 'search', scope: { body }, text: 'aa' }] }),
+      0
+    );
+
+    expect(found).toEqual([
+      {
+        start: { paragraph: paragraph!, offset: 0 },
+        end: { paragraph: paragraph!, offset: 1 },
+      },
+    ]);
+  });
+
+  test('offers raw field text through the model projection', () => {
+    const field =
+      '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+      '<w:r><w:instrText> DATE </w:instrText></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+      '<w:r><w:t>1 January 2030</w:t></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="end"/></w:r>';
+    const host = open(docx(`<w:p><w:r><w:t>A</w:t></w:r>${field}<w:r><w:t>Z</w:t></w:r></w:p>`));
+    const { body } = roots(host);
+    const [paragraph] = paragraphsOf(host, body);
+    const response = host.execute({
+      operations: [
+        { op: 'getText', target: body, projection: 'model' },
+        { op: 'getText', target: paragraph!, projection: 'model' },
+        { op: 'getSpanText', span: { paragraph: paragraph! }, projection: 'model' },
+      ],
+    });
+
+    expect([textAt(response, 0), textAt(response, 1), textAt(response, 2)]).toEqual([
+      'A\uFFFCZ',
+      'A\uFFFCZ',
+      'A\uFFFCZ',
+    ]);
+  });
+
+  test('uses raw field offsets when deciding that a paragraph span is whole', () => {
+    const field =
+      '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+      '<w:r><w:instrText> DATE </w:instrText></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+      '<w:r><w:t>1 January 2030</w:t></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="end"/></w:r>';
+    const loaded = readOoxmlPackage(
+      docx(`<w:p><w:r><w:t>A</w:t></w:r>${field}<w:r><w:t>Z</w:t></w:r></w:p>`)
+    );
+    if (!loaded.ok) throw new Error(loaded.reason);
+    const body = documentReads(loaded.package).body;
+    if (!body) throw new Error('body reads missing');
+    const paragraphId = body.paragraphIds[0]!;
+    const point = { story: body.story, paragraphId, index: 0 };
+
+    expect(
+      spanOffsets({ start: { ...point, offset: 0 }, end: { ...point, offset: 3 } }, body)
+    ).toEqual([{ paragraphId, start: 0, end: 3, whole: true }]);
+  });
+
+  test('clips field result matches against raw scope boundaries', () => {
+    const field =
+      '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+      '<w:r><w:instrText> DATE </w:instrText></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+      '<w:r><w:t>four</w:t></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="end"/></w:r>';
+    const host = open(docx(`<w:p><w:r><w:t>A</w:t></w:r>${field}<w:r><w:t>Z</w:t></w:r></w:p>`));
+    const { body } = roots(host);
+    const [paragraph] = paragraphsOf(host, body);
+    const inside = {
+      start: { paragraph: paragraph!, offset: 1 },
+      end: { paragraph: paragraph!, offset: 2 },
+    };
+    const before = {
+      start: { paragraph: paragraph!, offset: 0 },
+      end: { paragraph: paragraph!, offset: 1 },
+    };
+
+    expect(
+      spansAt(host.execute({ operations: [{ op: 'search', scope: inside, text: 'four' }] }), 0)
+    ).toEqual([inside]);
+    expect(
+      spansAt(host.execute({ operations: [{ op: 'search', scope: before, text: 'four' }] }), 0)
+    ).toEqual([]);
   });
 });
 

--- a/packages/core/src/automation/__tests__/automation-story-writes.test.ts
+++ b/packages/core/src/automation/__tests__/automation-story-writes.test.ts
@@ -59,6 +59,63 @@ describe('inserting text at a position', () => {
     expect(paragraphTexts(host, body)).toEqual(['<one', 'two>']);
   });
 
+  test('uses raw endpoints around a field while display reads show its result', () => {
+    const field =
+      '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+      '<w:r><w:instrText> DATE </w:instrText></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+      '<w:r><w:t>1 January 2030</w:t></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="end"/></w:r>';
+    const paragraph = `<w:p><w:r><w:t>A</w:t></w:r>${field}<w:r><w:t>Z</w:t></w:r></w:p>`;
+
+    for (const [at, expected] of [
+      ['start', '<A1 January 2030Z'],
+      ['end', 'A1 January 2030Z>'],
+    ] as const) {
+      const host = open(docx(paragraph));
+      const body = bodyOf(host);
+      const [handle] = paragraphsOf(host, body);
+      const response = host.execute({
+        operations: [
+          { op: 'insertText', at: { paragraph: handle!, at }, text: at === 'start' ? '<' : '>' },
+        ],
+      });
+
+      expect(response.ok).toBe(true);
+      expect(paragraphTexts(host, body)).toEqual([expected]);
+    }
+
+    const host = open(docx(paragraph));
+    const body = bodyOf(host);
+    const [handle] = paragraphsOf(host, body);
+    const response = host.execute({
+      operations: [{ op: 'replaceSpan', span: { paragraph: handle! }, text: 'replacement' }],
+    });
+    expect(response.ok).toBe(true);
+    expect(paragraphTexts(host, body)).toEqual(['replacement']);
+  });
+
+  test('replaces the field atom behind a visible search result', () => {
+    const field =
+      '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+      '<w:r><w:instrText> DATE </w:instrText></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+      '<w:r><w:t>1 January 2030</w:t></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="end"/></w:r>';
+    const host = open(docx(`<w:p><w:r><w:t>A</w:t></w:r>${field}<w:r><w:t>Z</w:t></w:r></w:p>`));
+    const body = bodyOf(host);
+    const [match] = spansAt(
+      host.execute({ operations: [{ op: 'search', scope: { body }, text: 'January' }] }),
+      0
+    );
+
+    const response = host.execute({
+      operations: [{ op: 'replaceSpan', span: match!, text: 'new' }],
+    });
+    expect(response.ok).toBe(true);
+    expect(paragraphTexts(host, body)).toEqual(['AnewZ']);
+  });
+
   test('two inserts into one paragraph shift each other, as two sequential edits would', () => {
     const host = open(docx(p('abcd')));
     const body = bodyOf(host);

--- a/packages/core/src/automation/__tests__/text-projection.test.ts
+++ b/packages/core/src/automation/__tests__/text-projection.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { bodyStoryRoot, storyParagraphs } from '../../store/package/story-blocks.ts';
 import { readOoxmlPackage } from '../../store/package/ooxml-package.ts';
-import type { OoxmlParagraphNode } from '../../store/package/ooxml-tree.ts';
+import { readOoxmlPart, type OoxmlParagraphNode } from '../../store/package/ooxml-tree.ts';
 import {
   MAX_FIELD_NESTING,
   collectFieldRunChildren,
@@ -15,8 +15,15 @@ import {
 import { SEARCH_MATCH_LIMIT } from '../../store/store/text-match.ts';
 import { paragraphTextOf } from '../../store/store/tree-op-apply.ts';
 import { docx } from './support/protocol.ts';
-import { projectParagraphText } from '../text-projection.ts';
+import {
+  hideInsertionSpansFromPieces,
+  projectionFromPieces,
+  projectParagraphText,
+  visibleParagraphPieces,
+  type RawSpan,
+} from '../text-projection.ts';
 
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const run = (text: string): string => `<w:r><w:t xml:space="preserve">${text}</w:t></w:r>`;
 const begin = '<w:r><w:fldChar w:fldCharType="begin"/></w:r>';
 const separate = '<w:r><w:fldChar w:fldCharType="separate"/></w:r>';
@@ -49,6 +56,22 @@ function paragraphOf(inline: string): { paragraph: OoxmlParagraphNode; rawText: 
   const paragraph = storyParagraphs(root)[0];
   if (!paragraph || paragraph.kind !== 'paragraph') throw new Error('paragraph missing');
   return { paragraph, rawText: paragraphTextOf(part, paragraph.id) ?? '' };
+}
+
+function largeParagraphOf(inline: string): { paragraph: OoxmlParagraphNode; rawText: string } {
+  const loaded = readOoxmlPart(
+    `<w:document xmlns:w="${W}"><w:body><w:p>${inline}</w:p></w:body></w:document>`,
+    {
+      name: '/word/document.xml',
+      contentType:
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml',
+    }
+  );
+  if (!loaded.ok) throw new Error(`fixture did not open: ${loaded.reason}`);
+  const root = bodyStoryRoot(loaded.part);
+  const paragraph = root ? storyParagraphs(root)[0] : undefined;
+  if (!paragraph || paragraph.kind !== 'paragraph') throw new Error('paragraph missing');
+  return { paragraph, rawText: paragraphTextOf(loaded.part, paragraph.id) ?? '' };
 }
 
 describe('projected text offset mapping', () => {
@@ -219,6 +242,34 @@ describe('projected text offset mapping', () => {
 
     expect(projectParagraphText(paragraph, rawText, 'allMarkup').text).toBe('Aold MOVEDZ');
     expect(projectParagraphText(paragraph, rawText, 'original').text).toBe('Aold Z');
+  });
+
+  test('walks thousands of fields and hidden insertions with a forward-only cursor', () => {
+    const count = 2_000;
+    const insertion = '<w:ins w:id="1" w:author="Ada">' + run('I') + '</w:ins>';
+    const { paragraph, rawText } = largeParagraphOf(
+      (field(' PAGE ', run('F')) + insertion).repeat(count)
+    );
+    const base = visibleParagraphPieces(paragraph, rawText, 'original');
+    const spans: RawSpan[] = Array.from({ length: count }, (_, index) => ({
+      start: index * 2 + 1,
+      end: index * 2 + 2,
+    }));
+    const visited: number[] = [];
+    const traced = new Proxy(spans, {
+      get(target, property, receiver) {
+        if (typeof property === 'string') {
+          const index = Number(property);
+          if (Number.isInteger(index) && index >= 0) visited.push(index);
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    const merged = hideInsertionSpansFromPieces(base, traced);
+
+    expect(projectParagraphText(paragraph, rawText, 'original').text).toBe('F'.repeat(count));
+    expect(projectionFromPieces(merged).text).toBe('F'.repeat(count));
+    expect(visited.every((value, index) => index === 0 || value >= visited[index - 1]!)).toBe(true);
   });
 
   test('does not spend the field result budget on preceding inline nodes', () => {

--- a/packages/core/src/automation/__tests__/text-projection.test.ts
+++ b/packages/core/src/automation/__tests__/text-projection.test.ts
@@ -1,24 +1,344 @@
 import { describe, expect, test } from 'bun:test';
-import { WML_NAMESPACE_URI, type OoxmlParagraphNode } from '../../store/package/ooxml-tree.ts';
+import { bodyStoryRoot, storyParagraphs } from '../../store/package/story-blocks.ts';
+import { readOoxmlPackage } from '../../store/package/ooxml-package.ts';
+import type { OoxmlParagraphNode } from '../../store/package/ooxml-tree.ts';
+import {
+  MAX_FIELD_NESTING,
+  collectFieldRunChildren,
+  type AtomicFieldSpan,
+  type FieldRunChildRef,
+} from '../../store/package/field-nodes.ts';
+import {
+  MAX_FIELD_RESULT_CHARS,
+  fieldResultTextsOf,
+} from '../../store/package/field-result-text.ts';
+import { SEARCH_MATCH_LIMIT } from '../../store/store/text-match.ts';
+import { paragraphTextOf } from '../../store/store/tree-op-apply.ts';
+import { docx } from './support/protocol.ts';
 import { projectParagraphText } from '../text-projection.ts';
 
+const run = (text: string): string => `<w:r><w:t xml:space="preserve">${text}</w:t></w:r>`;
+const begin = '<w:r><w:fldChar w:fldCharType="begin"/></w:r>';
+const separate = '<w:r><w:fldChar w:fldCharType="separate"/></w:r>';
+const end = '<w:r><w:fldChar w:fldCharType="end"/></w:r>';
+const field = (instruction: string, result: string): string =>
+  begin +
+  `<w:r><w:instrText xml:space="preserve">${instruction}</w:instrText></w:r>` +
+  separate +
+  result +
+  end;
+
+function lowCompressionText(length: number): string {
+  const alphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  let state = 0x1234_5678;
+  let text = '';
+  for (let index = 0; index < length; index += 1) {
+    state = (Math.imul(state, 1_664_525) + 1_013_904_223) >>> 0;
+    text += alphabet[state % alphabet.length];
+  }
+  return text;
+}
+
+function paragraphOf(inline: string): { paragraph: OoxmlParagraphNode; rawText: string } {
+  const loaded = readOoxmlPackage(docx(`<w:p>${inline}</w:p>`));
+  if (!loaded.ok) throw new Error(`fixture did not open: ${loaded.reason}`);
+  const part = loaded.package.parts.get(loaded.package.mainDocumentPart);
+  if (!part) throw new Error('main part missing');
+  const root = bodyStoryRoot(part);
+  if (!root) throw new Error('body missing');
+  const paragraph = storyParagraphs(root)[0];
+  if (!paragraph || paragraph.kind !== 'paragraph') throw new Error('paragraph missing');
+  return { paragraph, rawText: paragraphTextOf(part, paragraph.id) ?? '' };
+}
+
 describe('projected text offset mapping', () => {
-  test('maps valid ranges and refuses invalid ranges without targeting offset zero', () => {
-    const paragraph: OoxmlParagraphNode = {
-      id: 'paragraph',
-      kind: 'paragraph',
-      namespaceUri: WML_NAMESPACE_URI,
-      localName: 'p',
-      prefix: 'w',
-      namespaceBindings: [],
-      attributes: [],
-      children: [],
-    };
-    const projected = projectParagraphText(paragraph, 'alpha', 'allMarkup');
+  test('maps identity ranges and refuses invalid ranges', () => {
+    const { paragraph, rawText } = paragraphOf(run('alpha'));
+    const projected = projectParagraphText(paragraph, rawText, 'allMarkup');
 
     expect(projected.rawRange(1, 4)).toEqual({ start: 1, end: 4 });
     expect(projected.rawRange(0, 0)).toBeNull();
     expect(projected.rawRange(-1, 1)).toBeNull();
     expect(projected.rawRange(0, 6)).toBeNull();
+  });
+
+  test('expands one field atom and snaps visible ranges to its model edges', () => {
+    const { paragraph, rawText } = paragraphOf(run('A') + field(' DATE ', run('four')) + run('Z'));
+    const projected = projectParagraphText(paragraph, rawText, 'allMarkup');
+
+    expect(rawText).toBe('A\uFFFCZ');
+    expect(projected.text).toBe('AfourZ');
+    expect(projected.projectedOffset(1)).toBe(1);
+    expect(projected.projectedOffset(2)).toBe(5);
+    expect(projected.rawRange(2, 4)).toEqual({ start: 1, end: 2 });
+    expect(projected.rawRange(0, 3)).toEqual({ start: 0, end: 2 });
+    expect(projected.sliceRaw(1, 2)).toBe('four');
+    expect(projected.sliceRaw(0, 1)).toBe('A');
+    expect(projected.sliceRaw(2, 3)).toBe('Z');
+  });
+
+  test('projects an empty field result as no visible text', () => {
+    const { paragraph, rawText } = paragraphOf(run('A') + field(' DATE ', '') + run('Z'));
+    const projected = projectParagraphText(paragraph, rawText, 'allMarkup');
+
+    expect(rawText).toBe('A\uFFFCZ');
+    expect(projected.text).toBe('AZ');
+    expect(projected.projectedOffset(1)).toBe(1);
+    expect(projected.projectedOffset(2)).toBe(1);
+    expect(projected.sliceRaw(1, 2)).toBe('');
+  });
+
+  test('uses only nested field result text inside an outer result', () => {
+    const nested = field(' REF outer ', run('see ') + field(' REF inner ', run('Section 4')));
+    const { paragraph, rawText } = paragraphOf(nested);
+    const projected = projectParagraphText(paragraph, rawText, 'allMarkup');
+
+    expect(rawText).toBe('\uFFFC');
+    expect(projected.text).toBe('see Section 4');
+    expect(projected.rawRange(4, 11)).toEqual({ start: 0, end: 1 });
+  });
+
+  test('keeps store order for a nested simple field without endorsing visible order', () => {
+    const simple = `<w:fldSimple w:instr=" PAGE ">${run('7')}</w:fldSimple>`;
+    const outer = field(' IF ', run('x') + simple + run('y'));
+    const { paragraph, rawText } = paragraphOf(run('A') + outer + run('Z'));
+    const projected = projectParagraphText(paragraph, rawText, 'allMarkup');
+
+    expect(rawText).toBe('A\uFFFC\uFFFCZ');
+    expect(projected.text).toBe('Axy7Z');
+    expect(projected.rawRange(3, 4)).toEqual({ start: 2, end: 3 });
+  });
+
+  test('folds a complex field nested inside a simple field exactly once', () => {
+    const nested = field(' PAGE ', run('7'));
+    const simple = `<w:fldSimple w:instr=" IF ">${run('x')}${nested}${run('y')}</w:fldSimple>`;
+    const { paragraph, rawText } = paragraphOf(run('A') + simple + run('Z'));
+    const projected = projectParagraphText(paragraph, rawText, 'allMarkup');
+
+    expect(rawText).toBe('A\uFFFCZ');
+    expect(projected.text).toBe('Ax7yZ');
+    expect(projected.rawRange(2, 3)).toEqual({ start: 1, end: 2 });
+  });
+
+  test('keeps cached text from a simple field nested past the evaluation cap', () => {
+    let nested = run('deep');
+    for (let depth = 0; depth < MAX_FIELD_NESTING + 2; depth += 1) {
+      nested = `<w:fldSimple w:instr=" IF ">${nested}</w:fldSimple>`;
+    }
+    const { paragraph, rawText } = paragraphOf(nested);
+
+    expect(rawText).toBe('\uFFFC');
+    expect(projectParagraphText(paragraph, rawText, 'allMarkup').text).toBe('deep');
+  });
+
+  test('treats an unclosed nested begin in a simple-field cache as inert', () => {
+    const simple = `<w:fldSimple w:instr=" IF ">${run('A')}${begin}${run('B')}</w:fldSimple>`;
+    const { paragraph, rawText } = paragraphOf(simple);
+
+    expect(rawText).toBe('\uFFFC');
+    expect(projectParagraphText(paragraph, rawText, 'allMarkup').text).toBe('AB');
+  });
+
+  test('treats an unclosed nested begin in a complex-field result scan as inert', () => {
+    const malformed =
+      begin +
+      `<w:r><w:instrText xml:space="preserve"> IF </w:instrText></w:r>` +
+      separate +
+      run('A') +
+      begin +
+      run('B') +
+      end;
+    const { paragraph } = paragraphOf(malformed);
+    const entries: FieldRunChildRef[] = [];
+    collectFieldRunChildren(paragraph, entries);
+    const outerBegin = entries[0]!;
+    const syntheticOuterSpan: AtomicFieldSpan = {
+      kind: 'complex',
+      node: outerBegin.node,
+      runId: outerBegin.runId,
+      removeNodeIds: entries.map((entry) => entry.node.id),
+      formatRunIds: [],
+    };
+
+    expect(fieldResultTextsOf(paragraph, [syntheticOuterSpan]).get(outerBegin.node.id)).toBe('AB');
+  });
+
+  test('projects a simple field result through one atom', () => {
+    const simple = `<w:fldSimple w:instr=" DATE ">${run('1 January 2030')}</w:fldSimple>`;
+    const { paragraph, rawText } = paragraphOf(simple);
+    const projected = projectParagraphText(paragraph, rawText, 'allMarkup');
+
+    expect(rawText).toBe('\uFFFC');
+    expect(projected.text).toBe('1 January 2030');
+    expect(projected.rawRange(0, 14)).toEqual({ start: 0, end: 1 });
+  });
+
+  test('projects a field nested in an inline content control', () => {
+    const controlled = `<w:sdt><w:sdtContent>${field(' DATE ', run('visible'))}</w:sdtContent></w:sdt>`;
+    const { paragraph, rawText } = paragraphOf(run('A') + controlled + run('Z'));
+    const projected = projectParagraphText(paragraph, rawText, 'allMarkup');
+
+    expect(rawText).toBe('A\uFFFCZ');
+    expect(projected.text).toBe('AvisibleZ');
+    expect(projected.rawRange(2, 5)).toEqual({ start: 1, end: 2 });
+  });
+
+  test('uses one field walk through deep hyperlink, revision, and control wrappers', () => {
+    const wrapped =
+      '<w:hyperlink w:anchor="a"><w:ins w:id="1" w:author="Ada">' +
+      '<w:del w:id="2" w:author="Ada"><w:moveFrom w:id="3" w:author="Ada">' +
+      '<w:moveTo w:id="4" w:author="Ada"><w:sdt><w:sdtContent>' +
+      field(' DATE ', run('visible')) +
+      '</w:sdtContent></w:sdt></w:moveTo></w:moveFrom></w:del></w:ins></w:hyperlink>';
+    const { paragraph, rawText } = paragraphOf(wrapped);
+
+    expect(rawText).toBe('\uFFFC');
+    expect(projectParagraphText(paragraph, rawText, 'allMarkup').text).toBe('visible');
+  });
+
+  test('hides a pending inserted field from the original view', () => {
+    const inserted = `<w:ins w:id="1" w:author="Ada">${field(' DATE ', run('future'))}</w:ins>`;
+    const { paragraph, rawText } = paragraphOf(run('A') + inserted + run('Z'));
+
+    expect(projectParagraphText(paragraph, rawText, 'allMarkup').text).toBe('AfutureZ');
+    expect(projectParagraphText(paragraph, rawText, 'original').text).toBe('AZ');
+  });
+
+  test('hides an insertion inside a field result from the original view', () => {
+    const result = run('old ') + '<w:ins w:id="1" w:author="Ada">' + run('NEW') + '</w:ins>';
+    const { paragraph, rawText } = paragraphOf(run('A') + field(' DATE ', result) + run('Z'));
+
+    expect(projectParagraphText(paragraph, rawText, 'allMarkup').text).toBe('Aold NEWZ');
+    expect(projectParagraphText(paragraph, rawText, 'original').text).toBe('Aold Z');
+  });
+
+  test('hides a move destination inside a field result from the original view', () => {
+    const result =
+      run('old ') + '<w:moveTo w:id="1" w:author="Ada">' + run('MOVED') + '</w:moveTo>';
+    const { paragraph, rawText } = paragraphOf(run('A') + field(' DATE ', result) + run('Z'));
+
+    expect(projectParagraphText(paragraph, rawText, 'allMarkup').text).toBe('Aold MOVEDZ');
+    expect(projectParagraphText(paragraph, rawText, 'original').text).toBe('Aold Z');
+  });
+
+  test('does not spend the field result budget on preceding inline nodes', () => {
+    const prefix = Array.from(
+      { length: 4_200 },
+      (_, index) => `<w:bookmarkStart w:id="${index}" w:name="b${index}"/>`
+    ).join('');
+    const { paragraph, rawText } = paragraphOf(prefix + field(' DATE ', run('visible')));
+    const projected = projectParagraphText(paragraph, rawText, 'allMarkup');
+
+    expect(projected.text).toBe('visible');
+  });
+
+  test('falls back to the field atom when its own result exceeds the node budget', () => {
+    const result = `<w:r>${Array.from({ length: 4_200 }, () => '<w:tab/>').join('')}</w:r>`;
+    const { paragraph, rawText } = paragraphOf(field(' DATE ', result));
+
+    expect(rawText).toBe('\uFFFC');
+    expect(projectParagraphText(paragraph, rawText, 'allMarkup').text).toBe('\uFFFC');
+  });
+
+  test('falls back to the field atom when one result text node exceeds the character budget', () => {
+    const oversized = lowCompressionText(MAX_FIELD_RESULT_CHARS + 1);
+    const { paragraph, rawText } = paragraphOf(field(' DATE ', run(oversized)));
+
+    expect(rawText).toBe('\uFFFC');
+    expect(projectParagraphText(paragraph, rawText, 'allMarkup').text).toBe('\uFFFC');
+  });
+
+  test('projects and searches a result just under the character budget in full', () => {
+    const suffix = 'Needle';
+    const result = lowCompressionText(MAX_FIELD_RESULT_CHARS - suffix.length - 1) + suffix;
+    const { paragraph, rawText } = paragraphOf(field(' DATE ', run(result)));
+    const projected = projectParagraphText(paragraph, rawText, 'allMarkup');
+
+    expect(projected.text).toBe(result);
+    expect(projected.findOccurrences('needle', 1)).toEqual({
+      matches: [
+        {
+          start: result.length - suffix.length,
+          length: suffix.length,
+          rawStart: 0,
+          rawEnd: 1,
+        },
+      ],
+      truncated: false,
+    });
+  });
+
+  test('applies the character budget to a simple field result', () => {
+    const oversized = lowCompressionText(MAX_FIELD_RESULT_CHARS + 1);
+    const simple = `<w:fldSimple w:instr=" DATE ">${run(oversized)}</w:fldSimple>`;
+    const { paragraph, rawText } = paragraphOf(simple);
+
+    expect(rawText).toBe('\uFFFC');
+    expect(projectParagraphText(paragraph, rawText, 'allMarkup').text).toBe('\uFFFC');
+  });
+
+  test('does not mark duplicate occurrences in one expansion as truncated', () => {
+    const { paragraph, rawText } = paragraphOf(field(' PAGE ', run('x x')));
+    const projected = projectParagraphText(paragraph, rawText, 'allMarkup');
+
+    expect(projected.findOccurrences('x', 1)).toEqual({
+      matches: [{ start: 0, length: 1, rawStart: 0, rawEnd: 1 }],
+      truncated: false,
+    });
+  });
+
+  test('keeps a match that starts in a field expansion and ends after it', () => {
+    const { paragraph, rawText } = paragraphOf(field(' PAGE ', run('xxx')) + run('xx'));
+    const projected = projectParagraphText(paragraph, rawText, 'allMarkup');
+
+    expect(projected.findOccurrences('xx', 10)).toEqual({
+      matches: [
+        { start: 0, length: 2, rawStart: 0, rawEnd: 1 },
+        { start: 2, length: 2, rawStart: 0, rawEnd: 2 },
+      ],
+      truncated: false,
+    });
+  });
+
+  test('finds a boundary match after dropping an internal field duplicate', () => {
+    const { paragraph, rawText } = paragraphOf(field(' PAGE ', run('xxxxx')) + run('x'));
+    const projected = projectParagraphText(paragraph, rawText, 'allMarkup');
+
+    expect(projected.findOccurrences('xx', 10)).toEqual({
+      matches: [
+        { start: 0, length: 2, rawStart: 0, rawEnd: 1 },
+        { start: 4, length: 2, rawStart: 0, rawEnd: 2 },
+      ],
+      truncated: false,
+    });
+  });
+
+  test('keeps the ordinary match after an equal field-result match', () => {
+    const { paragraph, rawText } = paragraphOf(field(' PAGE ', run('ab')) + run('ab'));
+    const projected = projectParagraphText(paragraph, rawText, 'allMarkup');
+
+    expect(projected.findOccurrences('ab', 10)).toEqual({
+      matches: [
+        { start: 0, length: 2, rawStart: 0, rawEnd: 1 },
+        { start: 2, length: 2, rawStart: 1, rawEnd: 3 },
+      ],
+      truncated: false,
+    });
+  });
+
+  test('caps a dense long-paragraph search and reports remaining matches', () => {
+    const { paragraph, rawText } = paragraphOf(run('A'.repeat(5_000)));
+    const projected = projectParagraphText(paragraph, rawText, 'allMarkup');
+    const found = projected.findOccurrences('a', SEARCH_MATCH_LIMIT);
+
+    expect(found.matches).toHaveLength(SEARCH_MATCH_LIMIT);
+    expect(found.matches[0]).toEqual({ start: 0, length: 1, rawStart: 0, rawEnd: 1 });
+    expect(found.matches.at(-1)).toEqual({
+      start: SEARCH_MATCH_LIMIT - 1,
+      length: 1,
+      rawStart: SEARCH_MATCH_LIMIT - 1,
+      rawEnd: SEARCH_MATCH_LIMIT,
+    });
+    expect(found.truncated).toBe(true);
   });
 });

--- a/packages/core/src/automation/content-controls.ts
+++ b/packages/core/src/automation/content-controls.ts
@@ -19,11 +19,13 @@ import {
   type ContentControlProperties,
 } from '../store/package/content-control-nodes.ts';
 import { collectStoryParagraphs } from '../store/package/story-blocks.ts';
-import type { OoxmlNode } from '../store/package/ooxml-tree.ts';
+import type { OoxmlNode, OoxmlParagraphNode } from '../store/package/ooxml-tree.ts';
 import { contentControlLockAt } from '../store/store/tree-op-content-controls.ts';
+import { paragraphModelTextOf } from '../store/store/paragraph-model-text.ts';
 import { paragraphOffsetIndex } from '../store/store/tree-op-segments.ts';
 import type { AutomationTextProjection } from './operations.ts';
 import type { AutomationStoryReads } from './reads.ts';
+import { projectParagraphText } from './text-projection.ts';
 
 /**
  * Ceiling on how many controls one scope answers.
@@ -90,6 +92,18 @@ export function contentControlNodeOf(
   return null;
 }
 
+function paragraphContainingControl(
+  reads: AutomationStoryReads,
+  nodeId: string
+): OoxmlParagraphNode | null {
+  for (const paragraphId of reads.paragraphIds) {
+    const paragraph = reads.node(paragraphId);
+    if (!paragraph || paragraph.kind !== 'paragraph') continue;
+    if (contentControlsIn(paragraph).some((entry) => entry.node.id === nodeId)) return paragraph;
+  }
+  return null;
+}
+
 /**
  * The span a control's content covers, in the story's own addressing.
  *
@@ -116,20 +130,32 @@ export function contentControlSpan(
       end: { paragraphId: last, offset: lastText.length },
     };
   }
-  // Inline: find the paragraph whose children include this control, and ask that paragraph's
-  // own offset index where the control sits.
-  for (const paragraphId of reads.paragraphIds) {
-    const paragraph = reads.node(paragraphId);
-    if (!paragraph || paragraph.kind !== 'paragraph') continue;
-    if (!paragraph.children.some((child) => child.id === node.id)) continue;
-    const span = paragraphOffsetIndex(paragraph).spanOf(node);
-    if (!span) return null;
-    return {
-      start: { paragraphId, offset: span.start },
-      end: { paragraphId, offset: span.end },
-    };
-  }
-  return null;
+  // Inline controls can sit inside links, revisions, or other controls. The bounded shared
+  // control index finds them at any supported depth, while the offset index remains authoritative.
+  const paragraph = paragraphContainingControl(reads, node.id);
+  if (!paragraph) return null;
+  const span = paragraphOffsetIndex(paragraph).spanOf(node);
+  if (!span) return null;
+  return {
+    start: { paragraphId: paragraph.id, offset: span.start },
+    end: { paragraphId: paragraph.id, offset: span.end },
+  };
+}
+
+function inlineContentControlText(
+  reads: AutomationStoryReads,
+  node: OoxmlNode,
+  projection: Exclude<AutomationTextProjection, 'allMarkup'>
+): string | null {
+  const paragraph = paragraphContainingControl(reads, node.id);
+  const content = contentControlContentNodeOf(node);
+  if (!paragraph || !content) return null;
+  const scopedParagraph: OoxmlParagraphNode = {
+    ...paragraph,
+    children: content.children as OoxmlParagraphNode['children'],
+  };
+  const rawText = paragraphModelTextOf(scopedParagraph);
+  return projectParagraphText(scopedParagraph, rawText, projection).text;
 }
 
 /** The text the control encloses, as the document reads it. */
@@ -140,6 +166,10 @@ export function contentControlText(
 ): string {
   // Control values keep their established semantics. They omit struck text and paragraph marks.
   if (projection === 'allMarkup') return contentControlTextOf(node);
+  // Project inline content from its own subtree. An enclosing revision changes placement,
+  // but it does not erase the value returned for the control itself.
+  const inlineText = inlineContentControlText(reads, node, projection);
+  if (inlineText !== null) return inlineText;
   const span = contentControlSpan(reads, node);
   if (!span) return '';
   const first = reads.indexOf(span.start.paragraphId);

--- a/packages/core/src/automation/content-controls.ts
+++ b/packages/core/src/automation/content-controls.ts
@@ -109,7 +109,7 @@ export function contentControlSpan(
   if (held.length > 0) {
     const first = held[0]!;
     const last = held[held.length - 1]!;
-    const lastText = reads.paragraphText(last);
+    const lastText = reads.rawText(last);
     if (lastText === null || !reads.has(first)) return null;
     return {
       start: { paragraphId: first, offset: 0 },
@@ -138,7 +138,7 @@ export function contentControlText(
   node: OoxmlNode,
   projection: AutomationTextProjection = 'allMarkup'
 ): string {
-  // Preserve the existing content-control value semantics for ordinary reads.
+  // Control values keep their established semantics. They omit struck text and paragraph marks.
   if (projection === 'allMarkup') return contentControlTextOf(node);
   const span = contentControlSpan(reads, node);
   if (!span) return '';
@@ -149,7 +149,7 @@ export function contentControlText(
   for (let index = first; index <= last; index += 1) {
     const paragraphId = reads.paragraphIds[index]!;
     const projected = reads.projectedText(paragraphId, projection);
-    const raw = reads.paragraphText(paragraphId);
+    const raw = reads.rawText(paragraphId);
     if (!projected || raw === null) return '';
     text.push(
       projected.sliceRaw(

--- a/packages/core/src/automation/operations.ts
+++ b/packages/core/src/automation/operations.ts
@@ -123,7 +123,7 @@ export type AutomationParagraphRef =
 export interface AutomationSearchOptions {
   readonly matchCase?: boolean;
   readonly matchWholeWord?: boolean;
-  /** Text view to search. `allMarkup` preserves the historical behavior. */
+  /** Display or raw model text to search. `allMarkup` preserves the historical behavior. */
   readonly projection?: AutomationTextProjection;
   /** Not supported; `true` is refused. Punctuation-insensitive matching is not implemented. */
   readonly ignorePunct?: boolean;
@@ -136,12 +136,14 @@ export interface AutomationSearchOptions {
 }
 
 /**
- * Which revision text an automation read exposes.
+ * Which text an automation read exposes.
  *
  * `allMarkup` includes pending insertions, deletions, and both sides of replacements. `original`
  * matches Word's Original review view: deletions remain visible and insertions are hidden.
+ * Both are display text and expand saved field results. `model` returns raw model text with
+ * atomic fields represented by `U+FFFC`. Only `model` shares the protocol's offset vocabulary.
  */
-export type AutomationTextProjection = 'allMarkup' | 'original';
+export type AutomationTextProjection = 'allMarkup' | 'original' | 'model';
 
 /** Where a selection lands. `start`/`end` collapse it to one edge of the span. */
 export type AutomationSelectionMode = 'select' | 'start' | 'end';
@@ -172,14 +174,18 @@ export type AutomationOperation =
    * Text of a body or a paragraph.
    *
    * A story reads as its paragraphs joined by a carriage return — one paragraph mark, one
-   * `\r` — which is the separator Word's own text property uses.
+   * `\r` — which is the separator Word's own text property uses. Display projections expand
+   * fields, so clients must not derive model offsets from this text.
    */
   | {
       readonly op: 'getText';
       readonly target: AutomationHandle;
       readonly projection?: AutomationTextProjection;
     }
-  /** Text between two endpoints, with a carriage return at every paragraph mark crossed. */
+  /**
+   * Display text between two endpoints, with a carriage return at each paragraph boundary.
+   * Use the `model` projection when a client needs text in the endpoint offset vocabulary.
+   */
   | {
       readonly op: 'getSpanText';
       readonly span: AutomationSpanRef;

--- a/packages/core/src/automation/plan.ts
+++ b/packages/core/src/automation/plan.ts
@@ -414,7 +414,7 @@ function anchorForSection(
 /** Whether both ends of a range still name a paragraph and an offset inside it. */
 function placeable(range: ResolvedRange, reads: AutomationStoryReads): boolean {
   for (const point of [range.start, range.end]) {
-    const text = reads.paragraphText(point.paragraphId);
+    const text = reads.rawText(point.paragraphId);
     if (text === null || point.offset > text.length) return false;
   }
   return true;
@@ -611,8 +611,8 @@ export function createBatchPlanner(host: BatchPlannerHost): BatchPlanner {
       readonly end: { paragraphId: string; offset: number };
     }
   ): AutomationSpan | null => {
-    const startText = reads.paragraphText(range.start.paragraphId);
-    const endText = reads.paragraphText(range.end.paragraphId);
+    const startText = reads.rawText(range.start.paragraphId);
+    const endText = reads.rawText(range.end.paragraphId);
     if (startText === null || endText === null) return null;
     const start: ResolvedPoint = {
       story: reads.story,
@@ -719,7 +719,7 @@ export function createBatchPlanner(host: BatchPlannerHost): BatchPlanner {
     span === null ? null : packageReads.story(span.start.story);
 
   const isTextProjection = (value: unknown): value is AutomationTextProjection | undefined =>
-    value === undefined || value === 'allMarkup' || value === 'original';
+    value === undefined || value === 'allMarkup' || value === 'original' || value === 'model';
 
   const searchScope = (
     reads: AutomationStoryReads,
@@ -833,7 +833,7 @@ export function createBatchPlanner(host: BatchPlannerHost): BatchPlanner {
         if (conflict) return conflict;
       }
       const last = range.end.paragraphId;
-      const headLength = (reads.paragraphText(first) ?? '').length;
+      const headLength = (reads.rawText(first) ?? '').length;
       if (range.start.offset < headLength)
         ops.push({
           op: 'deleteText',
@@ -932,7 +932,7 @@ export function createBatchPlanner(host: BatchPlannerHost): BatchPlanner {
     const target = kept[0] as string;
 
     for (const paragraphId of kept) {
-      const length = (reads.paragraphText(paragraphId) ?? '').length;
+      const length = (reads.rawText(paragraphId) ?? '').length;
       if (length > 0) ops.push({ op: 'deleteText', paragraphId, start: 0, end: length });
     }
     for (const block of removed) {
@@ -1028,7 +1028,7 @@ export function createBatchPlanner(host: BatchPlannerHost): BatchPlanner {
 
     const anchorSlot = plan.slotById.get(anchor.paragraphId);
     if (!anchorSlot) return refuse('invalid-handle', 'that paragraph is not in the body');
-    const anchorLength = (reads.paragraphText(anchor.paragraphId) ?? '').length;
+    const anchorLength = (reads.rawText(anchor.paragraphId) ?? '').length;
     const ops: TreeDocOp[] = [];
     // One paragraph becomes two by splitting one: `splitParagraph` leaves the HEAD on the
     // original node and puts the TAIL on a new one. So "after" writes the new text at the end
@@ -1085,7 +1085,7 @@ export function createBatchPlanner(host: BatchPlannerHost): BatchPlanner {
 
     const slot = plan.slotById.get(paragraph.paragraphId);
     if (!slot) return refuse('invalid-handle', 'that paragraph is not in the body');
-    const text = reads.paragraphText(paragraph.paragraphId) ?? '';
+    const text = reads.rawText(paragraph.paragraphId) ?? '';
     const occurrences = delimiterOccurrences(text, delimiters);
 
     const ops: TreeDocOp[] = [];
@@ -1140,7 +1140,7 @@ export function createBatchPlanner(host: BatchPlannerHost): BatchPlanner {
       parts.forEach((part, index) => {
         const id = part.id;
         if (id === null) return;
-        const piece = after?.paragraphText(id) ?? pieces[index] ?? '';
+        const piece = after?.rawText(id) ?? pieces[index] ?? '';
         const [from, to] = trimSpacing ? trimmed(piece, 0, piece.length) : [0, piece.length];
         const handle = handles.paragraph(id, reads.story);
         spans.push({

--- a/packages/core/src/automation/protocol.ts
+++ b/packages/core/src/automation/protocol.ts
@@ -150,11 +150,11 @@ export interface AutomationError {
 /**
  * One end of a stretch of a story: a paragraph, and a UTF-16 offset in it.
  *
- * The only addressing vocabulary in this protocol. A stable paragraph handle plus a model
- * offset is what the tree ops take, what selection uses and what the layout reports — so a
- * position a consumer reads and a position it then writes at mean the same thing. Painted DOM
- * indices and document-wide character counters appear nowhere: the first is a picture, and the
- * second is a coordinate space no part of the engine maintains.
+ * The only addressing vocabulary in this protocol. A stable paragraph handle plus a raw model
+ * offset is what tree operations, selection, and layout use. Display text reads can expand field
+ * atoms and apply a review view. A client must not calculate offsets from display text. It can
+ * request the `model` projection when it needs text in this offset vocabulary. Painted DOM
+ * indices and document-wide character counters appear nowhere.
  */
 export interface AutomationEndpoint {
   /**

--- a/packages/core/src/automation/reads.ts
+++ b/packages/core/src/automation/reads.ts
@@ -6,10 +6,9 @@
 // drift from the headless one: it is not that two implementations agree, it is that there is
 // one implementation.
 //
-// TEXT COMES FROM `paragraphTextOf`, the same offset authority the tree ops validate against,
-// so a length a consumer reads and an offset it then writes at are the same vocabulary. A
-// paragraph text derived any other way — a layout span, a painted node, a projection — reads a
-// field or a note differently and puts every subsequent offset one character out.
+// RAW OFFSETS COME FROM `paragraphTextOf`, the same authority tree ops validate against.
+// Display reads use a projection that can expand one field atom into its visible result.
+// Projected ranges map back to the raw vocabulary before any write reaches the store.
 //
 // A DOCUMENT IS SEVERAL STORIES, and each is read on its own. The body, a header or footer per
 // variant per section, and one story per footnote and endnote: they live in different parts, hold
@@ -61,6 +60,7 @@ export interface AutomationParagraphRead {
   readonly nodeId: string;
   /** `w14:paraId` as the document writes it, or null when the file declared none. */
   readonly paraId: string | null;
+  /** Display text for the default review view. Do not derive model offsets from its length. */
   readonly text: string;
 }
 
@@ -123,9 +123,11 @@ export interface AutomationStoryReads {
    * alternative is every such read walking the part again to find a node this file already holds.
    */
   node(paragraphId: string): OoxmlNode | null;
-  /** A paragraph's text in model-offset vocabulary, or null when it is not in the story. */
+  /** A paragraph's raw model text. Every automation offset uses this vocabulary. */
+  rawText(paragraphId: string): string | null;
+  /** A paragraph's projected text. Display views can differ from model offset length. */
   paragraphText(paragraphId: string, projection?: AutomationTextProjection): string | null;
-  /** A paragraph projection with mappings back to model offsets. */
+  /** Projected text with mappings back to raw model offsets. */
   projectedText(
     paragraphId: string,
     projection?: AutomationTextProjection
@@ -281,9 +283,14 @@ function storyReadsOver(
     paragraph(paragraphId) {
       const node = byId.get(paragraphId);
       if (!node) return null;
-      return { nodeId: paragraphId, paraId: paraIdOf(node), text: rawTextOf(paragraphId) ?? '' };
+      return {
+        nodeId: paragraphId,
+        paraId: paraIdOf(node),
+        text: projectionOf(paragraphId)?.text ?? '',
+      };
     },
     node: (paragraphId) => byId.get(paragraphId) ?? null,
+    rawText: rawTextOf,
     paragraphText: (paragraphId, projection) => projectionOf(paragraphId, projection)?.text ?? null,
     projectedText: projectionOf,
     text: (projection) =>

--- a/packages/core/src/automation/search.ts
+++ b/packages/core/src/automation/search.ts
@@ -1,6 +1,6 @@
 // Projected text search with model-offset results.
 
-import { findOccurrences, SEARCH_MATCH_LIMIT } from '../store/store/text-match.ts';
+import { SEARCH_MATCH_LIMIT } from '../store/store/text-match.ts';
 import type { AutomationHandleTable } from './handles.ts';
 import type { AutomationSearchOptions } from './operations.ts';
 import type { AutomationSpan } from './protocol.ts';
@@ -27,21 +27,19 @@ export function projectedSearchSpans(
     if (budget <= 0) break;
     const projected = reads.projectedText(paragraphId, options?.projection ?? 'allMarkup');
     if (!projected) continue;
-    const found = findOccurrences(projected.text, text, budget, {
+    const found = projected.findOccurrences(text, budget, {
       matchCase: options?.matchCase === true,
       wholeWord: options?.matchWholeWord === true,
       ...(position === 0 && scope ? { from: projected.projectedOffset(scope.start.offset) } : {}),
       ...(position === last && scope ? { to: projected.projectedOffset(scope.end.offset) } : {}),
     });
     for (const occurrence of found.matches) {
-      const mapped = projected.rawRange(occurrence.start, occurrence.start + occurrence.length);
-      if (!mapped) return { ok: false, paragraphId };
-      if (position === 0 && scope && mapped.start < scope.start.offset) continue;
-      if (position === last && scope && mapped.end > scope.end.offset) continue;
+      if (position === 0 && scope && occurrence.rawStart < scope.start.offset) continue;
+      if (position === last && scope && occurrence.rawEnd > scope.end.offset) continue;
       const paragraph = handles.paragraph(paragraphId, reads.story);
       spans.push({
-        start: { paragraph, offset: mapped.start },
-        end: { paragraph, offset: mapped.end },
+        start: { paragraph, offset: occurrence.rawStart },
+        end: { paragraph, offset: occurrence.rawEnd },
       });
       budget -= 1;
     }

--- a/packages/core/src/automation/spans.ts
+++ b/packages/core/src/automation/spans.ts
@@ -105,7 +105,7 @@ export function resolveEndpoint(
   const paragraph = resolveParagraphHandle(endpoint.paragraph, handles, reads);
   if (!paragraph.ok) return paragraph;
   const story = reads.story(paragraph.value.story);
-  const length = (story?.paragraphText(paragraph.value.paragraphId) ?? '').length;
+  const length = (story?.rawText(paragraph.value.paragraphId) ?? '').length;
   const { offset } = endpoint;
   if (!Number.isInteger(offset) || offset < 0 || offset > length)
     return fail('invalid-offset', `offset ${String(offset)} outside 0..${String(length)}`);
@@ -124,7 +124,7 @@ export function resolvePoint(
     if (!paragraph.ok) return paragraph;
     if (point.at === 'start') return paragraph;
     const story = reads.story(paragraph.value.story);
-    const length = (story?.paragraphText(paragraph.value.paragraphId) ?? '').length;
+    const length = (story?.rawText(paragraph.value.paragraphId) ?? '').length;
     return ok({ ...paragraph.value, offset: length });
   }
   const story = storyOfHandle(point.body, 'body', handles, reads);
@@ -139,7 +139,7 @@ export function resolvePoint(
     story: story.value.story,
     paragraphId,
     index,
-    offset: (story.value.paragraphText(paragraphId) ?? '').length,
+    offset: (story.value.rawText(paragraphId) ?? '').length,
   });
 }
 
@@ -160,7 +160,7 @@ function wholeStory(reads: AutomationStoryReads): ResolvedSpan {
       story: reads.story,
       paragraphId: lastId,
       index: lastIndex,
-      offset: (reads.paragraphText(lastId) ?? '').length,
+      offset: (reads.rawText(lastId) ?? '').length,
     },
   };
 }
@@ -180,7 +180,7 @@ export function resolveSpanRef(
     const paragraph = resolveParagraphHandle(span.paragraph, handles, reads);
     if (!paragraph.ok) return paragraph;
     const story = reads.story(paragraph.value.story);
-    const length = (story?.paragraphText(paragraph.value.paragraphId) ?? '').length;
+    const length = (story?.rawText(paragraph.value.paragraphId) ?? '').length;
     return ok({ start: paragraph.value, end: { ...paragraph.value, offset: length } });
   }
   const start = resolvePoint(span.start, handles, reads);
@@ -269,7 +269,7 @@ export function spanOffsets(
   const ids = spanParagraphIds(span, reads);
   const last = ids.length - 1;
   return ids.map((paragraphId, position) => {
-    const length = (reads.paragraphText(paragraphId) ?? '').length;
+    const length = (reads.rawText(paragraphId) ?? '').length;
     const start = position === 0 ? span.start.offset : 0;
     const end = position === last ? span.end.offset : length;
     return { paragraphId, start, end, whole: start === 0 && end === length };
@@ -279,9 +279,8 @@ export function spanOffsets(
 /**
  * The text a span covers, with a paragraph mark at every paragraph boundary it crosses.
  *
- * The mark count is what makes this text usable as an offset vocabulary: a span over three
- * paragraphs reads two marks, so a caller counting characters counts the same positions the
- * engine writes at.
+ * This is display text. Field atoms can expand beyond their model length. Paragraph marks still
+ * preserve visible story boundaries, but callers must use raw reads for model offset math.
  */
 export function spanText(
   span: ResolvedSpan,
@@ -302,7 +301,7 @@ export function spanText(
     .map((id, position) => {
       const projected = reads.projectedText(id, projection);
       if (!projected) return '';
-      const rawLength = (reads.paragraphText(id) ?? '').length;
+      const rawLength = (reads.rawText(id) ?? '').length;
       if (position === 0) return projected.sliceRaw(span.start.offset, rawLength);
       if (position === ids.length - 1) return projected.sliceRaw(0, span.end.offset);
       return projected.text;

--- a/packages/core/src/automation/text-projection.ts
+++ b/packages/core/src/automation/text-projection.ts
@@ -1,35 +1,68 @@
 // Text projections for automation reads and searches.
 //
-// Model offsets always include every addressable segment. A projection can hide text from a
-// caller, but it must map every visible match back to that same model-offset space. Otherwise a
-// search can return words that its range cannot read, select, or edit.
+// Model offsets always include every addressable segment. A projection can show text that the
+// model does not address one-for-one. Every visible match still maps to one editable model range.
 
 import type { AutomationTextProjection } from './operations.ts';
 import type { OoxmlNode, OoxmlParagraphNode } from '../store/package/ooxml-tree.ts';
 import { paragraphOffsetIndex } from '../store/store/tree-op-segments.ts';
+import {
+  identityProjection,
+  projectionFromPieces,
+  visibleParagraphPieces,
+  type ProjectedParagraphText,
+  type VisiblePiece,
+} from '../store/store/text-projection.ts';
 
-interface VisiblePiece {
-  readonly projectedStart: number;
-  readonly projectedEnd: number;
-  readonly rawStart: number;
-  readonly rawEnd: number;
+export {
+  identityProjection,
+  projectionFromPieces,
+  projectVisibleParagraphText,
+  visibleParagraphPieces,
+  type ProjectedParagraphText,
+  type VisiblePiece,
+} from '../store/store/text-projection.ts';
+
+interface RawSpan {
+  readonly start: number;
+  readonly end: number;
 }
 
-/** One paragraph under a chosen text projection, with lossless links to model offsets. */
-export interface ProjectedParagraphText {
-  readonly text: string;
-  /** Map one model boundary into the projected UTF-16 offset space. */
-  projectedOffset(rawOffset: number): number;
-  /** Map a non-empty projected range back to one editable model range. */
-  rawRange(
-    start: number,
-    end: number
-  ): {
-    readonly start: number;
-    readonly end: number;
-  } | null;
-  /** Read a model range through this projection. */
-  sliceRaw(start: number, end: number): string;
+function clippedIdentityPiece(
+  piece: VisiblePiece,
+  start: number,
+  end: number
+): VisiblePiece | null {
+  if (start >= end) return null;
+  return {
+    text: piece.text.slice(start - piece.rawStart, end - piece.rawStart),
+    rawStart: start,
+    rawEnd: end,
+  };
+}
+
+function hideFromPiece(piece: VisiblePiece, hidden: readonly RawSpan[]): VisiblePiece[] {
+  const rawLength = piece.rawEnd - piece.rawStart;
+  if (piece.text.length !== rawLength) {
+    // Whole-atom revision wrappers are hidden here. Insertions inside a field result are
+    // removed while its cached result text is built.
+    const covered = hidden.some((span) => span.start < piece.rawEnd && span.end > piece.rawStart);
+    return covered ? [] : [piece];
+  }
+
+  const shown: VisiblePiece[] = [];
+  let cursor = piece.rawStart;
+  for (const span of hidden) {
+    if (span.end <= cursor) continue;
+    if (span.start >= piece.rawEnd) break;
+    const visible = clippedIdentityPiece(piece, cursor, Math.min(span.start, piece.rawEnd));
+    if (visible) shown.push(visible);
+    cursor = Math.max(cursor, span.end);
+    if (cursor >= piece.rawEnd) break;
+  }
+  const tail = clippedIdentityPiece(piece, cursor, piece.rawEnd);
+  if (tail) shown.push(tail);
+  return shown;
 }
 
 /** Build the projection once for one immutable paragraph node. */
@@ -38,102 +71,23 @@ export function projectParagraphText(
   rawText: string,
   projection: AutomationTextProjection
 ): ProjectedParagraphText {
-  if (projection === 'allMarkup') return identityProjection(rawText);
+  if (projection === 'model') return identityProjection(rawText);
+  const base = visibleParagraphPieces(paragraph, rawText, projection);
+  if (projection === 'allMarkup') return projectionFromPieces(base);
 
   const hidden = hiddenInsertionSpans(paragraph);
-  if (hidden.length === 0) return identityProjection(rawText);
-
+  if (hidden.length === 0) return projectionFromPieces(base);
   const pieces: VisiblePiece[] = [];
-  const text: string[] = [];
-  let raw = 0;
-  let projected = 0;
-  for (const span of hidden) {
-    if (raw < span.start) {
-      const value = rawText.slice(raw, span.start);
-      pieces.push({
-        projectedStart: projected,
-        projectedEnd: projected + value.length,
-        rawStart: raw,
-        rawEnd: span.start,
-      });
-      text.push(value);
-      projected += value.length;
-    }
-    raw = Math.max(raw, span.end);
+  for (const piece of base) {
+    for (const visible of hideFromPiece(piece, hidden)) pieces.push(visible);
   }
-  if (raw < rawText.length) {
-    const value = rawText.slice(raw);
-    pieces.push({
-      projectedStart: projected,
-      projectedEnd: projected + value.length,
-      rawStart: raw,
-      rawEnd: rawText.length,
-    });
-    text.push(value);
-  }
-
-  return projectionFromPieces(text.join(''), pieces);
-}
-
-function identityProjection(text: string): ProjectedParagraphText {
-  return projectionFromPieces(
-    text,
-    text.length === 0
-      ? []
-      : [{ projectedStart: 0, projectedEnd: text.length, rawStart: 0, rawEnd: text.length }]
-  );
-}
-
-function projectionFromPieces(
-  text: string,
-  pieces: readonly VisiblePiece[]
-): ProjectedParagraphText {
-  return {
-    text,
-    projectedOffset(rawOffset) {
-      let offset = 0;
-      for (const piece of pieces) {
-        if (rawOffset <= piece.rawStart) return offset;
-        offset += Math.max(0, Math.min(rawOffset, piece.rawEnd) - piece.rawStart);
-        if (rawOffset <= piece.rawEnd) return offset;
-      }
-      return offset;
-    },
-    rawRange(start, end) {
-      const first = pieces.find(
-        (piece) => start >= piece.projectedStart && start < piece.projectedEnd
-      );
-      const last = pieces.find((piece) => end > piece.projectedStart && end <= piece.projectedEnd);
-      if (!first || !last || start >= end) return null;
-      return {
-        start: first.rawStart + start - first.projectedStart,
-        end: last.rawStart + end - last.projectedStart,
-      };
-    },
-    sliceRaw(start, end) {
-      if (start >= end) return '';
-      return pieces
-        .map((piece) => {
-          const from = Math.max(start, piece.rawStart);
-          const to = Math.min(end, piece.rawEnd);
-          return from < to
-            ? text.slice(
-                piece.projectedStart + from - piece.rawStart,
-                piece.projectedStart + to - piece.rawStart
-              )
-            : '';
-        })
-        .join('');
-    },
-  };
+  return projectionFromPieces(pieces);
 }
 
 /** Pending insertions and move destinations are absent from Word's Original review view. */
-function hiddenInsertionSpans(
-  paragraph: OoxmlParagraphNode
-): readonly { readonly start: number; readonly end: number }[] {
+function hiddenInsertionSpans(paragraph: OoxmlParagraphNode): readonly RawSpan[] {
   const index = paragraphOffsetIndex(paragraph);
-  const found: { start: number; end: number }[] = [];
+  const found: RawSpan[] = [];
   const visit = (node: OoxmlNode, depth: number): void => {
     if (depth > 64 || node.kind === 'textValue') return;
     if (node.kind === 'revisionInsert' || node.kind === 'revisionMoveTo') {

--- a/packages/core/src/automation/text-projection.ts
+++ b/packages/core/src/automation/text-projection.ts
@@ -23,7 +23,7 @@ export {
   type VisiblePiece,
 } from '../store/store/text-projection.ts';
 
-interface RawSpan {
+export interface RawSpan {
   readonly start: number;
   readonly end: number;
 }
@@ -41,27 +41,43 @@ function clippedIdentityPiece(
   };
 }
 
-function hideFromPiece(piece: VisiblePiece, hidden: readonly RawSpan[]): VisiblePiece[] {
-  const rawLength = piece.rawEnd - piece.rawStart;
-  if (piece.text.length !== rawLength) {
-    // Whole-atom revision wrappers are hidden here. Insertions inside a field result are
-    // removed while its cached result text is built.
-    const covered = hidden.some((span) => span.start < piece.rawEnd && span.end > piece.rawStart);
-    return covered ? [] : [piece];
-  }
-
+/** Remove sorted hidden spans from sorted visible pieces with one forward-only cursor. */
+export function hideInsertionSpansFromPieces(
+  pieces: readonly VisiblePiece[],
+  hidden: readonly RawSpan[]
+): VisiblePiece[] {
   const shown: VisiblePiece[] = [];
-  let cursor = piece.rawStart;
-  for (const span of hidden) {
-    if (span.end <= cursor) continue;
-    if (span.start >= piece.rawEnd) break;
-    const visible = clippedIdentityPiece(piece, cursor, Math.min(span.start, piece.rawEnd));
-    if (visible) shown.push(visible);
-    cursor = Math.max(cursor, span.end);
-    if (cursor >= piece.rawEnd) break;
+  let hiddenIndex = 0;
+  for (const piece of pieces) {
+    while (hiddenIndex < hidden.length && hidden[hiddenIndex]!.end <= piece.rawStart) {
+      hiddenIndex += 1;
+    }
+    const rawLength = piece.rawEnd - piece.rawStart;
+    if (piece.text.length !== rawLength) {
+      // Whole-atom revision wrappers are hidden here. Insertions inside a field result are
+      // removed while its cached result text is built.
+      const span = hidden[hiddenIndex];
+      if (!span || span.start >= piece.rawEnd) shown.push(piece);
+      continue;
+    }
+
+    let rawCursor = piece.rawStart;
+    while (hiddenIndex < hidden.length) {
+      const span = hidden[hiddenIndex]!;
+      if (span.end <= rawCursor) {
+        hiddenIndex += 1;
+        continue;
+      }
+      if (span.start >= piece.rawEnd) break;
+      const visible = clippedIdentityPiece(piece, rawCursor, Math.min(span.start, piece.rawEnd));
+      if (visible) shown.push(visible);
+      rawCursor = Math.max(rawCursor, span.end);
+      if (span.end <= piece.rawEnd) hiddenIndex += 1;
+      if (rawCursor >= piece.rawEnd) break;
+    }
+    const tail = clippedIdentityPiece(piece, rawCursor, piece.rawEnd);
+    if (tail) shown.push(tail);
   }
-  const tail = clippedIdentityPiece(piece, cursor, piece.rawEnd);
-  if (tail) shown.push(tail);
   return shown;
 }
 
@@ -77,10 +93,7 @@ export function projectParagraphText(
 
   const hidden = hiddenInsertionSpans(paragraph);
   if (hidden.length === 0) return projectionFromPieces(base);
-  const pieces: VisiblePiece[] = [];
-  for (const piece of base) {
-    for (const visible of hideFromPiece(piece, hidden)) pieces.push(visible);
-  }
+  const pieces = hideInsertionSpansFromPieces(base, hidden);
   return projectionFromPieces(pieces);
 }
 

--- a/packages/core/src/binding/__tests__/document-search-stories.test.ts
+++ b/packages/core/src/binding/__tests__/document-search-stories.test.ts
@@ -140,6 +140,61 @@ function footnoteFixture(notes: string): Uint8Array {
   );
 }
 
+function twoSectionFurnitureFixture(): Uint8Array {
+  const firstSection =
+    '<w:headerReference w:type="default" r:id="rH1"/>' +
+    '<w:footerReference w:type="default" r:id="rF1"/>';
+  const secondSection =
+    '<w:headerReference w:type="default" r:id="rH2"/>' +
+    '<w:footerReference w:type="default" r:id="rF2"/>';
+  const body =
+    `<w:p><w:pPr><w:sectPr>${firstSection}</w:sectPr></w:pPr>` +
+    '<w:r><w:t>section one</w:t></w:r></w:p>' +
+    p('section two') +
+    `<w:sectPr>${secondSection}</w:sectPr>`;
+  const overrides = ['header1', 'header2', 'footer1', 'footer2']
+    .map((name) => {
+      const kind = name.startsWith('header') ? 'header' : 'footer';
+      return (
+        `<Override PartName="/word/${name}.xml" ` +
+        `ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.${kind}+xml"/>`
+      );
+    })
+    .join('');
+  const relationships = [
+    ['rH1', 'header', 'header1.xml'],
+    ['rH2', 'header', 'header2.xml'],
+    ['rF1', 'footer', 'footer1.xml'],
+    ['rF2', 'footer', 'footer2.xml'],
+  ]
+    .map(
+      ([id, kind, target]) => `<Relationship Id="${id}" Type="${R}/${kind}" Target="${target}"/>`
+    )
+    .join('');
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        overrides +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}" xmlns:r="${R}"><w:body>${body}</w:body></w:document>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}">${relationships}</Relationships>`
+    ),
+    'word/header1.xml': strToU8(`<w:hdr xmlns:w="${W}">${p('story h1')}</w:hdr>`),
+    'word/header2.xml': strToU8(`<w:hdr xmlns:w="${W}">${p('story h2')}</w:hdr>`),
+    'word/footer1.xml': strToU8(`<w:ftr xmlns:w="${W}">${p('story f1')}</w:ftr>`),
+    'word/footer2.xml': strToU8(`<w:ftr xmlns:w="${W}">${p('story f2')}</w:ftr>`),
+  });
+}
+
 function open(bytes: Uint8Array = fixture()): TreeDocxSession {
   const result = openTreeSession(bytes);
   if (!result.ok) throw new Error(`${result.reason}: ${result.detail ?? ''}`);
@@ -158,6 +213,18 @@ describe('navigation Find stories', () => {
       { kind: 'headerFooter', rId: 'rFooter' },
       { kind: 'note', id: 'footnote:1' },
       { kind: 'note', id: 'endnote:2' },
+    ]);
+  });
+
+  test('searches every section header before every section footer', () => {
+    const matches = open(twoSectionFurnitureFixture()).findText('story').matches;
+
+    expect(matches.map((match) => match.contextAfter.trim())).toEqual(['h1', 'h2', 'f1', 'f2']);
+    expect(matches.map((match) => match.scope)).toEqual([
+      { kind: 'headerFooter', rId: 'rH1' },
+      { kind: 'headerFooter', rId: 'rH2' },
+      { kind: 'headerFooter', rId: 'rF1' },
+      { kind: 'headerFooter', rId: 'rF2' },
     ]);
   });
 

--- a/packages/core/src/binding/__tests__/document-search-stories.test.ts
+++ b/packages/core/src/binding/__tests__/document-search-stories.test.ts
@@ -40,6 +40,7 @@ function fixture(): Uint8Array {
     `<w:document xmlns:w="${W}" xmlns:r="${R}" xmlns:wp="${WP}" ` +
     `xmlns:a="${A}" xmlns:wps="${WPS}"><w:body>` +
     p('needle body') +
+    '<w:p><w:r><w:footnoteReference w:id="1"/><w:endnoteReference w:id="2"/></w:r></w:p>' +
     `<w:p>${textbox('needle textbox')}<w:pPr>${section}</w:pPr></w:p>` +
     section +
     '</w:body></w:document>';
@@ -115,7 +116,8 @@ function variantFixture(titlePage: boolean, evenAndOddHeaders: boolean): Uint8Ar
   });
 }
 
-function footnoteFixture(notes: string): Uint8Array {
+function footnoteFixture(notes: string, referenceIds: readonly number[] = [1]): Uint8Array {
+  const references = referenceIds.map((id) => `<w:footnoteReference w:id="${id}"/>`).join('');
   return zipSync(
     {
       '[Content_Types].xml': strToU8(
@@ -129,7 +131,8 @@ function footnoteFixture(notes: string): Uint8Array {
         `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
       ),
       'word/document.xml': strToU8(
-        `<w:document xmlns:w="${W}"><w:body>${p('body')}</w:body></w:document>`
+        `<w:document xmlns:w="${W}"><w:body>${p('body')}` +
+          `<w:p><w:r>${references}</w:r></w:p></w:body></w:document>`
       ),
       'word/_rels/document.xml.rels': strToU8(
         `<Relationships xmlns="${REL}"><Relationship Id="rFootnotes" Type="${R}/footnotes" Target="footnotes.xml"/></Relationships>`
@@ -251,6 +254,17 @@ describe('navigation Find stories', () => {
     expect(open(footnoteFixture(notes)).findText('nested target').matches).toEqual([]);
   });
 
+  test('searches referenced notes and skips orphan notes', () => {
+    const notes =
+      `<w:footnote w:id="1">${p('note target referenced')}</w:footnote>` +
+      `<w:footnote w:id="2">${p('note target orphan')}</w:footnote>`;
+    const matches = open(footnoteFixture(notes, [1])).findText('note target').matches;
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.scope).toEqual({ kind: 'note', id: 'footnote:1' });
+    expect(matches[0]?.contextAfter.trim()).toBe('referenced');
+  });
+
   test('honours the note navigation count cap', () => {
     const prefix = Array.from(
       { length: MAX_NOTES_PER_PART - 1 },
@@ -260,7 +274,7 @@ describe('navigation Find stories', () => {
       prefix +
       `<w:footnote w:id="${MAX_NOTES_PER_PART}">${p('inside cap')}</w:footnote>` +
       `<w:footnote w:id="${MAX_NOTES_PER_PART + 1}">${p('outside cap')}</w:footnote>`;
-    const session = open(footnoteFixture(notes));
+    const session = open(footnoteFixture(notes, [MAX_NOTES_PER_PART, MAX_NOTES_PER_PART + 1]));
 
     expect(session.findText('inside cap').matches).toHaveLength(1);
     expect(session.findText('outside cap').matches).toEqual([]);

--- a/packages/core/src/binding/__tests__/document-search-stories.test.ts
+++ b/packages/core/src/binding/__tests__/document-search-stories.test.ts
@@ -1,0 +1,176 @@
+// Navigation Find ordering and scope metadata across addressable Word stories.
+
+import { describe, expect, test } from 'bun:test';
+import { strToU8, zipSync } from 'fflate';
+import { openTreeSession, type TreeDocxSession } from '../tree-session.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
+const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+const WPS = 'http://schemas.microsoft.com/office/word/2010/wordprocessingShape';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+
+const p = (text: string) => `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+
+function textbox(text: string): string {
+  return (
+    '<w:r><w:drawing><wp:anchor distT="0" distB="0" distL="0" distR="0" simplePos="0" ' +
+    'relativeHeight="1" behindDoc="0" locked="0" layoutInCell="1" allowOverlap="1">' +
+    '<wp:simplePos x="0" y="0"/>' +
+    '<wp:positionH relativeFrom="page"><wp:posOffset>0</wp:posOffset></wp:positionH>' +
+    '<wp:positionV relativeFrom="page"><wp:posOffset>0</wp:posOffset></wp:positionV>' +
+    '<wp:extent cx="914400" cy="457200"/><wp:effectExtent l="0" t="0" r="0" b="0"/>' +
+    '<wp:wrapNone/><wp:docPr id="1" name="Search box"/>' +
+    `<a:graphic><a:graphicData uri="${WPS}"><wps:wsp>` +
+    '<wps:spPr><a:xfrm><a:ext cx="914400" cy="457200"/></a:xfrm>' +
+    '<a:prstGeom prst="rect"><a:avLst/></a:prstGeom></wps:spPr>' +
+    `<wps:txbx><w:txbxContent>${p(text)}</w:txbxContent></wps:txbx>` +
+    '<wps:bodyPr/></wps:wsp></a:graphicData></a:graphic></wp:anchor></w:drawing></w:r>'
+  );
+}
+
+function fixture(): Uint8Array {
+  const section =
+    '<w:sectPr><w:headerReference w:type="default" r:id="rHeader"/>' +
+    '<w:footerReference w:type="default" r:id="rFooter"/></w:sectPr>';
+  const document =
+    `<w:document xmlns:w="${W}" xmlns:r="${R}" xmlns:wp="${WP}" ` +
+    `xmlns:a="${A}" xmlns:wps="${WPS}"><w:body>` +
+    p('needle body') +
+    `<w:p>${textbox('needle textbox')}<w:pPr>${section}</w:pPr></w:p>` +
+    section +
+    '</w:body></w:document>';
+  const contentTypes =
+    `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+    '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+    '<Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>' +
+    '<Override PartName="/word/footer1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml"/>' +
+    '<Override PartName="/word/footnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml"/>' +
+    '<Override PartName="/word/endnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.endnotes+xml"/>' +
+    '</Types>';
+  const relationships =
+    `<Relationships xmlns="${REL}">` +
+    `<Relationship Id="rHeader" Type="${R}/header" Target="header1.xml"/>` +
+    `<Relationship Id="rFooter" Type="${R}/footer" Target="footer1.xml"/>` +
+    `<Relationship Id="rFootnotes" Type="${R}/footnotes" Target="footnotes.xml"/>` +
+    `<Relationship Id="rEndnotes" Type="${R}/endnotes" Target="endnotes.xml"/>` +
+    '</Relationships>';
+  return zipSync({
+    '[Content_Types].xml': strToU8(contentTypes),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(document),
+    'word/_rels/document.xml.rels': strToU8(relationships),
+    'word/header1.xml': strToU8(`<w:hdr xmlns:w="${W}">${p('needle header')}</w:hdr>`),
+    'word/footer1.xml': strToU8(`<w:ftr xmlns:w="${W}">${p('needle footer')}</w:ftr>`),
+    'word/footnotes.xml': strToU8(
+      `<w:footnotes xmlns:w="${W}">` +
+        `<w:footnote w:id="-1" w:type="separator">${p('needle separator-only')}</w:footnote>` +
+        `<w:footnote w:id="1">${p('needle footnote')}</w:footnote></w:footnotes>`
+    ),
+    'word/endnotes.xml': strToU8(
+      `<w:endnotes xmlns:w="${W}">` +
+        `<w:endnote w:id="-1" w:type="separator">${p('needle separator-only')}</w:endnote>` +
+        `<w:endnote w:id="2">${p('needle endnote')}</w:endnote></w:endnotes>`
+    ),
+  });
+}
+
+function variantFixture(titlePage: boolean, evenAndOddHeaders: boolean): Uint8Array {
+  const section =
+    '<w:headerReference w:type="first" r:id="rFirst"/>' +
+    '<w:headerReference w:type="even" r:id="rEven"/>' +
+    (titlePage ? '<w:titlePg/>' : '');
+  const settings = evenAndOddHeaders ? '<w:evenAndOddHeaders/>' : '';
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '<Override PartName="/word/header-first.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>' +
+        '<Override PartName="/word/header-even.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>' +
+        '<Override PartName="/word/settings.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.settings+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}" xmlns:r="${R}"><w:body>${p('body')}<w:sectPr>${section}</w:sectPr></w:body></w:document>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}">` +
+        `<Relationship Id="rFirst" Type="${R}/header" Target="header-first.xml"/>` +
+        `<Relationship Id="rEven" Type="${R}/header" Target="header-even.xml"/>` +
+        `<Relationship Id="rSettings" Type="${R}/settings" Target="settings.xml"/>` +
+        '</Relationships>'
+    ),
+    'word/header-first.xml': strToU8(`<w:hdr xmlns:w="${W}">${p('variant first')}</w:hdr>`),
+    'word/header-even.xml': strToU8(`<w:hdr xmlns:w="${W}">${p('variant even')}</w:hdr>`),
+    'word/settings.xml': strToU8(`<w:settings xmlns:w="${W}">${settings}</w:settings>`),
+  });
+}
+
+function open(bytes: Uint8Array = fixture()): TreeDocxSession {
+  const result = openTreeSession(bytes);
+  if (!result.ok) throw new Error(`${result.reason}: ${result.detail ?? ''}`);
+  return result.session;
+}
+
+describe('navigation Find stories', () => {
+  test('searches stories in order with scopes and deduplicated furniture parts', () => {
+    const matches = open().findText('needle').matches;
+
+    expect(matches.map((match) => match.text)).toEqual(Array(5).fill('needle'));
+    expect(matches.map((match) => match.paragraphIndex)).toEqual([0, 0, 0, 0, 0]);
+    expect(matches.map((match) => match.scope)).toEqual([
+      undefined,
+      { kind: 'headerFooter', rId: 'rHeader' },
+      { kind: 'headerFooter', rId: 'rFooter' },
+      { kind: 'note', id: 'footnote:1' },
+      { kind: 'note', id: 'endnote:2' },
+    ]);
+  });
+
+  test('skips separator notes', () => {
+    expect(open().findText('separator-only').matches).toEqual([]);
+  });
+
+  test('skips text-box stories until the surface can address them', () => {
+    expect(open().findText('needle textbox').matches).toEqual([]);
+  });
+
+  test.each([
+    [false, false, []],
+    [true, false, ['variant first']],
+    [false, true, ['variant even']],
+    [true, true, ['variant first', 'variant even']],
+  ] as const)(
+    'searches only paintable first and even furniture for titlePage=%s evenAndOdd=%s',
+    (titlePage, evenAndOddHeaders, expected) => {
+      const matches = open(variantFixture(titlePage, evenAndOddHeaders)).findText(
+        'variant'
+      ).matches;
+
+      expect(matches.map((match) => match.contextAfter.trim())).toEqual(
+        expected.map((text) => text.slice('variant'.length).trim())
+      );
+      expect(matches.map((match) => match.scope)).toEqual(
+        expected.map((text) => ({
+          kind: 'headerFooter',
+          rId: text.endsWith('first') ? 'rFirst' : 'rEven',
+        }))
+      );
+    }
+  );
+
+  test('applies one match budget across story boundaries', () => {
+    const result = open().findText('needle', { limit: 4 });
+
+    expect(result.matches).toHaveLength(4);
+    expect(result.truncated).toBe(true);
+  });
+});

--- a/packages/core/src/binding/__tests__/document-search-stories.test.ts
+++ b/packages/core/src/binding/__tests__/document-search-stories.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, expect, test } from 'bun:test';
 import { strToU8, zipSync } from 'fflate';
+import { MAX_NOTES_PER_PART } from '../../store/package/note-nodes.ts';
 import { openTreeSession, type TreeDocxSession } from '../tree-session.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
@@ -114,6 +115,31 @@ function variantFixture(titlePage: boolean, evenAndOddHeaders: boolean): Uint8Ar
   });
 }
 
+function footnoteFixture(notes: string): Uint8Array {
+  return zipSync(
+    {
+      '[Content_Types].xml': strToU8(
+        `<Types xmlns="${CT}">` +
+          '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+          '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+          '<Override PartName="/word/footnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml"/>' +
+          '</Types>'
+      ),
+      '_rels/.rels': strToU8(
+        `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
+      ),
+      'word/document.xml': strToU8(
+        `<w:document xmlns:w="${W}"><w:body>${p('body')}</w:body></w:document>`
+      ),
+      'word/_rels/document.xml.rels': strToU8(
+        `<Relationships xmlns="${REL}"><Relationship Id="rFootnotes" Type="${R}/footnotes" Target="footnotes.xml"/></Relationships>`
+      ),
+      'word/footnotes.xml': strToU8(`<w:footnotes xmlns:w="${W}">${notes}</w:footnotes>`),
+    },
+    { level: 0 }
+  );
+}
+
 function open(bytes: Uint8Array = fixture()): TreeDocxSession {
   const result = openTreeSession(bytes);
   if (!result.ok) throw new Error(`${result.reason}: ${result.detail ?? ''}`);
@@ -137,6 +163,40 @@ describe('navigation Find stories', () => {
 
   test('skips separator notes', () => {
     expect(open().findText('separator-only').matches).toEqual([]);
+  });
+
+  test('searches only the first note with a duplicate id', () => {
+    const notes =
+      `<w:footnote w:id="1">${p('duplicate first')}</w:footnote>` +
+      `<w:footnote w:id="1">${p('duplicate second')}</w:footnote>`;
+    const matches = open(footnoteFixture(notes)).findText('duplicate').matches;
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.scope).toEqual({ kind: 'note', id: 'footnote:1' });
+    expect(matches[0]?.contextAfter.trim()).toBe('first');
+  });
+
+  test('skips a nested note element', () => {
+    const notes =
+      `<w:footnote w:id="1">${p('outer note')}` +
+      `<w:footnote w:id="2">${p('nested target')}</w:footnote></w:footnote>`;
+
+    expect(open(footnoteFixture(notes)).findText('nested target').matches).toEqual([]);
+  });
+
+  test('honours the note navigation count cap', () => {
+    const prefix = Array.from(
+      { length: MAX_NOTES_PER_PART - 1 },
+      (_, index) => `<w:footnote w:id="${index + 1}"/>`
+    ).join('');
+    const notes =
+      prefix +
+      `<w:footnote w:id="${MAX_NOTES_PER_PART}">${p('inside cap')}</w:footnote>` +
+      `<w:footnote w:id="${MAX_NOTES_PER_PART + 1}">${p('outside cap')}</w:footnote>`;
+    const session = open(footnoteFixture(notes));
+
+    expect(session.findText('inside cap').matches).toHaveLength(1);
+    expect(session.findText('outside cap').matches).toEqual([]);
   });
 
   test('skips text-box stories until the surface can address them', () => {

--- a/packages/core/src/binding/__tests__/document-search.test.ts
+++ b/packages/core/src/binding/__tests__/document-search.test.ts
@@ -237,6 +237,29 @@ describe('collectTextMatches', () => {
     });
   });
 
+  test('addresses revision-wrapped fields and every later run', () => {
+    const simple = `<w:fldSimple w:instr=" PAGE ">${run('field')}</w:fldSimple>`;
+    const body = para(
+      run('before'),
+      `<w:ins w:id="1" w:author="Ada">${simple}</w:ins>`,
+      run('after')
+    );
+
+    expect(search(body, 'field').matches[0]).toMatchObject({ runIndex: 1, runOffset: 0 });
+    expect(search(body, 'after').matches[0]).toMatchObject({ runIndex: 2, runOffset: 0 });
+  });
+
+  test('addresses a run inside a tracked deletion', () => {
+    const body = para(
+      run('before'),
+      `<w:del w:id="1" w:author="Ada"><w:r><w:delText>gone</w:delText></w:r></w:del>`,
+      run('after')
+    );
+
+    expect(search(body, 'gone').matches[0]).toMatchObject({ runIndex: 1, runOffset: 0 });
+    expect(search(body, 'after').matches[0]).toMatchObject({ runIndex: 2, runOffset: 0 });
+  });
+
   test('orders hyperlink, simple-field, and plain result runs together', () => {
     const simple = `<w:fldSimple w:instr=" PAGE ">${run('field')}</w:fldSimple>`;
     const body = para(

--- a/packages/core/src/binding/__tests__/document-search.test.ts
+++ b/packages/core/src/binding/__tests__/document-search.test.ts
@@ -203,6 +203,45 @@ describe('collectTextMatches', () => {
     expect(result.truncated).toBe(false);
   });
 
+  test('addresses a simple field result run and the following plain run', () => {
+    const simple = `<w:fldSimple w:instr=" PAGE ">${run('7')}</w:fldSimple>`;
+    const body = para(run('A'), simple, run('Z'));
+
+    expect(search(body, '7').matches[0]).toMatchObject({
+      start: 1,
+      runIndex: 1,
+      runOffset: 0,
+    });
+    expect(search(body, 'Z').matches[0]).toMatchObject({
+      start: 2,
+      runIndex: 2,
+      runOffset: 0,
+    });
+  });
+
+  test('orders hyperlink, simple-field, and plain result runs together', () => {
+    const simple = `<w:fldSimple w:instr=" PAGE ">${run('field')}</w:fldSimple>`;
+    const body = para(
+      run('before'),
+      `<w:hyperlink r:id="rId9">${run('link-one')}${run('link-two')}</w:hyperlink>`,
+      simple,
+      run('after')
+    );
+
+    expect(
+      ['before', 'link-one', 'link-two', 'field', 'after'].map((query) => {
+        const match = search(body, query).matches[0];
+        return [match?.runIndex, match?.runOffset];
+      })
+    ).toEqual([
+      [0, 0],
+      [1, 0],
+      [2, 0],
+      [3, 0],
+      [4, 0],
+    ]);
+  });
+
   test('keeps store segment order for a nested simple field without endorsing visible order', () => {
     const simple = `<w:fldSimple w:instr=" PAGE ">${run('7')}</w:fldSimple>`;
     const outer = complexFieldMarkup(' IF ', run('x') + simple + run('y'));

--- a/packages/core/src/binding/__tests__/document-search.test.ts
+++ b/packages/core/src/binding/__tests__/document-search.test.ts
@@ -10,6 +10,7 @@
 
 import { describe, expect, test } from 'bun:test';
 import { zipSync, strToU8 } from 'fflate';
+import { bodyStoryRoot, storyParagraphs } from '../../store/package/story-blocks.ts';
 import { openTreeSession, type TreeDocxSession } from '../tree-session.ts';
 import { collectTextMatches, SEARCH_MATCH_LIMIT, SEARCH_QUERY_MAX } from '../document-search.ts';
 
@@ -47,6 +48,23 @@ function open(bytes: Uint8Array): TreeDocxSession {
 
 const para = (...runs: string[]) => `<w:p>${runs.join('')}</w:p>`;
 const run = (text: string) => `<w:r><w:t xml:space="preserve">${text}</w:t></w:r>`;
+const cell = (...blocks: string[]) => `<w:tc>${blocks.join('')}</w:tc>`;
+const row = (...cells: string[]) => `<w:tr>${cells.join('')}</w:tr>`;
+const table = (...rows: string[]) => `<w:tbl>${rows.join('')}</w:tbl>`;
+
+const complexField = (instruction: string, result: string) =>
+  '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+  `<w:r><w:instrText xml:space="preserve">${instruction}</w:instrText></w:r>` +
+  '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+  run(result) +
+  '<w:r><w:fldChar w:fldCharType="end"/></w:r>';
+
+const complexFieldMarkup = (instruction: string, result: string) =>
+  '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+  `<w:r><w:instrText xml:space="preserve">${instruction}</w:instrText></w:r>` +
+  '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+  result +
+  '<w:r><w:fldChar w:fldCharType="end"/></w:r>';
 
 function search(body: string, query: string, options?: Parameters<typeof collectTextMatches>[2]) {
   return collectTextMatches(open(docx(body)).part(), query, options);
@@ -124,14 +142,83 @@ describe('collectTextMatches', () => {
     expect(matches[0]!.runOffset).toBe(1);
   });
 
-  test('does not descend into table cells, matching the contract paragraph ordinal', () => {
-    const body =
-      para(run('Body Exhibit.')) +
-      `<w:tbl><w:tr><w:tc>${para(run('Cell Exhibit.'))}</w:tc></w:tr></w:tbl>`;
-    const { matches } = search(body, 'Exhibit');
+  test('finds a cell in a 2x3 table by its paragraph block id', () => {
+    const body = table(
+      row(cell(para(run('one'))), cell(para(run('two'))), cell(para(run('three')))),
+      row(cell(para(run('four'))), cell(para(run('five'))), cell(para(run('six'))))
+    );
+    const session = open(docx(body));
+    const root = bodyStoryRoot(session.part());
+    if (!root) throw new Error('body missing');
+    const cellParagraph = storyParagraphs(root)[3]!;
+    const { matches } = collectTextMatches(session.part(), 'four');
 
     expect(matches).toHaveLength(1);
-    expect(matches[0]!.paragraphIndex).toBe(0);
+    expect(matches[0]!.blockId).toBe(cellParagraph.id);
+    expect(matches[0]!.paragraphIndex).toBe(3);
+  });
+
+  test('finds text in a nested table', () => {
+    const nested = table(row(cell(para(run('outer')), table(row(cell(para(run('deep'))))))));
+    expect(search(nested, 'deep').matches).toHaveLength(1);
+  });
+
+  test('finds a paragraph in a block content control', () => {
+    const body = `<w:sdt><w:sdtPr/><w:sdtContent>${para(run('controlled'))}</w:sdtContent></w:sdt>`;
+    expect(search(body, 'controlled').matches).toHaveLength(1);
+  });
+
+  test('keeps body, cell, and later body paragraphs in document order', () => {
+    const body =
+      para(run('needle before')) +
+      table(row(cell(para(run('needle cell'))))) +
+      para(run('needle after'));
+    const { matches } = search(body, 'needle');
+
+    expect(matches.map((match) => match.paragraphIndex)).toEqual([0, 1, 2]);
+  });
+
+  test('searches a visible field result through its one model atom', () => {
+    const body = para(
+      run('Renewal date: '),
+      complexField(' DATE \\@ "d MMMM yyyy" ', '1 January 2030'),
+      run(' is synthetic.')
+    );
+    const result = search(body, '1 January 2030', { matchCase: true });
+
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0]).toMatchObject({
+      start: 'Renewal date: '.length,
+      length: 1,
+      text: '1 January 2030',
+    });
+    expect(search(body, '\uFFFC').matches).toEqual([]);
+  });
+
+  test('reports repeated text inside one field result as one atom match', () => {
+    const result = search(para(run('A'), complexField(' PAGE ', 'x x'), run('B')), 'x');
+
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0]).toMatchObject({ start: 1, length: 1, text: 'x' });
+    expect(result.truncated).toBe(false);
+  });
+
+  test('keeps store segment order for a nested simple field without endorsing visible order', () => {
+    const simple = `<w:fldSimple w:instr=" PAGE ">${run('7')}</w:fldSimple>`;
+    const outer = complexFieldMarkup(' IF ', run('x') + simple + run('y'));
+    const result = search(para(run('A'), outer, run('Z')), '7');
+
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0]).toMatchObject({ start: 2, length: 1, text: '7' });
+  });
+
+  test('uses model run spans for matches around an atomic field', () => {
+    const body = para(run('A'), complexField(' PAGE ', '12'), run('B'));
+    const after = search(body, 'B').matches[0];
+    const fieldResult = search(body, '12').matches[0];
+
+    expect(after).toMatchObject({ start: 2, runIndex: 6, runOffset: 0 });
+    expect(fieldResult).toMatchObject({ start: 1, runIndex: 1, runOffset: 0 });
   });
 
   test('flattens control characters out of every string it returns', () => {

--- a/packages/core/src/binding/__tests__/document-search.test.ts
+++ b/packages/core/src/binding/__tests__/document-search.test.ts
@@ -219,6 +219,24 @@ describe('collectTextMatches', () => {
     });
   });
 
+  test('addresses visible offsets inside each simple-field result run', () => {
+    const simple = `<w:fldSimple w:instr=" PAGE ">${run('abc')}${run('def')}</w:fldSimple>`;
+    const body = para(run('A'), simple, run('Z'));
+
+    expect(search(body, 'def').matches[0]).toMatchObject({
+      runIndex: 2,
+      runOffset: 0,
+    });
+    expect(search(body, 'cd').matches[0]).toMatchObject({
+      runIndex: 1,
+      runOffset: 2,
+    });
+    expect(search(body, 'Aab').matches[0]).toMatchObject({
+      runIndex: 0,
+      runOffset: 0,
+    });
+  });
+
   test('orders hyperlink, simple-field, and plain result runs together', () => {
     const simple = `<w:fldSimple w:instr=" PAGE ">${run('field')}</w:fldSimple>`;
     const body = para(
@@ -251,7 +269,7 @@ describe('collectTextMatches', () => {
     expect(result.matches[0]).toMatchObject({ start: 2, length: 1, text: '7' });
   });
 
-  test('uses model run spans for matches around an atomic field', () => {
+  test('keeps the complex-field atom addressed at its begin run', () => {
     const body = para(run('A'), complexField(' PAGE ', '12'), run('B'));
     const after = search(body, 'B').matches[0];
     const fieldResult = search(body, '12').matches[0];

--- a/packages/core/src/binding/document-search.ts
+++ b/packages/core/src/binding/document-search.ts
@@ -12,30 +12,31 @@
 // runs against a SINGLE character at a time for the whole-word test, where there is no
 // backtracking to trigger.
 //
-// OFFSETS ARE `paragraphTextOf`'s VOCABULARY — UTF-16 offsets with tabs and hard breaks
-// counted as one character each — the same offsets the tree ops and the surface selection
-// use. That is what lets `selectMatch` hand a match straight to `setSelection` without
-// re-deriving anything.
+// OFFSETS ARE `paragraphTextOf`'s VOCABULARY — UTF-16 offsets with tabs, hard breaks, and
+// atomic fields counted as one character each. Match text and context use the visible text
+// projection, so a field result can be longer than the editable model range it maps to.
 //
-// WHAT IS SEARCHED: body-story paragraphs (direct children of `w:body`), matching the
-// contract's `TextMatch.paragraphIndex` definition — "ordinal among PARAGRAPHS in the body,
-// skipping tables and other non-paragraph blocks". Table-cell text is therefore not found
-// yet; widening to `allParagraphs` needs the contract's ordinal to be redefined first.
+// WHAT IS SEARCHED: body, furniture, footnotes, then endnotes. Each story uses the shared
+// paragraph walk, which descends into tables, nested tables, and block controls. Text-box
+// stories remain excluded until the surface can place a caret inside them.
 
 import {
   SEARCH_MATCH_LIMIT,
   SEARCH_QUERY_MAX,
-  findOccurrences,
   isSearchableQuery,
   paragraphTextOf,
 } from '@docx-editor.dev/core/store';
+import type { ViewScope } from '../contracts/editor.ts';
 import {
-  contentControlContentOf,
-  isContentControl,
-  walkParagraphInline,
-} from '../store/package/content-control-walk.ts';
-import type { OoxmlNode, OoxmlPart } from '../store/package/ooxml-tree.ts';
-import { bodyParagraphs } from './tree-binding.ts';
+  headerFooterVariantCanPaint,
+  type HeaderFooterSectionResolution,
+} from '../store/package/hf-references.ts';
+import { formatNoteScopeId, noteIdOf, type NoteKind } from '../store/package/note-nodes.ts';
+import { bodyStoryRoot, storyParagraphs, storyRootsOf } from '../store/package/story-blocks.ts';
+import { walkParagraphInline } from '../store/package/content-control-walk.ts';
+import type { OoxmlNode, OoxmlParagraphNode, OoxmlPart } from '../store/package/ooxml-tree.ts';
+import { projectVisibleParagraphText } from '../store/store/text-projection.ts';
+import { paragraphOffsetIndex } from '../store/store/tree-op-segments.ts';
 
 export { SEARCH_MATCH_LIMIT, SEARCH_QUERY_MAX };
 
@@ -51,10 +52,12 @@ export interface DocumentSearchOptions {
   readonly wholeWord?: boolean;
   /** Override the default {@link SEARCH_MATCH_LIMIT}. Clamped to it; never raised past it. */
   readonly limit?: number;
+  /** Stories the facade can navigate in its current mode. */
+  readonly stories?: 'all' | 'body';
 }
 
 /**
- * One occurrence of a query in the body story.
+ * One occurrence of a query in an editable document story.
  *
  * Carries the engine's own address (`blockId` + `start`) and the positional one a find UI
  * needs (`paragraphIndex` / `runIndex` / `runOffset`), both derived from the SAME walk —
@@ -69,12 +72,21 @@ export interface DocumentSearchMatch {
   readonly paragraphIndex: number;
   readonly runIndex: number;
   readonly runOffset: number;
+  /** Story containing the match. Omitted for the body. */
+  readonly scope?: ViewScope;
   /** The matched text as it appears in the document, control characters flattened. */
   readonly text: string;
   /** Paragraph text immediately before the match, bounded and flattened. */
   readonly contextBefore: string;
   /** Paragraph text immediately after the match, bounded and flattened. */
   readonly contextAfter: string;
+}
+
+/** Package stories outside the body, supplied without opening their story stores. */
+export interface DocumentSearchSources {
+  readonly headerFooterBySection: readonly HeaderFooterSectionResolution[];
+  readonly footnotes: OoxmlPart | null;
+  readonly endnotes: OoxmlPart | null;
 }
 
 /**
@@ -88,51 +100,81 @@ export interface DocumentSearchResult {
   readonly truncated: boolean;
 }
 
-function isElement(node: OoxmlNode): node is Exclude<OoxmlNode, { kind: 'textValue' }> {
-  return node.kind !== 'textValue';
-}
-
-/**
- * The measurable length of one inline node, in `paragraphTextOf`'s vocabulary: text
- * contributes its characters, a tab and a hard break contribute one each, and properties
- * contribute nothing.
- */
-function inlineLength(node: OoxmlNode): number {
-  if (node.kind === 'textValue') return node.value.length;
-  if (node.kind === 'tab' || node.kind === 'hardBreak') return 1;
-  if (node.kind === 'runProperties' || node.kind === 'generic') return 0;
-  if (node.kind === 'hyperlink' || isContentControl(node)) {
-    let total = 0;
-    const children =
-      node.kind === 'hyperlink' ? node.children : (contentControlContentOf(node) ?? []);
-    for (const child of children) total += inlineLength(child);
-    return total;
-  }
-  let total = 0;
-  for (const child of node.children) total += inlineLength(child);
-  return total;
-}
-
 /**
  * Where each run starts, in paragraph-text offsets, in document order. Runs nested inside
  * a `w:hyperlink` are flattened in place: a link's runs are runs, and a find UI addressing
  * "the third run" means the third one you would meet reading the paragraph.
  */
-function runStarts(paragraph: OoxmlNode): number[] {
+function runStarts(paragraph: OoxmlParagraphNode): number[] {
   const starts: number[] = [];
-  let offset = 0;
-  if (!isElement(paragraph)) return starts;
+  const offsets = paragraphOffsetIndex(paragraph);
   walkParagraphInline(paragraph.children, 0, (node) => {
-    if (node.kind === 'run') {
-      starts.push(offset);
-      offset += inlineLength(node);
-      return;
-    }
-    // Everything else at paragraph level (properties, bookmarks, unmodelled content)
-    // contributes its own measurable length without being addressable as a run.
-    offset += inlineLength(node);
+    if (node.kind !== 'run') return;
+    starts.push(offsets.spanOf(node)?.start ?? 0);
   });
   return starts;
+}
+
+interface SearchStory {
+  readonly part: OoxmlPart;
+  readonly root: OoxmlNode;
+  readonly scope?: ViewScope;
+}
+
+function bodyStories(part: OoxmlPart): SearchStory[] {
+  const body = bodyStoryRoot(part);
+  return body ? [{ part, root: body }] : [];
+}
+
+function furnitureStories(
+  sections: readonly HeaderFooterSectionResolution[],
+  seen: Set<OoxmlPart>
+): SearchStory[] {
+  const stories: SearchStory[] = [];
+  for (const section of sections) {
+    for (const kind of ['header', 'footer'] as const) {
+      const slots = kind === 'header' ? section.headers : section.footers;
+      for (const [variant, slot] of slots) {
+        if (!headerFooterVariantCanPaint(section, variant)) continue;
+        if (seen.has(slot.part)) continue;
+        seen.add(slot.part);
+        const story = storyRootsOf(slot.part).find((candidate) => candidate.kind === kind);
+        if (story) {
+          stories.push({
+            part: slot.part,
+            root: story.root,
+            scope: { kind: 'headerFooter', rId: slot.rId },
+          });
+        }
+      }
+    }
+  }
+  return stories;
+}
+
+function noteStories(part: OoxmlPart | null, noteKind: NoteKind): SearchStory[] {
+  if (!part) return [];
+  const stories: SearchStory[] = [];
+  for (const story of storyRootsOf(part)) {
+    const noteId = noteIdOf(story.root);
+    if (story.kind !== 'note' || noteId === null) continue;
+    stories.push({
+      part,
+      root: story.root,
+      scope: { kind: 'note', id: formatNoteScopeId(noteKind, noteId) },
+    });
+  }
+  return stories;
+}
+
+function searchStories(part: OoxmlPart, sources?: DocumentSearchSources): SearchStory[] {
+  const stories = bodyStories(part);
+  if (!sources) return stories;
+  const seen = new Set<OoxmlPart>();
+  for (const story of furnitureStories(sources.headerFooterBySection, seen)) stories.push(story);
+  for (const story of noteStories(sources.footnotes, 'footnote')) stories.push(story);
+  for (const story of noteStories(sources.endnotes, 'endnote')) stories.push(story);
+  return stories;
 }
 
 /** The run a paragraph offset falls in, and the offset inside it. */
@@ -141,8 +183,6 @@ function runAddressAt(
   offset: number
 ): { index: number; offset: number } {
   if (starts.length === 0) return { index: 0, offset };
-  // Linear from the end: a paragraph has few runs, and a binary search here would be
-  // more code than the walk it replaces.
   for (let index = starts.length - 1; index >= 0; index -= 1) {
     const start = starts[index]!;
     if (offset >= start) return { index, offset: offset - start };
@@ -156,7 +196,7 @@ function bounded(raw: string, max: number): string {
 }
 
 /**
- * Every occurrence of `query` in the body story, in document order.
+ * Every occurrence of `query` across stories, in navigation order.
  *
  * Matches are NON-OVERLAPPING, which is what a find dialog counts: searching `aa` in
  * `aaaa` finds two, not three. An empty or over-long query finds nothing rather than
@@ -165,7 +205,8 @@ function bounded(raw: string, max: number): string {
 export function collectTextMatches(
   part: OoxmlPart,
   query: string,
-  options: DocumentSearchOptions = {}
+  options: DocumentSearchOptions = {},
+  sources?: DocumentSearchSources
 ): DocumentSearchResult {
   const empty: DocumentSearchResult = { matches: [], truncated: false };
   if (!isSearchableQuery(query)) return empty;
@@ -180,40 +221,49 @@ export function collectTextMatches(
   };
 
   const matches: DocumentSearchMatch[] = [];
-  let paragraphIndex = 0;
+  const searchableSources = options.stories === 'body' ? undefined : sources;
+  for (const story of searchStories(part, searchableSources)) {
+    let paragraphIndex = 0;
+    for (const paragraph of storyParagraphs(story.root)) {
+      if (paragraph.kind !== 'paragraph') continue;
+      const index = paragraphIndex;
+      paragraphIndex += 1;
+      const rawText = paragraphTextOf(story.part, paragraph.id) ?? '';
+      const projected = projectVisibleParagraphText(paragraph, rawText);
+      if (projected.text.length === 0) continue;
 
-  for (const paragraph of bodyParagraphs(part)) {
-    if (!isElement(paragraph)) continue;
-    const index = paragraphIndex;
-    paragraphIndex += 1;
-    const text = paragraphTextOf(part, paragraph.id) ?? '';
-    if (text.length === 0) continue;
-
-    // One global budget, not one per paragraph: the cap is on the whole search.
-    const found = findOccurrences(text, query, limit - matches.length, scan);
-    // Run starts are derived once per paragraph that has a hit, not per paragraph:
-    // most paragraphs in a document do not match, and the walk is the expensive half.
-    let starts: number[] | null = null;
-    for (const occurrence of found.matches) {
-      const end = occurrence.start + occurrence.length;
-      starts ??= runStarts(paragraph);
-      const address = runAddressAt(starts, occurrence.start);
-      matches.push({
-        blockId: paragraph.id,
-        start: occurrence.start,
-        length: occurrence.length,
-        paragraphIndex: index,
-        runIndex: address.index,
-        runOffset: address.offset,
-        text: bounded(text.slice(occurrence.start, end), SEARCH_QUERY_MAX),
-        contextBefore: bounded(
-          text.slice(Math.max(0, occurrence.start - CONTEXT_RADIUS), occurrence.start),
-          CONTEXT_RADIUS
-        ),
-        contextAfter: bounded(text.slice(end, end + CONTEXT_RADIUS), CONTEXT_RADIUS),
-      });
+      // One global budget, not one per paragraph or story.
+      const remaining = limit - matches.length;
+      // Once full, scan for one more occurrence to distinguish an exact total from truncation.
+      const found = projected.findOccurrences(query, Math.max(remaining, 1), scan);
+      if (remaining === 0 && found.matches.length > 0) return { matches, truncated: true };
+      // Run starts are derived once per paragraph that has a hit, not per occurrence.
+      let starts: number[] | null = null;
+      for (const occurrence of found.matches) {
+        const projectedEnd = occurrence.start + occurrence.length;
+        starts ??= runStarts(paragraph);
+        const address = runAddressAt(starts, occurrence.rawStart);
+        matches.push({
+          blockId: paragraph.id,
+          start: occurrence.rawStart,
+          length: occurrence.rawEnd - occurrence.rawStart,
+          paragraphIndex: index,
+          runIndex: address.index,
+          runOffset: address.offset,
+          ...(story.scope ? { scope: story.scope } : {}),
+          text: bounded(projected.text.slice(occurrence.start, projectedEnd), SEARCH_QUERY_MAX),
+          contextBefore: bounded(
+            projected.text.slice(Math.max(0, occurrence.start - CONTEXT_RADIUS), occurrence.start),
+            CONTEXT_RADIUS
+          ),
+          contextAfter: bounded(
+            projected.text.slice(projectedEnd, projectedEnd + CONTEXT_RADIUS),
+            CONTEXT_RADIUS
+          ),
+        });
+      }
+      if (found.truncated) return { matches, truncated: true };
     }
-    if (found.truncated) return { matches, truncated: true };
   }
 
   return { matches, truncated: false };

--- a/packages/core/src/binding/document-search.ts
+++ b/packages/core/src/binding/document-search.ts
@@ -31,7 +31,13 @@ import {
   headerFooterVariantCanPaint,
   type HeaderFooterSectionResolution,
 } from '../store/package/hf-references.ts';
-import { formatNoteScopeId, noteIdOf, type NoteKind } from '../store/package/note-nodes.ts';
+import {
+  formatNoteScopeId,
+  isNormalNote,
+  noteIdOf,
+  resolvableNotesOf,
+  type NoteKind,
+} from '../store/package/note-nodes.ts';
 import { bodyStoryRoot, storyParagraphs, storyRootsOf } from '../store/package/story-blocks.ts';
 import { walkParagraphInline } from '../store/package/content-control-walk.ts';
 import type { OoxmlNode, OoxmlParagraphNode, OoxmlPart } from '../store/package/ooxml-tree.ts';
@@ -155,12 +161,12 @@ function furnitureStories(
 function noteStories(part: OoxmlPart | null, noteKind: NoteKind): SearchStory[] {
   if (!part) return [];
   const stories: SearchStory[] = [];
-  for (const story of storyRootsOf(part)) {
-    const noteId = noteIdOf(story.root);
-    if (story.kind !== 'note' || noteId === null) continue;
+  for (const note of resolvableNotesOf(part.root)) {
+    const noteId = noteIdOf(note);
+    if (!isNormalNote(note) || noteId === null) continue;
     stories.push({
       part,
-      root: story.root,
+      root: note,
       scope: { kind: 'note', id: formatNoteScopeId(noteKind, noteId) },
     });
   }

--- a/packages/core/src/binding/document-search.ts
+++ b/packages/core/src/binding/document-search.ts
@@ -113,8 +113,13 @@ export interface DocumentSearchResult {
  * contributes no run, and its empty result cannot start a match. A complex field keeps its
  * existing run sequence; its atom starts in the begin run.
  */
-function runStarts(paragraph: OoxmlParagraphNode): number[] {
-  const starts: number[] = [];
+interface RunStart {
+  readonly id: string;
+  readonly start: number;
+}
+
+function runStarts(paragraph: OoxmlParagraphNode): RunStart[] {
+  const starts: RunStart[] = [];
   const offsets = paragraphOffsetIndex(paragraph);
   const simpleResultRuns = new Map<string, readonly string[]>();
   for (const segment of offsets.segments) {
@@ -124,13 +129,13 @@ function runStarts(paragraph: OoxmlParagraphNode): number[] {
   }
   walkParagraphInline(paragraph.children, 0, (node) => {
     if (node.kind === 'run') {
-      starts.push(offsets.spanOf(node)?.start ?? 0);
+      starts.push({ id: node.id, start: offsets.spanOf(node)?.start ?? 0 });
       return;
     }
     if (!isFldSimple(node)) return;
     for (const runId of simpleResultRuns.get(node.id) ?? []) {
       const span = offsets.spanOf(runId);
-      if (span) starts.push(span.start);
+      if (span) starts.push({ id: runId, start: span.start });
     }
   });
   return starts;
@@ -152,8 +157,8 @@ function furnitureStories(
   seen: Set<OoxmlPart>
 ): SearchStory[] {
   const stories: SearchStory[] = [];
-  for (const section of sections) {
-    for (const kind of ['header', 'footer'] as const) {
+  for (const kind of ['header', 'footer'] as const) {
+    for (const section of sections) {
       const slots = kind === 'header' ? section.headers : section.footers;
       for (const [variant, slot] of slots) {
         if (!headerFooterVariantCanPaint(section, variant)) continue;
@@ -200,15 +205,24 @@ function searchStories(part: OoxmlPart, sources?: DocumentSearchSources): Search
 
 /** The run a paragraph offset falls in, and the offset inside it. */
 function runAddressAt(
-  starts: readonly number[],
+  starts: readonly RunStart[],
   offset: number
 ): { index: number; offset: number } {
   if (starts.length === 0) return { index: 0, offset };
   for (let index = starts.length - 1; index >= 0; index -= 1) {
-    const start = starts[index]!;
+    const start = starts[index]!.start;
     if (offset >= start) return { index, offset: offset - start };
   }
   return { index: 0, offset };
+}
+
+function resultRunAddressAt(
+  starts: readonly RunStart[],
+  runId: string,
+  offset: number
+): { index: number; offset: number } | null {
+  const index = starts.findIndex((run) => run.id === runId);
+  return index < 0 ? null : { index, offset };
 }
 
 /** Bound and flatten one file-derived string on its way out of this module. */
@@ -259,11 +273,17 @@ export function collectTextMatches(
       const found = projected.findOccurrences(query, Math.max(remaining, 1), scan);
       if (remaining === 0 && found.matches.length > 0) return { matches, truncated: true };
       // Run starts are derived once per paragraph that has a hit, not per occurrence.
-      let starts: number[] | null = null;
+      let starts: RunStart[] | null = null;
       for (const occurrence of found.matches) {
         const projectedEnd = occurrence.start + occurrence.length;
         starts ??= runStarts(paragraph);
-        const address = runAddressAt(starts, occurrence.rawStart);
+        // Simple-field expansions retain their visible result-run boundaries. Complex-field
+        // results remain one editable atom, so their address names the field's begin run.
+        const resultRun = projected.resultRunAddressAt(occurrence.start);
+        const address = resultRun
+          ? (resultRunAddressAt(starts, resultRun.runId, resultRun.offset) ??
+            runAddressAt(starts, occurrence.rawStart))
+          : runAddressAt(starts, occurrence.rawStart);
         matches.push({
           blockId: paragraph.id,
           start: occurrence.rawStart,

--- a/packages/core/src/binding/document-search.ts
+++ b/packages/core/src/binding/document-search.ts
@@ -38,6 +38,7 @@ import {
   resolvableNotesOf,
   type NoteKind,
 } from '../store/package/note-nodes.ts';
+import { isFldSimple } from '../store/package/field-nodes.ts';
 import { bodyStoryRoot, storyParagraphs, storyRootsOf } from '../store/package/story-blocks.ts';
 import { walkParagraphInline } from '../store/package/content-control-walk.ts';
 import type { OoxmlNode, OoxmlParagraphNode, OoxmlPart } from '../store/package/ooxml-tree.ts';
@@ -107,16 +108,30 @@ export interface DocumentSearchResult {
 }
 
 /**
- * Where each run starts, in paragraph-text offsets, in document order. Runs nested inside
- * a `w:hyperlink` are flattened in place: a link's runs are runs, and a find UI addressing
- * "the third run" means the third one you would meet reading the paragraph.
+ * Where each run starts, in paragraph-text offsets, in document order. Hyperlink runs and
+ * `w:fldSimple` result runs are flattened where a reader meets them. An empty simple field
+ * contributes no run, and its empty result cannot start a match. A complex field keeps its
+ * existing run sequence; its atom starts in the begin run.
  */
 function runStarts(paragraph: OoxmlParagraphNode): number[] {
   const starts: number[] = [];
   const offsets = paragraphOffsetIndex(paragraph);
+  const simpleResultRuns = new Map<string, readonly string[]>();
+  for (const segment of offsets.segments) {
+    if (isFldSimple(segment.node)) {
+      simpleResultRuns.set(segment.node.id, segment.formatRunIds ?? []);
+    }
+  }
   walkParagraphInline(paragraph.children, 0, (node) => {
-    if (node.kind !== 'run') return;
-    starts.push(offsets.spanOf(node)?.start ?? 0);
+    if (node.kind === 'run') {
+      starts.push(offsets.spanOf(node)?.start ?? 0);
+      return;
+    }
+    if (!isFldSimple(node)) return;
+    for (const runId of simpleResultRuns.get(node.id) ?? []) {
+      const span = offsets.spanOf(runId);
+      if (span) starts.push(span.start);
+    }
   });
   return starts;
 }

--- a/packages/core/src/binding/document-search.ts
+++ b/packages/core/src/binding/document-search.ts
@@ -94,6 +94,11 @@ export interface DocumentSearchSources {
   readonly headerFooterBySection: readonly HeaderFooterSectionResolution[];
   readonly footnotes: OoxmlPart | null;
   readonly endnotes: OoxmlPart | null;
+  /** Normal note ids with a body reference that the surface can place. */
+  readonly referencedNoteIds: {
+    readonly footnote: ReadonlySet<number>;
+    readonly endnote: ReadonlySet<number>;
+  };
 }
 
 /**
@@ -127,17 +132,22 @@ function runStarts(paragraph: OoxmlParagraphNode): RunStart[] {
       simpleResultRuns.set(segment.node.id, segment.formatRunIds ?? []);
     }
   }
-  walkParagraphInline(paragraph.children, 0, (node) => {
-    if (node.kind === 'run') {
-      starts.push({ id: node.id, start: offsets.spanOf(node)?.start ?? 0 });
-      return;
-    }
-    if (!isFldSimple(node)) return;
-    for (const runId of simpleResultRuns.get(node.id) ?? []) {
-      const span = offsets.spanOf(runId);
-      if (span) starts.push({ id: runId, start: span.start });
-    }
-  });
+  walkParagraphInline(
+    paragraph.children,
+    0,
+    (node) => {
+      if (node.kind === 'run') {
+        starts.push({ id: node.id, start: offsets.spanOf(node)?.start ?? 0 });
+        return;
+      }
+      if (!isFldSimple(node)) return;
+      for (const runId of simpleResultRuns.get(node.id) ?? []) {
+        const span = offsets.spanOf(runId);
+        if (span) starts.push({ id: runId, start: span.start });
+      }
+    },
+    { descendRevisions: true }
+  );
   return starts;
 }
 
@@ -178,12 +188,16 @@ function furnitureStories(
   return stories;
 }
 
-function noteStories(part: OoxmlPart | null, noteKind: NoteKind): SearchStory[] {
+function noteStories(
+  part: OoxmlPart | null,
+  noteKind: NoteKind,
+  referencedIds: ReadonlySet<number>
+): SearchStory[] {
   if (!part) return [];
   const stories: SearchStory[] = [];
   for (const note of resolvableNotesOf(part.root)) {
     const noteId = noteIdOf(note);
-    if (!isNormalNote(note) || noteId === null) continue;
+    if (!isNormalNote(note) || noteId === null || !referencedIds.has(noteId)) continue;
     stories.push({
       part,
       root: note,
@@ -198,8 +212,16 @@ function searchStories(part: OoxmlPart, sources?: DocumentSearchSources): Search
   if (!sources) return stories;
   const seen = new Set<OoxmlPart>();
   for (const story of furnitureStories(sources.headerFooterBySection, seen)) stories.push(story);
-  for (const story of noteStories(sources.footnotes, 'footnote')) stories.push(story);
-  for (const story of noteStories(sources.endnotes, 'endnote')) stories.push(story);
+  for (const story of noteStories(
+    sources.footnotes,
+    'footnote',
+    sources.referencedNoteIds.footnote
+  )) {
+    stories.push(story);
+  }
+  for (const story of noteStories(sources.endnotes, 'endnote', sources.referencedNoteIds.endnote)) {
+    stories.push(story);
+  }
   return stories;
 }
 

--- a/packages/core/src/binding/tree-session-contract.ts
+++ b/packages/core/src/binding/tree-session-contract.ts
@@ -360,11 +360,10 @@ export interface TreeDocxSessionView extends HeadlessDocumentView {
    */
   sweepCustomNodePayloads(namespaces: readonly string[]): CustomNodeSweepOutcome;
   /**
-   * Every occurrence of `query` in the BODY story, in document order, addressed in the
-   * same offset vocabulary the tree ops and the surface selection use — so a match can be
-   * handed straight to `setSelection` without re-deriving anything.
+   * Every occurrence of `query` across editable stories, in navigation order. Each match uses
+   * the same offset vocabulary as tree operations and surface selections.
    *
-   * Memoized one deep, keyed on the revision AND the question asked: a find panel asks the
+   * Memoized one deep, keyed on the package revision AND the question asked: a find panel asks the
    * same question on every tick, and a different query replaces the entry rather than
    * growing a cache the session would have to bound.
    */

--- a/packages/core/src/binding/tree-session.ts
+++ b/packages/core/src/binding/tree-session.ts
@@ -54,6 +54,7 @@ import {
   relationshipTargetIn,
   normalizeParagraphIdentity,
   paragraphTextOf,
+  collectNoteReferences,
   collectRevisionSites,
   type BookmarkIndex,
   type EmbeddedFont,
@@ -943,10 +944,18 @@ export function openTreeSession(
           return searchCache.result;
         }
         const pkg = currentPackage();
+        const referencedNoteIds = {
+          footnote: new Set<number>(),
+          endnote: new Set<number>(),
+        };
+        for (const reference of collectNoteReferences(store.part)) {
+          referencedNoteIds[reference.noteKind].add(reference.noteId);
+        }
         const result = collectTextMatches(store.part, query, options ?? {}, {
           headerFooterBySection: resolvedHeaderFooterBySection().resolution,
           footnotes: resolveNotesPart(pkg, 'footnote') ?? null,
           endnotes: resolveNotesPart(pkg, 'endnote') ?? null,
+          referencedNoteIds,
         });
         searchCache = { revision, key, result };
         return result;

--- a/packages/core/src/binding/tree-session.ts
+++ b/packages/core/src/binding/tree-session.ts
@@ -935,14 +935,20 @@ export function openTreeSession(
 
       findText(query, options) {
         const store = bodyStore();
+        const revision = packageStore.packageRevision;
         const key = `${options?.matchCase === true ? 'c' : ''}${
           options?.wholeWord === true ? 'w' : ''
-        }${options?.limit ?? ''}${'\u0000'}${query}`;
-        if (searchCache && searchCache.revision === store.revision && searchCache.key === key) {
+        }${options?.limit ?? ''}:${options?.stories ?? 'all'}${'\u0000'}${query}`;
+        if (searchCache && searchCache.revision === revision && searchCache.key === key) {
           return searchCache.result;
         }
-        const result = collectTextMatches(store.part, query, options ?? {});
-        searchCache = { revision: store.revision, key, result };
+        const pkg = currentPackage();
+        const result = collectTextMatches(store.part, query, options ?? {}, {
+          headerFooterBySection: resolvedHeaderFooterBySection().resolution,
+          footnotes: resolveNotesPart(pkg, 'footnote') ?? null,
+          endnotes: resolveNotesPart(pkg, 'endnote') ?? null,
+        });
+        searchCache = { revision, key, result };
         return result;
       },
 

--- a/packages/core/src/contracts/editor.ts
+++ b/packages/core/src/contracts/editor.ts
@@ -476,7 +476,12 @@ export interface Editor {
     readonly underline?: boolean;
   } | null;
 
-  /** Find matches for a query, for the find/replace dialog. The BODY story only. */
+  /**
+   * Find across body, headers, footers, footnotes, then endnotes. Shared parts appear once.
+   *
+   * The search narrows to the body when the surface cannot open other stories. This includes
+   * viewing mode and surfaces without header, footer, or note entry methods.
+   */
   findMatches(
     query: string,
     options?: { readonly matchCase?: boolean; readonly wholeWord?: boolean }
@@ -997,6 +1002,7 @@ import type {
   TableCellVerticalAlignment,
   TableColumnDividerResizeTarget,
   TableColumnOccurrenceTarget,
+  TableContext,
   TableRightEdgeResizeTarget,
   TableRowOccurrenceTarget,
 } from './table-targets.ts';
@@ -1015,6 +1021,7 @@ export type {
   TableCellVerticalAlignment,
   TableColumnDividerResizeTarget,
   TableColumnOccurrenceTarget,
+  TableContext,
   TableRightEdgeResizeTarget,
   TableRowOccurrenceTarget,
 } from './table-targets.ts';
@@ -1441,21 +1448,6 @@ export interface EditorQueryResults extends DocQueryResults {
 }
 
 /**
- * Where the caret sits inside a table: the table's shape, and the cell holding it.
- *
- * Null from the `tableContext` query when the selection is not in a table at all, which is how
- * table-only chrome decides whether to render.
- */
-export interface TableContext {
-  readonly rows: number;
-  readonly columns: number;
-  /** Zero-based, within the table. */
-  readonly rowIndex: number;
-  /** Zero-based, within the row. */
-  readonly columnIndex: number;
-}
-
-/**
  * One occurrence of a search query in the document.
  *
  * Carries TWO addresses on purpose. `blockId` + `start` is the engine's own: stable
@@ -1465,18 +1457,26 @@ export interface TableContext {
  * guessing at run boundaries would send the selection to the wrong place.
  *
  * A match can span runs when formatting changes mid-word; the run address is where it
- * STARTS.
+ * STARTS. `scope` identifies a non-body story so navigation opens the correct surface.
+ * A match inside a field result reports the field atom's model range. Its `length` is one,
+ * while `text` carries the visible match and can be longer. Select with `start` and `length`.
+ * Never derive the selected length from `text.length`.
  */
 export interface TextMatch {
   readonly blockId: string;
   /** Character offset within the paragraph's concatenated run text. */
   readonly start: number;
   readonly length: number;
-  /** Ordinal among PARAGRAPHS in the body, skipping tables and other non-paragraph blocks. */
+  /**
+   * Paragraph ordinal within this match's story. Table and nested-table paragraphs count.
+   * Non-paragraph blocks add no ordinal.
+   */
   readonly paragraphIndex: number;
   /** Index of the run the match starts in, and the offset within that run. */
   readonly runIndex: number;
   readonly runOffset: number;
+  /** Story containing the match. Absence means the body. */
+  readonly scope?: ViewScope;
   /** The matched text as it appears in the document. */
   readonly text: string;
   /**

--- a/packages/core/src/contracts/table-targets.ts
+++ b/packages/core/src/contracts/table-targets.ts
@@ -8,6 +8,16 @@
 
 import type { ColorValue } from './types';
 
+/** Where the caret sits inside a table: its shape and current cell. */
+export interface TableContext {
+  readonly rows: number;
+  readonly columns: number;
+  /** Zero-based, within the table. */
+  readonly rowIndex: number;
+  /** Zero-based, within the row. */
+  readonly columnIndex: number;
+}
+
 /** Which cell edges a table border command targets. */
 export type TableBorderTarget =
   | 'all'

--- a/packages/core/src/editor/__tests__/document-search-facade.test.ts
+++ b/packages/core/src/editor/__tests__/document-search-facade.test.ts
@@ -1,0 +1,175 @@
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+
+import { describe, expect, test } from 'bun:test';
+import { strFromU8, strToU8, unzipSync, zipSync } from 'fflate';
+import { createDocxEditor } from '../docx-editor.ts';
+import { FOOTNOTE_SCOPE_ID, HEADER_R_ID, storyParityDocx } from './story-parity-fixture.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+
+function docx(body: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`
+    ),
+  });
+}
+
+function storyParityDocxWithBodyTable(): Uint8Array {
+  const files = unzipSync(storyParityDocx());
+  const documentXml = strFromU8(files['word/document.xml']!);
+  const table =
+    '<w:tbl><w:tr><w:tc><w:p><w:r><w:t>table cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl>';
+  files['word/document.xml'] = strToU8(documentXml.replace('<w:sectPr>', `${table}<w:sectPr>`));
+  return zipSync(files);
+}
+
+describe('document search facade', () => {
+  test('selects a match inside a table cell by paragraph id', () => {
+    const body =
+      '<w:tbl><w:tr><w:tc><w:p><w:r><w:t>one</w:t></w:r></w:p></w:tc>' +
+      '<w:tc><w:p><w:r><w:t>four</w:t></w:r></w:p></w:tc></w:tr></w:tbl>';
+    const editor = createDocxEditor({
+      container: document.createElement('div'),
+      document: docx(body),
+    });
+    if (!editor.surface) throw new Error('surface did not open');
+    const matches = editor.findMatches('four');
+
+    expect(matches).toHaveLength(1);
+    expect(editor.selectMatch(matches[0]!)).toEqual({ ok: true, changed: false });
+    const paraId = editor.surface.session.paraIdOf(matches[0]!.blockId);
+    expect(paraId).not.toBeNull();
+    expect(editor.snapshot().selection).toEqual({
+      from: { paraId },
+      to: { paraId },
+    });
+    expect(editor.surface.state().selection).toEqual({
+      anchor: { paragraphId: matches[0]!.blockId, offset: 0 },
+      head: { paragraphId: matches[0]!.blockId, offset: 4 },
+    });
+  });
+
+  test('opens a header and selects its match', () => {
+    const editor = createDocxEditor({
+      container: document.createElement('div'),
+      document: storyParityDocx(),
+    });
+    const match = editor
+      .findMatches('Alpha')
+      .find((candidate) => candidate.scope?.kind === 'headerFooter');
+    if (!match || !editor.surface) throw new Error('header match did not open');
+
+    expect(editor.selectMatch(match)).toEqual({ ok: true, changed: false });
+    expect(editor.getActiveScope()).toEqual({ kind: 'headerFooter', rId: HEADER_R_ID });
+    expect(editor.surface.state().selection).toEqual({
+      anchor: { paragraphId: match.blockId, offset: 0 },
+      head: { paragraphId: match.blockId, offset: 5 },
+    });
+    editor.destroy();
+  });
+
+  test('opens a footnote and selects its match', () => {
+    const editor = createDocxEditor({
+      container: document.createElement('div'),
+      document: storyParityDocx(),
+    });
+    const match = editor.findMatches('Alpha').find((candidate) => candidate.scope?.kind === 'note');
+    if (!match || !editor.surface) throw new Error('footnote match did not open');
+
+    expect(editor.selectMatch(match)).toEqual({ ok: true, changed: false });
+    expect(editor.getActiveScope()).toEqual({ kind: 'note', id: FOOTNOTE_SCOPE_ID });
+    expect(editor.surface.state().selection).toEqual({
+      anchor: { paragraphId: match.blockId, offset: 0 },
+      head: { paragraphId: match.blockId, offset: 5 },
+    });
+    editor.destroy();
+  });
+
+  test('leaves an open header when selecting a body match', () => {
+    const editor = createDocxEditor({
+      container: document.createElement('div'),
+      document: storyParityDocx(),
+    });
+    const matches = editor.findMatches('Alpha');
+    const header = matches.find((candidate) => candidate.scope?.kind === 'headerFooter');
+    const body = matches.find((candidate) => candidate.scope === undefined);
+    if (!header || !body) throw new Error('search matches are incomplete');
+    expect(editor.selectMatch(header).ok).toBe(true);
+
+    expect(editor.selectMatch(body)).toEqual({ ok: true, changed: false });
+    expect(editor.getActiveScope()).toEqual({ kind: 'body' });
+    expect(editor.surface?.state().selection.head.paragraphId).toBe(body.blockId);
+    editor.destroy();
+  });
+
+  test('searches scoped stories only while the surface can open them', () => {
+    const editor = createDocxEditor({
+      container: document.createElement('div'),
+      document: storyParityDocx(),
+    });
+
+    expect(editor.findMatches('Alpha')).toHaveLength(5);
+    expect(editor.exec({ type: 'setEditingMode', mode: 'viewing' }).ok).toBe(true);
+    expect(editor.findMatches('Alpha')).toHaveLength(1);
+    expect(editor.findMatches('Alpha')[0]!.scope).toBeUndefined();
+    expect(editor.exec({ type: 'setEditingMode', mode: 'editing' }).ok).toBe(true);
+    expect(editor.findMatches('Alpha')).toHaveLength(5);
+    editor.destroy();
+  });
+
+  test('limits a view-only editor to body matches', () => {
+    const editor = createDocxEditor({
+      container: document.createElement('div'),
+      document: storyParityDocx(),
+      mode: 'view',
+    });
+
+    expect(editor.findMatches('Alpha')).toHaveLength(1);
+    expect(editor.findMatches('Alpha')[0]!.scope).toBeUndefined();
+    editor.destroy();
+  });
+
+  test('limits search to the body when a scoped entry method is unavailable', () => {
+    const editor = createDocxEditor({
+      container: document.createElement('div'),
+      document: storyParityDocx(),
+    });
+    if (!editor.surface) throw new Error('surface did not open');
+    Object.defineProperty(editor.surface, 'enterNote', { configurable: true, value: undefined });
+
+    expect(editor.findMatches('Alpha')).toHaveLength(1);
+    expect(editor.findMatches('Alpha')[0]!.scope).toBeUndefined();
+    editor.destroy();
+  });
+
+  test('keeps an open note when scrollToBlock receives a table id', () => {
+    const editor = createDocxEditor({
+      container: document.createElement('div'),
+      document: storyParityDocxWithBodyTable(),
+    });
+    if (!editor.surface) throw new Error('surface did not open');
+    const table = editor.surface
+      .layout()
+      .pages.flatMap((page) => page.fragments)
+      .find((fragment) => fragment.kind === 'table');
+    if (!table || table.kind !== 'table') throw new Error('table did not lay out');
+    expect(editor.surface.enterNote(FOOTNOTE_SCOPE_ID)).toBe(true);
+
+    editor.scrollToBlock(table.tableId);
+
+    expect(editor.getActiveScope()).toEqual({ kind: 'note', id: FOOTNOTE_SCOPE_ID });
+    editor.destroy();
+  });
+});

--- a/packages/core/src/editor/__tests__/document-search-facade.test.ts
+++ b/packages/core/src/editor/__tests__/document-search-facade.test.ts
@@ -97,6 +97,23 @@ describe('document search facade', () => {
     editor.destroy();
   });
 
+  test('selects every note match that search reports', () => {
+    const editor = createDocxEditor({
+      container: document.createElement('div'),
+      document: storyParityDocx(),
+    });
+    const matches = editor
+      .findMatches('Alpha')
+      .filter((candidate) => candidate.scope?.kind === 'note');
+
+    expect(matches).toHaveLength(2);
+    for (const match of matches) {
+      expect(editor.selectMatch(match)).toEqual({ ok: true, changed: false });
+      expect(editor.getActiveScope()).toEqual(match.scope);
+    }
+    editor.destroy();
+  });
+
   test('leaves an open header when selecting a body match', () => {
     const editor = createDocxEditor({
       container: document.createElement('div'),

--- a/packages/core/src/editor/__tests__/document-search-facade.test.ts
+++ b/packages/core/src/editor/__tests__/document-search-facade.test.ts
@@ -98,8 +98,16 @@ describe('document search facade', () => {
   });
 
   test('selects every note match that search reports', () => {
+    const scroller = document.createElement('div');
+    scroller.className = 'docx-editor__scroll-container';
+    const container = document.createElement('div');
+    scroller.append(container);
+    document.body.append(scroller);
+    Object.defineProperty(scroller, 'clientHeight', { value: 600, configurable: true });
+    Object.defineProperty(scroller, 'scrollHeight', { value: 100_000, configurable: true });
+    scroller.scrollTo = (() => {}) as HTMLElement['scrollTo'];
     const editor = createDocxEditor({
-      container: document.createElement('div'),
+      container,
       document: storyParityDocx(),
     });
     const matches = editor
@@ -110,8 +118,10 @@ describe('document search facade', () => {
     for (const match of matches) {
       expect(editor.selectMatch(match)).toEqual({ ok: true, changed: false });
       expect(editor.getActiveScope()).toEqual(match.scope);
+      expect(editor.surface?.revealParagraph(match.blockId)).toBe(true);
     }
     editor.destroy();
+    scroller.remove();
   });
 
   test('leaves an open header when selecting a body match', () => {

--- a/packages/core/src/editor/docx-editor-story-navigation.ts
+++ b/packages/core/src/editor/docx-editor-story-navigation.ts
@@ -1,0 +1,92 @@
+// Shared scoped-story navigation for facade search and review activation.
+
+import type { DocumentEditingMode, ExecResult, TextMatch, ViewScope } from '../contracts/editor.ts';
+import type { SemanticPosition } from '../layout/semantic-interaction.ts';
+import type { PaginatedSurface } from './paginated-surface-contract.ts';
+
+type ScopedStory =
+  | {
+      readonly kind: 'headerFooter';
+      readonly rId: string;
+      readonly furnitureKind?: 'header' | 'footer';
+    }
+  | { readonly kind: 'note'; readonly id: string };
+
+/** Enter one non-body story at a model position. */
+export function enterStoryPosition(
+  surface: PaginatedSurface,
+  scope: ScopedStory,
+  position: SemanticPosition
+): ExecResult {
+  if (scope.kind === 'note') {
+    const entered = surface.enterNote?.(scope.id, position);
+    return entered
+      ? { ok: true, changed: false }
+      : { ok: false, code: 'unsupported', reason: 'the note could not be opened' };
+  }
+
+  const entered = scope.furnitureKind
+    ? surface.enterHeaderFooter?.({
+        rId: scope.rId,
+        kind: scope.furnitureKind,
+        position,
+      })
+    : surface.enterHeaderFooter?.({ rId: scope.rId, position });
+  return entered
+    ? { ok: true, changed: false }
+    : { ok: false, code: 'unsupported', reason: 'the header or footer could not be opened' };
+}
+
+/** Whether a public view scope is one this helper can open. */
+export function isScopedStory(scope: ViewScope | undefined): scope is ScopedStory {
+  return scope?.kind === 'headerFooter' || scope?.kind === 'note';
+}
+
+/** Whether navigation can open every story returned by document search. */
+export function searchStoriesForSurface(
+  surface: PaginatedSurface,
+  editingMode: DocumentEditingMode
+): 'all' | 'body' {
+  return editingMode !== 'viewing' &&
+    typeof surface.enterHeaderFooter === 'function' &&
+    typeof surface.enterNote === 'function'
+    ? 'all'
+    : 'body';
+}
+
+/** Leave a scoped story only when the destination is a body paragraph. */
+export function leaveScopeForBodyParagraph(surface: PaginatedSurface, paragraphId: string): void {
+  if (surface.activeScope().kind === 'body') return;
+  if (!surface.session.paragraphIds().includes(paragraphId)) return;
+  surface.exitNote?.();
+  surface.exitHeaderFooter?.();
+}
+
+/** Select and reveal one match in the story that owns it. */
+export function selectDocumentSearchMatch(surface: PaginatedSurface, match: TextMatch): ExecResult {
+  if (
+    typeof match?.blockId !== 'string' ||
+    match.blockId.length === 0 ||
+    !Number.isInteger(match.start) ||
+    match.start < 0 ||
+    !Number.isInteger(match.length) ||
+    match.length < 0
+  ) {
+    return { ok: false, code: 'invalidArgs', reason: 'match must carry a blockId and offsets' };
+  }
+  const position = { paragraphId: match.blockId, offset: match.start };
+  if (isScopedStory(match.scope)) {
+    const entered = enterStoryPosition(surface, match.scope, position);
+    if (!entered.ok) return entered;
+  } else if (match.scope && match.scope.kind !== 'body') {
+    return { ok: false, code: 'unsupported', reason: 'the match scope cannot be opened' };
+  } else {
+    leaveScopeForBodyParagraph(surface, match.blockId);
+  }
+  surface.setSelection({
+    anchor: position,
+    head: { paragraphId: match.blockId, offset: match.start + match.length },
+  });
+  surface.revealParagraph(match.blockId);
+  return { ok: true, changed: false };
+}

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -101,6 +101,12 @@ import {
   type TextMeasurer,
 } from '@docx-editor.dev/core/layout';
 import { createAnchorIndex } from './docx-editor-anchors.ts';
+import {
+  enterStoryPosition,
+  leaveScopeForBodyParagraph,
+  searchStoriesForSurface,
+  selectDocumentSearchMatch,
+} from './docx-editor-story-navigation.ts';
 import { fragmentParagraphs } from '../layout/line-segments.ts';
 import {
   classifyCommand,
@@ -1339,26 +1345,6 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
     return noteStoryScopeOf(item) ?? { kind: 'body' };
   }
 
-  /**
-   * Leave the open header/footer or note story when the paragraph being navigated to does
-   * not live in it.
-   *
-   * Every "go to this position" API addresses a paragraph, and an open furniture scope makes
-   * that address ambiguous: a body id set while a header is open clamps the caret back into
-   * the story the reader is in, and the surface then refuses each keystroke as
-   * `unknown-paragraph` — the page scrolls to the target and typing goes nowhere. Called
-   * BEFORE the selection is set, so the caret lands in the story that owns it.
-   */
-  function leaveScopeForParagraph(paragraphId: string): void {
-    if (!surface || surface.activeScope().kind === 'body') return;
-    // Only for a BODY target. A paragraph belonging to some other story is not somewhere
-    // leaving this one would help, and in-story navigation must not close the story the
-    // reader opened.
-    if (!surface.session.paragraphIds().includes(paragraphId)) return;
-    surface.exitNote?.();
-    surface.exitHeaderFooter?.();
-  }
-
   /** Word writes `@w:date` to the second; milliseconds group with nothing. */
   const secondsPrecisionNow = (): string => `${new Date().toISOString().slice(0, 19)}Z`;
 
@@ -2064,48 +2050,21 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
     getSelectionFormatting: () =>
       selectionFormattingHalfPoints(surface ? snapshotNow().formatting : null),
 
-    // Search reads the canonical tree through the session's memo, so repeated identical
-    // questions (a find panel re-rendering, a next/previous press) cost nothing. The
-    // `truncated` half of the derivation is dropped here because this member's declared
-    // answer is an array; a caller comparing the length against the documented cap learns
-    // the same thing.
     findMatches: (query, options) =>
       surface?.session.findText(query, {
         ...(options?.matchCase !== undefined ? { matchCase: options.matchCase } : {}),
         ...(options?.wholeWord !== undefined ? { wholeWord: options.wholeWord } : {}),
+        stories: searchStoriesForSurface(surface, editingMode),
       }).matches ?? [],
 
-    // Finding is a read and selecting is a write, so this is the only half that moves the
-    // caret. The match already carries the paragraph id and the offsets in the surface's
-    // own vocabulary, so there is nothing to re-derive — and REVEALING is separate from
-    // selecting, because moving the caret does not move the viewport: a match twenty pages
-    // down would otherwise be selected where nobody could see it.
+    // Selection uses the match's model address and then reveals its paragraph.
     selectMatch(match: TextMatch): ExecResult {
       // Same rule as `exec`: a selection aimed into the yield window lands, not refuses.
       openScheduler.flush();
       if (!surface) {
         return { ok: false, code: 'notFound', reason: 'no document is loaded' };
       }
-      if (
-        typeof match?.blockId !== 'string' ||
-        match.blockId.length === 0 ||
-        !Number.isInteger(match.start) ||
-        match.start < 0 ||
-        !Number.isInteger(match.length) ||
-        match.length < 0
-      ) {
-        return { ok: false, code: 'invalidArgs', reason: 'match must carry a blockId and offsets' };
-      }
-      // A hit in the body while a header is open belongs to the body: land the caret in the
-      // story that owns it, or the selection clamps back into the furniture and the reader
-      // types into nothing.
-      leaveScopeForParagraph(match.blockId);
-      surface.setSelection({
-        anchor: { paragraphId: match.blockId, offset: match.start },
-        head: { paragraphId: match.blockId, offset: match.start + match.length },
-      });
-      surface.revealParagraph(match.blockId);
-      return { ok: true, changed: false };
+      return selectDocumentSearchMatch(surface, match);
     },
 
     getSelectedImage: () => snapshotNow().image,
@@ -2309,31 +2268,13 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
       // its scope names the NOTE rather than the part. Without this the note's own
       // paragraph id went to a body selection, which clamps it to an unrelated position.
       const note = home === null && item ? noteHomeOf(item) : null;
-      if (home !== null) {
-        const entered = surface.enterHeaderFooter?.({
-          rId: home.rId,
-          kind: home.kind,
-          position: { paragraphId: range.start.paragraphId, offset: range.start.offset },
-        });
-        if (!entered) {
-          return {
-            ok: false,
-            code: 'unsupported',
-            reason: 'the header or footer this change lives in could not be opened',
-          };
-        }
-      } else if (note !== null) {
-        const entered = surface.enterNote?.(note, {
-          paragraphId: range.start.paragraphId,
-          offset: range.start.offset,
-        });
-        if (!entered) {
-          return {
-            ok: false,
-            code: 'unsupported',
-            reason: 'the note this change lives in could not be opened',
-          };
-        }
+      if (home !== null || note !== null) {
+        const target =
+          home !== null
+            ? { kind: 'headerFooter' as const, rId: home.rId, furnitureKind: home.kind }
+            : { kind: 'note' as const, id: note! };
+        const entered = enterStoryPosition(surface, target, range.start);
+        if (!entered.ok) return entered;
       } else {
         // Card to document. The caret may be parked in a furniture or note scope from the
         // PREVIOUS card — leave it first, exactly as the pointer path does, or the body
@@ -2585,7 +2526,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
       // Revealing a body block is a move OUT of an open header or note: the outline and the
       // search pane both drive this, and leaving the scope on the furniture left the reader
       // looking at the body with every keystroke going to a story off screen.
-      leaveScopeForParagraph(blockId);
+      if (surface) leaveScopeForBodyParagraph(surface, blockId);
       return surface?.revealParagraph(blockId) ?? false;
     },
 

--- a/packages/core/src/layout/__tests__/field-projection-body-fields.test.ts
+++ b/packages/core/src/layout/__tests__/field-projection-body-fields.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, test } from 'bun:test';
 import { createFixedMeasurer } from '../index.ts';
 import { piecesOfParagraph } from '../field-projection.ts';
 import { breakParagraph } from '../paragraph-flow.ts';
+import { projectParagraphText } from '../../automation/text-projection.ts';
 import { runPropertyEdits } from '../../editor/surface-formatting.ts';
 import {
   FIELD_ATOM_CHAR,
@@ -96,6 +97,82 @@ describe('inert body field atom projection', () => {
       }
     });
   }
+
+  test('nested result content occupies the same outer atom in store and layout', () => {
+    const nested = complexField('DATE', '<w:r><w:t>inner</w:t></w:r>');
+    const part = parse(
+      '<w:p><w:r><w:t>A</w:t></w:r>' +
+        complexField('IF', `<w:r><w:t>outer </w:t></w:r>${nested}<w:r><w:t> tail</w:t></w:r>`) +
+        '<w:r><w:t>Z</w:t></w:r></w:p>'
+    );
+    const paragraph = paragraphOf(part);
+    const model = paragraphTextOf(part, paragraph.id)!;
+    const pieces = piecesOfParagraph(paragraph);
+
+    expect(model).toBe(`A${FIELD_ATOM_CHAR}Z`);
+    expect(pieces.at(-1)?.end).toBe(model.length);
+    expect(pieces.filter((piece) => piece.projected)).toEqual([
+      expect.objectContaining({ start: 1, end: 2 }),
+    ]);
+  });
+
+  test('deep simple-field cached text agrees across store, projection, and layout', () => {
+    let nested = '<w:r><w:t>deep</w:t></w:r>';
+    for (let depth = 0; depth < 6; depth += 1) {
+      nested = `<w:fldSimple w:instr=" IF ">${nested}</w:fldSimple>`;
+    }
+    const part = parse(`<w:p>${nested}</w:p>`);
+    const paragraph = paragraphOf(part);
+    const model = paragraphTextOf(part, paragraph.id)!;
+
+    expect(model).toBe(FIELD_ATOM_CHAR);
+    expect(projectParagraphText(paragraph, model, 'allMarkup').text).toBe('deep');
+    expect(
+      piecesOfParagraph(paragraph)
+        .map((piece) => piece.text)
+        .join('')
+    ).toBe('deep');
+  });
+
+  test('an unmatched begin in a simple cache fails open everywhere', () => {
+    const malformed =
+      '<w:fldSimple w:instr=" IF "><w:r><w:t>A</w:t></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+      '<w:r><w:t>B</w:t></w:r></w:fldSimple>';
+    const part = parse(`<w:p>${malformed}</w:p>`);
+    const paragraph = paragraphOf(part);
+    const model = paragraphTextOf(part, paragraph.id)!;
+
+    expect(model).toBe(FIELD_ATOM_CHAR);
+    expect(projectParagraphText(paragraph, model, 'allMarkup').text).toBe('AB');
+    expect(
+      piecesOfParagraph(paragraph)
+        .map((piece) => piece.text)
+        .join('')
+    ).toBe('AB');
+  });
+
+  test('an unmatched begin in a complex result demotes to visible text everywhere', () => {
+    const malformed =
+      '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+      '<w:r><w:instrText> IF </w:instrText></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+      '<w:r><w:t>A</w:t></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+      '<w:r><w:t>B</w:t></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="end"/></w:r>';
+    const part = parse(`<w:p>${malformed}</w:p>`);
+    const paragraph = paragraphOf(part);
+    const model = paragraphTextOf(part, paragraph.id)!;
+
+    expect(model).toBe('AB');
+    expect(projectParagraphText(paragraph, model, 'allMarkup').text).toBe('AB');
+    expect(
+      piecesOfParagraph(paragraph)
+        .map((piece) => piece.text)
+        .join('')
+    ).toBe('AB');
+  });
 });
 
 describe('field format ownership', () => {

--- a/packages/core/src/layout/field-instruction.ts
+++ b/packages/core/src/layout/field-instruction.ts
@@ -17,7 +17,11 @@ import {
   isInstrText as isInstrTextHelper,
   type OoxmlNode,
 } from '@docx-editor.dev/core/store';
-import { isDeletedInstrText, MAX_FIELD_INSTRUCTION_CHARS } from '../store/package/field-nodes.ts';
+import {
+  isDeletedInstrText,
+  MAX_FIELD_INSTRUCTION_CHARS,
+  MAX_FIELD_NESTING,
+} from '../store/package/field-nodes.ts';
 
 /**
  * Caps hostile instruction blobs and nesting depth (fail closed → inert).
@@ -27,8 +31,7 @@ import { isDeletedInstrText, MAX_FIELD_INSTRUCTION_CHARS } from '../store/packag
  * the `w:fldSimple` lane (`MAX_HYPERLINK_INSTRUCTION_CHARS`): a long `HYPERLINK` URL parses
  * identically as a complex field and as a simple field.
  */
-export { MAX_FIELD_INSTRUCTION_CHARS };
-export const MAX_FIELD_NESTING = 4;
+export { MAX_FIELD_INSTRUCTION_CHARS, MAX_FIELD_NESTING };
 
 /**
  * Caps for furniture field-presence scans and paragraph projection walks. Attacker-controlled

--- a/packages/core/src/layout/page-furniture-insets.ts
+++ b/packages/core/src/layout/page-furniture-insets.ts
@@ -11,6 +11,7 @@
 
 import type { HeaderFooterStoryLayout } from './hf-layout.ts';
 import type { HeaderFooterStoryRecord, LayoutBox, SemanticLayout } from './semantic-records.ts';
+import { headerFooterVariantCanPaint } from '../store/package/hf-references.ts';
 
 /** Which header/footer variant a page shows (ECMA-376 §17.10.5). */
 export type HeaderFooterVariantName = 'default' | 'first' | 'even';
@@ -84,8 +85,14 @@ export function headerFooterVariantFor(
   pageIndexStart: number,
   index: number
 ): HeaderFooterVariantName {
-  if (furniture?.titlePage && index === 0) return 'first';
-  if (furniture?.evenAndOddHeaders && (pageIndexStart + index + 1) % 2 === 0) return 'even';
+  if (furniture && headerFooterVariantCanPaint(furniture, 'first') && index === 0) return 'first';
+  if (
+    furniture &&
+    headerFooterVariantCanPaint(furniture, 'even') &&
+    (pageIndexStart + index + 1) % 2 === 0
+  ) {
+    return 'even';
+  }
   return 'default';
 }
 

--- a/packages/core/src/store/__tests__/typed-field-nodes.test.ts
+++ b/packages/core/src/store/__tests__/typed-field-nodes.test.ts
@@ -433,6 +433,23 @@ describe('malformed demotion (fail-open)', () => {
     expect(pieces.every((p) => !p.projected)).toBe(true);
   });
 
+  test('nested field result stays inside the outer field atom', () => {
+    const part = parse(
+      '<w:p><w:r><w:t>A</w:t></w:r>' +
+        '<w:r><w:fldChar w:fldCharType="begin"/><w:instrText>IF</w:instrText>' +
+        '<w:fldChar w:fldCharType="separate"/><w:t>outer </w:t>' +
+        '<w:fldChar w:fldCharType="begin"/><w:instrText>DATE</w:instrText>' +
+        '<w:fldChar w:fldCharType="separate"/><w:t>inner</w:t>' +
+        '<w:fldChar w:fldCharType="end"/><w:t> tail</w:t>' +
+        '<w:fldChar w:fldCharType="end"/></w:r>' +
+        '<w:r><w:t>Z</w:t></w:r></w:p>'
+    );
+    const paragraph = paragraphOf(part);
+
+    expect(atomicFieldSpansOf(paragraph)).toHaveLength(1);
+    expect(paragraphTextOf(part, paragraph.id)).toBe(`A${FIELD_ATOM_CHAR}Z`);
+  });
+
   test('begin without separate still keeps following run text', () => {
     const part = parse(
       `<w:p><w:r><w:fldChar w:fldCharType="begin"/><w:instrText>PAGE</w:instrText>` +

--- a/packages/core/src/store/package/content-control-walk.ts
+++ b/packages/core/src/store/package/content-control-walk.ts
@@ -8,7 +8,7 @@
 // `contentControlContent` nodes are the authority once the reader emits them. Both paths
 // share one bound so nesting cannot recurse without limit.
 
-import { WML_NAMESPACE_URI } from './ooxml-shared.ts';
+import { isContentRevisionKind, WML_NAMESPACE_URI } from './ooxml-shared.ts';
 import type {
   OoxmlContentControlContentNode,
   OoxmlContentControlNode,
@@ -167,15 +167,17 @@ export function walkAllStoryParagraphs(
 }
 
 /**
- * Paragraph-level inline sequence — runs, hyperlinks, and inline content controls in order.
+ * Paragraph-level inline sequence — runs and their bounded containers in document order.
  *
  * `visit` receives each direct `w:r` and any other inline node the caller treats as opaque
- * (bookmarks, drawings, …). Hyperlinks and content controls are descended transparently.
+ * (bookmarks, drawings, …). Hyperlinks and controls are descended transparently. Callers
+ * that address the runs inside tracked revisions can opt into descending those wrappers too.
  */
 export function walkParagraphInline(
   children: readonly OoxmlNode[],
   depth: number,
-  visit: (child: OoxmlNode) => void
+  visit: (child: OoxmlNode) => void,
+  options: { readonly descendRevisions?: boolean } = {}
 ): void {
   for (const child of children) {
     if (child.kind === 'textValue' || child.kind === 'paragraphProperties') continue;
@@ -183,15 +185,18 @@ export function walkParagraphInline(
       visit(child);
       continue;
     }
-    if (child.kind === 'hyperlink') {
+    if (
+      child.kind === 'hyperlink' ||
+      (options.descendRevisions === true && isContentRevisionKind(child.kind))
+    ) {
       if (depth < MAX_CONTENT_CONTROL_NESTING)
-        walkParagraphInline(child.children, depth + 1, visit);
+        walkParagraphInline(child.children, depth + 1, visit, options);
       continue;
     }
     if (isContentControl(child)) {
       if (depth < MAX_CONTENT_CONTROL_NESTING) {
         const content = contentControlContentOf(child);
-        if (content) walkParagraphInline(content, depth + 1, visit);
+        if (content) walkParagraphInline(content, depth + 1, visit, options);
       }
       continue;
     }

--- a/packages/core/src/store/package/field-nodes.ts
+++ b/packages/core/src/store/package/field-nodes.ts
@@ -17,6 +17,7 @@ import {
   isContentControl,
   MAX_CONTENT_CONTROL_NESTING,
 } from './content-control-walk.ts';
+import { hardBreakText } from './hard-break.ts';
 import { isContentRevisionKind, WML_NAMESPACE_URI } from './ooxml-shared.ts';
 import type {
   OoxmlFldCharNode,
@@ -413,9 +414,71 @@ export interface ParsedFieldSpan extends AtomicFieldSpan {
   readonly addressing: 'atomic' | 'editable-result';
 }
 
-interface RunChildRef {
+/** One field-machine entry from the shared paragraph-inline flatten. @internal */
+export interface FieldRunChildRef {
   readonly runId: string;
   readonly node: OoxmlNode;
+  readonly hiddenInOriginal: boolean;
+}
+
+/** Text contributed by one supported field-result inline node. @internal */
+export function fieldResultInlineTextOf(node: OoxmlNode): string {
+  if (node.kind === 'textValue') return node.value;
+  if (node.kind === 'tab') return '\t';
+  if (node.kind === 'hardBreak') return hardBreakText(node);
+  if (node.kind !== 'text' && node.kind !== 'deletedText') return '';
+  let text = '';
+  for (const child of node.children) if (child.kind === 'textValue') text += child.value;
+  return text;
+}
+
+/**
+ * Flatten the inline nodes one field machine sees. Only content controls spend nesting depth.
+ * @internal
+ */
+export function collectFieldRunChildren(
+  container: OoxmlNode,
+  entries: FieldRunChildRef[],
+  budget?: { left: number }
+): boolean {
+  let complete = true;
+  const visit = (child: OoxmlNode, sdtDepth: number, hiddenInOriginal: boolean): void => {
+    if (!complete) return;
+    if (budget && budget.left-- <= 0) {
+      complete = false;
+      return;
+    }
+    const hidden =
+      hiddenInOriginal || child.kind === 'revisionInsert' || child.kind === 'revisionMoveTo';
+    if (isFldSimple(child)) {
+      entries.push({ runId: '', node: child, hiddenInOriginal: hidden });
+      return;
+    }
+    if (child.kind === 'run') {
+      for (const node of child.children) {
+        if (node.kind === 'runProperties') continue;
+        if (budget && budget.left-- <= 0) {
+          complete = false;
+          return;
+        }
+        entries.push({ runId: child.id, node, hiddenInOriginal: hidden });
+      }
+      return;
+    }
+    if (isContentControl(child)) {
+      if (sdtDepth >= MAX_CONTENT_CONTROL_NESTING) return;
+      for (const inner of contentControlContentChildren(child)) visit(inner, sdtDepth + 1, hidden);
+      return;
+    }
+    if (child.kind === 'textValue') return;
+    if (child.kind === 'hyperlink' || isContentRevisionKind(child.kind)) {
+      for (const inner of child.children) visit(inner, sdtDepth, hidden);
+    }
+  };
+  if (container.kind !== 'textValue') {
+    for (const child of container.children) visit(child, 0, false);
+  }
+  return complete;
 }
 
 const MERGEFORMAT_SUFFIX = /\s*\\\*\s*MERGEFORMAT\s*$/i;
@@ -432,6 +495,9 @@ const MERGEFORMAT_SUFFIX = /\s*\\\*\s*MERGEFORMAT\s*$/i;
  * caps on purpose.
  */
 export const MAX_FIELD_INSTRUCTION_CHARS = 4096;
+
+/** Maximum supported nesting for complex fields inside one paragraph. */
+export const MAX_FIELD_NESTING = 4;
 
 /** Whether a bounded instruction denotes Word's editable legacy text-form input. */
 export function isEditableFormTextInstruction(
@@ -461,13 +527,13 @@ export function parsedFieldSpansOf(
   paragraph: OoxmlParagraphNode,
   options?: { readonly maxNesting?: number; readonly maxInstructionChars?: number }
 ): readonly ParsedFieldSpan[] {
-  const maxNesting = options?.maxNesting ?? 4;
+  const maxNesting = options?.maxNesting ?? MAX_FIELD_NESTING;
   const maxInstructionChars = options?.maxInstructionChars ?? MAX_FIELD_INSTRUCTION_CHARS;
   const spans: ParsedFieldSpan[] = [];
 
   // Flatten run children in document order for the complex-field machine.
   // Hyperlink is a run container: fields inside a link are ordinary paragraph text.
-  const flat: RunChildRef[] = [];
+  const flat: FieldRunChildRef[] = [];
   /** Child `w:r` ids inside a `fldSimple` — those runs own displayed result formatting. */
   const formatRunIdsOfSimple = (simple: OoxmlNode): readonly string[] => {
     if (simple.kind === 'textValue') return [];
@@ -484,8 +550,10 @@ export function parsedFieldSpansOf(
     return ids;
   };
 
-  const visitInline = (child: OoxmlNode, sdtDepth = 0): void => {
-    if (child.kind === 'fldSimple' || (child.kind === 'generic' && isFldSimple(child))) {
+  collectFieldRunChildren(paragraph, flat);
+  for (const entry of flat) {
+    const child = entry.node;
+    if (isFldSimple(child)) {
       spans.push({
         kind: 'simple',
         node: child,
@@ -494,42 +562,8 @@ export function parsedFieldSpansOf(
         formatRunIds: formatRunIdsOfSimple(child),
         addressing: 'atomic',
       });
-      return;
     }
-    if (child.kind === 'run') {
-      for (const grand of child.children) {
-        if (grand.kind === 'runProperties') continue;
-        flat.push({ runId: child.id, node: grand });
-      }
-      return;
-    }
-    // An inline content control flattens into the paragraph's run stream, so a field inside
-    // one is an ordinary field. Layout descends here and this walk did not, so a `w:fldSimple`
-    // in an `w:sdt` was worth one offset to layout and nothing to the store — the same
-    // disagreement, in the same direction, as the revision wrappers below.
-    if (isContentControl(child)) {
-      if (sdtDepth < MAX_CONTENT_CONTROL_NESTING) {
-        for (const inner of contentControlContentChildren(child)) {
-          visitInline(inner, sdtDepth + 1);
-        }
-      }
-      return;
-    }
-    if (
-      child.kind !== 'textValue' &&
-      (child.kind === 'hyperlink' || isContentRevisionKind(child.kind))
-    ) {
-      // Revision wrappers are run containers like `w:hyperlink` is. Not descending made a
-      // field whose RESULT is wrapped in `w:del` disagree with itself: the begin/end markers
-      // formed an atom worth one offset, but the struck result run was not among the nodes
-      // that atom swallowed, so the paragraph counted its characters a SECOND time as
-      // ordinary text. Layout folds them into the atom, the store did not, and every offset
-      // after the field was out by the length of the deleted words — the caret painted in one
-      // place and typing landed elsewhere.
-      for (const inner of child.children) visitInline(inner, sdtDepth);
-    }
-  };
-  for (const child of paragraph.children) visitInline(child);
+  }
 
   let i = 0;
   while (i < flat.length) {
@@ -625,7 +659,10 @@ export function parsedFieldSpansOf(
       // Interior content: instruction-phase run content is chrome (skipped for addressing);
       // result-phase measurable content is part of the atomic unit (removed on delete).
       if (nesting >= 1) {
-        if (phase === 'result' && nesting === 1) {
+        if (phase === 'result') {
+          // Include nested result content. Layout buffers nested results inside the outer
+          // field and commits one atom only when the outer field ends. Only outer-result
+          // runs own formatting, so `formatRunIds` remains gated on `nesting === 1` below.
           if (
             node.kind === 'text' ||
             // `w:delText` is result content that a tracked deletion struck — still the field's
@@ -639,7 +676,7 @@ export function parsedFieldSpansOf(
             node.kind === 'textValue'
           ) {
             removeIds.push(node.id);
-            if (entry.runId && !seenFormatRuns.has(entry.runId)) {
+            if (nesting === 1 && entry.runId && !seenFormatRuns.has(entry.runId)) {
               seenFormatRuns.add(entry.runId);
               resultFormatRunIds.push(entry.runId);
             }

--- a/packages/core/src/store/package/field-result-text.ts
+++ b/packages/core/src/store/package/field-result-text.ts
@@ -23,6 +23,19 @@ import type { OoxmlNode, OoxmlParagraphNode } from './ooxml-tree.ts';
 /** Review view applied to cached field-result content. */
 export type FieldResultTextView = 'allMarkup' | 'original';
 
+/** One visible interval contributed by a result run. @internal */
+export interface FieldResultRunBoundary {
+  readonly runId: string;
+  readonly start: number;
+  readonly end: number;
+}
+
+/** Visible cached result text and its result-run intervals. @internal */
+export interface FieldResultProjection {
+  readonly text: string;
+  readonly runs: readonly FieldResultRunBoundary[];
+}
+
 interface FieldState {
   readonly beginId: string;
   separated: boolean;
@@ -40,7 +53,7 @@ interface ActiveComplexField {
   readonly states: FieldState[];
   readonly markers: FieldMarkerPlan;
   readonly endId: string;
-  readonly out: string[];
+  readonly result: MutableFieldResult;
   readonly chars: CharacterBudget;
   nodesLeft: number;
   overflow: boolean;
@@ -62,11 +75,63 @@ interface CharacterBudget {
   left: number;
 }
 
-function appendResultText(out: string[], text: string, budget: CharacterBudget): boolean {
+interface MutableFieldResult {
+  readonly out: string[];
+  readonly runs: FieldResultRunBoundary[];
+  length: number;
+}
+
+function emptyFieldResult(): MutableFieldResult {
+  return { out: [], runs: [], length: 0 };
+}
+
+function appendRunBoundary(
+  result: MutableFieldResult,
+  runId: string,
+  start: number,
+  end: number
+): void {
+  if (runId.length === 0 || start === end) return;
+  const previous = result.runs[result.runs.length - 1];
+  if (previous?.runId === runId && previous.end === start) {
+    result.runs[result.runs.length - 1] = { runId, start: previous.start, end };
+    return;
+  }
+  result.runs.push({ runId, start, end });
+}
+
+function appendResultText(
+  result: MutableFieldResult,
+  text: string,
+  runId: string,
+  budget: CharacterBudget
+): boolean {
   if (text.length > budget.left) return false;
   budget.left -= text.length;
-  if (text.length > 0) out.push(text);
+  if (text.length > 0) {
+    const start = result.length;
+    result.out.push(text);
+    result.length += text.length;
+    appendRunBoundary(result, runId, start, result.length);
+  }
   return true;
+}
+
+function appendNestedResult(result: MutableFieldResult, nested: FieldResultProjection): void {
+  const start = result.length;
+  if (nested.text.length > 0) result.out.push(nested.text);
+  result.length += nested.text.length;
+  for (const run of nested.runs) {
+    appendRunBoundary(result, run.runId, start + run.start, start + run.end);
+  }
+}
+
+function finishFieldResult(result: MutableFieldResult): FieldResultProjection {
+  return { text: result.out.join(''), runs: result.runs };
+}
+
+function placeholderResult(): FieldResultProjection {
+  return { text: FIELD_ATOM_CHAR, runs: [] };
 }
 
 function statesAreVisible(states: readonly FieldState[]): boolean {
@@ -135,11 +200,11 @@ function plainFieldResultText(
   view: FieldResultTextView,
   budget: { left: number },
   chars: CharacterBudget
-): string | null {
+): FieldResultProjection | null {
   const initial: FieldRunChildRef[] = [];
   if (!collectFieldRunChildren(node, initial, budget)) return null;
   const pending = initial.reverse();
-  const out: string[] = [];
+  const result = emptyFieldResult();
   while (pending.length > 0) {
     const entry = pending.pop()!;
     if (view === 'original' && entry.hiddenInOriginal) continue;
@@ -151,9 +216,9 @@ function plainFieldResultText(
     }
     if (isInstrText(entry.node)) continue;
     const text = fieldResultInlineTextOf(entry.node);
-    if (!appendResultText(out, text, chars)) return null;
+    if (!appendResultText(result, text, entry.runId, chars)) return null;
   }
-  return out.join('');
+  return finishFieldResult(result);
 }
 
 function scanSimpleEntries(
@@ -162,8 +227,8 @@ function scanSimpleEntries(
   budget: { left: number },
   chars: CharacterBudget,
   depth: number
-): string | null {
-  const out: string[] = [];
+): FieldResultProjection | null {
+  const result = emptyFieldResult();
   const states: FieldState[] = [];
   const markers = fieldMarkerPlan(entries);
   for (const entry of entries) {
@@ -179,13 +244,13 @@ function scanSimpleEntries(
           : simpleFieldResultText(node, view, budget, chars, depth + 1);
       if (nested === null) return null;
       // The recursive scan already charged every character to this field's shared budget.
-      if (nested.length > 0) out.push(nested);
+      appendNestedResult(result, nested);
       continue;
     }
     const text = fieldResultInlineTextOf(node);
-    if (!appendResultText(out, text, chars)) return null;
+    if (!appendResultText(result, text, entry.runId, chars)) return null;
   }
-  return out.join('');
+  return finishFieldResult(result);
 }
 
 function simpleFieldResultText(
@@ -194,7 +259,7 @@ function simpleFieldResultText(
   budget: { left: number },
   chars: CharacterBudget,
   depth: number
-): string | null {
+): FieldResultProjection | null {
   const entries: FieldRunChildRef[] = [];
   if (!collectFieldRunChildren(node, entries, budget)) return null;
   return scanSimpleEntries(entries, view, budget, chars, depth);
@@ -240,17 +305,17 @@ function consumeComplexEntry(
     return false;
   }
   const text = fieldResultInlineTextOf(node);
-  if (!appendResultText(active.out, text, active.chars)) active.overflow = true;
+  if (!appendResultText(active.result, text, entry.runId, active.chars)) active.overflow = true;
   return false;
 }
 
-/** Visible cached results for all supplied atomic spans, from one paragraph scan. */
-export function fieldResultTextsOf(
+/** Visible cached result projections for all supplied atomic spans, from one paragraph scan. */
+export function fieldResultProjectionsOf(
   paragraph: OoxmlParagraphNode,
   spans: readonly AtomicFieldSpan[],
   view: FieldResultTextView = 'allMarkup'
-): ReadonlyMap<string, string> {
-  const results = new Map<string, string>();
+): ReadonlyMap<string, FieldResultProjection> {
+  const results = new Map<string, FieldResultProjection>();
   const complexByBegin = new Map<string, AtomicFieldSpan>();
   const simpleByNode = new Map<string, AtomicFieldSpan>();
   for (const span of spans) {
@@ -272,7 +337,7 @@ export function fieldResultTextsOf(
       const budget = { left: MAX_FIELD_RESULT_NODES };
       const chars = { left: MAX_FIELD_RESULT_CHARS };
       const text = simpleFieldResultText(simple.node, view, budget, chars, 0);
-      results.set(simple.node.id, text ?? FIELD_ATOM_CHAR);
+      results.set(simple.node.id, text ?? placeholderResult());
     }
 
     if (active === null) {
@@ -290,7 +355,7 @@ export function fieldResultTextsOf(
       }
       const endEntry = entries[endIndex];
       if (!endEntry) {
-        results.set(complex.node.id, FIELD_ATOM_CHAR);
+        results.set(complex.node.id, placeholderResult());
         continue;
       }
       active = {
@@ -299,7 +364,7 @@ export function fieldResultTextsOf(
         states: [{ beginId: complex.node.id, separated: false }],
         markers: fieldMarkerPlan(entries, entryIndex + 1, endIndex, complex.node.id),
         endId: endEntry.node.id,
-        out: [],
+        result: emptyFieldResult(),
         chars: { left: MAX_FIELD_RESULT_CHARS },
         nodesLeft: MAX_FIELD_RESULT_NODES,
         overflow: false,
@@ -307,10 +372,25 @@ export function fieldResultTextsOf(
     }
 
     if (consumeComplexEntry(active, entry, view)) {
-      results.set(active.span.node.id, active.overflow ? FIELD_ATOM_CHAR : active.out.join(''));
+      results.set(
+        active.span.node.id,
+        active.overflow ? placeholderResult() : finishFieldResult(active.result)
+      );
       active = null;
     }
   }
-  if (active !== null) results.set(active.span.node.id, FIELD_ATOM_CHAR);
+  if (active !== null) results.set(active.span.node.id, placeholderResult());
+  return results;
+}
+
+/** Visible cached results for all supplied atomic spans, from one paragraph scan. */
+export function fieldResultTextsOf(
+  paragraph: OoxmlParagraphNode,
+  spans: readonly AtomicFieldSpan[],
+  view: FieldResultTextView = 'allMarkup'
+): ReadonlyMap<string, string> {
+  const projections = fieldResultProjectionsOf(paragraph, spans, view);
+  const results = new Map<string, string>();
+  for (const [nodeId, projection] of projections) results.set(nodeId, projection.text);
   return results;
 }

--- a/packages/core/src/store/package/field-result-text.ts
+++ b/packages/core/src/store/package/field-result-text.ts
@@ -1,0 +1,316 @@
+// Visible cached text for atomic Word fields.
+//
+// Field instructions are inert source text. This walk exposes only saved result content.
+// It follows the same typed run vocabulary as `paragraphTextOf`. Unknown generic content,
+// drawings, and note references stay invisible. Nested fields expose their own results.
+// Exhausting a field's node budget returns its atom placeholder. The walk fails soft and
+// never makes a file-sized allocation.
+
+import {
+  collectFieldRunChildren,
+  FIELD_ATOM_CHAR,
+  MAX_FIELD_INSTRUCTION_CHARS,
+  MAX_FIELD_NESTING,
+  fieldResultInlineTextOf,
+  isFldChar,
+  isFldSimple,
+  isInstrText,
+  type AtomicFieldSpan,
+  type FieldRunChildRef,
+} from './field-nodes.ts';
+import type { OoxmlNode, OoxmlParagraphNode } from './ooxml-tree.ts';
+
+/** Review view applied to cached field-result content. */
+export type FieldResultTextView = 'allMarkup' | 'original';
+
+interface FieldState {
+  readonly beginId: string;
+  separated: boolean;
+}
+
+interface FieldMarkerPlan {
+  readonly activeBegins: ReadonlySet<string>;
+  readonly separateBegin: ReadonlyMap<string, string>;
+  readonly endBegin: ReadonlyMap<string, string>;
+}
+
+interface ActiveComplexField {
+  readonly span: AtomicFieldSpan;
+  readonly owned: ReadonlySet<string>;
+  readonly states: FieldState[];
+  readonly markers: FieldMarkerPlan;
+  readonly endId: string;
+  readonly out: string[];
+  readonly chars: CharacterBudget;
+  nodesLeft: number;
+  overflow: boolean;
+}
+
+/** Fixed node budget for one field's cached result. */
+const MAX_FIELD_RESULT_NODES = 4_096;
+
+/**
+ * Fixed UTF-16 budget for one field's cached result.
+ *
+ * Sixteen instruction-sized buffers admit unusually long generated labels and references,
+ * while capping the text that projection and case-folding can copy to about 128 KiB of UTF-16
+ * payload per field. Lengths are checked before append; file-supplied strings are never sliced.
+ */
+export const MAX_FIELD_RESULT_CHARS = MAX_FIELD_INSTRUCTION_CHARS * 16;
+
+interface CharacterBudget {
+  left: number;
+}
+
+function appendResultText(out: string[], text: string, budget: CharacterBudget): boolean {
+  if (text.length > budget.left) return false;
+  budget.left -= text.length;
+  if (text.length > 0) out.push(text);
+  return true;
+}
+
+function statesAreVisible(states: readonly FieldState[]): boolean {
+  for (const state of states) if (!state.separated) return false;
+  return true;
+}
+
+function fieldMarkerPlan(
+  entries: readonly FieldRunChildRef[],
+  from = 0,
+  to = entries.length,
+  enclosingBeginId?: string
+): FieldMarkerPlan {
+  const activeBegins = new Set<string>();
+  const separateBegin = new Map<string, string>();
+  const endBegin = new Map<string, string>();
+  const stack = enclosingBeginId ? [enclosingBeginId] : [];
+  if (enclosingBeginId) activeBegins.add(enclosingBeginId);
+  for (let index = from; index < to; index += 1) {
+    const node = entries[index]!.node;
+    if (isFldChar(node, 'begin')) {
+      stack.push(node.id);
+      continue;
+    }
+    if (isFldChar(node, 'separate')) {
+      const beginId = stack[stack.length - 1];
+      if (beginId) {
+        activeBegins.add(beginId);
+        separateBegin.set(node.id, beginId);
+      }
+      continue;
+    }
+    if (isFldChar(node, 'end')) {
+      const beginId = stack.pop();
+      if (beginId) {
+        activeBegins.add(beginId);
+        endBegin.set(node.id, beginId);
+      }
+    }
+  }
+  return { activeBegins, separateBegin, endBegin };
+}
+
+function consumeMarker(states: FieldState[], markers: FieldMarkerPlan, node: OoxmlNode): boolean {
+  if (isFldChar(node, 'begin')) {
+    if (markers.activeBegins.has(node.id)) states.push({ beginId: node.id, separated: false });
+    return true;
+  }
+  if (isFldChar(node, 'separate')) {
+    const beginId = markers.separateBegin.get(node.id);
+    const state = states[states.length - 1];
+    if (beginId && state?.beginId === beginId) state.separated = true;
+    return true;
+  }
+  if (isFldChar(node, 'end')) {
+    const beginId = markers.endBegin.get(node.id);
+    const state = states[states.length - 1];
+    if (beginId && state?.beginId === beginId) states.pop();
+    return true;
+  }
+  return false;
+}
+
+function plainFieldResultText(
+  node: OoxmlNode,
+  view: FieldResultTextView,
+  budget: { left: number },
+  chars: CharacterBudget
+): string | null {
+  const initial: FieldRunChildRef[] = [];
+  if (!collectFieldRunChildren(node, initial, budget)) return null;
+  const pending = initial.reverse();
+  const out: string[] = [];
+  while (pending.length > 0) {
+    const entry = pending.pop()!;
+    if (view === 'original' && entry.hiddenInOriginal) continue;
+    if (isFldSimple(entry.node)) {
+      const nested: FieldRunChildRef[] = [];
+      if (!collectFieldRunChildren(entry.node, nested, budget)) return null;
+      for (let index = nested.length - 1; index >= 0; index -= 1) pending.push(nested[index]!);
+      continue;
+    }
+    if (isInstrText(entry.node)) continue;
+    const text = fieldResultInlineTextOf(entry.node);
+    if (!appendResultText(out, text, chars)) return null;
+  }
+  return out.join('');
+}
+
+function scanSimpleEntries(
+  entries: readonly FieldRunChildRef[],
+  view: FieldResultTextView,
+  budget: { left: number },
+  chars: CharacterBudget,
+  depth: number
+): string | null {
+  const out: string[] = [];
+  const states: FieldState[] = [];
+  const markers = fieldMarkerPlan(entries);
+  for (const entry of entries) {
+    const node = entry.node;
+    if (consumeMarker(states, markers, node)) continue;
+    if (isInstrText(node)) continue;
+    if (!statesAreVisible(states)) continue;
+    if (view === 'original' && entry.hiddenInOriginal) continue;
+    if (isFldSimple(node)) {
+      const nested =
+        depth >= MAX_FIELD_NESTING
+          ? plainFieldResultText(node, view, budget, chars)
+          : simpleFieldResultText(node, view, budget, chars, depth + 1);
+      if (nested === null) return null;
+      // The recursive scan already charged every character to this field's shared budget.
+      if (nested.length > 0) out.push(nested);
+      continue;
+    }
+    const text = fieldResultInlineTextOf(node);
+    if (!appendResultText(out, text, chars)) return null;
+  }
+  return out.join('');
+}
+
+function simpleFieldResultText(
+  node: OoxmlNode,
+  view: FieldResultTextView,
+  budget: { left: number },
+  chars: CharacterBudget,
+  depth: number
+): string | null {
+  const entries: FieldRunChildRef[] = [];
+  if (!collectFieldRunChildren(node, entries, budget)) return null;
+  return scanSimpleEntries(entries, view, budget, chars, depth);
+}
+
+function consumeComplexEntry(
+  active: ActiveComplexField,
+  entry: FieldRunChildRef,
+  view: FieldResultTextView
+): boolean {
+  const node = entry.node;
+  if (active.owned.has(node.id)) {
+    active.nodesLeft -= 1;
+    if (active.nodesLeft < 0) active.overflow = true;
+  }
+  if (isFldChar(node, 'begin')) {
+    if (node.id !== active.span.node.id && active.markers.activeBegins.has(node.id)) {
+      active.states.push({ beginId: node.id, separated: false });
+    }
+    return false;
+  }
+  if (isFldChar(node, 'separate')) {
+    const beginId = active.markers.separateBegin.get(node.id);
+    const state = active.states[active.states.length - 1];
+    if (beginId && state?.beginId === beginId) state.separated = true;
+    return false;
+  }
+  if (isFldChar(node, 'end')) {
+    if (node.id === active.endId) return true;
+    const beginId = active.markers.endBegin.get(node.id);
+    const state = active.states[active.states.length - 1];
+    if (beginId && state?.beginId === beginId) active.states.pop();
+    return false;
+  }
+  if (
+    active.overflow ||
+    isInstrText(node) ||
+    isFldSimple(node) ||
+    !active.owned.has(node.id) ||
+    !statesAreVisible(active.states) ||
+    (view === 'original' && entry.hiddenInOriginal)
+  ) {
+    return false;
+  }
+  const text = fieldResultInlineTextOf(node);
+  if (!appendResultText(active.out, text, active.chars)) active.overflow = true;
+  return false;
+}
+
+/** Visible cached results for all supplied atomic spans, from one paragraph scan. */
+export function fieldResultTextsOf(
+  paragraph: OoxmlParagraphNode,
+  spans: readonly AtomicFieldSpan[],
+  view: FieldResultTextView = 'allMarkup'
+): ReadonlyMap<string, string> {
+  const results = new Map<string, string>();
+  const complexByBegin = new Map<string, AtomicFieldSpan>();
+  const simpleByNode = new Map<string, AtomicFieldSpan>();
+  for (const span of spans) {
+    if (span.kind === 'complex') complexByBegin.set(span.node.id, span);
+    else simpleByNode.set(span.node.id, span);
+  }
+
+  const entries: FieldRunChildRef[] = [];
+  collectFieldRunChildren(paragraph, entries);
+  const entryIndexById = new Map<string, number>();
+  for (let index = 0; index < entries.length; index += 1) {
+    entryIndexById.set(entries[index]!.node.id, index);
+  }
+  let active: ActiveComplexField | null = null;
+  for (let entryIndex = 0; entryIndex < entries.length; entryIndex += 1) {
+    const entry = entries[entryIndex]!;
+    const simple = simpleByNode.get(entry.node.id);
+    if (simple) {
+      const budget = { left: MAX_FIELD_RESULT_NODES };
+      const chars = { left: MAX_FIELD_RESULT_CHARS };
+      const text = simpleFieldResultText(simple.node, view, budget, chars, 0);
+      results.set(simple.node.id, text ?? FIELD_ATOM_CHAR);
+    }
+
+    if (active === null) {
+      const complex = complexByBegin.get(entry.node.id);
+      if (!complex) continue;
+      const owned = new Set(complex.removeNodeIds);
+      let endIndex = -1;
+      for (let index = complex.removeNodeIds.length - 1; index >= 0; index -= 1) {
+        const candidateIndex = entryIndexById.get(complex.removeNodeIds[index]!);
+        if (candidateIndex === undefined || candidateIndex <= entryIndex) continue;
+        if (isFldChar(entries[candidateIndex]!.node, 'end')) {
+          endIndex = candidateIndex;
+          break;
+        }
+      }
+      const endEntry = entries[endIndex];
+      if (!endEntry) {
+        results.set(complex.node.id, FIELD_ATOM_CHAR);
+        continue;
+      }
+      active = {
+        span: complex,
+        owned,
+        states: [{ beginId: complex.node.id, separated: false }],
+        markers: fieldMarkerPlan(entries, entryIndex + 1, endIndex, complex.node.id),
+        endId: endEntry.node.id,
+        out: [],
+        chars: { left: MAX_FIELD_RESULT_CHARS },
+        nodesLeft: MAX_FIELD_RESULT_NODES,
+        overflow: false,
+      };
+    }
+
+    if (consumeComplexEntry(active, entry, view)) {
+      results.set(active.span.node.id, active.overflow ? FIELD_ATOM_CHAR : active.out.join(''));
+      active = null;
+    }
+  }
+  if (active !== null) results.set(active.span.node.id, FIELD_ATOM_CHAR);
+  return results;
+}

--- a/packages/core/src/store/package/hf-references.ts
+++ b/packages/core/src/store/package/hf-references.ts
@@ -75,6 +75,16 @@ export interface HeaderFooterSectionResolution {
   readonly titlePage: boolean;
 }
 
+/** Whether a section can paint one authored furniture variant. @internal */
+export function headerFooterVariantCanPaint(
+  section: { readonly evenAndOddHeaders: boolean; readonly titlePage: boolean },
+  variant: HeaderFooterVariant
+): boolean {
+  if (variant === 'first') return section.titlePage;
+  if (variant === 'even') return section.evenAndOddHeaders;
+  return true;
+}
+
 const EMPTY: HeaderFooterParts = Object.freeze({
   headers: new Map(),
   footers: new Map(),

--- a/packages/core/src/store/package/note-nodes.ts
+++ b/packages/core/src/store/package/note-nodes.ts
@@ -349,10 +349,35 @@ export function notesOf(root: OoxmlNode): readonly OoxmlNoteNode[] {
   return notes;
 }
 
+interface ResolvableNoteIndex {
+  readonly notes: readonly OoxmlNoteNode[];
+  readonly byId: ReadonlyMap<number, OoxmlNoteNode>;
+}
+
+const resolvableNoteIndexes = new WeakMap<OoxmlNode, ResolvableNoteIndex>();
+
+function resolvableNoteIndexOf(root: OoxmlNode): ResolvableNoteIndex {
+  const cached = resolvableNoteIndexes.get(root);
+  if (cached) return cached;
+  const resolved: OoxmlNoteNode[] = [];
+  const byId = new Map<number, OoxmlNoteNode>();
+  for (const note of notesOf(root)) {
+    const id = noteIdOf(note);
+    if (id === null || byId.has(id)) continue;
+    byId.set(id, note);
+    resolved.push(note);
+  }
+  const index = { notes: Object.freeze(resolved), byId };
+  resolvableNoteIndexes.set(root, index);
+  return index;
+}
+
+/** Direct, bounded note bodies that note navigation can resolve, with the first id winning. */
+export function resolvableNotesOf(root: OoxmlNode): readonly OoxmlNoteNode[] {
+  return resolvableNoteIndexOf(root).notes;
+}
+
 /** Find a typed note by id inside a notes-part root. */
 export function findNoteById(root: OoxmlNode, noteId: number): OoxmlNoteNode | undefined {
-  for (const note of notesOf(root)) {
-    if (noteIdOf(note) === noteId) return note;
-  }
-  return undefined;
+  return resolvableNoteIndexOf(root).byId.get(noteId);
 }

--- a/packages/core/src/store/store/paragraph-model-text.ts
+++ b/packages/core/src/store/store/paragraph-model-text.ts
@@ -1,0 +1,29 @@
+// Raw paragraph text in the canonical model offset vocabulary.
+
+import { fieldAtomText } from '../package/field-nodes.ts';
+import { hardBreakText } from '../package/hard-break.ts';
+import type { OoxmlParagraphNode } from '../package/ooxml-tree.ts';
+import { segmentsOf } from './tree-op-segments.ts';
+
+/** Paragraph text as the ops address it, from one canonical paragraph node. @internal */
+export function paragraphModelTextOf(paragraph: OoxmlParagraphNode): string {
+  let text = '';
+  for (const segment of segmentsOf(paragraph)) {
+    if (segment.removeNodeIds && segment.removeNodeIds.length > 0) {
+      text += fieldAtomText();
+      continue;
+    }
+    if (segment.node.kind === 'textValue') text += segment.node.value;
+    else if (segment.node.kind === 'tab') text += '\t';
+    else if (segment.node.kind === 'hardBreak') text += hardBreakText(segment.node);
+    else if (
+      segment.node.kind === 'fldChar' ||
+      segment.node.kind === 'fldSimple' ||
+      (segment.node.kind === 'generic' &&
+        (segment.node.localName === 'fldChar' || segment.node.localName === 'fldSimple'))
+    ) {
+      text += fieldAtomText();
+    }
+  }
+  return text;
+}

--- a/packages/core/src/store/store/text-projection.ts
+++ b/packages/core/src/store/store/text-projection.ts
@@ -1,0 +1,247 @@
+// Visible paragraph text with exact links to the model offset space.
+//
+// A piece can preserve text one-for-one or expand one atomic field offset into its cached
+// result. Every visible range maps back to one editable model range.
+
+import { atomicFieldSpansOf, FIELD_ATOM_CHAR } from '../package/field-nodes.ts';
+import { fieldResultTextsOf, type FieldResultTextView } from '../package/field-result-text.ts';
+import type { OoxmlParagraphNode } from '../package/ooxml-tree.ts';
+import {
+  foldCase,
+  isSearchableQuery,
+  isWholeWord,
+  type TextMatchOptions,
+  type TextOccurrence,
+} from './text-match.ts';
+import { segmentsOfWithFieldSpans } from './tree-op-segments.ts';
+
+/** One visible interval linked to one raw model interval. */
+export interface VisiblePiece {
+  readonly text: string;
+  readonly rawStart: number;
+  readonly rawEnd: number;
+}
+
+/** One paragraph projection with lossless links to model offsets. */
+export interface ProjectedParagraphText {
+  readonly text: string;
+  /** Map one model boundary into the projected UTF-16 offset space. */
+  projectedOffset(rawOffset: number): number;
+  /** Map a non-empty projected range back to one editable model range. */
+  rawRange(
+    start: number,
+    end: number
+  ): {
+    readonly start: number;
+    readonly end: number;
+  } | null;
+  /** Read a model range through this projection. */
+  sliceRaw(start: number, end: number): string;
+  /** Find distinct editable ranges in the displayed text. */
+  findOccurrences(
+    query: string,
+    limit: number,
+    options?: TextMatchOptions
+  ): ProjectedTextOccurrences;
+}
+
+/** One displayed occurrence and its editable model range. */
+export interface ProjectedTextOccurrence extends TextOccurrence {
+  readonly rawStart: number;
+  readonly rawEnd: number;
+}
+
+/** Distinct projected occurrences, bounded by the caller's limit. */
+export interface ProjectedTextOccurrences {
+  readonly matches: readonly ProjectedTextOccurrence[];
+  readonly truncated: boolean;
+}
+
+interface PositionedPiece extends VisiblePiece {
+  readonly projectedStart: number;
+  readonly projectedEnd: number;
+  readonly expansion: boolean;
+}
+
+function positionedPieces(pieces: readonly VisiblePiece[]): PositionedPiece[] {
+  const result: PositionedPiece[] = [];
+  let projected = 0;
+  for (const piece of pieces) {
+    const projectedEnd = projected + piece.text.length;
+    result.push({
+      text: piece.text,
+      rawStart: piece.rawStart,
+      rawEnd: piece.rawEnd,
+      projectedStart: projected,
+      projectedEnd,
+      expansion: piece.text.length !== piece.rawEnd - piece.rawStart,
+    });
+    projected = projectedEnd;
+  }
+  return result;
+}
+
+function projectedBoundary(piece: PositionedPiece, rawOffset: number): number {
+  if (rawOffset <= piece.rawStart) return piece.projectedStart;
+  if (rawOffset >= piece.rawEnd) return piece.projectedEnd;
+  if (piece.expansion) return piece.projectedStart;
+  return piece.projectedStart + rawOffset - piece.rawStart;
+}
+
+function rawStartBoundary(piece: PositionedPiece, projectedOffset: number): number {
+  if (piece.expansion) return piece.rawStart;
+  return piece.rawStart + projectedOffset - piece.projectedStart;
+}
+
+function rawEndBoundary(piece: PositionedPiece, projectedOffset: number): number {
+  if (piece.expansion) return piece.rawEnd;
+  return piece.rawStart + projectedOffset - piece.projectedStart;
+}
+
+/** Build a mapped projection from visible pieces in raw order. */
+export function projectionFromPieces(pieces: readonly VisiblePiece[]): ProjectedParagraphText {
+  const positioned = positionedPieces(pieces);
+  let text = '';
+  for (const piece of pieces) text += piece.text;
+  return {
+    text,
+    projectedOffset(rawOffset) {
+      let offset = 0;
+      for (const piece of positioned) {
+        if (rawOffset <= piece.rawEnd) return projectedBoundary(piece, rawOffset);
+        offset = piece.projectedEnd;
+      }
+      return offset;
+    },
+    rawRange(start, end) {
+      if (start < 0 || start >= end || end > text.length) return null;
+      const first = positioned.find(
+        (piece) => start >= piece.projectedStart && start < piece.projectedEnd
+      );
+      const last = positioned.find(
+        (piece) => end > piece.projectedStart && end <= piece.projectedEnd
+      );
+      if (!first || !last) return null;
+      return {
+        start: rawStartBoundary(first, start),
+        end: rawEndBoundary(last, end),
+      };
+    },
+    sliceRaw(start, end) {
+      if (start >= end) return '';
+      let value = '';
+      for (const piece of positioned) {
+        if (piece.expansion) {
+          if (start <= piece.rawStart && end >= piece.rawEnd) value += piece.text;
+          continue;
+        }
+        const from = Math.max(start, piece.rawStart);
+        const to = Math.min(end, piece.rawEnd);
+        if (from < to) {
+          value += piece.text.slice(from - piece.rawStart, to - piece.rawStart);
+        }
+      }
+      return value;
+    },
+    findOccurrences(query, limit, options = {}) {
+      const matches: ProjectedTextOccurrence[] = [];
+      if (limit <= 0 || !isSearchableQuery(query) || text.length === 0) {
+        return { matches, truncated: false };
+      }
+      const matchCase = options.matchCase === true;
+      const wholeWord = options.wholeWord === true;
+      const needle = matchCase ? query : foldCase(query);
+      const haystack = matchCase ? text : foldCase(text);
+      const to = Math.min(text.length, options.to ?? text.length);
+      const matchedExpansions = new Set<PositionedPiece>();
+      let cursor = haystack.indexOf(needle, Math.max(0, options.from ?? 0));
+      while (cursor >= 0) {
+        const end = cursor + needle.length;
+        if (end > to) return { matches, truncated: false };
+        if (!wholeWord || isWholeWord(text, cursor, end)) {
+          const first = positioned.find(
+            (piece) => cursor >= piece.projectedStart && cursor < piece.projectedEnd
+          );
+          const last = positioned.find(
+            (piece) => end > piece.projectedStart && end <= piece.projectedEnd
+          );
+          if (!first || !last) return { matches, truncated: false };
+          // Only two matches wholly inside the same expansion select the same field atom.
+          // A match that starts in the field and ends after it has a wider raw range and is
+          // therefore a distinct navigation target.
+          const containedExpansion = first === last && first.expansion ? first : null;
+          if (!containedExpansion || !matchedExpansions.has(containedExpansion)) {
+            if (matches.length >= limit) return { matches, truncated: true };
+            matches.push({
+              start: cursor,
+              length: needle.length,
+              rawStart: rawStartBoundary(first, cursor),
+              rawEnd: rawEndBoundary(last, end),
+            });
+            if (containedExpansion) matchedExpansions.add(containedExpansion);
+          }
+        }
+        cursor = haystack.indexOf(needle, end);
+      }
+      return { matches, truncated: false };
+    },
+  };
+}
+
+/** Identity mapping for text without a visible expansion or hidden interval. */
+export function identityProjection(text: string): ProjectedParagraphText {
+  if (text.length === 0) return projectionFromPieces([]);
+  return projectionFromPieces([{ text, rawStart: 0, rawEnd: text.length }]);
+}
+
+/** Visible pieces for one paragraph, with field atoms expanded to cached result text. */
+export function visibleParagraphPieces(
+  paragraph: OoxmlParagraphNode,
+  rawText: string,
+  view: FieldResultTextView = 'allMarkup'
+): readonly VisiblePiece[] {
+  if (!rawText.includes(FIELD_ATOM_CHAR)) {
+    return rawText.length === 0 ? [] : [{ text: rawText, rawStart: 0, rawEnd: rawText.length }];
+  }
+
+  const spans = atomicFieldSpansOf(paragraph);
+  const segments = segmentsOfWithFieldSpans(paragraph, spans);
+  const results = fieldResultTextsOf(paragraph, spans, view);
+  const spansByNodeId = new Map<string, (typeof spans)[number]>();
+  for (const span of spans) spansByNodeId.set(span.node.id, span);
+  const pieces: VisiblePiece[] = [];
+  let rawStart = 0;
+  for (const segment of segments) {
+    const span = spansByNodeId.get(segment.node.id);
+    if (!span) continue;
+    if (rawStart < segment.start) {
+      pieces.push({
+        text: rawText.slice(rawStart, segment.start),
+        rawStart,
+        rawEnd: segment.start,
+      });
+    }
+    pieces.push({
+      // Nested simple fields keep the store segment order here. This does not endorse Word's
+      // visible ordering; changing it would change the model offset authority.
+      text: results.get(span.node.id) ?? FIELD_ATOM_CHAR,
+      rawStart: segment.start,
+      rawEnd: segment.end,
+    });
+    rawStart = segment.end;
+  }
+  if (rawStart < rawText.length) {
+    pieces.push({ text: rawText.slice(rawStart), rawStart, rawEnd: rawText.length });
+  }
+  return pieces;
+}
+
+/** Visible field-result projection for one paragraph. */
+export function projectVisibleParagraphText(
+  paragraph: OoxmlParagraphNode,
+  rawText: string,
+  view: FieldResultTextView = 'allMarkup'
+): ProjectedParagraphText {
+  if (!rawText.includes(FIELD_ATOM_CHAR)) return identityProjection(rawText);
+  return projectionFromPieces(visibleParagraphPieces(paragraph, rawText, view));
+}

--- a/packages/core/src/store/store/text-projection.ts
+++ b/packages/core/src/store/store/text-projection.ts
@@ -4,7 +4,11 @@
 // result. Every visible range maps back to one editable model range.
 
 import { atomicFieldSpansOf, FIELD_ATOM_CHAR } from '../package/field-nodes.ts';
-import { fieldResultTextsOf, type FieldResultTextView } from '../package/field-result-text.ts';
+import {
+  fieldResultProjectionsOf,
+  type FieldResultRunBoundary,
+  type FieldResultTextView,
+} from '../package/field-result-text.ts';
 import type { OoxmlParagraphNode } from '../package/ooxml-tree.ts';
 import {
   foldCase,
@@ -20,6 +24,8 @@ export interface VisiblePiece {
   readonly text: string;
   readonly rawStart: number;
   readonly rawEnd: number;
+  /** Result-run intervals for a simple-field expansion. */
+  readonly resultRuns?: readonly FieldResultRunBoundary[];
 }
 
 /** One paragraph projection with lossless links to model offsets. */
@@ -37,6 +43,11 @@ export interface ProjectedParagraphText {
   } | null;
   /** Read a model range through this projection. */
   sliceRaw(start: number, end: number): string;
+  /** Resolve a displayed offset inside a simple field to its visible result run. */
+  resultRunAddressAt(projectedOffset: number): {
+    readonly runId: string;
+    readonly offset: number;
+  } | null;
   /** Find distinct editable ranges in the displayed text. */
   findOccurrences(
     query: string,
@@ -68,14 +79,26 @@ function positionedPieces(pieces: readonly VisiblePiece[]): PositionedPiece[] {
   let projected = 0;
   for (const piece of pieces) {
     const projectedEnd = projected + piece.text.length;
-    result.push({
-      text: piece.text,
-      rawStart: piece.rawStart,
-      rawEnd: piece.rawEnd,
-      projectedStart: projected,
-      projectedEnd,
-      expansion: piece.text.length !== piece.rawEnd - piece.rawStart,
-    });
+    if (piece.resultRuns) {
+      result.push({
+        text: piece.text,
+        rawStart: piece.rawStart,
+        rawEnd: piece.rawEnd,
+        resultRuns: piece.resultRuns,
+        projectedStart: projected,
+        projectedEnd,
+        expansion: piece.text.length !== piece.rawEnd - piece.rawStart,
+      });
+    } else {
+      result.push({
+        text: piece.text,
+        rawStart: piece.rawStart,
+        rawEnd: piece.rawEnd,
+        projectedStart: projected,
+        projectedEnd,
+        expansion: piece.text.length !== piece.rawEnd - piece.rawStart,
+      });
+    }
     projected = projectedEnd;
   }
   return result;
@@ -143,6 +166,22 @@ export function projectionFromPieces(pieces: readonly VisiblePiece[]): Projected
       }
       return value;
     },
+    resultRunAddressAt(projectedOffset) {
+      const piece = positioned.find(
+        (candidate) =>
+          candidate.resultRuns !== undefined &&
+          projectedOffset >= candidate.projectedStart &&
+          projectedOffset < candidate.projectedEnd
+      );
+      if (!piece?.resultRuns) return null;
+      const localOffset = projectedOffset - piece.projectedStart;
+      for (const run of piece.resultRuns) {
+        if (localOffset >= run.start && localOffset < run.end) {
+          return { runId: run.runId, offset: localOffset - run.start };
+        }
+      }
+      return null;
+    },
     findOccurrences(query, limit, options = {}) {
       const matches: ProjectedTextOccurrence[] = [];
       if (limit <= 0 || !isSearchableQuery(query) || text.length === 0) {
@@ -206,7 +245,7 @@ export function visibleParagraphPieces(
 
   const spans = atomicFieldSpansOf(paragraph);
   const segments = segmentsOfWithFieldSpans(paragraph, spans);
-  const results = fieldResultTextsOf(paragraph, spans, view);
+  const results = fieldResultProjectionsOf(paragraph, spans, view);
   const spansByNodeId = new Map<string, (typeof spans)[number]>();
   for (const span of spans) spansByNodeId.set(span.node.id, span);
   const pieces: VisiblePiece[] = [];
@@ -221,13 +260,23 @@ export function visibleParagraphPieces(
         rawEnd: segment.start,
       });
     }
-    pieces.push({
-      // Nested simple fields keep the store segment order here. This does not endorse Word's
-      // visible ordering; changing it would change the model offset authority.
-      text: results.get(span.node.id) ?? FIELD_ATOM_CHAR,
-      rawStart: segment.start,
-      rawEnd: segment.end,
-    });
+    const result = results.get(span.node.id);
+    // Nested simple fields keep the store segment order here. This does not endorse Word's
+    // visible ordering; changing it would change the model offset authority.
+    if (span.kind === 'simple' && result) {
+      pieces.push({
+        text: result.text,
+        rawStart: segment.start,
+        rawEnd: segment.end,
+        resultRuns: result.runs,
+      });
+    } else {
+      pieces.push({
+        text: result?.text ?? FIELD_ATOM_CHAR,
+        rawStart: segment.start,
+        rawEnd: segment.end,
+      });
+    }
     rawStart = segment.end;
   }
   if (rawStart < rawText.length) {

--- a/packages/core/src/store/store/tree-op-apply.ts
+++ b/packages/core/src/store/store/tree-op-apply.ts
@@ -6,8 +6,7 @@
 // validation live in sibling tree-op-* modules; tree-ops.ts re-exports the public surface.
 /* eslint-disable max-lines -- pre-existing size; furniture lifecycle only adds union narrowing */
 
-import { hardBreakAttributes, hardBreakText } from '../package/hard-break.ts';
-import { fieldAtomText } from '../package/field-nodes.ts';
+import { hardBreakAttributes } from '../package/hard-break.ts';
 import { isContentRevisionKind, W14_NAMESPACE_URI } from '../package/ooxml-shared.ts';
 import { linearMathToOmml } from '../package/omml-equation.ts';
 import {
@@ -46,6 +45,7 @@ import {
   ownProposedMark,
   withPropertyChangeRecord,
 } from './tree-op-tracked-properties.ts';
+import { paragraphModelTextOf } from './paragraph-model-text.ts';
 import { nextRevisionId } from './tree-op-revision-ids.ts';
 import {
   isValidParaId,
@@ -3473,23 +3473,5 @@ export function splitRunsAt(
 export function paragraphTextOf(part: OoxmlPart, paragraphId: string): string | null {
   const paragraph = findNode(part, paragraphId);
   if (!isParagraph(paragraph)) return null;
-  let text = '';
-  for (const segment of segmentsOf(paragraph)) {
-    if (segment.removeNodeIds && segment.removeNodeIds.length > 0) {
-      text += fieldAtomText();
-      continue;
-    }
-    if (segment.node.kind === 'textValue') text += segment.node.value;
-    else if (segment.node.kind === 'tab') text += '\t';
-    else if (segment.node.kind === 'hardBreak') text += hardBreakText(segment.node);
-    else if (
-      segment.node.kind === 'fldChar' ||
-      segment.node.kind === 'fldSimple' ||
-      (segment.node.kind === 'generic' &&
-        (segment.node.localName === 'fldChar' || segment.node.localName === 'fldSimple'))
-    ) {
-      text += fieldAtomText();
-    }
-  }
-  return text;
+  return paragraphModelTextOf(paragraph);
 }

--- a/packages/core/src/store/store/tree-op-segments.ts
+++ b/packages/core/src/store/store/tree-op-segments.ts
@@ -346,7 +346,14 @@ function walkParagraph(
     }
     if (isFldSimple(child)) {
       const atom = atomByBeginId.get(child.id);
-      if (atom) emitAtom(atom);
+      if (atom) {
+        emitAtom(atom);
+        // A simple field is one model atom, but its result runs remain public run addresses.
+        // Give every result run the atom span without changing the paragraph offset space.
+        if (spans !== null) {
+          for (const runId of atom.formatRunIds) spans.set(runId, { start, end: offset });
+        }
+      }
       record(child, start);
       return;
     }

--- a/packages/core/src/store/store/tree-op-segments.ts
+++ b/packages/core/src/store/store/tree-op-segments.ts
@@ -18,6 +18,7 @@ import {
   isFldChar,
   isFldSimple,
   isInstrText,
+  type AtomicFieldSpan,
 } from '../package/field-nodes.ts';
 import { atomicNoteSpansOf, isNoteAtomNode } from '../package/note-nodes.ts';
 import { isContentRevisionKind } from '../package/ooxml-shared.ts';
@@ -83,6 +84,14 @@ export function isParagraph(node: OoxmlNode | null): node is OoxmlParagraphNode 
  */
 export function segmentsOf(paragraph: OoxmlParagraphNode): Segment[] {
   return walkParagraph(paragraph, null, null);
+}
+
+/** Build segments with field spans already computed by the caller. @internal */
+export function segmentsOfWithFieldSpans(
+  paragraph: OoxmlParagraphNode,
+  fieldSpans: readonly AtomicFieldSpan[]
+): Segment[] {
+  return walkParagraph(paragraph, null, null, fieldSpans);
 }
 
 export interface NoteSegmentProjection {
@@ -189,7 +198,8 @@ function buildParagraphOffsetIndex(paragraph: OoxmlParagraphNode): ParagraphOffs
 function walkParagraph(
   paragraph: OoxmlParagraphNode,
   spans: Map<string, OffsetSpan> | null,
-  noteAncestors: Map<string, readonly OoxmlNode[]> | null
+  noteAncestors: Map<string, readonly OoxmlNode[]> | null,
+  suppliedFieldSpans?: readonly AtomicFieldSpan[]
 ): Segment[] {
   const segments: Segment[] = [];
   let offset = 0;
@@ -197,7 +207,7 @@ function walkParagraph(
   const record = (node: OoxmlNode, start: number): void => {
     if (spans !== null) spans.set(node.id, { start, end: offset });
   };
-  const atoms = atomicFieldSpansOf(paragraph);
+  const atoms = suppliedFieldSpans ?? atomicFieldSpansOf(paragraph);
   const noteAtoms = atomicNoteSpansOf(paragraph);
   const atomByBeginId = new Map(atoms.map((span) => [span.node.id, span]));
   const noteAtomById = new Map(noteAtoms.map((span) => [span.node.id, span]));

--- a/packages/editor-api/src/__tests__/field-result-search.test.ts
+++ b/packages/editor-api/src/__tests__/field-result-search.test.ts
@@ -1,0 +1,184 @@
+/*
+Copyright (c) 2026 EigenPal, Inc. All rights reserved.
+Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/editor-api/LICENSE.md.
+Production use requires a commercial agreement: licensing@eigenpal.com
+*/
+
+import { describe, expect, test } from 'bun:test';
+import { strToU8, zipSync } from 'fflate';
+import { DocxEditor } from '../index.ts';
+import { docx } from '../model/__tests__/support/documents.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const OFFICE = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+
+const field =
+  '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+  '<w:r><w:instrText xml:space="preserve"> DATE \\@ "d MMMM yyyy" </w:instrText></w:r>' +
+  '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+  '<w:r><w:t>1 January 2030</w:t></w:r>' +
+  '<w:r><w:fldChar w:fldCharType="end"/></w:r>';
+
+function storyFixture(): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '<Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>' +
+        '<Override PartName="/word/footnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml"/></Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OFFICE}/officeDocument" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(
+      `<Relationships xmlns="${REL}">` +
+        `<Relationship Id="rHeader" Type="${OFFICE}/header" Target="header1.xml"/>` +
+        `<Relationship Id="rFootnotes" Type="${OFFICE}/footnotes" Target="footnotes.xml"/>` +
+        '</Relationships>'
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}" xmlns:r="${OFFICE}"><w:body>` +
+        '<w:p><w:r><w:footnoteReference w:id="2"/></w:r></w:p>' +
+        '<w:sectPr><w:headerReference w:type="default" r:id="rHeader"/></w:sectPr>' +
+        '</w:body></w:document>'
+    ),
+    'word/header1.xml': strToU8(`<w:hdr xmlns:w="${W}"><w:p>${field}</w:p></w:hdr>`),
+    'word/footnotes.xml': strToU8(
+      `<w:footnotes xmlns:w="${W}"><w:footnote w:id="2">` +
+        '<w:p><w:r><w:t>synthetic note text</w:t></w:r></w:p>' +
+        '</w:footnote></w:footnotes>'
+    ),
+  });
+}
+
+describe('field result search', () => {
+  test('returns the visible cached result through the server object model', async () => {
+    const bytes = docx(
+      `<w:p><w:r><w:t xml:space="preserve">Renewal date: </w:t></w:r>${field}` +
+        '<w:r><w:t xml:space="preserve"> is synthetic.</w:t></w:r></w:p>'
+    );
+    const runtime = await DocxEditor.createServer(bytes);
+
+    try {
+      const result = await runtime.run(async (context) => {
+        const matches = context.document.body.search('1 January 2030', { matchCase: true });
+        matches.load('items');
+        await context.sync();
+        const match = matches.items[0];
+        if (!match) return { count: 0, text: '' };
+        match.load('text');
+        await context.sync();
+        return { count: matches.items.length, text: match.text };
+      });
+
+      expect(result).toEqual({ count: 1, text: '1 January 2030' });
+    } finally {
+      runtime.dispose();
+    }
+  });
+
+  test('writes at every paragraph location using raw field offsets', async () => {
+    const paragraph = `<w:p><w:r><w:t>A</w:t></w:r>${field}<w:r><w:t>Z</w:t></w:r></w:p>`;
+    const cases = [
+      { location: 'Start', text: '<', expected: '<A1 January 2030Z' },
+      { location: 'End', text: '>', expected: 'A1 January 2030Z>' },
+      { location: 'Replace', text: 'replacement', expected: 'replacement' },
+    ] as const;
+
+    for (const entry of cases) {
+      const runtime = await DocxEditor.createServer(docx(paragraph));
+      try {
+        const result = await runtime.run(async (context) => {
+          const body = context.document.body;
+          const paragraphs = body.paragraphs;
+          paragraphs.load('items');
+          await context.sync();
+          const first = paragraphs.items[0]!;
+          first.insertText(entry.text, entry.location);
+          await context.sync();
+          body.load('text');
+          first.load('text');
+          await context.sync();
+          return { body: body.text, paragraph: first.text };
+        });
+
+        expect(result).toEqual({ body: entry.expected, paragraph: entry.expected });
+      } finally {
+        runtime.dispose();
+      }
+    }
+  });
+
+  test('replaces the whole field through a visible search range', async () => {
+    const bytes = docx(`<w:p><w:r><w:t>A</w:t></w:r>${field}<w:r><w:t>Z</w:t></w:r></w:p>`);
+    const runtime = await DocxEditor.createServer(bytes);
+
+    try {
+      const result = await runtime.run(async (context) => {
+        const body = context.document.body;
+        const matches = body.search('1 January 2030', { matchCase: true });
+        matches.load('items');
+        await context.sync();
+        matches.items[0]!.insertText('new', 'Replace');
+        await context.sync();
+        body.load('text');
+        await context.sync();
+        return body.text;
+      });
+
+      expect(result).toBe('AnewZ');
+    } finally {
+      runtime.dispose();
+    }
+  });
+
+  test('finds a visible field result in a primary header', async () => {
+    const runtime = await DocxEditor.createServer(storyFixture());
+
+    try {
+      const result = await runtime.run(async (context) => {
+        const sections = context.document.sections;
+        sections.load('items');
+        await context.sync();
+        const header = sections.items[0]!.getHeader('Primary');
+        await context.sync();
+        const matches = header.search('1 January 2030', { matchCase: true });
+        matches.load('items');
+        await context.sync();
+        matches.items[0]?.load('text');
+        await context.sync();
+        return { count: matches.items.length, text: matches.items[0]?.text };
+      });
+
+      expect(result).toEqual({ count: 1, text: '1 January 2030' });
+    } finally {
+      runtime.dispose();
+    }
+  });
+
+  test('finds text in a footnote body', async () => {
+    const runtime = await DocxEditor.createServer(storyFixture());
+
+    try {
+      const result = await runtime.run(async (context) => {
+        const notes = context.document.footnotes;
+        notes.load('items');
+        await context.sync();
+        const body = notes.items[0]!.body;
+        await context.sync();
+        const matches = body.search('synthetic note text', { matchCase: true });
+        matches.load('items');
+        await context.sync();
+        matches.items[0]?.load('text');
+        await context.sync();
+        return { count: matches.items.length, text: matches.items[0]?.text };
+      });
+
+      expect(result).toEqual({ count: 1, text: 'synthetic note text' });
+    } finally {
+      runtime.dispose();
+    }
+  });
+});


### PR DESCRIPTION
The navigation pane's Find scanned only the direct paragraphs of `w:body`, and both search lanes read a complex field or `w:fldSimple` as one placeholder character, so text in table cells and cached field results was never found.

## What changes

- The Find walks every paragraph of the body story in reading order, including table cells, nested tables, and block content controls. It then searches the headers and footers a page can paint, footnotes, and endnotes. A match outside the body carries a `scope`, and `selectMatch` opens that story before it selects. In view mode the search stays in the body, because the surface cannot open other stories there.
- A visible-text projection in the store lane expands each field atom to its cached result and maps every hit back to the atom's one-character model range. The navigation Find and the automation `search` both read that projection, so a match reported by one is the same match for the other. One field result yields one match even when the query occurs in it more than once.
- In the automation lane, display reads (`getText`, `getSpanText`, `Range.text`) show field results, while every offset stays in the raw model vocabulary through a dedicated raw read. A `model` projection returns the raw text for clients that need the offset vocabulary. Content control values keep their existing semantics.
- Nested field results now join the outer field's atom in the store, which is what layout already painted.
- `TextMatch.paragraphIndex` is the ordinal within the match's story, table-cell paragraphs included. `TextMatch.scope` is additive.

Text boxes are still not searched, because the surface cannot place a caret in one (#711). Text inside `w:smartTag`, `w:customXml`, `w:dir`, and `w:bdo` wrappers is not rendered at all (#710).

Fixes #703
Fixes #694

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C3mzHcQeGoaxSkK5791272

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791024251&installation_model_id=422592&pr_number=713&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F713&signature=9fb2fd4752b729080f49854f1e69e154e92286454088f8f32700c999f1fd09a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->