### PR TITLE
fix(core): couple hosted story flow dependencies

### DIFF
--- a/.changeset/gentle-hosted-stories.md
+++ b/.changeset/gentle-hosted-stories.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Keep table-hosted text-box list markers current while reducing repeated layout work for their host paragraphs. Fixes #639.

--- a/packages/core/src/layout/__tests__/textbox-story-layout.test.ts
+++ b/packages/core/src/layout/__tests__/textbox-story-layout.test.ts
@@ -28,7 +28,8 @@ import { createParagraphLayoutCache, type ParagraphLayoutCache } from '../layout
 import { flowBlocksInBox } from '../semantic-table-layout.ts';
 import type { PendingLine } from '../paragraph-flow.ts';
 import {
-  hostedListTokenDeps,
+  hostedTextboxContents,
+  hostedStoryFlowDeps,
   layoutTextboxStory,
   MAX_TEXTBOX_STORY_NESTING,
   type TextboxStoryLayout,
@@ -38,6 +39,7 @@ import {
   readOoxmlPackage,
   readOoxmlPart,
   resolveHeaderFooterPartsBySection,
+  type OoxmlNode,
   type OoxmlPackage,
   type OoxmlPart,
 } from '@docx-editor.dev/core/store';
@@ -657,6 +659,15 @@ describe('list markers inside textbox stories', () => {
     expect(boxMarkers(lay(2, '(%1)'))).toEqual(['(1)', '(2)']);
   });
 
+  test('body text boxes do not render without a drawing context', () => {
+    const layout = layoutSemanticDocument(bodyTextboxPart(), 1, {
+      measurer,
+      producer: 'test',
+      numberingIndex: numberingIndexFor('%1.'),
+    });
+    expect(layout.pages[0]!.anchoredDrawings).toBeUndefined();
+  });
+
   /** A one-cell table whose paragraph hosts a text box with a two-item numbered list. */
   function cellTextboxPart(): OoxmlPart {
     return documentPart(
@@ -722,7 +733,7 @@ describe('list markers inside textbox stories', () => {
         cache: createParagraphLayoutCache(),
         producer: 'test',
         nextLineId: (paragraphId, start, lineIndex) => `${paragraphId}-${start}-${lineIndex}`,
-        ...hostedListTokenDeps(numberingIndex, undefined, 'all-markup'),
+        hostedStory: hostedStoryFlowDeps(() => null, numberingIndex, undefined, 'all-markup'),
         onCellBreakKey: (key) => keys.push(key),
       });
       return keys;
@@ -747,8 +758,8 @@ describe('list markers inside textbox stories', () => {
   }
 
   test('the body flow wires hosted list state into cell break keys', () => {
-    // The production wiring, not a hand-built provider: dropping the `hostedListTokenDeps`
-    // spread from the body flow's table deps must fail this test.
+    // The production wiring, not a hand-built provider: dropping the `hostedStory` bundle
+    // from the body flow's table deps must fail this test.
     const part = cellTextboxPart();
     const keysFor = (lvlText: string): string[] => {
       const keys: string[] = [];
@@ -762,6 +773,70 @@ describe('list markers inside textbox stories', () => {
       return hostKeysOnly(keys);
     };
     expectKeysTrackNumbering(keysFor);
+  });
+
+  test('the hosted-story dependency bundle makes the no-numbering state explicit', () => {
+    const layoutTextboxStoryFor = () => null;
+    const hostedStory = hostedStoryFlowDeps(layoutTextboxStoryFor, undefined, undefined);
+    expect(hostedStory.layoutTextboxStoryFor).toBe(layoutTextboxStoryFor);
+    expect(hostedStory.hostedListTokenForParagraph).toBeNull();
+    expect(Object.isFrozen(hostedStory)).toBe(true);
+  });
+
+  test('a truncated table scan seeds only fully visited descendant paragraphs', () => {
+    const generic = (id: string, children: readonly OoxmlNode[] = []): OoxmlNode =>
+      ({
+        id,
+        kind: 'generic',
+        namespaceUri: W,
+        localName: 'probe',
+        namespaceBindings: [],
+        attributes: [],
+        children,
+      }) as OoxmlNode;
+    const observedParagraph = (id: string, children: readonly OoxmlNode[]) => {
+      let childReads = 0;
+      const paragraph = new Proxy(
+        {
+          id,
+          kind: 'paragraph' as const,
+          namespaceUri: W,
+          localName: 'p' as const,
+          namespaceBindings: [],
+          attributes: [],
+          children,
+        },
+        {
+          get(target, property, receiver) {
+            if (property === 'children') childReads += 1;
+            return Reflect.get(target, property, receiver);
+          },
+        }
+      ) as OoxmlNode;
+      return { paragraph, childReads: () => childReads };
+    };
+    const textboxContent = {
+      ...generic('textbox-content'),
+      localName: 'txbxContent',
+    } as OoxmlNode;
+    const complete = observedParagraph('complete', [textboxContent]);
+    const incomplete = observedParagraph(
+      'incomplete',
+      Array.from({ length: 20_050 }, (_, index) => generic(`padding-${index}`))
+    );
+    const table = {
+      ...generic('table', [complete.paragraph, incomplete.paragraph]),
+      kind: 'table',
+      localName: 'tbl',
+    } as OoxmlNode;
+
+    expect(hostedTextboxContents(table).truncated).toBe(true);
+    const completeReads = complete.childReads();
+    const incompleteReads = incomplete.childReads();
+    expect(hostedTextboxContents(complete.paragraph).contents).toEqual([textboxContent]);
+    expect(complete.childReads()).toBe(completeReads);
+    expect(hostedTextboxContents(incomplete.paragraph).truncated).toBe(true);
+    expect(incomplete.childReads()).toBeGreaterThan(incompleteReads);
   });
 
   test('the header/footer drawing branch wires hosted list state into break keys', () => {

--- a/packages/core/src/layout/hf-layout.ts
+++ b/packages/core/src/layout/hf-layout.ts
@@ -45,7 +45,7 @@ import { flowBlocksInBox } from './semantic-table-layout.ts';
 import { forEachStoryDrawing, forEachStoryParagraphFragment } from './semantic-record-queries.ts';
 import { withResolvedListItems, type ResolvedListItem } from './list-resolve.ts';
 import type { NumberingIndex } from './numbering-index.ts';
-import { hostedListTokenDeps, layoutTextboxStory } from './textbox-story-layout.ts';
+import { hostedStoryFlowDeps, layoutTextboxStory } from './textbox-story-layout.ts';
 import type {
   BlockFragmentRecord,
   HeaderFooterStoryRecord,
@@ -259,14 +259,6 @@ export function layoutHeaderFooterStory(
   ).listItems;
   // Content identity is of the authored part, not of a page-field projection.
   const contentKey = headerFooterContentKey(part);
-  // ONE provider for the whole story layout — every reflow pass and page-field projection
-  // reuses it, the body lane's own rule ("ONE provider for every fold of this flow").
-  const hostedListDeps = hostedListTokenDeps(
-    inputs?.numberingIndex,
-    styleCascade,
-    displayMode,
-    revisionAuthorFilter
-  );
   let baseline: HeaderFooterStoryLayout | undefined;
 
   const layoutOnce = (ctx: HeaderFooterLayoutPageContext | undefined): HeaderFooterStoryLayout => {
@@ -344,6 +336,50 @@ export function layoutHeaderFooterStory(
       });
     };
 
+    // Textbox stories flow with the SAME page-field context as the host story, so a PAGE
+    // field inside an anchored footer text box evaluates per page like a direct footer
+    // field. The context token already keys this cache entry.
+    const layoutTextboxStoryFor = (
+      projection: import('../store/package/drawing-projection.ts').DrawingProjection
+    ) =>
+      layoutTextboxStory(projection, {
+        measurer,
+        producer:
+          producer +
+          token +
+          (displayMode === DEFAULT_REVISION_DISPLAY_MODE ? '' : `|rev:${displayMode}`) +
+          (revisionAuthorFilter ? `|reviewers:${revisionAuthorFilter.cacheKey}` : ''),
+        cache,
+        styleCascade,
+        ...(effectiveCtx ? { pageContext: effectiveCtx } : {}),
+        ...(defaultTabStopPt !== undefined ? { defaultTabStopPt } : {}),
+        displayMode,
+        ...(revisionAuthorFilter ? { revisionAuthorFilter } : {}),
+        ...(documentProperties ? { documentProperties } : {}),
+        ...(inputs?.projectLink ? { projectLink: inputs.projectLink } : {}),
+        ...(inputs?.projectFieldLink ? { projectFieldLink: inputs.projectFieldLink } : {}),
+        inlineDrawingLayout,
+        ...(drawingTokenForParagraph ? { drawingTokenForParagraph } : {}),
+        ...(inputs?.projectionTokenForParagraph
+          ? { projectionTokenForParagraph: inputs.projectionTokenForParagraph }
+          : {}),
+        ...(inputs?.projectionTokenForTable
+          ? { projectionTokenForTable: inputs.projectionTokenForTable }
+          : {}),
+        ...(inputs?.numberingIndex ? { numberingIndex: inputs.numberingIndex } : {}),
+      });
+    // ONE capability for the whole projected story — every exclusion reflow pass uses the
+    // same layout callback and list-token provider, structurally paired for table-cell flow.
+    const hostedStory = inlineDrawingLayout
+      ? hostedStoryFlowDeps(
+          layoutTextboxStoryFor,
+          inputs?.numberingIndex,
+          styleCascade,
+          displayMode,
+          revisionAuthorFilter
+        )
+      : undefined;
+
     let exclusionZones: readonly ExclusionZone[] = Object.freeze([]);
     let flow!: { readonly blocks: BlockFragmentRecord[]; readonly bottom: number };
 
@@ -363,9 +399,7 @@ export function layoutHeaderFooterStory(
           nextLineId: () => `hf-${part.name}-line-${lineCounter++}`,
           styleCascade,
           ...(listItems ? { listItems } : {}),
-          // Only this branch lays hosted stories out (`layoutTextboxStoryFor` below), so
-          // only this branch folds their list state into the cell-lane break keys.
-          ...hostedListDeps,
+          hostedStory,
           pageContext: effectiveCtx,
           ...(defaultTabStopPt !== undefined ? { defaultTabStopPt } : {}),
           displayMode,
@@ -392,36 +426,6 @@ export function layoutHeaderFooterStory(
                 })
               : pageClipRegion(frame);
           },
-          // Textbox stories flow with the SAME page-field context as the host story, so a
-          // PAGE field inside an anchored footer text box evaluates per page like a direct
-          // footer field. The context token already keys this cache entry.
-          layoutTextboxStoryFor: (projection) =>
-            layoutTextboxStory(projection, {
-              measurer,
-              producer:
-                producer +
-                token +
-                (displayMode === DEFAULT_REVISION_DISPLAY_MODE ? '' : `|rev:${displayMode}`) +
-                (revisionAuthorFilter ? `|reviewers:${revisionAuthorFilter.cacheKey}` : ''),
-              cache,
-              styleCascade,
-              ...(effectiveCtx ? { pageContext: effectiveCtx } : {}),
-              ...(defaultTabStopPt !== undefined ? { defaultTabStopPt } : {}),
-              displayMode,
-              ...(revisionAuthorFilter ? { revisionAuthorFilter } : {}),
-              ...(documentProperties ? { documentProperties } : {}),
-              ...(inputs?.projectLink ? { projectLink: inputs.projectLink } : {}),
-              ...(inputs?.projectFieldLink ? { projectFieldLink: inputs.projectFieldLink } : {}),
-              inlineDrawingLayout,
-              ...(drawingTokenForParagraph ? { drawingTokenForParagraph } : {}),
-              ...(inputs?.projectionTokenForParagraph
-                ? { projectionTokenForParagraph: inputs.projectionTokenForParagraph }
-                : {}),
-              ...(inputs?.projectionTokenForTable
-                ? { projectionTokenForTable: inputs.projectionTokenForTable }
-                : {}),
-              ...(inputs?.numberingIndex ? { numberingIndex: inputs.numberingIndex } : {}),
-            }),
           collectAnchoredDrawings: (drawings) => {
             pendingAnchoredDrawings.push(...drawings);
           },

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -201,7 +201,7 @@ import {
 import { createLayoutSession, type FlowCheckpoint, type LayoutSession } from './layout-session.ts';
 import { replaceLayoutSession } from './layout-session.ts';
 import { furnitureForSection, layoutMultiSectionDocument } from './multi-section-layout.ts';
-import { hostedListTokenDeps, layoutTextboxStory } from './textbox-story-layout.ts';
+import { hostedStoryFlowDeps, layoutTextboxStory } from './textbox-story-layout.ts';
 import {
   layoutBlocksWithColumnBalance,
   type BlockLayoutOptions as ColumnBalanceBlockLayoutOptions,
@@ -1079,14 +1079,41 @@ function layoutBlocksPass(
   // disagree about which context minted a key — including a caller that supplies tokens
   // while toggling the context, which a fallback-only namespace could not separate.
   const hasInlineDrawingContext = options.inlineDrawingLayout !== undefined;
-  // ONE provider for every fold of this flow — the prepass block fold and the cell-lane
-  // deps below hand `hostedTextboxListToken` the same (index, cascade, mode) tuple.
-  const hostedListDeps = hostedListTokenDeps(
-    options.numberingIndex,
-    styleCascade,
-    displayMode,
-    authorFilter
-  );
+  // Body textbox stories flow without a page-field context: body PAGE projection stays
+  // deferred, so a PAGE field inside a body text box contributes only its cached result,
+  // consistent with direct body fields today.
+  const layoutTextboxStoryForBody = (
+    projection: import('../store/package/drawing-projection.ts').DrawingProjection
+  ) =>
+    layoutTextboxStory(projection, {
+      measurer,
+      producer,
+      cache,
+      styleCascade,
+      ...(defaultTabStopPt !== undefined ? { defaultTabStopPt } : {}),
+      ...(displayMode ? { displayMode } : {}),
+      ...(authorFilter ? { revisionAuthorFilter: authorFilter } : {}),
+      ...(options.documentProperties ? { documentProperties: options.documentProperties } : {}),
+      ...(options.projectLink ? { projectLink: options.projectLink } : {}),
+      ...(options.projectFieldLink ? { projectFieldLink: options.projectFieldLink } : {}),
+      ...(options.numberingIndex ? { numberingIndex: options.numberingIndex } : {}),
+      inlineDrawingLayout: options.inlineDrawingLayout,
+      drawingTokenForParagraph: options.drawingTokenForParagraph,
+      projectionTokenForParagraph: options.projectionTokenForParagraph,
+      projectionTokenForTable: options.projectionTokenForTable,
+    });
+  // ONE capability for every hosted-story fold of this flow. The prepass block fold and
+  // the cell lane below therefore cannot drift to different numbering inputs, and a future
+  // lane cannot publish hosted stories without carrying the invalidation provider too.
+  const hostedStory = hasInlineDrawingContext
+    ? hostedStoryFlowDeps(
+        layoutTextboxStoryForBody,
+        options.numberingIndex,
+        styleCascade,
+        displayMode,
+        authorFilter
+      )
+    : undefined;
   const prepareBlock = (block: OoxmlElement, availableWidth: number): PreparedBlock => {
     // The RAW token, compared by the memo below so a table's kilobyte aggregate keeps its
     // identity fast path; the context joins only when a key is actually built. `||`, not
@@ -1119,7 +1146,7 @@ function layoutBlocksPass(
     // The list state of any text-box story this block hosts, for the same reason the drawing
     // token aggregates hosted-story atoms: a box's markers come from `numbering.xml`, and a
     // numbering edit moves nothing else in this block's key.
-    const hostedListToken = hostedListDeps.hostedListTokenForParagraph?.(block) ?? '';
+    const hostedListToken = hostedStory?.hostedListTokenForParagraph?.(block) ?? '';
     // Length-framed pair: both sides embed file-influenced marker text (and the table
     // aggregate itself contains NULs), so no separator join stays injective.
     const ownListToken =
@@ -1681,30 +1708,6 @@ function layoutBlocksPass(
     carryDeferredToNextPage();
   };
 
-  // Body textbox stories flow without a page-field context: body PAGE projection stays
-  // deferred, so a PAGE field inside a body text box contributes only its cached result,
-  // consistent with direct body fields today.
-  const layoutTextboxStoryForBody = (
-    projection: import('../store/package/drawing-projection.ts').DrawingProjection
-  ) =>
-    layoutTextboxStory(projection, {
-      measurer,
-      producer,
-      cache,
-      styleCascade,
-      ...(defaultTabStopPt !== undefined ? { defaultTabStopPt } : {}),
-      ...(displayMode ? { displayMode } : {}),
-      ...(authorFilter ? { revisionAuthorFilter: authorFilter } : {}),
-      ...(options.documentProperties ? { documentProperties: options.documentProperties } : {}),
-      ...(options.projectLink ? { projectLink: options.projectLink } : {}),
-      ...(options.projectFieldLink ? { projectFieldLink: options.projectFieldLink } : {}),
-      ...(options.numberingIndex ? { numberingIndex: options.numberingIndex } : {}),
-      inlineDrawingLayout: options.inlineDrawingLayout,
-      drawingTokenForParagraph: options.drawingTokenForParagraph,
-      projectionTokenForParagraph: options.projectionTokenForParagraph,
-      projectionTokenForTable: options.projectionTokenForTable,
-    });
-
   // Table layout shares the flow's line count, paragraph cache, and precomputed list items
   // (counters already advanced in document order, including cell paragraphs).
   // Border ownership intervals and vMerge cell visits are budgeted once per pass so nested
@@ -1750,11 +1753,7 @@ function layoutBlocksPass(
       ? {
           anchorFrameBase,
           pageContentClip,
-          layoutTextboxStoryFor: layoutTextboxStoryForBody,
-          // The CELL lane folds only where stories can render (`layoutTextboxStoryFor`
-          // above). The body block fold in `prepareBlock` stays ungated on purpose: it
-          // predates this gate and fails open — extra invalidation, never a stale reuse.
-          ...hostedListDeps,
+          hostedStory,
           publishAnchoredDrawings: collectAnchoredDrawings,
           collectAnchoredDrawings,
           columnBoxForParagraph: anchorColumnBox,
@@ -2626,7 +2625,8 @@ function layoutBlocksPass(
             pageClip: pageContentClip(),
             measurer,
             sourceOrderOf,
-            layoutTextboxStory: layoutTextboxStoryForBody,
+            // The drawing-context guard above is the same predicate that creates this bundle.
+            layoutTextboxStory: hostedStory!.layoutTextboxStoryFor,
             displayMode,
             ...(authorFilter ? { revisionAuthorFilter: authorFilter } : {}),
           })

--- a/packages/core/src/layout/semantic-table-layout.ts
+++ b/packages/core/src/layout/semantic-table-layout.ts
@@ -198,6 +198,14 @@ export class TablePaginationError extends Error {
   }
 }
 
+/** Coupled text-box layout and cache invalidation for a hosted-story table flow lane. */
+export interface HostedStoryFlowDeps {
+  readonly layoutTextboxStoryFor: (
+    projection: import('../store/package/drawing-projection.ts').DrawingProjection
+  ) => import('./textbox-story-layout.ts').TextboxStoryLayout | null;
+  readonly hostedListTokenForParagraph: ((paragraph: OoxmlNode) => string) | null;
+}
+
 export interface TableFlowDeps {
   readonly measurer: TextMeasurer;
   readonly cache?: ParagraphLayoutCache<readonly PendingLine[]> | undefined;
@@ -221,13 +229,8 @@ export interface TableFlowDeps {
    * stories that do not share the body counter stream.
    */
   readonly listItems?: ReadonlyMap<string, ResolvedListItem>;
-  /**
-   * The hosted text-box list state a cell paragraph's break key folds — the cell twin of
-   * the `hostedTextboxListToken` fold in `prepareBlock`, built with `hostedListTokenDeps`
-   * and provided only by lanes that lay hosted stories out
-   * ({@link layoutTextboxStoryFor}): where no story renders, the fold would be key churn.
-   */
-  readonly hostedListTokenForParagraph?: (paragraph: OoxmlNode) => string;
+  /** Text-box story layout and its host break-key invalidation, structurally inseparable. */
+  readonly hostedStory?: HostedStoryFlowDeps;
   /**
    * `w:settings/w:defaultTabStop` in points; absent keeps the 0.5" schema default. A cell
    * paragraph tabs on the same document-wide grid as a body paragraph.
@@ -295,10 +298,6 @@ export interface TableFlowDeps {
     DrawingAnchorFrameContext,
     'paragraphBox' | 'anchorLineBox' | 'anchorCharacterX' | 'columnBox' | 'cellBox' | 'layoutInCell'
   >;
-  /** Lays out a textbox drawing's story; absent hosts degrade to the placeholder path. */
-  readonly layoutTextboxStoryFor?: (
-    projection: import('../store/package/drawing-projection.ts').DrawingProjection
-  ) => import('./textbox-story-layout.ts').TextboxStoryLayout | null;
   readonly pageContentClip?: () => import('./semantic-records.ts').LayoutBox;
   readonly collectAnchoredDrawings?: (drawings: readonly AnchoredDrawingRecord[]) => void;
   /** Root anchor sink — preserved when row defer strips {@link collectAnchoredDrawings}. */
@@ -517,7 +516,7 @@ function placeCellParagraph(
   // The list state of any hosted text-box story, keyed as the body flow keys it: its own
   // `txbxList` property. A numbering edit moves only this property while the host's
   // subtree stays byte-identical; box-free paragraphs keep their pre-existing key shape.
-  const hostedListToken = deps.hostedListTokenForParagraph?.(paragraph) ?? '';
+  const hostedListToken = deps.hostedStory?.hostedListTokenForParagraph?.(paragraph) ?? '';
   const key = keyFor({
     paragraph,
     properties: [
@@ -955,7 +954,9 @@ function placeCellParagraph(
           cellBox,
           pageClip: deps.pageContentClip(),
           measurer: deps.measurer,
-          ...(deps.layoutTextboxStoryFor ? { layoutTextboxStory: deps.layoutTextboxStoryFor } : {}),
+          ...(deps.hostedStory
+            ? { layoutTextboxStory: deps.hostedStory.layoutTextboxStoryFor }
+            : {}),
           ...(deps.displayMode ? { displayMode: deps.displayMode } : {}),
           ...(deps.revisionAuthorFilter ? { revisionAuthorFilter: deps.revisionAuthorFilter } : {}),
         })

--- a/packages/core/src/layout/table-anchor-republish.ts
+++ b/packages/core/src/layout/table-anchor-republish.ts
@@ -91,7 +91,7 @@ export function publishDeferredRowAnchors(
         cellBox,
         pageClip: deps.pageContentClip(),
         measurer: deps.measurer,
-        ...(deps.layoutTextboxStoryFor ? { layoutTextboxStory: deps.layoutTextboxStoryFor } : {}),
+        ...(deps.hostedStory ? { layoutTextboxStory: deps.hostedStory.layoutTextboxStoryFor } : {}),
         ...(deps.displayMode ? { displayMode: deps.displayMode } : {}),
       })
     );
@@ -133,7 +133,7 @@ export function republishAnchoredParagraphsInBlocks(
         cellBox,
         pageClip: deps.pageContentClip(),
         measurer: deps.measurer,
-        ...(deps.layoutTextboxStoryFor ? { layoutTextboxStory: deps.layoutTextboxStoryFor } : {}),
+        ...(deps.hostedStory ? { layoutTextboxStory: deps.hostedStory.layoutTextboxStoryFor } : {}),
         ...(deps.displayMode ? { displayMode: deps.displayMode } : {}),
       })
     );

--- a/packages/core/src/layout/table-fragment-finalize.ts
+++ b/packages/core/src/layout/table-fragment-finalize.ts
@@ -69,7 +69,7 @@ function republishAnchoredParagraphsInBlocks(
         cellBox,
         pageClip: deps.pageContentClip(),
         measurer: deps.measurer,
-        ...(deps.layoutTextboxStoryFor ? { layoutTextboxStory: deps.layoutTextboxStoryFor } : {}),
+        ...(deps.hostedStory ? { layoutTextboxStory: deps.hostedStory.layoutTextboxStoryFor } : {}),
         ...(deps.displayMode ? { displayMode: deps.displayMode } : {}),
       })
     );

--- a/packages/core/src/layout/textbox-story-layout.ts
+++ b/packages/core/src/layout/textbox-story-layout.ts
@@ -30,7 +30,7 @@ import {
 import type { NumberingIndex } from './numbering-index.ts';
 import type { PendingLine } from './paragraph-flow.ts';
 import type { RevisionAuthorFilter, RevisionDisplayMode } from './revision-projection.ts';
-import { flowBlocksInBox } from './semantic-table-layout.ts';
+import { flowBlocksInBox, type HostedStoryFlowDeps } from './semantic-table-layout.ts';
 import type { BlockFragmentRecord, TextMeasurer } from './semantic-records.ts';
 import type { StyleCascadeTable } from './style-cascade.ts';
 import { textboxStoryBlocks } from './story-roots.ts';
@@ -223,16 +223,77 @@ const NO_HOSTED_CONTENTS: HostedContentsScan = Object.freeze({
  */
 const hostedTextboxContentsByBlock = new WeakMap<OoxmlNode, HostedContentsScan>();
 
-/** Discover text-box stories hosted by one layout block. @internal */
-export function hostedTextboxContents(block: OoxmlNode): HostedContentsScan {
-  const cached = hostedTextboxContentsByBlock.get(block);
-  if (cached) return cached;
+/** The allocation-light path for the overwhelmingly common non-table block. */
+function scanHostedTextboxContents(block: OoxmlNode): HostedContentsScan {
   const found: OoxmlNode[] = [];
   let visited = 0;
   let truncated = false;
   const stack: OoxmlNode[] = [block];
   while (stack.length > 0) {
     const node = stack.pop()!;
+    visited += 1;
+    if (visited > MAX_HOSTED_STORY_SCAN_NODES) {
+      truncated = true;
+      break;
+    }
+    if (node.kind !== 'textValue' && node.localName === 'txbxContent') {
+      found.push(node);
+      continue;
+    }
+    if (!('children' in node)) continue;
+    for (let index = node.children.length - 1; index >= 0; index -= 1) {
+      stack.push(node.children[index]!);
+    }
+  }
+  return found.length > 0 || truncated
+    ? Object.freeze({ contents: Object.freeze(found), truncated })
+    : NO_HOSTED_CONTENTS;
+}
+
+/** Discover text-box stories hosted by one layout block. @internal */
+export function hostedTextboxContents(block: OoxmlNode): HostedContentsScan {
+  const cached = hostedTextboxContentsByBlock.get(block);
+  if (cached) return cached;
+  // Only a table-level scan is followed by cold scans of many descendant cell paragraphs.
+  // Preserve the raw-node stack for direct paragraph calls instead of paying a frame object
+  // per visited node where there are no descendant paragraph results to seed.
+  if (block.kind !== 'table') {
+    const scan = scanHostedTextboxContents(block);
+    hostedTextboxContentsByBlock.set(block, scan);
+    return scan;
+  }
+  const found: OoxmlNode[] = [];
+  let visited = 0;
+  let truncated = false;
+  interface ParagraphScan {
+    readonly paragraph: OoxmlNode;
+    readonly contents: OoxmlNode[];
+  }
+  type ScanFrame =
+    | {
+        readonly phase: 'enter';
+        readonly node: OoxmlNode;
+        readonly paragraphOwners: readonly ParagraphScan[];
+      }
+    | { readonly phase: 'exit-paragraph'; readonly scan: ParagraphScan };
+  const stack: ScanFrame[] = [{ phase: 'enter', node: block, paragraphOwners: [] }];
+  while (stack.length > 0) {
+    const frame = stack.pop()!;
+    if (frame.phase === 'exit-paragraph') {
+      if (!hostedTextboxContentsByBlock.has(frame.scan.paragraph)) {
+        hostedTextboxContentsByBlock.set(
+          frame.scan.paragraph,
+          frame.scan.contents.length > 0
+            ? Object.freeze({
+                contents: Object.freeze(frame.scan.contents),
+                truncated: false,
+              })
+            : NO_HOSTED_CONTENTS
+        );
+      }
+      continue;
+    }
+    const node = frame.node;
     visited += 1;
     // Defensive, like every other file-derived walk — but a stopped scan can MISS a box, and
     // an unseen box's list state must fail OPEN, not stale. The truncation flag is recorded
@@ -245,11 +306,18 @@ export function hostedTextboxContents(block: OoxmlNode): HostedContentsScan {
     }
     if (node.kind !== 'textValue' && node.localName === 'txbxContent') {
       found.push(node);
+      for (const owner of frame.paragraphOwners) owner.contents.push(node);
       continue;
     }
     if (!('children' in node)) continue;
+    let paragraphOwners = frame.paragraphOwners;
+    if (node.kind === 'paragraph') {
+      const paragraphScan: ParagraphScan = { paragraph: node, contents: [] };
+      paragraphOwners = Object.freeze([...paragraphOwners, paragraphScan]);
+      stack.push({ phase: 'exit-paragraph', scan: paragraphScan });
+    }
     for (let index = node.children.length - 1; index >= 0; index -= 1) {
-      stack.push(node.children[index]!);
+      stack.push({ phase: 'enter', node: node.children[index]!, paragraphOwners });
     }
   }
   const scan: HostedContentsScan =
@@ -352,23 +420,33 @@ function hostedTextboxListToken(
 }
 
 /**
- * The `hostedListTokenForParagraph` slice of a `TableFlowDeps`, built in ONE place so the
- * lanes that lay hosted stories out (body flow, header/footer stories) cannot drift apart
- * on the (index, cascade, mode) call shape. Empty without numbering DEFINITIONS — not just
- * without an index — so a document with no lists installs no provider and the cell lane
- * pays no per-paragraph call at all; the same emptiness check guards the token function.
+ * Build the structurally coupled hosted-story capability for a table flow lane.
+ *
+ * The layout callback and list-token provider are returned together so a new lane cannot
+ * publish text-box stories while silently reusing stale host breaks after numbering changes.
+ * `null` without numbering definitions preserves the zero-call fast path for box-free cells.
  */
-export function hostedListTokenDeps(
+export function hostedStoryFlowDeps(
+  layoutTextboxStoryFor: HostedStoryFlowDeps['layoutTextboxStoryFor'],
   numberingIndex: NumberingIndex | undefined,
   styleCascade: StyleCascadeTable | undefined,
   displayMode?: RevisionDisplayMode,
   authorFilter?: RevisionAuthorFilter
-): { readonly hostedListTokenForParagraph?: (paragraph: OoxmlNode) => string } {
-  if (!numberingIndex || numberingIndex.nums.size === 0) return {};
-  return {
-    hostedListTokenForParagraph: (paragraph) =>
-      hostedTextboxListToken(paragraph, numberingIndex, styleCascade, displayMode, authorFilter),
-  };
+): HostedStoryFlowDeps {
+  return Object.freeze({
+    layoutTextboxStoryFor,
+    hostedListTokenForParagraph:
+      !numberingIndex || numberingIndex.nums.size === 0
+        ? null
+        : (paragraph: OoxmlNode) =>
+            hostedTextboxListToken(
+              paragraph,
+              numberingIndex,
+              styleCascade,
+              displayMode,
+              authorFilter
+            ),
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

- Replace the independent table-flow hooks with one `hostedStory` capability whose list-token member is required and explicitly `null` when numbering is irrelevant.
- Thread that capability through body, table-cell, deferred-anchor, fragment-finalize, and header/footer publication paths.
- Seed hosted-textbox discovery results for fully scanned descendant table paragraphs while preserving fail-open behavior when the bounded scan truncates.
- Keep the allocation-light scan path for ordinary non-table blocks.
- Add a core patch changeset.

## Regression coverage

- Production body and header/footer wiring tracks text-box numbering changes.
- No-numbering bundles retain the layout callback and expose an explicit `null` token provider.
- Text boxes remain disabled without a drawing context.
- Over-budget table scans cache completed paragraphs but force partially scanned paragraphs to rescan.
- Existing table-cell marker and incremental-layout coverage remains green.

## Validation

- `bun run test`: 11,284 passed, 0 failed across 891 files.
- `bun run typecheck` passed.
- `bun run lint` passed with zero errors (existing repository warnings only).
- `bun run api:check` passed.
- Commit-hook parity, license, formatting, API, lint, and staged-file gates passed.
- GitHub CI, CodeQL, Vercel, performance benchmarks, build, and package-size checks are green.

## Review

Two independent Claude Fable 5.1 reviewers audited correctness and adversarial cache behavior. Their initial Medium findings were resolved, and both second-pass reviews returned `CLEAN` with no Medium-or-higher findings.

Closes #639
