### PR TITLE
fix(core): group every tracked field control into one review card

### DIFF
--- a/.changeset/lucky-fields-regroup.md
+++ b/.changeset/lucky-fields-regroup.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Group every tracked field control into the review card beside it, so a struck or inserted field is one decision instead of one card per control. Fixes #718

--- a/packages/core/src/store/store/review-reads.ts
+++ b/packages/core/src/store/store/review-reads.ts
@@ -469,6 +469,15 @@ function pairReplacements(
  * decision to the reviewer, and Word shows them as one. Adjacency is the same exact
  * end-to-start test the replacement pairing uses, so an untracked character between two
  * deletions keeps them apart.
+ *
+ * ZERO-WIDTH members are why this is a sweep rather than a lookup keyed by start position.
+ * Tracking the removal of a field wraps each `w:fldChar` and each `w:instrText` run in a
+ * `w:del` of its own, so a struck form field arrives as several revisions that cover no
+ * characters and share one offset with the struck text beside them. They are not separate
+ * decisions — Word cards the field once — and a map from start position to item can hold
+ * only one of them, which stranded every other one as a blank `Deleted` card. A member
+ * covering no characters therefore joins the chain WITHOUT moving its frontier: the
+ * revision it sits against still begins where the wrapper does.
  */
 function mergeAdjacentSameKindEdits(
   items: readonly ReviewRevisionItem[]
@@ -481,42 +490,43 @@ function mergeAdjacentSameKindEdits(
   );
   if (mergeable.length < 2) return items;
 
-  const keyOf = (item: ReviewRevisionItem, position: ReviewPosition): string =>
-    `${item.revisionKind}\u0000${item.author}\u0000${position.paragraphId}\u0000${position.offset}`;
-  const byStart = new Map<string, ReviewRevisionItem>();
-  const endKeys = new Set<string>();
+  const keyOf = (position: ReviewPosition): string =>
+    `${position.paragraphId}\u0000${position.offset}`;
+  // A chain never crosses kinds or authors, so each pair sweeps on its own. `mergeable` is
+  // in document order, because the site walk that built the items is, and bucketing keeps
+  // that order — which is what lets one forward pass find every chain.
+  const buckets = new Map<string, ReviewRevisionItem[]>();
   for (const item of mergeable) {
-    byStart.set(keyOf(item, item.ranges[0]!.start), item);
-    // An empty field-control wrapper can prefix a visible revision at the same position.
-    // Its point is not evidence that the visible revision has a predecessor.
-    if (
-      item.ranges.some(
-        (range) =>
-          range.start.paragraphId !== range.end.paragraphId ||
-          range.start.offset !== range.end.offset
-      )
-    ) {
-      endKeys.add(keyOf(item, item.ranges[item.ranges.length - 1]!.end));
-    }
+    const key = `${item.revisionKind}\u0000${item.author}`;
+    const bucket = buckets.get(key);
+    if (bucket) bucket.push(item);
+    else buckets.set(key, [item]);
   }
 
   const consumed = new Set<string>();
   const merged = new Map<string, ReviewRevisionItem>();
-  for (const head of mergeable) {
-    if (consumed.has(head.id)) continue;
-    // A chain is walked from its HEAD only — an item whose start some sibling's end meets
-    // is a tail, and walking it early would split the chain in two.
-    if (endKeys.has(keyOf(head, head.ranges[0]!.start))) continue;
-    const chain = [head];
-    let current = head;
-    for (;;) {
-      const next = byStart.get(keyOf(current, current.ranges[current.ranges.length - 1]!.end));
-      if (!next || next === current || consumed.has(next.id)) break;
-      consumed.add(next.id);
-      chain.push(next);
-      current = next;
+  for (const bucket of buckets.values()) {
+    let chain: ReviewRevisionItem[] = [];
+    let frontier = '';
+    const close = (): void => {
+      if (chain.length > 1) {
+        merged.set(chain[0]!.id, foldChain(chain));
+        for (let index = 1; index < chain.length; index += 1) consumed.add(chain[index]!.id);
+      }
+      chain = [];
+    };
+    for (const item of bucket) {
+      const start = keyOf(item.ranges[0]!.start);
+      const end = keyOf(item.ranges[item.ranges.length - 1]!.end);
+      if (chain.length > 0 && start !== frontier) close();
+      const opening = chain.length === 0;
+      chain.push(item);
+      // Covering no characters leaves the frontier where it is, so the next member is still
+      // measured against the text this wrapper sits in front of. An opening member sets the
+      // frontier either way: there is nothing yet for it to sit in front of.
+      if (opening || start !== end) frontier = end;
     }
-    if (chain.length > 1) merged.set(head.id, foldChain(chain));
+    close();
   }
   if (merged.size === 0) return items;
 

--- a/packages/core/src/store/store/review-reads.ts
+++ b/packages/core/src/store/store/review-reads.ts
@@ -506,15 +506,24 @@ function mergeAdjacentSameKindEdits(
     if (bucket) bucket.push(item);
     else buckets.set(key, [item]);
   }
-  // The same rank the queue itself is ordered by. Coincident members score EQUAL, so the
-  // sort is stable over them and the wrappers sharing one offset keep file order.
-  const rank = (item: ReviewRevisionItem): number => reviewItemPositionRank(item, order);
+  // Position as a PAIR, not the packed rank the queue itself sorts by: that one folds the
+  // offset into a fixed stride and clamps it, so every offset past the clamp in one
+  // paragraph scores the same — and a bucket ordered by it would report itself sorted in
+  // exactly the paragraph long enough to reach it. Coincident members compare EQUAL, and the
+  // sort is stable, so wrappers sharing one offset keep the order the file wrote them in;
+  // the sort fixes where a decision SITS, never how two at one offset are stacked.
+  const compare = (a: ReviewRevisionItem, b: ReviewRevisionItem): number => {
+    const first = a.ranges[0]!.start;
+    const second = b.ranges[0]!.start;
+    const paragraph = (order.get(first.paragraphId) ?? 0) - (order.get(second.paragraphId) ?? 0);
+    return paragraph !== 0 ? paragraph : first.offset - second.offset;
+  };
   for (const bucket of buckets.values()) {
     let sorted = true;
     for (let index = 1; index < bucket.length && sorted; index += 1) {
-      sorted = rank(bucket[index - 1]!) <= rank(bucket[index]!);
+      sorted = compare(bucket[index - 1]!, bucket[index]!) <= 0;
     }
-    if (!sorted) bucket.sort((a, b) => rank(a) - rank(b));
+    if (!sorted) bucket.sort(compare);
   }
 
   const consumed = new Set<string>();

--- a/packages/core/src/store/store/review-reads.ts
+++ b/packages/core/src/store/store/review-reads.ts
@@ -511,7 +511,9 @@ function mergeAdjacentSameKindEdits(
   // paragraph scores the same — and a bucket ordered by it would report itself sorted in
   // exactly the paragraph long enough to reach it. Coincident members compare EQUAL, and the
   // sort is stable, so wrappers sharing one offset keep the order the file wrote them in;
-  // the sort fixes where a decision SITS, never how two at one offset are stacked.
+  // the sort fixes where a decision SITS, never how two at one offset are stacked. `order`
+  // is total over the paragraphs a located site can name, so the fallback below asserts that
+  // rather than guarding it: it would rank an unmapped paragraph FIRST, not last.
   const compare = (a: ReviewRevisionItem, b: ReviewRevisionItem): number => {
     const first = a.ranges[0]!.start;
     const second = b.ranges[0]!.start;

--- a/packages/core/src/store/store/review-reads.ts
+++ b/packages/core/src/store/store/review-reads.ts
@@ -360,7 +360,7 @@ function pairReplacements(
   allItems: readonly ReviewRevisionItem[],
   order: ReadonlyMap<string, number>
 ): ReviewRevisionItem[] {
-  const items = mergeAdjacentSameKindEdits(allItems);
+  const items = mergeAdjacentSameKindEdits(allItems, order);
   // Not `ranges.length === 1`. One tracked edit becomes SEVERAL `w:del` elements whenever the
   // struck text crosses something that is not text — an endnote or footnote reference, a
   // field, a break — because those cannot go inside the same wrapper. Requiring a single range
@@ -480,7 +480,8 @@ function pairReplacements(
  * revision it sits against still begins where the wrapper does.
  */
 function mergeAdjacentSameKindEdits(
-  items: readonly ReviewRevisionItem[]
+  items: readonly ReviewRevisionItem[],
+  order: ReadonlyMap<string, number>
 ): readonly ReviewRevisionItem[] {
   const mergeable = items.filter(
     (item) =>
@@ -492,15 +493,28 @@ function mergeAdjacentSameKindEdits(
 
   const keyOf = (position: ReviewPosition): string =>
     `${position.paragraphId}\u0000${position.offset}`;
-  // A chain never crosses kinds or authors, so each pair sweeps on its own. `mergeable` is
-  // in document order, because the site walk that built the items is, and bucketing keeps
-  // that order — which is what lets one forward pass find every chain.
+  // A chain never crosses kinds or authors, so each pair sweeps on its own. The sweep needs
+  // each bucket in document order, and `mergeable` almost always already is: the site walk
+  // that built the items runs in document order. It is only ALMOST, because an item is
+  // positioned by its first LOCATED site, and a site inside a drawing or a text box has no
+  // location at all — so a group that starts in one carries a later range than its place in
+  // the list claims. Checking costs one pass and sorting is skipped whenever it holds.
   const buckets = new Map<string, ReviewRevisionItem[]>();
   for (const item of mergeable) {
     const key = `${item.revisionKind}\u0000${item.author}`;
     const bucket = buckets.get(key);
     if (bucket) bucket.push(item);
     else buckets.set(key, [item]);
+  }
+  // The same rank the queue itself is ordered by. Coincident members score EQUAL, so the
+  // sort is stable over them and the wrappers sharing one offset keep file order.
+  const rank = (item: ReviewRevisionItem): number => reviewItemPositionRank(item, order);
+  for (const bucket of buckets.values()) {
+    let sorted = true;
+    for (let index = 1; index < bucket.length && sorted; index += 1) {
+      sorted = rank(bucket[index - 1]!) <= rank(bucket[index]!);
+    }
+    if (!sorted) bucket.sort((a, b) => rank(a) - rank(b));
   }
 
   const consumed = new Set<string>();
@@ -517,14 +531,15 @@ function mergeAdjacentSameKindEdits(
     };
     for (const item of bucket) {
       const start = keyOf(item.ranges[0]!.start);
-      const end = keyOf(item.ranges[item.ranges.length - 1]!.end);
       if (chain.length > 0 && start !== frontier) close();
       const opening = chain.length === 0;
       chain.push(item);
       // Covering no characters leaves the frontier where it is, so the next member is still
       // measured against the text this wrapper sits in front of. An opening member sets the
       // frontier either way: there is nothing yet for it to sit in front of.
-      if (opening || start !== end) frontier = end;
+      if (opening || coversCharacters(item)) {
+        frontier = keyOf(item.ranges[item.ranges.length - 1]!.end);
+      }
     }
     close();
   }
@@ -536,6 +551,20 @@ function mergeAdjacentSameKindEdits(
     out.push(merged.get(item.id) ?? item);
   }
   return out;
+}
+
+/**
+ * Whether a revision covers any text at all.
+ *
+ * Asked per RANGE rather than of the whole span, because a group's outermost start and end
+ * can differ while every range in it is a point: the wrappers a tracked field is made of are
+ * empty, and a group that reuses one id across two paragraphs holds two of them.
+ */
+function coversCharacters(item: ReviewRevisionItem): boolean {
+  return item.ranges.some(
+    (range) =>
+      range.start.paragraphId !== range.end.paragraphId || range.start.offset !== range.end.offset
+  );
 }
 
 /** One card from a chain of adjacent same-kind halves, in document order. */

--- a/packages/pro/src/__tests__/review-model.test.ts
+++ b/packages/pro/src/__tests__/review-model.test.ts
@@ -265,6 +265,20 @@ describe('one decision is one card', () => {
     expect(revisionsOf(collectReviewItems({ storyPart: part }))).toHaveLength(2);
   });
 
+  // Grouping follows DOCUMENT position, not list position. A revision whose first site sits
+  // somewhere with no offset of its own — inside a drawing or a text box — is listed by a
+  // later range than its place in the list claims, and a sweep that trusted the list split
+  // the run it belonged to.
+  test('grouping follows document position when the item list does not', () => {
+    const part = story(
+      `<w:p><w:r><w:del w:id="5" w:author="QA" w:date="D">${delRun('x')}</w:del></w:r>` +
+        `${del('3', delRun('ab'), 'QA')}${del('5', delRun('cd'), 'QA')}</w:p>`
+    );
+    const items = revisionsOf(collectReviewItems({ storyPart: part }));
+    expect(items).toHaveLength(1);
+    expect(items[0]!.addresses.map((address) => address.id)).toEqual(['3', '5']);
+  });
+
   test('card ids are unique, so a list key never collides', () => {
     const part = story(
       `<w:p>${ins('7', run('a'))}${run(' x ')}${ins('7', run('b'))}${del('7', delRun('c'), 'QA')}</w:p>`

--- a/packages/pro/src/__tests__/review-model.test.ts
+++ b/packages/pro/src/__tests__/review-model.test.ts
@@ -76,6 +76,12 @@ const ins = (id: string, inner: string, author = 'QA') =>
   `<w:ins w:id="${id}" w:author="${author}" w:date="D">${inner}</w:ins>`;
 const del = (id: string, inner: string, author = 'Dev') =>
   `<w:del w:id="${id}" w:author="${author}" w:date="D">${inner}</w:del>`;
+const delFld = (id: string, kind: string, author = 'QA') =>
+  `<w:del w:id="${id}" w:author="${author}" w:date="D">` +
+  `<w:r><w:fldChar w:fldCharType="${kind}"/></w:r></w:del>`;
+const insFld = (id: string, kind: string, author = 'QA') =>
+  `<w:ins w:id="${id}" w:author="${author}" w:date="D">` +
+  `<w:r><w:fldChar w:fldCharType="${kind}"/></w:r></w:ins>`;
 const insAt = (id: string, inner: string, date: string, author = 'QA') =>
   `<w:ins w:id="${id}" w:author="${author}" w:date="${date}">${inner}</w:ins>`;
 const delAt = (id: string, inner: string, date: string, author = 'QA') =>
@@ -192,6 +198,71 @@ describe('one decision is one card', () => {
     expect(items[0]!.replacedText).toBe('old');
     expect(items[0]!.text).toBe('new');
     expect(items[0]!.addresses.map((address) => address.id)).toEqual(['33', '34', '35', '36']);
+  });
+
+  // Word wraps every part of a struck field in its own `w:del`: the two `w:fldChar` runs,
+  // the instruction run, and the result text. Four of those five cover no characters and
+  // share the result's start offset, so a grouping keyed by start position kept one and
+  // stranded the rest as blank `Deleted` cards.
+  test('a struck field is one card, however many empty controls it has', () => {
+    const part = story(
+      `<w:p>${run('Pre ')}` +
+        `${delFld('1', 'begin')}` +
+        `<w:del w:id="2" w:author="QA" w:date="D">` +
+        `<w:r><w:delInstrText xml:space="preserve"> FORMTEXT </w:delInstrText></w:r></w:del>` +
+        `${delFld('3', 'separate')}` +
+        `${del('4', delRun('old'), 'QA')}` +
+        `${delFld('5', 'end')}</w:p>`
+    );
+    const items = revisionsOf(collectReviewItems({ storyPart: part }));
+    expect(items).toHaveLength(1);
+    expect(items[0]!.revisionKind).toBe('delete');
+    expect(items[0]!.text).toBe('old');
+    // Every address rides along, so one Accept resolves the whole field.
+    expect(items[0]!.addresses.map((address) => address.id)).toEqual(['1', '2', '3', '4', '5']);
+  });
+
+  test('an inserted field is one card, and its controls come with it', () => {
+    const part = story(
+      `<w:p>${run('Pre ')}` +
+        `${insFld('1', 'begin')}${ins('2', run('new'), 'QA')}${insFld('3', 'end')}</w:p>`
+    );
+    const items = revisionsOf(collectReviewItems({ storyPart: part }));
+    expect(items).toHaveLength(1);
+    expect(items[0]!.revisionKind).toBe('insert');
+    expect(items[0]!.text).toBe('new');
+    expect(items[0]!.addresses.map((address) => address.id)).toEqual(['1', '2', '3']);
+  });
+
+  test('empty controls with nothing between them still make one card', () => {
+    const part = story(
+      `<w:p>${run('Pre ')}${delFld('1', 'begin')}${delFld('2', 'separate')}${delFld('3', 'end')}</w:p>`
+    );
+    const items = revisionsOf(collectReviewItems({ storyPart: part }));
+    expect(items).toHaveLength(1);
+    expect(items[0]!.addresses.map((address) => address.id)).toEqual(['1', '2', '3']);
+  });
+
+  // The frontier is what keeps grouping honest: two struck fields in one paragraph are two
+  // decisions, and the untracked text between them says so.
+  test('two struck fields in one paragraph stay two cards', () => {
+    const part = story(
+      `<w:p>${run('A ')}` +
+        `${delFld('1', 'separate')}${del('2', delRun('one'), 'QA')}${delFld('3', 'end')}` +
+        `${run(' B ')}` +
+        `${delFld('4', 'separate')}${del('5', delRun('two'), 'QA')}${delFld('6', 'end')}</w:p>`
+    );
+    const items = revisionsOf(collectReviewItems({ storyPart: part }));
+    expect(items).toHaveLength(2);
+    expect(items.map((item) => item.text)).toEqual(['one', 'two']);
+  });
+
+  // A wrapper is absorbed by the neighbour it belongs to, never by a stranger's edit.
+  test('an empty control by another author stays its own decision', () => {
+    const part = story(
+      `<w:p>${run('Pre ')}${delFld('1', 'separate', 'Dev')}${del('2', delRun('old'), 'QA')}</w:p>`
+    );
+    expect(revisionsOf(collectReviewItems({ storyPart: part }))).toHaveLength(2);
   });
 
   test('card ids are unique, so a list key never collides', () => {


### PR DESCRIPTION
Tracking the removal of a field wraps each `w:fldChar` and each `w:instrText` run in a `w:del` of its own. Four of the five revisions a struck form field produces cover no characters, and they share the struck text's start offset.

The pass that folds adjacent revisions into one card grouped them through a map from start position to item. A map holds one entry per position, so only one wrapper joined the group. Every other wrapper stayed a blank `Deleted` card that carried no text and did not resolve with the change it belonged to.

The pass is now a forward sweep per kind and author. A member that covers no characters joins the chain without moving its frontier, so any number of wrappers at one offset fold into the revision they sit against. Untracked text between two fields still keeps them apart, and a wrapper by another author still stays its own decision.

## Ordering

The sweep needs each bucket in document order. An item is positioned by its first located site, and a site inside a drawing or a text box has no location, so a group that starts in one is listed by a later range than its place claims. The sweep sorts each bucket by paragraph order and offset, and skips the sort when the list already holds.

The comparison is a pair rather than the queue's packed rank. That rank clamps the offset into a fixed stride, so every offset past the clamp in one paragraph scores the same, and a bucket ordered by it reported itself sorted in the one paragraph long enough to reach it.

## Scope

A wrapper is absorbed, never dropped. Its address rides along on the folded card, so one Accept or Reject resolves the whole field. A wrapper with no same-kind, same-author neighbor keeps a card of its own: it is a pending decision, and hiding it would leave tracked markup the pane says is not there.

The sort fixes where a decision sits. It does not reorder two decisions at one offset, because file order is the only evidence for how those stack.

Fixes #718

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791071065&installation_model_id=422592&pr_number=720&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F720&signature=76832b2f78a5653b41528c98933b72b799ad7b88c921429572adefb70cc84d5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->