### PR TITLE
fix(core): wrap long suggested words

### DIFF
--- a/.changeset/fair-words-wrap.md
+++ b/.changeset/fair-words-wrap.md
@@ -1,0 +1,6 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Reflow long unbroken words across tracked-insertion run boundaries while typing in Suggesting
+mode. Fixes #716.

--- a/.changeset/fair-words-wrap.md
+++ b/.changeset/fair-words-wrap.md
@@ -2,5 +2,5 @@
 '@docx-editor.dev/core': patch
 ---
 
-Reflow long unbroken words across tracked-insertion run boundaries while typing in Suggesting
-mode. Fixes #716.
+Reflow long unbroken words continuously across tracked-insertion run boundaries while typing in
+Suggesting mode, without splitting Unicode graphemes. Fixes #716.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -429,17 +429,11 @@ export default [
   {
     files: [
       'packages/core/src/contracts/editor.ts',
+      'packages/core/src/layout/paragraph-flow.ts',
       'packages/pro/src/__tests__/review-facade.test.ts',
     ],
     rules: {
       'max-lines': ['error', { max: 1700, skipBlankLines: false, skipComments: false }],
-    },
-  },
-
-  {
-    files: ['packages/core/src/layout/paragraph-flow.ts'],
-    rules: {
-      'max-lines': ['error', { max: 1750, skipBlankLines: false, skipComments: false }],
     },
   },
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -429,11 +429,17 @@ export default [
   {
     files: [
       'packages/core/src/contracts/editor.ts',
-      'packages/core/src/layout/paragraph-flow.ts',
       'packages/pro/src/__tests__/review-facade.test.ts',
     ],
     rules: {
       'max-lines': ['error', { max: 1700, skipBlankLines: false, skipComments: false }],
+    },
+  },
+
+  {
+    files: ['packages/core/src/layout/paragraph-flow.ts'],
+    rules: {
+      'max-lines': ['error', { max: 1750, skipBlankLines: false, skipComments: false }],
     },
   },
 

--- a/packages/core/src/layout/__tests__/run-spanning-word-break.test.ts
+++ b/packages/core/src/layout/__tests__/run-spanning-word-break.test.ts
@@ -168,4 +168,59 @@ describe('a word wider than the measure breaks at the margin', () => {
 
     expect(linesOf(body)).toEqual(['xxxx ', 'aaaaabbbbb', 'bbbbb']);
   });
+
+  test('a word keeps filling lines through runs after its inserted part was chopped', () => {
+    const body =
+      `<w:p>${run('xxxx ')}${run('aaaaa')}` +
+      `<w:ins w:id="1" w:author="A" w:date="D">${run('bbbbbbbbbbbb')}</w:ins>` +
+      `${run('ccccc')}</w:p>`;
+
+    expect(linesOf(body)).toEqual(['xxxx ', 'aaaaabbbbb', 'bbbbbbbccc', 'cc']);
+  });
+
+  test('a nine-character prefix leaves the final character on the next line', () => {
+    const body =
+      `<w:p>${run('xxxx ')}${run('a')}` +
+      `<w:ins w:id="1" w:author="A" w:date="D">${run('bbbbbbbbbb')}</w:ins></w:p>`;
+
+    expect(linesOf(body)).toEqual(['xxxx ', 'abbbbbbbbb', 'b']);
+  });
+
+  test('oversized-word splits preserve graphemes and UTF-16 model ranges', () => {
+    const lines = breakParagraph(
+      paragraph(`<w:p>${run('aa😀bb')}</w:p>`),
+      'p',
+      0,
+      18,
+      measurer,
+      undefined,
+      null
+    );
+
+    expect(lines.map((line) => line.spans.map((span) => span.text).join(''))).toEqual([
+      'aa',
+      '😀b',
+      'b',
+    ]);
+    expect(
+      lines.map((line) => line.spans.map((span) => [span.range.start, span.range.end]))
+    ).toEqual([[[0, 2]], [[2, 5]], [[5, 6]]]);
+  });
+
+  test('a grapheme wider than the measure overflows whole instead of splitting UTF-16', () => {
+    const lines = breakParagraph(
+      paragraph(`<w:p>${run('😀a')}</w:p>`),
+      'p',
+      0,
+      6,
+      measurer,
+      undefined,
+      null
+    );
+
+    expect(lines.map((line) => line.spans.map((span) => span.text).join(''))).toEqual(['😀', 'a']);
+    expect(
+      lines.map((line) => line.spans.map((span) => [span.range.start, span.range.end]))
+    ).toEqual([[[0, 2]], [[2, 3]]]);
+  });
 });

--- a/packages/core/src/layout/__tests__/run-spanning-word-break.test.ts
+++ b/packages/core/src/layout/__tests__/run-spanning-word-break.test.ts
@@ -160,4 +160,12 @@ describe('a word wider than the measure breaks at the margin', () => {
   test('a word that follows text on the line wraps first, then chops', () => {
     expect(linesOf(`<w:p>${run('aaa cccccccccccc')}</w:p>`)).toEqual(['aaa ', 'cccccccccc', 'cc']);
   });
+
+  test('a tracked insertion extending a run-spanning word reflows within the measure', () => {
+    const body =
+      `<w:p>${run('xxxx ')}${run('aaaaa')}` +
+      `<w:ins w:id="1" w:author="A" w:date="D">${run('bbbbbbbbbb')}</w:ins></w:p>`;
+
+    expect(linesOf(body)).toEqual(['xxxx ', 'aaaaabbbbb', 'bbbbb']);
+  });
 });

--- a/packages/core/src/layout/__tests__/run-spanning-word-break.test.ts
+++ b/packages/core/src/layout/__tests__/run-spanning-word-break.test.ts
@@ -6,10 +6,13 @@
 // does, and which then changed where every following line broke, so a document's line and page
 // count drifted from Word's.
 
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, spyOn, test } from 'bun:test';
 import { readOoxmlPart, type OoxmlNode } from '@docx-editor.dev/core/store';
+import { resetGraphemeBoundary, setGraphemeBoundary } from '../grapheme.ts';
+import * as oversizedWordBreak from '../oversized-word-break.ts';
 import { breakParagraph } from '../paragraph-flow.ts';
 import { createFixedMeasurer } from '../semantic-layout.ts';
+import { squareWrapZone } from './float-over-table-harness.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 /** 6pt per character, so a 60pt measure holds exactly ten. */
@@ -85,6 +88,35 @@ describe('a word split across runs stays whole', () => {
   test('a run-spanning word at the very start of a line cannot be carried anywhere', () => {
     const lines = linesOf(`<w:p>${run('bbbbbbbbbb')}${run('cccccccccc')}</w:p>`);
     expect(lines.join('')).toBe('bbbbbbbbbbcccccccccc');
+  });
+
+  test('a continuing run uses the next float passage before chopping', () => {
+    const zone = squareWrapZone({
+      anchorParagraphId: 'earlier-paragraph',
+      top: 0,
+      height: 100,
+      left: 18,
+      width: 24,
+      contentWidth: 60,
+    });
+    const lines = breakParagraph(
+      paragraph(`<w:p>${run('aa')}${run('bbb')}</w:p>`),
+      'p',
+      0,
+      60,
+      measurer,
+      undefined,
+      null,
+      [],
+      undefined,
+      undefined,
+      undefined,
+      { pageExclusionZones: [zone], paragraphStartY: 0, contentLeft: 0, contentRight: 60 }
+    );
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]!.spans.map((span) => span.text).join('')).toBe('aabbb');
+    expect(lines[0]!.spans[1]!.box.x).toBe(42);
   });
 
   test('a tab in its own run is a break opportunity for the text after it', () => {
@@ -222,5 +254,48 @@ describe('a word wider than the measure breaks at the margin', () => {
     expect(
       lines.map((line) => line.spans.map((span) => [span.range.start, span.range.end]))
     ).toEqual([[[0, 2]], [[2, 3]]]);
+  });
+});
+
+describe('oversized-word chop cost', () => {
+  test('fitting candidates stay off the grapheme-chop path', () => {
+    const chop = spyOn(oversizedWordBreak, 'chopOversizedWord');
+    try {
+      linesOf(`<w:p>${run('word '.repeat(100))}</w:p>`, 100_000);
+      expect(chop).toHaveBeenCalledTimes(0);
+
+      linesOf(`<w:p>${run('a'.repeat(20))}</w:p>`);
+      expect(chop).toHaveBeenCalledTimes(1);
+    } finally {
+      chop.mockRestore();
+    }
+  });
+
+  test('a defensive fitting helper call returns before grapheme segmentation', () => {
+    setGraphemeBoundary({
+      segment: () => {
+        throw new Error('fitting text must not be segmented');
+      },
+    });
+    try {
+      expect(
+        oversizedWordBreak.chopOversizedWord('word', 7, 24, {
+          remainingLineWidth: () => 24,
+          lineHasText: () => false,
+          measureText: () => {
+            throw new Error('fitting text must not be remeasured');
+          },
+          appendPrefix: () => {
+            throw new Error('fitting text must not be split');
+          },
+          closeLine: () => {
+            throw new Error('fitting text must not close a line');
+          },
+          overflowTolerancePt: 0.001,
+        })
+      ).toEqual({ text: 'word', modelStart: 7, width: 24, brokeLine: false });
+    } finally {
+      resetGraphemeBoundary();
+    }
   });
 });

--- a/packages/core/src/layout/oversized-word-break.ts
+++ b/packages/core/src/layout/oversized-word-break.ts
@@ -1,0 +1,103 @@
+// Grapheme-safe chopping for an unbroken word that is wider than the line measure.
+
+import { segmentGraphemes } from './grapheme.ts';
+
+export interface OversizedWordPrefix {
+  readonly text: string;
+  readonly modelStart: number;
+  readonly width: number;
+}
+
+export interface OversizedWordRemainder extends OversizedWordPrefix {
+  /** Whether chopping closed at least one line, so the caller can preserve word state. */
+  readonly brokeLine: boolean;
+}
+
+/**
+ * Fill and close lines with the longest grapheme-safe prefix of an oversized word.
+ *
+ * The callbacks keep paragraph-owned geometry and span construction outside this focused
+ * algorithm. Their values are read again after every close because floats can change the next
+ * line's measure. At least one grapheme remains for ordinary placement; if one grapheme alone
+ * is wider than an empty line, it is the indivisible unit that is allowed to overflow.
+ */
+export function chopOversizedWord(
+  text: string,
+  modelStart: number,
+  width: number,
+  options: {
+    readonly remainingLineWidth: () => number;
+    readonly lineHasText: () => boolean;
+    readonly measureText: (text: string) => number;
+    readonly appendPrefix: (prefix: OversizedWordPrefix) => void;
+    readonly closeLine: () => void;
+    readonly overflowTolerancePt: number;
+  }
+): OversizedWordRemainder {
+  const graphemes = segmentGraphemes(text);
+  let graphemeFrom = 0;
+  let utf16From = 0;
+  let remainingWidth = width;
+  let brokeLine = false;
+
+  while (
+    graphemeFrom < graphemes.length &&
+    remainingWidth > options.remainingLineWidth() + options.overflowTolerancePt
+  ) {
+    const graphemesLeft = graphemes.length - graphemeFrom;
+    if (graphemesLeft === 1) {
+      if (options.lineHasText()) {
+        options.closeLine();
+        brokeLine = true;
+        continue;
+      }
+      break;
+    }
+
+    const available = options.remainingLineWidth();
+    let low = graphemeFrom + 1;
+    // Leave at least one whole grapheme for ordinary placement after the final chopped line.
+    let high = graphemes.length - 1;
+    let fitTo = graphemeFrom;
+    while (low <= high) {
+      const mid = (low + high) >> 1;
+      const utf16To = graphemes[mid - 1]!.utf16To;
+      const prefixWidth = options.measureText(text.slice(utf16From, utf16To));
+      if (prefixWidth <= available + options.overflowTolerancePt) {
+        fitTo = mid;
+        low = mid + 1;
+      } else {
+        high = mid - 1;
+      }
+    }
+
+    if (fitTo === graphemeFrom && options.lineHasText()) {
+      options.closeLine();
+      brokeLine = true;
+      continue;
+    }
+    // An empty line that cannot fit one grapheme must overflow by that whole grapheme, never
+    // by one UTF-16 code unit (which could split a surrogate pair or combining sequence).
+    if (fitTo === graphemeFrom) fitTo += 1;
+
+    const utf16To = graphemes[fitTo - 1]!.utf16To;
+    const prefixText = text.slice(utf16From, utf16To);
+    options.appendPrefix({
+      text: prefixText,
+      modelStart: modelStart + utf16From,
+      width: options.measureText(prefixText),
+    });
+    options.closeLine();
+    brokeLine = true;
+    graphemeFrom = fitTo;
+    utf16From = utf16To;
+    remainingWidth = options.measureText(text.slice(utf16From));
+  }
+
+  return {
+    text: text.slice(utf16From),
+    modelStart: modelStart + utf16From,
+    width: remainingWidth,
+    brokeLine,
+  };
+}

--- a/packages/core/src/layout/oversized-word-break.ts
+++ b/packages/core/src/layout/oversized-word-break.ts
@@ -34,6 +34,9 @@ export function chopOversizedWord(
     readonly overflowTolerancePt: number;
   }
 ): OversizedWordRemainder {
+  if (width <= options.remainingLineWidth() + options.overflowTolerancePt) {
+    return { text, modelStart, width, brokeLine: false };
+  }
   const graphemes = segmentGraphemes(text);
   let graphemeFrom = 0;
   let utf16From = 0;

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -78,6 +78,7 @@ import {
 } from './drawing-exclusion.ts';
 import { createEquationLayouter } from './equation-layout.ts';
 import { isCollapsibleLineEndWhitespace } from './line-end-whitespace.ts';
+import { chopOversizedWord } from './oversized-word-break.ts';
 
 /**
  * How far past the line's right edge a span may reach before it counts as overflow.
@@ -1556,17 +1557,22 @@ export function breakParagraph(
       if (lineEndWhitespace) {
         width = Math.min(width, Math.max(0, lineAvailable() - line.width));
       }
-      let carriedWordToEmptyLine = false;
       if (
         line.width + width > lineAvailable() + OVERFLOW_TOLERANCE_PT &&
         (line.spans.length > 0 || line.drawings.length > 0)
       ) {
-        if (opensWord || wordStartSpan <= 0) {
+        if (!opensWord && wordStartSpan === 0) {
+          // Fill this oversized word's remaining capacity in the chop below.
+        } else if (opensWord || wordStartSpan < 0) {
           if (tryAdvanceToNextPassage() && line.width + width <= lineAvailable() + 0.001) {
             // carry on in the next horizontal passage on this line
           } else {
             closeLine();
             if (!ensurePlacementWidth(width)) continue;
+            // This candidate starts the word anew after closeLine cleared its state.
+            wordStartSpan = 0;
+            wordStartWidth = 0;
+            wordStartEnd = line.end;
           }
         } else {
           // Mid-word overflow: carry the whole word to the next line rather than splitting it
@@ -1596,7 +1602,6 @@ export function breakParagraph(
           }
           wordStartSpan = 0;
           wordStartWidth = 0;
-          carriedWordToEmptyLine = true;
         }
       } else if (
         line.spans.length === 0 &&
@@ -1605,86 +1610,53 @@ export function breakParagraph(
       ) {
         if (!ensurePlacementWidth(width)) continue;
       }
-      // A word wider than an EMPTY line has no boundary to wrap at, and Word breaks it at
-      // the margin rather than letting it run past the right edge — or, in a table cell,
-      // into the neighbouring cell. The longest fitting prefix closes each full line and
-      // the tail falls through to ordinary placement. Layout-owned pieces stay whole:
-      // every span they emit publishes the piece's model range, so cutting one would
-      // publish the same range twice; `measureText` pieces reserve a width their sliced
-      // text does not measure to.
+      // Break an oversized ordinary word at the margin. Layout-owned pieces stay whole because
+      // each span publishes the whole model range; measureText pieces reserve an unsliceable width.
       let remaining = candidate;
       let remainingStart = piece.start + consumed;
       let remainingWidth = width;
       if (!layoutOwned && piece.measureText === undefined) {
-        while (
-          (line.spans.length === 0 || carriedWordToEmptyLine) &&
-          remaining.length > 0 &&
-          remainingWidth > lineAvailable() - line.width + OVERFLOW_TOLERANCE_PT
-        ) {
-          const availableForPrefix = lineAvailable() - line.width;
-          // The carried prefix may exactly fill the fresh line. Close it before placing the
-          // next character; forcing one character into zero slack would recreate the overflow
-          // this path exists to prevent.
-          if (line.spans.length > 0 && availableForPrefix <= OVERFLOW_TOLERANCE_PT) {
-            closeLine();
-            carriedWordToEmptyLine = false;
-            continue;
-          }
-          // One glyph wider than an empty measure cannot be split further and must overflow.
-          if (remaining.length === 1) {
-            if (line.spans.length > 0) {
-              closeLine();
-              carriedWordToEmptyLine = false;
-              continue;
-            }
-            break;
-          }
-          let low = 1;
-          let high = remaining.length - 1;
-          let fitLength = 0;
-          while (low <= high) {
-            const mid = (low + high) >> 1;
-            const midWidth = measurer.measure(
-              displayText(remaining.slice(0, mid), faceStyle),
-              faceStyle
-            );
-            if (midWidth <= availableForPrefix) {
-              fitLength = mid;
-              low = mid + 1;
-            } else {
-              high = mid - 1;
-            }
-          }
-          // No character fits after a carried prefix. Finish that line and retry against the
-          // full width; on an empty line the fallback below lets one unsplittable glyph stand.
-          if (fitLength === 0 && line.spans.length > 0) {
-            closeLine();
-            carriedWordToEmptyLine = false;
-            continue;
-          }
-          if (fitLength === 0) fitLength = 1;
-          const prefix = remaining.slice(0, fitLength);
-          const prefixWidth = measurer.measure(displayText(prefix, faceStyle), faceStyle);
-          line.spans.push({
-            range: { paragraphId, start: remainingStart, end: remainingStart + fitLength },
-            text: prefix,
-            props: piece.props,
-            style: piece.style,
-            box: { x: lineOrigin() + line.width, y: 0, width: prefixWidth, height: metrics.height },
-            ...(piece.link ? { link: piece.link } : {}),
-            ...(piece.noteNav ? { noteNav: piece.noteNav } : {}),
-            ...(piece.fontSlot ? { fontSlot: piece.fontSlot } : {}),
-            ...revisionsOf(piece),
-          });
-          line.width += prefixWidth;
-          line.height = Math.max(line.height, metrics.height);
-          line.baseline = Math.max(line.baseline, metrics.baseline);
-          line.end = remainingStart + fitLength;
-          closeLine();
-          carriedWordToEmptyLine = false;
-          remaining = remaining.slice(fitLength);
-          remainingStart += fitLength;
-          remainingWidth = measurer.measure(displayText(remaining, faceStyle), faceStyle);
+        const chopped = chopOversizedWord(candidate, remainingStart, width, {
+          remainingLineWidth,
+          lineHasText: () => line.spans.length > 0,
+          measureText: (text) => measurer.measure(displayText(text, faceStyle), faceStyle),
+          appendPrefix: (prefix) => {
+            line.spans.push({
+              range: {
+                paragraphId,
+                start: prefix.modelStart,
+                end: prefix.modelStart + prefix.text.length,
+              },
+              text: prefix.text,
+              props: piece.props,
+              style: piece.style,
+              box: {
+                x: lineOrigin() + line.width,
+                y: 0,
+                width: prefix.width,
+                height: metrics.height,
+              },
+              ...(piece.link ? { link: piece.link } : {}),
+              ...(piece.noteNav ? { noteNav: piece.noteNav } : {}),
+              ...(piece.fontSlot ? { fontSlot: piece.fontSlot } : {}),
+              ...revisionsOf(piece),
+            });
+            line.width += prefix.width;
+            line.height = Math.max(line.height, metrics.height);
+            line.baseline = Math.max(line.baseline, metrics.baseline);
+            line.end = prefix.modelStart + prefix.text.length;
+          },
+          closeLine,
+          overflowTolerancePt: OVERFLOW_TOLERANCE_PT,
+        });
+        remaining = chopped.text;
+        remainingStart = chopped.modelStart;
+        remainingWidth = chopped.width;
+        if (chopped.brokeLine) {
+          // Preserve the split word through future run boundaries after closeLine reset it.
+          wordStartSpan = 0;
+          wordStartWidth = 0;
+          wordStartEnd = line.end;
         }
       }
       line.spans.push({

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -1550,8 +1550,7 @@ export function breakParagraph(
         wordStartEnd = line.end;
       }
       advancePastAnchorExclusionForPlacement(piece.start + consumed);
-      // Word hangs trailing fill spaces at the line edge: they occupy the remaining band
-      // (and keep their underline) but never open continuation lines of their own.
+      // Trailing fill spaces occupy the remaining band but never open continuation lines.
       const lineEndWhitespace =
         isCollapsibleLineEndWhitespace(candidate) && placeableSuffixes[pieceIndex]![boundary] !== 1;
       if (lineEndWhitespace) {
@@ -1562,14 +1561,14 @@ export function breakParagraph(
         (line.spans.length > 0 || line.drawings.length > 0)
       ) {
         if (!opensWord && wordStartSpan === 0) {
-          // Fill this oversized word's remaining capacity in the chop below.
+          // Prefer a later float passage; otherwise fill this one's remainder in the chop below.
+          tryAdvanceToNextPassage();
         } else if (opensWord || wordStartSpan < 0) {
           if (tryAdvanceToNextPassage() && line.width + width <= lineAvailable() + 0.001) {
             // carry on in the next horizontal passage on this line
           } else {
             closeLine();
             if (!ensurePlacementWidth(width)) continue;
-            // This candidate starts the word anew after closeLine cleared its state.
             wordStartSpan = 0;
             wordStartWidth = 0;
             wordStartEnd = line.end;
@@ -1610,12 +1609,16 @@ export function breakParagraph(
       ) {
         if (!ensurePlacementWidth(width)) continue;
       }
-      // Break an oversized ordinary word at the margin. Layout-owned pieces stay whole because
-      // each span publishes the whole model range; measureText pieces reserve an unsliceable width.
+      // Layout-owned and measureText pieces have ranges or widths that cannot be sliced.
       let remaining = candidate;
       let remainingStart = piece.start + consumed;
       let remainingWidth = width;
-      if (!layoutOwned && piece.measureText === undefined) {
+      const canChopWord = !layoutOwned && piece.measureText === undefined;
+      if (
+        canChopWord &&
+        (line.spans.length === 0 || (!opensWord && wordStartSpan === 0)) &&
+        width > remainingLineWidth() + OVERFLOW_TOLERANCE_PT
+      ) {
         const chopped = chopOversizedWord(candidate, remainingStart, width, {
           remainingLineWidth,
           lineHasText: () => line.spans.length > 0,
@@ -1653,7 +1656,6 @@ export function breakParagraph(
         remainingStart = chopped.modelStart;
         remainingWidth = chopped.width;
         if (chopped.brokeLine) {
-          // Preserve the split word through future run boundaries after closeLine reset it.
           wordStartSpan = 0;
           wordStartWidth = 0;
           wordStartEnd = line.end;

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -1556,6 +1556,7 @@ export function breakParagraph(
       if (lineEndWhitespace) {
         width = Math.min(width, Math.max(0, lineAvailable() - line.width));
       }
+      let carriedWordToEmptyLine = false;
       if (
         line.width + width > lineAvailable() + OVERFLOW_TOLERANCE_PT &&
         (line.spans.length > 0 || line.drawings.length > 0)
@@ -1595,6 +1596,7 @@ export function breakParagraph(
           }
           wordStartSpan = 0;
           wordStartWidth = 0;
+          carriedWordToEmptyLine = true;
         }
       } else if (
         line.spans.length === 0 &&
@@ -1615,26 +1617,52 @@ export function breakParagraph(
       let remainingWidth = width;
       if (!layoutOwned && piece.measureText === undefined) {
         while (
-          line.spans.length === 0 &&
-          remaining.length > 1 &&
-          remainingWidth > lineAvailable()
+          (line.spans.length === 0 || carriedWordToEmptyLine) &&
+          remaining.length > 0 &&
+          remainingWidth > lineAvailable() - line.width + OVERFLOW_TOLERANCE_PT
         ) {
+          const availableForPrefix = lineAvailable() - line.width;
+          // The carried prefix may exactly fill the fresh line. Close it before placing the
+          // next character; forcing one character into zero slack would recreate the overflow
+          // this path exists to prevent.
+          if (line.spans.length > 0 && availableForPrefix <= OVERFLOW_TOLERANCE_PT) {
+            closeLine();
+            carriedWordToEmptyLine = false;
+            continue;
+          }
+          // One glyph wider than an empty measure cannot be split further and must overflow.
+          if (remaining.length === 1) {
+            if (line.spans.length > 0) {
+              closeLine();
+              carriedWordToEmptyLine = false;
+              continue;
+            }
+            break;
+          }
           let low = 1;
           let high = remaining.length - 1;
-          let fitLength = 1;
+          let fitLength = 0;
           while (low <= high) {
             const mid = (low + high) >> 1;
             const midWidth = measurer.measure(
               displayText(remaining.slice(0, mid), faceStyle),
               faceStyle
             );
-            if (midWidth <= lineAvailable()) {
+            if (midWidth <= availableForPrefix) {
               fitLength = mid;
               low = mid + 1;
             } else {
               high = mid - 1;
             }
           }
+          // No character fits after a carried prefix. Finish that line and retry against the
+          // full width; on an empty line the fallback below lets one unsplittable glyph stand.
+          if (fitLength === 0 && line.spans.length > 0) {
+            closeLine();
+            carriedWordToEmptyLine = false;
+            continue;
+          }
+          if (fitLength === 0) fitLength = 1;
           const prefix = remaining.slice(0, fitLength);
           const prefixWidth = measurer.measure(displayText(prefix, faceStyle), faceStyle);
           line.spans.push({
@@ -1653,6 +1681,7 @@ export function breakParagraph(
           line.baseline = Math.max(line.baseline, metrics.baseline);
           line.end = remainingStart + fitLength;
           closeLine();
+          carriedWordToEmptyLine = false;
           remaining = remaining.slice(fitLength);
           remainingStart += fitLength;
           remainingWidth = measurer.measure(displayText(remaining, faceStyle), faceStyle);


### PR DESCRIPTION
## Summary

- Reflow oversized suggested words continuously across tracked-insertion run boundaries.
- Split only at Unicode grapheme boundaries while preserving UTF-16 model ranges.
- Keep fitting words on the allocation-free fast path and preserve float-passage behavior.
- Extract oversized-word chopping into a focused helper and document the change in a Core patch changeset.

## Root cause

Suggesting mode stores inserted text in a tracked-insertion run. When a word crossed into that run, line layout carried the existing prefix to a fresh line. The oversized inserted suffix then bypassed the line-splitting path because the carried prefix made the line nonempty, so the combined word overflowed the measure.

## Verification

- Confirmed the regression test fails before the fix with an overflowing line.
- Focused word-breaking suite: 22 passed.
- Full layout suite: 2,395 passed.
- Core and workspace type checking passed.
- Formatting, lint, API snapshots, parity, license, and ESLint line-cap checks passed.
- A 4,000-word microbenchmark returned to near-main performance: 2.48 ms branch median versus 2.30 ms on `main` after correcting a reviewed fast-path regression.


Fixes #716.
