### PR TITLE
fix(core): write suggested replacements as Word does

### DIFF
--- a/.changeset/tidy-replacement-ids.md
+++ b/.changeset/tidy-replacement-ids.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': minor
+---
+
+Write a suggested replacement as Word does: the deletion first, then the insertion, each under its own revision id, wherever in the paragraph the replaced text sits. Add `replacementLanding` to the editor surface and the automation port, so a scripted replacement writes and reports the same position typing does. Fixes #691.

--- a/docs/api/docx-editor-core/editor.api.md
+++ b/docs/api/docx-editor-core/editor.api.md
@@ -1509,6 +1509,7 @@ export interface PaginatedSurface {
         readonly commitGuard?: () => boolean;
         readonly expectedPackageRevision: number;
     }): Promise<ImageIntentResult>;
+    replacementLanding(paragraphId: string, start: number, end: number): number | null;
     retainedSelection(): SemanticSelection | null;
     retainSelection(): SelectionPin;
     revealPage(pageIndex: number, options?: RevealOptions): boolean;

--- a/docs/api/docx-editor-core/store.api.md
+++ b/docs/api/docx-editor-core/store.api.md
@@ -1188,6 +1188,7 @@ export interface EditOptions {
     // (undocumented)
     readonly deferValidation?: boolean;
     readonly revisionIds?: () => string;
+    readonly trackedRevisionIds?: TransactionRevisionIds;
 }
 
 // @public
@@ -4102,6 +4103,13 @@ export interface TocOutlineHeading {
 
 // @public
 export function toSafeRecord(value: unknown, path?: string): unknown;
+
+// @public
+export interface TransactionRevisionIds {
+    mint(): string;
+    wrote(key: string): void;
+    wroteUnder(key: string): boolean;
+}
 
 // @public
 export interface TransportPort {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -341,11 +341,9 @@ export default [
   {
     files: [
       'packages/core/src/editor/chrome-controls.ts',
-      'packages/core/src/editor/paginated-surface-contract.ts',
       'packages/core/src/layout/semantic-table.ts',
       'packages/core/src/store/__tests__/table-resize-ops.test.ts',
       'packages/core/src/store/__tests__/table-row-ops.test.ts',
-      'packages/core/src/store/store/tree-op-tracked.ts',
     ],
     rules: {
       'max-lines': ['error', { max: 1100, skipBlankLines: false, skipComments: false }],

--- a/packages/core/src/automation/content-control-input.ts
+++ b/packages/core/src/automation/content-control-input.ts
@@ -1,0 +1,103 @@
+// What a caller may say ABOUT a content control, before the planner acts on it.
+//
+// The vocabularies the operation protocol accepts for a control — its lock names, the places a
+// range may name on it, the subtypes it may be created as — and the validation of a caller-supplied
+// value. Split from `plan.ts`, which consults these while planning and is long enough already;
+// nothing here reads the document, so it needs no planner state.
+
+import type { OoxmlNode } from '../store/package/ooxml-tree.ts';
+import {
+  contentControlContentNodeOf,
+  contentControlsIn,
+} from '../store/package/content-control-nodes.ts';
+import type { ContentControlValueInput } from '../store/store/tree-op-content-controls.ts';
+import type { AutomationErrorCode } from './protocol.ts';
+
+/**
+ * Every control under a scope, nested ones included, in document order.
+ *
+ * For the lookups that search what the FILE wrote — an id, a tag, a title. Word's own numbering
+ * is not scoped to a nesting level, so a lookup restricted to a scope's direct children would
+ * report a control that plainly exists as absent.
+ */
+export function allControlsUnder(scope: OoxmlNode): readonly OoxmlNode[] {
+  const root = scope.kind === 'contentControl' ? contentControlContentNodeOf(scope) : scope;
+  if (!root) return [];
+  return contentControlsIn(root).map((entry) => entry.node);
+}
+
+export const CONTENT_CONTROL_LOCKS: ReadonlySet<string> = new Set([
+  'unlocked',
+  'sdtLocked',
+  'contentLocked',
+  'sdtContentLocked',
+]);
+
+export const CONTENT_CONTROL_RANGE_LOCATIONS: ReadonlySet<string> = new Set([
+  'whole',
+  'content',
+  'start',
+  'end',
+  'before',
+  'after',
+]);
+
+export const CONTENT_CONTROL_SUBTYPES: ReadonlySet<string> = new Set([
+  'richText',
+  'plainText',
+  'dropDownList',
+  'comboBox',
+  'date',
+]);
+
+/** Longest tag/title/value a caller may author, so a script cannot ask for an unbounded write. */
+const MAX_CONTROL_STRING = 4_096;
+
+/**
+ * The typed value a caller offered, or why it is not one.
+ *
+ * Validated HERE and not only in the store, because a caller-supplied object is untrusted input
+ * arriving over a transport: a `value` that is a number, or a `kind` nobody declares, must be a
+ * named refusal rather than something the tree lane has to defend against.
+ */
+export function contentControlValueOf(value: unknown):
+  | { readonly ok: true; readonly value: ContentControlValueInput }
+  | {
+      readonly ok: false;
+      readonly code: AutomationErrorCode;
+      readonly message: string;
+      readonly detail?: string;
+    } {
+  const bad = (message: string, detail?: string) => ({
+    ok: false as const,
+    code: 'unsupported-content' as AutomationErrorCode,
+    message,
+    detail,
+  });
+  if (typeof value !== 'object' || value === null || !('kind' in value)) {
+    return bad('a control value states its kind', 'value');
+  }
+  const offered = value as Record<string, unknown>;
+  const kind = offered.kind;
+  if (kind === 'text' || kind === 'listItem') {
+    const raw = kind === 'text' ? offered.text : offered.value;
+    if (typeof raw !== 'string') return bad('that value is not a string', String(kind));
+    if (raw.length > MAX_CONTROL_STRING) return bad('that value is too long', String(raw.length));
+    return {
+      ok: true,
+      value: kind === 'text' ? { kind: 'text', text: raw } : { kind: 'listItem', value: raw },
+    };
+  }
+  if (kind === 'checkbox') {
+    const checked = offered.checked;
+    if (typeof checked !== 'boolean') return bad('a checkbox is checked or not', 'checked');
+    return { ok: true, value: { kind: 'checkbox', checked } };
+  }
+  if (kind === 'date') {
+    const iso = offered.iso;
+    if (typeof iso !== 'string') return bad('a date is an ISO-8601 string', 'iso');
+    if (iso.length > 64) return bad('that is not a date', String(iso.length));
+    return { ok: true, value: { kind: 'date', iso } };
+  }
+  return bad('that is not a value any control accepts', String(kind));
+}

--- a/packages/core/src/automation/document-port.ts
+++ b/packages/core/src/automation/document-port.ts
@@ -110,6 +110,15 @@ export interface AutomationDocumentPort {
    */
   revisionDisplayMode?(): FormattingDisplayMode;
   /**
+   * Where a replacement for `[start, end)` of a paragraph lands under the owner's editing
+   * mode, or null when the edit would not be tracked — the surface's own landing rule.
+   *
+   * A scripted `Replace` in suggesting mode strikes the words and must put the new text after
+   * them, as typing does; the planner has no editing mode of its own, so it asks. Absent on a
+   * headless owner, which writes nothing tracked.
+   */
+  replacementLanding?(paragraphId: string, start: number, end: number): number | null;
+  /**
    * Commit ops as ONE transaction against ONE story.
    *
    * Ordered and atomic is the port's contract, not the caller's convention: on any rejection

--- a/packages/core/src/automation/host.ts
+++ b/packages/core/src/automation/host.ts
@@ -160,6 +160,9 @@ export function createAutomationHost(composition: AutomationHostComposition): Au
       // Read ONCE per batch: the formatting lanes must not answer one operation against
       // All Markup and the next against the resolved result.
       ...(port.revisionDisplayMode ? { displayMode: port.revisionDisplayMode() } : {}),
+      ...(port.replacementLanding
+        ? { replacementLanding: port.replacementLanding.bind(port) }
+        : {}),
       ...(port.select ? { select: port.select.bind(port) } : {}),
     });
 

--- a/packages/core/src/automation/plan.ts
+++ b/packages/core/src/automation/plan.ts
@@ -108,12 +108,14 @@ import {
   contentControlText,
   type AutomationContentControlRead,
 } from './content-controls.ts';
+import { contentControlPropertiesOf } from '../store/package/content-control-nodes.ts';
 import {
-  contentControlContentNodeOf,
-  contentControlPropertiesOf,
-  contentControlsIn,
-} from '../store/package/content-control-nodes.ts';
-import type { ContentControlValueInput } from '../store/store/tree-op-content-controls.ts';
+  CONTENT_CONTROL_LOCKS,
+  CONTENT_CONTROL_RANGE_LOCATIONS,
+  CONTENT_CONTROL_SUBTYPES,
+  allControlsUnder,
+  contentControlValueOf,
+} from './content-control-input.ts';
 import type { InsertCustomNodeWrite } from '../store/store/custom-node-writes.ts';
 import {
   customNodePayloadOf,
@@ -228,6 +230,8 @@ export interface BatchPlannerHost {
   readonly capabilities: AutomationCapabilities;
   /** The reader's view — see `AutomationDocumentPort.revisionDisplayMode`. */
   readonly displayMode?: FormattingDisplayMode;
+  /** Where a tracked replacement lands — see `AutomationDocumentPort.replacementLanding`. */
+  readonly replacementLanding?: (paragraphId: string, start: number, end: number) => number | null;
   /** Moves a reader's caret. Only called when `capabilities.selection` is true. */
   readonly select?: (range: ResolvedRange, mode: AutomationSelectionMode) => void;
 }
@@ -271,95 +275,6 @@ const APPLIED: AutomationValue = Object.freeze({ kind: 'applied' as const });
 
 function query(value: AutomationValue): PlannedOperation {
   return { ok: true, kind: 'query', value };
-}
-
-/**
- * Every control under a scope, nested ones included, in document order.
- *
- * For the lookups that search what the FILE wrote — an id, a tag, a title. Word's own numbering
- * is not scoped to a nesting level, so a lookup restricted to a scope's direct children would
- * report a control that plainly exists as absent.
- */
-function allControlsUnder(scope: OoxmlNode): readonly OoxmlNode[] {
-  const root = scope.kind === 'contentControl' ? contentControlContentNodeOf(scope) : scope;
-  if (!root) return [];
-  return contentControlsIn(root).map((entry) => entry.node);
-}
-
-const CONTENT_CONTROL_LOCKS: ReadonlySet<string> = new Set([
-  'unlocked',
-  'sdtLocked',
-  'contentLocked',
-  'sdtContentLocked',
-]);
-
-const CONTENT_CONTROL_RANGE_LOCATIONS: ReadonlySet<string> = new Set([
-  'whole',
-  'content',
-  'start',
-  'end',
-  'before',
-  'after',
-]);
-
-const CONTENT_CONTROL_SUBTYPES: ReadonlySet<string> = new Set([
-  'richText',
-  'plainText',
-  'dropDownList',
-  'comboBox',
-  'date',
-]);
-
-/** Longest tag/title/value a caller may author, so a script cannot ask for an unbounded write. */
-const MAX_CONTROL_STRING = 4_096;
-
-/**
- * The typed value a caller offered, or why it is not one.
- *
- * Validated HERE and not only in the store, because a caller-supplied object is untrusted input
- * arriving over a transport: a `value` that is a number, or a `kind` nobody declares, must be a
- * named refusal rather than something the tree lane has to defend against.
- */
-function contentControlValueOf(value: unknown):
-  | { readonly ok: true; readonly value: ContentControlValueInput }
-  | {
-      readonly ok: false;
-      readonly code: AutomationErrorCode;
-      readonly message: string;
-      readonly detail?: string;
-    } {
-  const bad = (message: string, detail?: string) => ({
-    ok: false as const,
-    code: 'unsupported-content' as AutomationErrorCode,
-    message,
-    detail,
-  });
-  if (typeof value !== 'object' || value === null || !('kind' in value)) {
-    return bad('a control value states its kind', 'value');
-  }
-  const offered = value as Record<string, unknown>;
-  const kind = offered.kind;
-  if (kind === 'text' || kind === 'listItem') {
-    const raw = kind === 'text' ? offered.text : offered.value;
-    if (typeof raw !== 'string') return bad('that value is not a string', String(kind));
-    if (raw.length > MAX_CONTROL_STRING) return bad('that value is too long', String(raw.length));
-    return {
-      ok: true,
-      value: kind === 'text' ? { kind: 'text', text: raw } : { kind: 'listItem', value: raw },
-    };
-  }
-  if (kind === 'checkbox') {
-    const checked = offered.checked;
-    if (typeof checked !== 'boolean') return bad('a checkbox is checked or not', 'checked');
-    return { ok: true, value: { kind: 'checkbox', checked } };
-  }
-  if (kind === 'date') {
-    const iso = offered.iso;
-    if (typeof iso !== 'string') return bad('a date is an ISO-8601 string', 'iso');
-    if (iso.length > 64) return bad('that is not a date', String(iso.length));
-    return { ok: true, value: { kind: 'date', iso } };
-  }
-  return bad('that is not a value any control accepts', String(kind));
 }
 
 /** Every occurrence of any delimiter in `text`, non-overlapping, in order. */
@@ -851,10 +766,34 @@ export function createBatchPlanner(host: BatchPlannerHost): BatchPlanner {
       }
     }
 
-    if (text.length > 0)
-      ops.push({ op: 'insertText', paragraphId: first, offset: range.start.offset, text });
+    // WHERE THE TEXT GOES. In suggesting mode the deletion strikes the words in place and the
+    // replacement belongs after them — Word's order, the order the keyboard writes, and the
+    // adjacency the review lane pairs into one card. The owner's landing rule says where that
+    // is: past the struck stretch, minus whatever of it was this author's own pending
+    // insertion, which leaves. With no rule, or none that tracks, the words are simply gone
+    // and the range start is the spot. The answer is that same spot, so a caller that
+    // formats or comments on what it just wrote addresses the new text; with an empty `text`
+    // it is where a replacement would have gone.
+    //
+    // ALWAYS THE FIRST PARAGRAPH, past its own struck tail. The keyboard puts a spanning
+    // replacement in the last paragraph instead, and matching that here refused the batch
+    // outright: the proposed merge REALLY merges when the first paragraph's mark is this
+    // author's own pending insertion, so the last paragraph leaves the tree and an op naming
+    // it vetoes the transaction. The two lanes therefore still pair a spanning replacement
+    // into different review cards; a refused edit is the worse of the two.
+    // Read against the document as the batch was PLANNED, like every offset a batch carries:
+    // a second `replaceSpan` earlier in the same paragraph shifts this one, and a caller
+    // orders such a batch back to front. The landing inherits that constraint, no more.
+    // RAW text, the offset authority the `deleteText` above measures with. The projected
+    // reading expands a field to its result, so a paragraph holding one made the struck
+    // stretch a range that does not exist — and the landing computed from it aimed past the
+    // paragraph's end, refusing the whole scripted replacement as `offset-out-of-range`.
+    const struckEnd = ids.length === 1 ? range.end.offset : (reads.rawText(first) ?? '').length;
+    const landing = host.replacementLanding?.(first, range.start.offset, struckEnd);
+    const at = landing ?? range.start.offset;
+    if (text.length > 0) ops.push({ op: 'insertText', paragraphId: first, offset: at, text });
 
-    const start: ResolvedPoint = { ...range.start, paragraphId: first };
+    const start: ResolvedPoint = { ...range.start, paragraphId: first, offset: at };
     const answer = (): AutomationValue => ({
       kind: 'span',
       span: spanOf({ start, end: { ...start, offset: start.offset + text.length } }),
@@ -931,6 +870,9 @@ export function createBatchPlanner(host: BatchPlannerHost): BatchPlanner {
     );
     const target = kept[0] as string;
 
+    // RAW text, for the reason `planReplaceSpan` spells out: this is the same measure the
+    // `deleteText` below strikes with, and the projected one disagrees over a field.
+    const targetLength = (reads.rawText(target) ?? '').length;
     for (const paragraphId of kept) {
       const length = (reads.rawText(paragraphId) ?? '').length;
       if (length > 0) ops.push({ op: 'deleteText', paragraphId, start: 0, end: length });
@@ -939,7 +881,12 @@ export function createBatchPlanner(host: BatchPlannerHost): BatchPlanner {
       if (block.id === keeper?.id) continue;
       ops.push({ op: 'deleteBlock', blockId: block.id });
     }
-    if (text.length > 0) ops.push({ op: 'insertText', paragraphId: target, offset: 0, text });
+    // The same landing rule `planReplaceSpan` reads, for the same reason: in suggesting mode
+    // the struck words keep their offsets and the new text belongs after them. Aimed at
+    // offset 0 the store relocates it anyway, and the span answered here then named the
+    // struck words rather than what replaced them.
+    const at = host.replacementLanding?.(target, 0, targetLength) ?? 0;
+    if (text.length > 0) ops.push({ op: 'insertText', paragraphId: target, offset: at, text });
 
     for (const block of removed) {
       if (block.id === keeper?.id) continue;
@@ -953,11 +900,11 @@ export function createBatchPlanner(host: BatchPlannerHost): BatchPlanner {
       story: reads.story,
       paragraphId: target,
       index: reads.indexOf(target),
-      offset: 0,
+      offset: at,
     };
     const answer = (): AutomationValue => ({
       kind: 'span',
-      span: spanOf({ start, end: { ...start, offset: text.length } }),
+      span: spanOf({ start, end: { ...start, offset: at + text.length } }),
     });
     return { ok: true, kind: 'command', ops, story: reads.story, answer };
   };

--- a/packages/core/src/editor/__tests__/automation-host-gating.test.ts
+++ b/packages/core/src/editor/__tests__/automation-host-gating.test.ts
@@ -18,6 +18,7 @@ import { describe, expect, test } from 'bun:test';
 import { strToU8, unzipSync, zipSync } from 'fflate';
 import { createBrowserAutomationHost } from '../automation-host.ts';
 import { createDocxEditor, type DocxEditorInstance } from '../docx-editor.ts';
+import { serializeOoxmlPart } from '../../store/package/ooxml-tree.ts';
 import type { AutomationHandle, AutomationHost } from '../../automation/index.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
@@ -86,6 +87,25 @@ function noteDocx(): Uint8Array {
       `<w:document xmlns:w="${W}" xmlns:r="${R}"><w:body>${body}${p('beta')}<w:sectPr/></w:body></w:document>`
     ),
     'word/footnotes.xml': strToU8(`<w:footnotes xmlns:w="${W}">${footnotes}</w:footnotes>`),
+  });
+}
+
+/** A document whose body is exactly `body`, for a write that needs particular words. */
+function bodyDocx(body: string): Uint8Array {
+  return zipSync({
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}">` +
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/_rels/document.xml.rels': strToU8(`<Relationships xmlns="${REL}"/>`),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}" xmlns:r="${R}"><w:body>${body}<w:sectPr/></w:body></w:document>`
+    ),
   });
 }
 
@@ -247,6 +267,405 @@ describe('a scripted write obeys the editing mode', () => {
     const xml = savedDocumentXml(host);
     expect(xml).toContain('w:ins');
     expect(xml).toContain('Ada');
+  });
+
+  test('suggesting writes a replacement as Word does and answers where the text landed', () => {
+    // A scripted `Range.insertText(…, 'Replace')` aims the insertion where the range began,
+    // which in suggesting mode is the front edge of the fresh strike. The store puts the
+    // replacement AFTER the struck words — `w:del` then `w:ins`, each under its own id, as
+    // Word writes it (#691) — so the answered span must name where the text actually sits,
+    // not the struck words it was aimed at.
+    const { host, editor } = mount({
+      author: 'Ada',
+      bytes: bodyDocx(
+        '<w:p><w:r><w:t xml:space="preserve">The Receiving Party shall hold it.</w:t></w:r></w:p>'
+      ),
+    });
+    editor.surface!.setEditingMode('suggest');
+    const body = bodyOf(host);
+    const found = host.execute({
+      operations: [{ op: 'search', scope: { body }, text: 'Receiving Party' }],
+    });
+    const hit = found.results[0];
+    if (hit?.status !== 'ok' || hit.value.kind !== 'spans' || !hit.value.spans[0]) {
+      throw new Error('expected one search result');
+    }
+
+    const write = host.execute({
+      operations: [{ op: 'replaceSpan', span: hit.value.spans[0], text: 'Recipient' }],
+    });
+    expect({ ok: write.ok, changed: write.changed }).toEqual({ ok: true, changed: true });
+    const answered = write.results[0];
+    if (answered?.status !== 'ok' || answered.value.kind !== 'span') {
+      throw new Error('expected the written span');
+    }
+    const readBack = host.execute({
+      operations: [{ op: 'getSpanText', span: answered.value.span, projection: 'allMarkup' }],
+    });
+    const text = readBack.results[0];
+    if (text?.status !== 'ok' || text.value.kind !== 'text') throw new Error('expected text');
+    expect(text.value.text).toBe('Recipient');
+
+    const xml = savedDocumentXml(host);
+    const struck = xml.indexOf('<w:del ');
+    const inserted = xml.indexOf('<w:ins ');
+    expect(struck).toBeGreaterThan(-1);
+    expect(inserted).toBeGreaterThan(struck);
+    const ids = [...xml.matchAll(/<w:(?:ins|del) [^>]*w:id="(\d+)"/g)].map((match) => match[1]);
+    expect(ids).toHaveLength(2);
+    expect(new Set(ids).size).toBe(2);
+  });
+
+  test('two replacements in one batch, in edit mode, each answer their own text', () => {
+    // The answer is the planned landing, not an inference from the paragraph's length after
+    // the whole batch — which counted the first replacement's growth into the second's span.
+    const { host } = mount({
+      bytes: bodyDocx(
+        '<w:p><w:r><w:t>The quick brown fox jumps over the lazy dog.</w:t></w:r></w:p>'
+      ),
+    });
+    const body = bodyOf(host);
+    const found = host.execute({
+      operations: [
+        { op: 'search', scope: { body }, text: 'lazy' },
+        { op: 'search', scope: { body }, text: 'quick' },
+      ],
+    });
+    const lazy = found.results[0];
+    const quick = found.results[1];
+    if (lazy?.status !== 'ok' || lazy.value.kind !== 'spans' || !lazy.value.spans[0])
+      throw new Error('lazy');
+    if (quick?.status !== 'ok' || quick.value.kind !== 'spans' || !quick.value.spans[0])
+      throw new Error('quick');
+    const write = host.execute({
+      operations: [
+        { op: 'replaceSpan', span: lazy.value.spans[0], text: 'sleepy' },
+        { op: 'replaceSpan', span: quick.value.spans[0], text: 'extraordinarily fast' },
+      ],
+    });
+    expect(write.ok).toBe(true);
+    const second = write.results[1];
+    if (second?.status !== 'ok' || second.value.kind !== 'span') throw new Error('expected a span');
+    const read = host.execute({ operations: [{ op: 'getSpanText', span: second.value.span }] });
+    const text = read.results[0];
+    if (text?.status !== 'ok' || text.value.kind !== 'text') throw new Error('expected text');
+    expect(text.value.text).toBe('extraordinarily fast');
+  });
+
+  test('suggesting over words another author already struck lands after them, and says so', () => {
+    // Nothing of the range is struck by THIS edit, so the front edge of the range is the front
+    // edge of Grace's deletion. The landing rule aims past it, as typing does; the new text
+    // sits after the struck words, and the answered span names it.
+    const { host, editor } = mount({
+      author: 'Ada',
+      bytes: bodyDocx(
+        '<w:p><w:r><w:t xml:space="preserve">The </w:t></w:r>' +
+          '<w:del w:id="3" w:author="Grace" w:date="2020-01-01T00:00:00Z">' +
+          '<w:r><w:delText>Receiving Party</w:delText></w:r></w:del>' +
+          '<w:r><w:t xml:space="preserve"> shall hold it.</w:t></w:r></w:p>'
+      ),
+    });
+    editor.surface!.setEditingMode('suggest');
+    const body = bodyOf(host);
+    const found = host.execute({
+      operations: [
+        {
+          op: 'search',
+          scope: { body },
+          text: 'Receiving Party',
+          options: { projection: 'allMarkup' },
+        },
+      ],
+    });
+    const hit = found.results[0];
+    if (hit?.status !== 'ok' || hit.value.kind !== 'spans' || !hit.value.spans[0]) {
+      throw new Error('expected one search result');
+    }
+    const write = host.execute({
+      operations: [{ op: 'replaceSpan', span: hit.value.spans[0], text: 'Recipient' }],
+    });
+    expect(write.ok).toBe(true);
+    const answered = write.results[0];
+    if (answered?.status !== 'ok' || answered.value.kind !== 'span')
+      throw new Error('expected a span');
+    const read = host.execute({
+      operations: [{ op: 'getSpanText', span: answered.value.span, projection: 'allMarkup' }],
+    });
+    const text = read.results[0];
+    if (text?.status !== 'ok' || text.value.kind !== 'text') throw new Error('expected text');
+    expect(text.value.text).toBe('Recipient');
+    const xml = savedDocumentXml(host);
+    expect(xml.indexOf('<w:del ')).toBeLessThan(xml.indexOf('<w:ins '));
+  });
+
+  test('replacing with nothing in suggesting mode answers where a replacement would go', () => {
+    const { host, editor } = mount({
+      author: 'Ada',
+      bytes: bodyDocx('<w:p><w:r><w:t>alpha beta</w:t></w:r></w:p>'),
+    });
+    editor.surface!.setEditingMode('suggest');
+    const body = bodyOf(host);
+    const found = host.execute({ operations: [{ op: 'search', scope: { body }, text: 'beta' }] });
+    const hit = found.results[0];
+    if (hit?.status !== 'ok' || hit.value.kind !== 'spans' || !hit.value.spans[0])
+      throw new Error('hit');
+    const write = host.execute({
+      operations: [{ op: 'replaceSpan', span: hit.value.spans[0], text: '' }],
+    });
+    expect(write.ok).toBe(true);
+    const answered = write.results[0];
+    if (answered?.status !== 'ok' || answered.value.kind !== 'span')
+      throw new Error('expected a span');
+    // The struck words keep their offsets, so the spot after them is the range END.
+    expect(answered.value.span.start.offset).toBe('alpha beta'.length);
+    expect(answered.value.span.end.offset).toBe('alpha beta'.length);
+  });
+
+  test('a scripted replacement across a paragraph mark lands after the struck head', () => {
+    // The whole range is struck, the mark between the paragraphs is proposed deleted, and the
+    // new text goes after the FIRST paragraph's struck tail. Not the last paragraph, where
+    // typing puts it: the proposed merge really merges when the first paragraph's mark is
+    // this author's own pending insertion, and an op naming the second paragraph would then
+    // veto the transaction.
+    const { host, editor } = mount({ author: 'Ada' });
+    editor.surface!.setEditingMode('suggest');
+    const paragraphs = paragraphsOf(host);
+    const write = host.execute({
+      operations: [
+        {
+          op: 'replaceSpan',
+          span: {
+            start: { paragraph: paragraphs[0]!, offset: 2 },
+            end: { paragraph: paragraphs[1]!, offset: 2 },
+          },
+          text: 'XY',
+        },
+      ],
+    });
+    expect({ ok: write.ok, changed: write.changed }).toEqual({ ok: true, changed: true });
+    const answered = write.results[0];
+    if (answered?.status !== 'ok' || answered.value.kind !== 'span') {
+      throw new Error('expected a span');
+    }
+    const read = host.execute({
+      operations: [{ op: 'getSpanText', span: answered.value.span, projection: 'allMarkup' }],
+    });
+    const text = read.results[0];
+    if (text?.status !== 'ok' || text.value.kind !== 'text') throw new Error('expected text');
+    expect(text.value.text).toBe('XY');
+    const xml = savedDocumentXml(host);
+    expect(xml).toMatch(
+      /<w:delText>pha<\/w:delText><\/w:r><\/w:del><w:ins[^>]*><w:r><w:t>XY<\/w:t><\/w:r><\/w:ins>/
+    );
+  });
+
+  test('a spanning replacement commits when the first mark is the author’s own insertion', () => {
+    // The proposed merge REALLY merges here — the first paragraph retracts its own mark, so
+    // the second leaves the tree. Writing the new text into that second paragraph refused the
+    // whole batch with `unknown-paragraph`, and the scripted edit did nothing at all.
+    const { host, editor } = mount({
+      author: 'Ada',
+      bytes: bodyDocx(
+        '<w:p><w:pPr><w:rPr><w:ins w:id="4" w:author="Ada" w:date="2026-09-01T00:00:00Z"/></w:rPr></w:pPr>' +
+          '<w:r><w:t>alpha</w:t></w:r></w:p>' +
+          '<w:p><w:r><w:t>beta</w:t></w:r></w:p>'
+      ),
+    });
+    editor.surface!.setEditingMode('suggest');
+    const paragraphs = paragraphsOf(host);
+    const write = host.execute({
+      operations: [
+        {
+          op: 'replaceSpan',
+          span: {
+            start: { paragraph: paragraphs[0]!, offset: 2 },
+            end: { paragraph: paragraphs[1]!, offset: 2 },
+          },
+          text: 'XY',
+        },
+      ],
+    });
+    expect({ ok: write.ok, changed: write.changed }).toEqual({ ok: true, changed: true });
+    // Pinned: the merge really happens, so the words land after the FIRST paragraph's struck
+    // tail and the second paragraph's strike follows them into the merged host.
+    expect(savedDocumentXml(host)).toMatch(
+      /<w:delText>pha<\/w:delText><\/w:r><\/w:del><w:ins[^>]*><w:r><w:t>XY<\/w:t><\/w:r><\/w:ins><w:del[^>]*><w:r><w:delText>be<\/w:delText>/
+    );
+  });
+
+  test("setting a whole story's text in suggesting mode answers the new words", () => {
+    // `Body.insertText(…, 'Replace')` strikes the story and writes its text after the struck
+    // words, the same relocation a span replacement gets. Answering offset 0 named the struck
+    // words instead, so a script that formatted what it wrote formatted the strike.
+    const { host, editor } = mount({
+      author: 'Ada',
+      bytes: bodyDocx('<w:p><w:r><w:t>alpha beta</w:t></w:r></w:p>'),
+    });
+    editor.surface!.setEditingMode('suggest');
+    const body = bodyOf(host);
+    const write = host.execute({
+      operations: [{ op: 'replaceSpan', span: { body }, text: 'omega' }],
+    });
+    expect({ ok: write.ok, changed: write.changed }).toEqual({ ok: true, changed: true });
+    const answered = write.results[0];
+    if (answered?.status !== 'ok' || answered.value.kind !== 'span') {
+      throw new Error('expected a span');
+    }
+    const read = host.execute({
+      operations: [{ op: 'getSpanText', span: answered.value.span, projection: 'allMarkup' }],
+    });
+    const text = read.results[0];
+    if (text?.status !== 'ok' || text.value.kind !== 'text') throw new Error('expected text');
+    expect(text.value.text).toBe('omega');
+    const xml = savedDocumentXml(host);
+    expect(xml.indexOf('<w:del ')).toBeLessThan(xml.indexOf('<w:ins '));
+  });
+
+  test('a replacement whose strike JOINS one already standing answers the new words', () => {
+    // The fresh strike merges with Ada\'s existing one, so the store clears the whole merged
+    // wrapper before writing. The planner predicted the shorter, unmerged landing and answered
+    // a span over the struck words instead of over what replaced them.
+    const { host, editor } = mount({
+      author: 'Ada',
+      bytes: bodyDocx(
+        '<w:p><w:r><w:t xml:space="preserve">hello </w:t></w:r>' +
+          '<w:del w:id="5" w:author="Ada" w:date="2026-09-04T00:00:00Z">' +
+          '<w:r><w:delText>world</w:delText></w:r></w:del></w:p>'
+      ),
+    });
+    editor.surface!.setEditingMode('suggest');
+    const body = bodyOf(host);
+    const found = host.execute({
+      operations: [
+        { op: 'search', scope: { body }, text: 'hello ', options: { projection: 'allMarkup' } },
+      ],
+    });
+    const hit = found.results[0];
+    if (hit?.status !== 'ok' || hit.value.kind !== 'spans' || !hit.value.spans[0]) {
+      throw new Error('expected one search result');
+    }
+    const write = host.execute({
+      operations: [{ op: 'replaceSpan', span: hit.value.spans[0], text: 'hi ' }],
+    });
+    expect(write.ok).toBe(true);
+    const answered = write.results[0];
+    if (answered?.status !== 'ok' || answered.value.kind !== 'span') {
+      throw new Error('expected a span');
+    }
+    const read = host.execute({
+      operations: [{ op: 'getSpanText', span: answered.value.span, projection: 'allMarkup' }],
+    });
+    const text = read.results[0];
+    if (text?.status !== 'ok' || text.value.kind !== 'text') throw new Error('expected text');
+    expect(text.value.text).toBe('hi ');
+  });
+
+  test('typing over your own pending insertion plus a strike lands before the live words', () => {
+    // The landing rule maps past the strike in the paragraph\'s PRE-edit offsets and only then
+    // subtracts what this author\'s own insertion retracts. Mixing the two spaces read the
+    // post-retraction offset against pre-edit spans and carried the words past "gh", which the
+    // edit never touched.
+    const { editor } = mount({
+      author: 'Ada',
+      bytes: bodyDocx(
+        '<w:p><w:ins w:id="1" w:author="Ada" w:date="2026-09-04T00:00:00Z">' +
+          '<w:r><w:t>ab</w:t></w:r></w:ins>' +
+          '<w:del w:id="2" w:author="Ada" w:date="2026-09-04T00:00:00Z">' +
+          '<w:r><w:delText>cd</w:delText></w:r></w:del><w:r><w:t>gh</w:t></w:r></w:p>'
+      ),
+    });
+    const surface = editor.surface!;
+    surface.setEditingMode('suggest');
+    const paragraphId = surface.session.paragraphIds()[0]!;
+    surface.setSelection({
+      anchor: { paragraphId, offset: 0 },
+      head: { paragraphId, offset: 4 },
+    });
+    surface.type('X');
+    const out = serializeOoxmlPart(surface.session.part());
+    expect(out).toMatch(
+      /<w:delText>cd<\/w:delText><\/w:r><\/w:del><w:ins[^>]*><w:r><w:t>X<\/w:t><\/w:r><\/w:ins><w:r><w:t>gh<\/w:t>/
+    );
+  });
+
+  test('a zero-width replaceSpan writes exactly where an insert at the same point writes', () => {
+    // It strikes nothing, so it replaces nothing, and the landing rule has no words to put it
+    // after. Asking anyway carried it past a whole chain of struck text it never named.
+    const paragraph =
+      '<w:p><w:r><w:t>AA</w:t></w:r>' +
+      '<w:del w:id="7" w:author="Ada" w:date="2026-09-04T00:00:00Z">' +
+      '<w:r><w:delText>BB</w:delText></w:r></w:del>' +
+      '<w:bookmarkStart w:id="1" w:name="m"/>' +
+      '<w:del w:id="7" w:author="Ada" w:date="2026-09-04T00:00:00Z">' +
+      '<w:r><w:delText>CC</w:delText></w:r></w:del>' +
+      '<w:bookmarkEnd w:id="1"/><w:r><w:t>DD</w:t></w:r></w:p>';
+
+    const replaced = mount({ author: 'Ada', bytes: bodyDocx(paragraph) });
+    replaced.editor.surface!.setEditingMode('suggest');
+    const target = paragraphsOf(replaced.host)[0]!;
+    expect(
+      replaced.host.execute({
+        operations: [
+          {
+            op: 'replaceSpan',
+            span: {
+              start: { paragraph: target, offset: 3 },
+              end: { paragraph: target, offset: 3 },
+            },
+            text: 'X',
+          },
+        ],
+      }).ok
+    ).toBe(true);
+
+    const inserted = mount({ author: 'Ada', bytes: bodyDocx(paragraph) });
+    inserted.editor.surface!.setEditingMode('suggest');
+    expect(
+      inserted.host.execute({
+        operations: [
+          {
+            op: 'insertText',
+            at: { paragraph: paragraphsOf(inserted.host)[0]!, offset: 3 },
+            text: 'X',
+          },
+        ],
+      }).ok
+    ).toBe(true);
+
+    expect(savedDocumentXml(replaced.host)).toBe(savedDocumentXml(inserted.host));
+  });
+
+  test('a batch settles buffered typing before it plans, and refuses a stale expectation', () => {
+    // Coalesced keystrokes land as their own transaction the moment the host reads the
+    // surface. Settled at the batch's entry, so `expectedRevision` is compared against the
+    // document the batch will actually write to rather than the one it was about to leave.
+    const { host, editor } = mount();
+    const before = host.revision();
+    const paragraphs = paragraphsOf(host);
+    const paragraphId = editor.surface!.session.paragraphIds()[0]!;
+    editor.surface!.setSelection({
+      anchor: { paragraphId, offset: 0 },
+      head: { paragraphId, offset: 0 },
+    });
+    editor.surface!.enqueueType('QQQ');
+
+    // The stale expectation is refused rather than silently planned against.
+    const stale = host.execute({
+      expectedRevision: before,
+      operations: [{ op: 'insertText', at: { paragraph: paragraphs[0]!, offset: 0 }, text: 'Z' }],
+    });
+    expect(stale.ok).toBe(false);
+    // And the buffered keystrokes are in the document, not still pending.
+    expect(textOf(host, paragraphs[0]!)).toBe('QQQalpha');
+    expect(host.revision()).toBeGreaterThan(before);
+
+    // A batch that names the settled revision goes through.
+    const fresh = host.execute({
+      expectedRevision: host.revision(),
+      operations: [{ op: 'insertText', at: { paragraph: paragraphs[0]!, offset: 0 }, text: 'Z' }],
+    });
+    expect(fresh.ok).toBe(true);
+    expect(textOf(host, paragraphs[0]!)).toBe('ZQQQalpha');
   });
 
   test('suggesting with no author refuses, exactly as a keystroke would', () => {

--- a/packages/core/src/editor/__tests__/propose-commands.test.ts
+++ b/packages/core/src/editor/__tests__/propose-commands.test.ts
@@ -81,7 +81,12 @@ describe('explicit tracked-change commands', () => {
       const deletionId = /<w:del\b[^>]*w:id="([^"]+)"/.exec(xml)?.[1];
       const insertionId = /<w:ins\b[^>]*w:id="([^"]+)"/.exec(xml)?.[1];
       expect(deletionId).toBeDefined();
-      expect(insertionId).toBe(deletionId);
+      // One decision, two elements: as Word writes it, the deletion first and each half under
+      // its own id (#691). The review lane pairs them on adjacency into one card — see
+      // `store/__tests__/tracked-replacement.test.ts`.
+      expect(insertionId).toBeDefined();
+      expect(insertionId).not.toBe(deletionId);
+      expect(xml.indexOf('<w:del ')).toBeLessThan(xml.indexOf('<w:ins '));
       expect(xml).toContain('<w:delText>bc</w:delText>');
       expect(xml).toContain('<w:t>XY</w:t>');
     } finally {

--- a/packages/core/src/editor/automation-host.ts
+++ b/packages/core/src/editor/automation-host.ts
@@ -81,10 +81,33 @@ function automationCommentIntent(
  * subscription this adapter took and leaves the editor mounted and editable.
  */
 export function createBrowserAutomationHost(editor: DocxEditorInstance): AutomationHost {
-  return createAutomationHost({
+  const host = createAutomationHost({
     port: sessionPort(editor),
     capabilities: BROWSER_AUTOMATION_CAPABILITIES,
   });
+  let disposed = false;
+  return {
+    ...host,
+    dispose: () => {
+      disposed = true;
+      host.dispose();
+    },
+    execute: (request) => {
+      // COALESCED TYPING FIRST, ONCE, at the batch's own entry.
+      //
+      // A keystroke still in the buffer lands as its own transaction the moment anything asks
+      // the surface for state, so a batch that read a revision or a package ahead of it
+      // planned against a document it no longer writes to — and `expectedRevision` waved
+      // through exactly the move it exists to catch. Settling HERE rather than inside those
+      // reads keeps the commit off the change-notification path: `revision()` is called from
+      // the host's own `on('change')` subscriber, and flushing there would commit typing from
+      // inside a render.
+      // Nothing to settle for a batch that will be refused anyway: a disposed host must not
+      // commit the editor's buffered keystrokes on its way to saying it is disposed.
+      if (!disposed) editor.surface?.flushPendingInput();
+      return host.execute(request);
+    },
+  };
 }
 
 function sessionPort(editor: DocxEditorInstance): AutomationDocumentPort {
@@ -131,6 +154,8 @@ function sessionPort(editor: DocxEditorInstance): AutomationDocumentPort {
     // caller with no view means.
     revisionDisplayMode: () =>
       editor.surface?.revisionDisplayMode() ?? DEFAULT_FORMATTING_DISPLAY_MODE,
+    replacementLanding: (paragraphId, start, end) =>
+      editor.surface?.replacementLanding(paragraphId, start, end) ?? null,
     apply(staged: AutomationStagedOps, scope: StoryScope): AutomationPortApplyResult {
       sync();
       const surface = editor.surface;

--- a/packages/core/src/editor/paginated-surface-contract.ts
+++ b/packages/core/src/editor/paginated-surface-contract.ts
@@ -19,15 +19,10 @@ import type {
 } from '../contracts/editor.ts';
 import type { RevisionDisplayMode } from '../layout/revision-projection.ts';
 import type { RevisionStyles } from '../output/revision-presentation.ts';
-import type { FieldShadingMode } from '../output/semantic-paint.ts';
-import type {
-  ReviewModuleContribution,
-  CollaborationModuleContribution,
-} from '../contracts/modules.ts';
 import type { CollaborationStatus } from '../collaboration/index.ts';
 import type { HyperlinkOps } from './surface-hyperlinks.ts';
-import type { EquationActivation, EquationOps } from './surface-equations.ts';
-import type { HyperlinkActivation, SurfaceNavigation } from './surface-navigation.ts';
+import type { EquationOps } from './surface-equations.ts';
+import type { SurfaceNavigation } from './surface-navigation.ts';
 import type {
   CellSelection,
   NavigationCommand,
@@ -35,7 +30,6 @@ import type {
   SemanticLayout,
   SemanticPosition,
   SemanticSelection,
-  TextMeasurer,
 } from '@docx-editor.dev/core/layout';
 
 /**
@@ -69,123 +63,9 @@ export type { PaginatedSurfacePerf };
 import type { RemoteCaretLabelAnchor, RemoteCaretLabelHost } from './surface-remote-caret-label.ts';
 export type { RemoteCaretLabelAnchor, RemoteCaretLabelHost };
 
-/**
- * How a paginated surface opens. Every field is optional.
- *
- * `measurer` is the injection seam that keeps layout DOM-free — supply one to lay a document out
- * on a server, or leave it off in a browser to get the canvas measurer.
- */
-export interface PaginatedSurfaceOptions {
-  /**
-   * The collaboration module's replica for this surface's session. Absent,
-   * the surface does not attach, and local store history remains the undo
-   * authority.
-   */
-  readonly collaborationModel?: CollaborationModuleContribution;
-  readonly measurer?: TextMeasurer;
-  /** Ambient author for tracked edits. Required before suggesting can write anything. */
-  readonly author?: string;
-  /** Opening mode; changeable at runtime with `setEditingMode`. */
-  readonly editingMode?: SurfaceEditingMode;
-  /**
-   * Identifies the measurer for cache invalidation.
-   *
-   * Fonts resolve asynchronously, so a host that swaps its measurer must change this or the
-   * cached pre-font layout is served for the rest of the session.
-   */
-  readonly producer?: string;
-  /**
-   * Maps a document-declared font family to the alias its registered bytes live under, so
-   * painted runs can use embedded glyphs without the file's family name entering the
-   * page-global CSS font namespace.
-   */
-  readonly fontAlias?: (family: string) => string | undefined;
-  /** Points to CSS pixels. */
-  readonly scale?: number;
-  /**
-   * How revisions project into layout and paint. Omitted keeps the layout default
-   * (`all-markup`). The editor facade passes `proposed` when no review module is
-   * registered — the free tier's final-state rendering; the machinery below this
-   * option is shared either way.
-   */
-  readonly revisionDisplayMode?: RevisionDisplayMode;
-  /** Authors whose changes open in their accepted view-time projection. */
-  readonly hiddenRevisionAuthors?: readonly string[];
-  /**
-   * When a field's result wears Word's grey shading. Omitted keeps Word's own default,
-   * `when-selected`.
-   *
-   * Applies to ORDINARY fields only. Legacy form fields follow the document's
-   * `w:doNotShadeFormData`, because a form's blanks are the document's own statement about
-   * itself rather than a reader's preference.
-   *
-   * A paint-level option, not a layout one: it changes no geometry, so switching it repaints
-   * without remeasuring a single line.
-   */
-  readonly fieldShading?: FieldShadingMode;
-  /**
-   * How tracked changes are coloured: by AUTHOR (the default), by kind, or by author with
-   * host-pinned colours. A paint-level option like {@link fieldShading}: it changes no
-   * geometry, so switching it repaints without remeasuring a line. Applies wherever
-   * revision markup paints, whatever the {@link revisionDisplayMode} leaves visible.
-   */
-  readonly revisionStyles?: RevisionStyles;
-  /**
-   * The review module's derivation hooks for this surface's session. Absent,
-   * `session.reviewItems()` is the typed empty queue and every review affordance
-   * built on it stays inert.
-   */
-  readonly reviewModel?: ReviewModuleContribution;
-  /**
-   * The family a run with no authored font is reported as by `formatting()` AND painted
-   * in — the face the measurer falls back to. Absent, such a run reports
-   * `fontFamily: null` and paints in whatever font the page inherits, which the measurer
-   * did not measure: visible glyphs drift from wrap points and caret geometry.
-   */
-  readonly defaultFontFamily?: string;
-  /**
-   * Who resolves a pointer to a caret.
-   *
-   * `'engine'` (the default) answers from the layout records, which is what makes a click in
-   * a margin, an indent or a cell's padding land where it was aimed. `'native'` binds no
-   * pointer handlers and leaves the browser's own caret placement in charge.
-   */
-  readonly pointer?: 'engine' | 'native';
-  readonly onChange?: (state: PaginatedSurfaceState) => void;
-  /**
-   * A plain click on an external (or inert) hyperlink, for a host to open its popover with.
-   *
-   * Absent means such a click does nothing. That is deliberate: a host with no popover
-   * mounted must not have clicks silently opening tabs, and the popover is the only path to
-   * activation (see the navigation module's single `window.open` gate).
-   */
-  readonly onHyperlinkPopover?: (activation: HyperlinkActivation) => void;
-  readonly onEquationPopover?: (activation: EquationActivation) => void;
-  /**
-   * Ctrl/Cmd+K — Word's Insert Hyperlink. The engine reports the request; the host's chrome
-   * decides what a link dialog looks like. A host that passes nothing leaves the key alone
-   * rather than doing something surprising with it.
-   */
-  readonly onRequestHyperlink?: () => void;
-  /**
-   * Localized accessible names for core-owned table insertion furniture.
-   * Defaults to English from `@docx-editor.dev/i18n` when omitted.
-   */
-  readonly tableInteractionLabel?: (
-    key: 'table.insertRowBelow' | 'table.insertColumnRight'
-  ) => string;
-  /** Localized drawing refusal labels; defaults to English when omitted. */
-  readonly drawingStrings?: import('../output/semantic-paint-drawings.ts').DrawingPaintStrings;
-  /** Override raster decode for package image intents; defaults to browser/headless. */
-  readonly imageDecodePort?: import('../store/package/image-resources.ts').ImageDecodePort;
-  /**
-   * Localized name for a generated TOC, written as the control's `w:alias` on insert.
-   *
-   * The update ACTIONS are not here: they are rows in the host's context menu, which owns
-   * its own labels. The engine paints no menu of its own.
-   */
-  readonly tocLabels?: { readonly title: string };
-}
+import type { PaginatedSurfaceOptions } from './paginated-surface-options.ts';
+
+export type { PaginatedSurfaceOptions } from './paginated-surface-options.ts';
 
 /**
  * What the selection is currently formatted as.
@@ -839,6 +719,16 @@ export interface PaginatedSurface {
    * would mean another to a script that assumed the resolved result.
    */
   revisionDisplayMode(): RevisionDisplayMode;
+  /**
+   * Where a replacement for `[start, end)` of a paragraph lands, or null when the edit would
+   * not be tracked.
+   *
+   * Non-null exactly when suggesting: the struck words stay, so the replacement goes past
+   * them, minus whatever of the range was this author's own pending insertion, which leaves.
+   * The SAME rule every replacing lane of the keyboard reads, exposed so the automation object
+   * model aims a scripted `Replace` where typing does and can answer the span it wrote.
+   */
+  replacementLanding(paragraphId: string, start: number, end: number): number | null;
   /**
    * Commit review ops — accept, reject, a new comment — through the SAME path a keystroke
    * takes: layout, paint, and a caret clamped to what the document now holds.

--- a/packages/core/src/editor/paginated-surface-options.ts
+++ b/packages/core/src/editor/paginated-surface-options.ts
@@ -1,0 +1,135 @@
+// What `openPaginated` takes: the options record of the paginated surface.
+//
+// Split from `paginated-surface-contract.ts`, which is long enough to hold the surface
+// interface alone; the record is only ever read at open time, and every consumer imports it
+// from the contract, which re-exports it.
+
+import type { RevisionDisplayMode } from '../layout/revision-projection.ts';
+import type { RevisionStyles } from '../output/revision-presentation.ts';
+import type { FieldShadingMode } from '../output/semantic-paint.ts';
+import type {
+  ReviewModuleContribution,
+  CollaborationModuleContribution,
+} from '../contracts/modules.ts';
+import type { EquationActivation } from './surface-equations.ts';
+import type { HyperlinkActivation } from './surface-navigation.ts';
+import type { TextMeasurer } from '@docx-editor.dev/core/layout';
+import type { PaginatedSurfaceState, SurfaceEditingMode } from './paginated-surface-contract.ts';
+
+/**
+ * How a paginated surface opens. Every field is optional.
+ *
+ * `measurer` is the injection seam that keeps layout DOM-free — supply one to lay a document out
+ * on a server, or leave it off in a browser to get the canvas measurer.
+ */
+export interface PaginatedSurfaceOptions {
+  /**
+   * The collaboration module's replica for this surface's session. Absent,
+   * the surface does not attach, and local store history remains the undo
+   * authority.
+   */
+  readonly collaborationModel?: CollaborationModuleContribution;
+  readonly measurer?: TextMeasurer;
+  /** Ambient author for tracked edits. Required before suggesting can write anything. */
+  readonly author?: string;
+  /** Opening mode; changeable at runtime with `setEditingMode`. */
+  readonly editingMode?: SurfaceEditingMode;
+  /**
+   * Identifies the measurer for cache invalidation.
+   *
+   * Fonts resolve asynchronously, so a host that swaps its measurer must change this or the
+   * cached pre-font layout is served for the rest of the session.
+   */
+  readonly producer?: string;
+  /**
+   * Maps a document-declared font family to the alias its registered bytes live under, so
+   * painted runs can use embedded glyphs without the file's family name entering the
+   * page-global CSS font namespace.
+   */
+  readonly fontAlias?: (family: string) => string | undefined;
+  /** Points to CSS pixels. */
+  readonly scale?: number;
+  /**
+   * How revisions project into layout and paint. Omitted keeps the layout default
+   * (`all-markup`). The editor facade passes `proposed` when no review module is
+   * registered — the free tier's final-state rendering; the machinery below this
+   * option is shared either way.
+   */
+  readonly revisionDisplayMode?: RevisionDisplayMode;
+  /** Authors whose changes open in their accepted view-time projection. */
+  readonly hiddenRevisionAuthors?: readonly string[];
+  /**
+   * When a field's result wears Word's grey shading. Omitted keeps Word's own default,
+   * `when-selected`.
+   *
+   * Applies to ORDINARY fields only. Legacy form fields follow the document's
+   * `w:doNotShadeFormData`, because a form's blanks are the document's own statement about
+   * itself rather than a reader's preference.
+   *
+   * A paint-level option, not a layout one: it changes no geometry, so switching it repaints
+   * without remeasuring a single line.
+   */
+  readonly fieldShading?: FieldShadingMode;
+  /**
+   * How tracked changes are coloured: by AUTHOR (the default), by kind, or by author with
+   * host-pinned colours. A paint-level option like {@link fieldShading}: it changes no
+   * geometry, so switching it repaints without remeasuring a line. Applies wherever
+   * revision markup paints, whatever the {@link revisionDisplayMode} leaves visible.
+   */
+  readonly revisionStyles?: RevisionStyles;
+  /**
+   * The review module's derivation hooks for this surface's session. Absent,
+   * `session.reviewItems()` is the typed empty queue and every review affordance
+   * built on it stays inert.
+   */
+  readonly reviewModel?: ReviewModuleContribution;
+  /**
+   * The family a run with no authored font is reported as by `formatting()` AND painted
+   * in — the face the measurer falls back to. Absent, such a run reports
+   * `fontFamily: null` and paints in whatever font the page inherits, which the measurer
+   * did not measure: visible glyphs drift from wrap points and caret geometry.
+   */
+  readonly defaultFontFamily?: string;
+  /**
+   * Who resolves a pointer to a caret.
+   *
+   * `'engine'` (the default) answers from the layout records, which is what makes a click in
+   * a margin, an indent or a cell's padding land where it was aimed. `'native'` binds no
+   * pointer handlers and leaves the browser's own caret placement in charge.
+   */
+  readonly pointer?: 'engine' | 'native';
+  readonly onChange?: (state: PaginatedSurfaceState) => void;
+  /**
+   * A plain click on an external (or inert) hyperlink, for a host to open its popover with.
+   *
+   * Absent means such a click does nothing. That is deliberate: a host with no popover
+   * mounted must not have clicks silently opening tabs, and the popover is the only path to
+   * activation (see the navigation module's single `window.open` gate).
+   */
+  readonly onHyperlinkPopover?: (activation: HyperlinkActivation) => void;
+  readonly onEquationPopover?: (activation: EquationActivation) => void;
+  /**
+   * Ctrl/Cmd+K — Word's Insert Hyperlink. The engine reports the request; the host's chrome
+   * decides what a link dialog looks like. A host that passes nothing leaves the key alone
+   * rather than doing something surprising with it.
+   */
+  readonly onRequestHyperlink?: () => void;
+  /**
+   * Localized accessible names for core-owned table insertion furniture.
+   * Defaults to English from `@docx-editor.dev/i18n` when omitted.
+   */
+  readonly tableInteractionLabel?: (
+    key: 'table.insertRowBelow' | 'table.insertColumnRight'
+  ) => string;
+  /** Localized drawing refusal labels; defaults to English when omitted. */
+  readonly drawingStrings?: import('../output/semantic-paint-drawings.ts').DrawingPaintStrings;
+  /** Override raster decode for package image intents; defaults to browser/headless. */
+  readonly imageDecodePort?: import('../store/package/image-resources.ts').ImageDecodePort;
+  /**
+   * Localized name for a generated TOC, written as the control's `w:alias` on insert.
+   *
+   * The update ACTIONS are not here: they are rows in the host's context menu, which owns
+   * its own labels. The engine paints no menu of its own.
+   */
+  readonly tocLabels?: { readonly title: string };
+}

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -1102,6 +1102,16 @@ export function mountPaginatedSurface(
         level
       ) !== null,
   });
+  /** The contract's `replacementLanding`; the hyperlink lane reads the same rule. */
+  function replacementLanding(paragraphId: string, start: number, end: number): number | null {
+    if (editingMode !== 'suggest') return null;
+    // A POSITIONAL READ, and it does not settle anything itself: flushing here would commit
+    // buffered typing in the middle of a caller that had already captured the offsets it
+    // builds ops from. Both callers settle first — the hyperlink lane through
+    // `orderedRange()`, an automation batch at its own entry — which is where a flush belongs.
+    return replacementOffset({ paragraphId, offset: start }, { paragraphId, offset: end });
+  }
+
   const hyperlinks = createHyperlinkOps({
     session: gatedSession,
     // A HYPERLINK field is not a tree node, so its link resolves from the layout projection
@@ -1114,14 +1124,8 @@ export function mountPaginatedSurface(
     refusesWrite: () => writeRefusal(true) !== null,
     withMintActor: (mint) => runWithTransactionActor(collaborationSession?.identity.actorId, mint),
     storyScope,
-    // Non-null exactly when suggesting: the link lane then replaces the selection with
-    // tracked ops and wraps the fresh insertion, instead of writing an unattributed wrap.
-    // The landing is the SAME rule every replacing lane reads — past the struck words,
-    // minus this author's own retracted insertion.
-    suggestReplacementOffset: (paragraphId, start, end) =>
-      editingMode === 'suggest'
-        ? replacementOffset({ paragraphId, offset: start }, { paragraphId, offset: end })
-        : null,
+    // Non-null exactly when suggesting: the link lane then replaces with tracked ops.
+    replacementLanding,
     insertionLanding: (paragraphId, offset) =>
       positionPastDeletion(currentLayout, { paragraphId, offset }).offset,
     selection: () => selection,
@@ -4528,6 +4532,7 @@ export function mountPaginatedSurface(
     cellSelection: () => cellSelection,
     editingMode: () => editingMode,
     author: () => author,
+    trackedDate,
     storyScope,
     paragraphOrder,
     flushPendingInputAndLayout,
@@ -5273,6 +5278,7 @@ export function mountPaginatedSurface(
     },
 
     revisionDisplayMode,
+    replacementLanding,
     applyAutomationOps: (staged, scope) => {
       // THE SAME PATH A KEYSTROKE TAKES, minus the keystroke. `applyOps` is where viewing
       // refuses and where suggesting turns an edit into a proposal, and `commit` is where the

--- a/packages/core/src/editor/surface-hyperlinks.ts
+++ b/packages/core/src/editor/surface-hyperlinks.ts
@@ -279,11 +279,7 @@ export interface HyperlinkOpsDeps {
    * an unattributed edit — a link Accept/Reject could not act on — into a document whose
    * author believed everything they did was a proposal.
    */
-  readonly suggestReplacementOffset?: (
-    paragraphId: string,
-    start: number,
-    end: number
-  ) => number | null;
+  readonly replacementLanding?: (paragraphId: string, start: number, end: number) => number | null;
   /**
    * Where an insertion aimed at `offset` actually lands, in EVERY mode: past the deletion
    * the caret rests in. Both insert appliers relocate beside a `w:del` rather than into
@@ -446,7 +442,7 @@ export function createHyperlinkOps(deps: HyperlinkOpsDeps): HyperlinkOps {
         // both land inside the link because the range is strictly inside it.
         if (input.text !== undefined && input.text !== existing.text) {
           if (input.text.length === 0) return false;
-          const landing = deps.suggestReplacementOffset?.(
+          const landing = deps.replacementLanding?.(
             existing.paragraphId,
             existing.start,
             existing.end
@@ -561,7 +557,7 @@ export function createHyperlinkOps(deps: HyperlinkOpsDeps): HyperlinkOps {
         ops.push({ op: 'insertText', paragraphId, offset: start, text: display });
         end = start + display.length;
       } else {
-        const landing = deps.suggestReplacementOffset?.(paragraphId, start, end);
+        const landing = deps.replacementLanding?.(paragraphId, start, end);
         if (landing !== null && landing !== undefined) {
           // SUGGESTING proposes the link as a replacement, because a bare wrap of somebody
           // else's words is an edit no review card can carry. The selection is struck in
@@ -677,7 +673,7 @@ function withinLink(
  * The suggesting-mode lowering of "replace `[start, end)` with `text`", spelled ONCE.
  *
  * Strike first — the struck words stay in place, as every suggested deletion does — then
- * land the copy at the landing `suggestReplacementOffset` computed, where the tracked-insert
+ * land the copy at the landing `replacementLanding` computed, where the tracked-insert
  * core adopts the fresh deletion and follows it into the link that holds it. The reverse
  * order put the copy at the range start, which the core places beside a link's boundary.
  */

--- a/packages/core/src/editor/surface-range-edit.ts
+++ b/packages/core/src/editor/surface-range-edit.ts
@@ -43,6 +43,7 @@ import {
 } from '@docx-editor.dev/core/layout';
 import { directParagraphsInCells } from '../layout/semantic-cell-selection.ts';
 import { retractedLengthOf, retractedRangesOf } from '../store/store/tree-op-retraction.ts';
+import { trackedInsertionLanding } from '../store/store/tree-op-tracked-adjacency.ts';
 import { retractsOwnParagraphMark } from '../store/store/tree-op-tracked-marks.ts';
 import { partOfNodeId } from './surface-scope.ts';
 import {
@@ -64,6 +65,8 @@ export interface SurfaceRangeEditDeps {
   editingMode(): SurfaceEditingMode;
   /** The configured tracked-change author, unnormalized — each reader trims its own. */
   author(): string | undefined;
+  /** The stamp a tracked edit made now would carry; see `sameEditingMoment`. */
+  trackedDate(): string;
   storyScope(): StoryScope;
   /** Scoped document order: a header/footer or note selection orders within its own story. */
   paragraphOrder(): readonly string[];
@@ -271,12 +274,36 @@ export function createSurfaceRangeEditOps(deps: SurfaceRangeEditDeps): SurfaceRa
     // automation lane's — so the after-the-strike rule applies under that author instead.
     const tracked = trackedAuthor !== undefined || deps.editingMode() === 'suggest';
     if (!tracked || from.paragraphId !== to.paragraphId) return from.offset;
+    // NOTHING TO REPLACE, nothing to land after. A zero-width range strikes no words, and
+    // mapping it out of a deletion it merely touches carried a scripted insert past struck
+    // text the operation never named — further than the same text inserted at that point.
+    if (to.offset <= from.offset) return from.offset;
     // A range end INSIDE a pre-existing deletion aims the insert at the interior of that
-    // `w:del`: the store relocates it past the deletion, the caret math does not hear about
-    // it, and the next keystroke lands before the previous one. Map past the old deletion
-    // FIRST; the retracted characters all sit before it, so the subtraction still holds.
-    const past = positionPastDeletion(deps.layout(), to);
-    return past.offset - retractedByInsertionAuthor(from, past, trackedAuthor ?? deps.author());
+    // `w:del`: the store relocates it past the deletion, and the caret math has to hear about
+    // it or the next keystroke lands before the previous one. That mapping, the adjacency
+    // question and the strike's end all come from the paragraph's OWN tree — one rule, the
+    // store's, so the surface cannot predict a landing the store will not use.
+    const author = (trackedAuthor ?? deps.author())?.trim();
+    if (!author) return positionPastDeletion(deps.layout(), to).offset;
+    const part = partOfNodeId(session, to.paragraphId) ?? session.part();
+    const paragraph = findNode(part, to.paragraphId);
+    if (!paragraph || paragraph.kind !== 'paragraph') {
+      return positionPastDeletion(deps.layout(), to).offset;
+    }
+    const struck = { start: from.offset, end: to.offset };
+    const { past, landing } = trackedInsertionLanding(
+      paragraph,
+      struck,
+      to.offset,
+      author,
+      deps.trackedDate()
+    );
+    const retracted = retractedLengthOf(paragraph, from.offset, past, author);
+    // NOTHING STRUCK, nothing to land after: a zero-width range, or one covering only this
+    // author's own pending insertion, which retracts and writes no strike at all. The store
+    // then places at the aim, and so must this.
+    const strikes = past - from.offset > retracted;
+    return (strikes ? landing : past) - retracted;
   }
 
   /**
@@ -480,7 +507,12 @@ export function createSurfaceRangeEditOps(deps: SurfaceRangeEditDeps): SurfaceRa
     const author = authorValue?.trim();
     if (!author) return 0;
     if (from.paragraphId !== to.paragraphId) return 0;
-    const part = session.partFor(deps.storyScope()) ?? session.part();
+    // The paragraph's OWN part, by its id: a scripted replacement addresses the body while
+    // the reader has a header open, and the reader's story would answer no paragraph and no
+    // retraction, landing the copy past its own pending text. `partOfNodeId` is a pure
+    // ancestry read; `partFor` would retain a story store for what is only a lookup.
+    const part =
+      partOfNodeId(session, to.paragraphId) ?? session.partFor(deps.storyScope()) ?? session.part();
     const paragraph = findNode(part, to.paragraphId);
     if (!paragraph || paragraph.kind !== 'paragraph') return 0;
     return retractedLengthOf(paragraph, from.offset, to.offset, author);

--- a/packages/core/src/store/__tests__/tracked-edit-fixture.ts
+++ b/packages/core/src/store/__tests__/tracked-edit-fixture.ts
@@ -1,0 +1,39 @@
+// The fixture the tracked-edit test files share: one paragraph, applied ops, serialized XML.
+//
+// Asserted against serialized XML rather than tree shape, because the whole point of a
+// tracked edit is what another editor reads back.
+
+import { readOoxmlPart, serializeOoxmlPart, type OoxmlPart } from '../package/ooxml-tree.ts';
+import { applyTreeOp } from '../store/tree-op-apply.ts';
+import type { TreeDocOp } from '../store/tree-op-validate.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+export const ADA = { author: 'Ada Lovelace', date: '2026-01-02T03:04:05Z' };
+
+export function part(body: string): OoxmlPart {
+  const read = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml',
+  });
+  if (!read.ok) throw new Error(`fixture did not parse: ${read.reason}`);
+  return read.part;
+}
+
+/** The only paragraph in the fixture. */
+export function paragraphId(source: OoxmlPart): string {
+  const body = source.root.children.find((child) => child.kind !== 'textValue');
+  const found = body && body.kind !== 'textValue' ? body.children[0] : undefined;
+  if (!found) throw new Error('no paragraph');
+  return found.id;
+}
+
+export function apply(source: OoxmlPart, op: TreeDocOp): OoxmlPart {
+  const result = applyTreeOp(source, op);
+  if (!result.ok) throw new Error(`op refused: ${result.reason} ${result.detail ?? ''}`);
+  return result.part;
+}
+
+/** Serialized, with the noise a diff does not care about collapsed. */
+export function xml(source: OoxmlPart): string {
+  return serializeOoxmlPart(source).replace(/^<\?xml[^>]*\?>/, '');
+}

--- a/packages/core/src/store/__tests__/tracked-edits.test.ts
+++ b/packages/core/src/store/__tests__/tracked-edits.test.ts
@@ -6,40 +6,8 @@
 // the cases where a naive implementation still produces valid XML that says the wrong thing.
 
 import { describe, expect, test } from 'bun:test';
-import { readOoxmlPart, serializeOoxmlPart, type OoxmlPart } from '../package/ooxml-tree.ts';
 import { applyTreeOp } from '../store/tree-op-apply.ts';
-import type { TreeDocOp } from '../store/tree-op-validate.ts';
-
-const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
-const ADA = { author: 'Ada Lovelace', date: '2026-01-02T03:04:05Z' };
-
-function part(body: string): OoxmlPart {
-  const read = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
-    name: '/word/document.xml',
-    contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml',
-  });
-  if (!read.ok) throw new Error(`fixture did not parse: ${read.reason}`);
-  return read.part;
-}
-
-/** The only paragraph in the fixture. */
-function paragraphId(source: OoxmlPart): string {
-  const body = source.root.children.find((child) => child.kind !== 'textValue');
-  const found = body && body.kind !== 'textValue' ? body.children[0] : undefined;
-  if (!found) throw new Error('no paragraph');
-  return found.id;
-}
-
-function apply(source: OoxmlPart, op: TreeDocOp): OoxmlPart {
-  const result = applyTreeOp(source, op);
-  if (!result.ok) throw new Error(`op refused: ${result.reason} ${result.detail ?? ''}`);
-  return result.part;
-}
-
-/** Serialized, with the noise a diff does not care about collapsed. */
-function xml(source: OoxmlPart): string {
-  return serializeOoxmlPart(source).replace(/^<\?xml[^>]*\?>/, '');
-}
+import { ADA, apply, paragraphId, part, xml } from './tracked-edit-fixture.ts';
 
 describe('a tracked insertion', () => {
   test('splits the run and lands between the halves as w:ins', () => {
@@ -193,62 +161,6 @@ describe('a tracked insertion', () => {
     expect(out.match(/<w:ins\b/g)?.length).toBe(2);
     expect(out).toMatch(/w:author="Ada Lovelace"/);
     expect(out).toMatch(/w:author="Alan Turing"/);
-  });
-});
-
-describe('a replacement', () => {
-  test('the halves share one revision identity and read in Word order', () => {
-    // Typing over a selection: the delete lands first, then the insert, in one transaction.
-    let current = part('<w:p><w:r><w:t>alpha beta</w:t></w:r></w:p>');
-    const id = paragraphId(current);
-    current = apply(current, {
-      op: 'deleteText',
-      paragraphId: id,
-      start: 0,
-      end: 5,
-      revision: ADA,
-    });
-    current = apply(current, {
-      op: 'insertText',
-      paragraphId: id,
-      offset: 0,
-      text: 'omega',
-      // The same instant, because it is the same edit — the surface stamps one timestamp per
-      // transaction. A month apart would NOT join, and must not: see the next test.
-      revision: ADA,
-    });
-    const out = xml(current);
-    // Struck text first, then what takes its place — Word's arrangement, and the order that
-    // reads as a sentence. Before it, the replacement would read "omega alpha".
-    expect(out).toMatch(
-      /<w:del[^>]*><w:r><w:delText>alpha<\/w:delText><\/w:r><\/w:del><w:ins[^>]*><w:r><w:t>omega<\/w:t><\/w:r><\/w:ins>/
-    );
-    // ONE identity across both halves: the insert adopted the deletion's id AND its date,
-    // which is what makes accept/reject resolve the pair together.
-    const ids = [...out.matchAll(/<w:(?:ins|del)[^>]*w:id="(\d+)"/g)].map((match) => match[1]);
-    expect(new Set(ids).size).toBe(1);
-    const dates = [...out.matchAll(/<w:(?:ins|del)[^>]*w:date="([^"]+)"/g)].map((m) => m[1]);
-    expect(new Set(dates).size).toBe(1);
-  });
-
-  test("an OLD deletion by the same author is not absorbed into today's edit", () => {
-    const before = part(
-      `<w:p><w:del w:id="5" w:author="Ada Lovelace" w:date="2020-01-01T00:00:00Z">` +
-        `<w:r><w:delText>old</w:delText></w:r></w:del><w:r><w:t>new</w:t></w:r></w:p>`
-    );
-    const after = apply(before, {
-      op: 'deleteText',
-      paragraphId: paragraphId(before),
-      start: 3,
-      end: 6,
-      revision: ADA,
-    });
-    const out = xml(after);
-    // Two decisions. Joining them would backdate today's edit into a revision from 2020 and
-    // make rejecting one reject the other.
-    expect(out.match(/<w:del\b/g)?.length).toBe(2);
-    expect(out).toContain('w:date="2020-01-01T00:00:00Z"');
-    expect(out).toContain(`w:date="${ADA.date}"`);
   });
 });
 

--- a/packages/core/src/store/__tests__/tracked-replacement.test.ts
+++ b/packages/core/src/store/__tests__/tracked-replacement.test.ts
@@ -1,0 +1,526 @@
+// A suggested REPLACEMENT: typing over a selection, or `Range.insertText(…, 'Replace')` in
+// suggesting mode. The deletion lands first and the insertion joins it in the SAME
+// transaction, and what the file says about the pair is what every other reader — Word
+// first — goes by: struck words first, then what takes their place, each half under its own
+// revision id (#691).
+//
+// Applied through `TreeDocumentStore.transact`, not `applyTreeOp` alone: the store lends its
+// ops the transaction's minter, and the insertion relocates past a strike only when that
+// strike is the transaction's own. Aimed at the strike's front edge (the automation lane) or
+// past it (the keyboard), the same transaction must write the same markup.
+
+import { describe, expect, test } from 'bun:test';
+import type { OoxmlParagraphNode, OoxmlPart } from '../package/ooxml-tree.ts';
+import { revisionItemsOf } from '../store/review-reads.ts';
+import { trackedInsertionLanding } from '../store/tree-op-tracked-adjacency.ts';
+import { TreeDocumentStore } from '../store/tree-store.ts';
+import type { TreeDocOp } from '../store/tree-op-validate.ts';
+import { ADA, apply, paragraphId, part, xml } from './tracked-edit-fixture.ts';
+
+const WML = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+/** Strike `[start, end)` of the only paragraph and insert `text` at `aim`, in ONE transaction. */
+function replaced(
+  before: OoxmlPart,
+  start: number,
+  end: number,
+  aim: number,
+  text: string,
+  revision: { author: string; date: string } = ADA
+): OoxmlPart {
+  const id = paragraphId(before);
+  return transacted(before, [
+    { op: 'deleteText', paragraphId: id, start, end, revision },
+    { op: 'insertText', paragraphId: id, offset: aim, text, revision },
+  ]);
+}
+
+function transacted(before: OoxmlPart, ops: readonly TreeDocOp[]): OoxmlPart {
+  const store = new TreeDocumentStore(before);
+  const result = store.transact((tx) => {
+    for (const op of ops) tx.apply(op);
+  });
+  if (!result.ok) throw new Error(`transaction refused: ${result.reason} ${result.detail ?? ''}`);
+  return store.part;
+}
+
+/** The fixture's only paragraph, as a node. */
+function paragraphNode(source: OoxmlPart): OoxmlParagraphNode {
+  const body = source.root.children.find((child) => child.kind === 'body');
+  if (!body || body.kind === 'textValue') throw new Error('no body');
+  const first = body.children[0];
+  if (!first || first.kind !== 'paragraph') throw new Error('no paragraph');
+  return first;
+}
+
+/** Every revision id in the paragraph, in document order. */
+const revisionIds = (out: string): string[] =>
+  [...out.matchAll(/<w:(?:ins|del)[^>]*w:id="(\d+)"/g)].map((match) => match[1]!);
+
+describe('a replacement', () => {
+  test('the halves carry distinct ids, one date, and read in Word order', () => {
+    const before = part('<w:p><w:r><w:t>alpha beta</w:t></w:r></w:p>');
+    const out = xml(replaced(before, 0, 5, 0, 'omega'));
+    // Struck text first, then what takes its place — Word's arrangement, and the order that
+    // reads as a sentence. Before it, the replacement would read "omega alpha".
+    expect(out).toMatch(
+      /<w:del[^>]*><w:r><w:delText>alpha<\/w:delText><\/w:r><\/w:del><w:ins[^>]*><w:r><w:t>omega<\/w:t><\/w:r><\/w:ins>/
+    );
+    // TWO ids, as Word writes them: it numbers every revision element uniquely, and a reader
+    // keyed on the id saw one collided revision when the halves shared one. The pair is
+    // still one moment — the insert adopts the deletion's date — and the review lane pairs
+    // it on adjacency, so accept and reject resolve both halves together (#691).
+    const ids = revisionIds(out);
+    expect(ids).toHaveLength(2);
+    expect(new Set(ids).size).toBe(2);
+    const dates = [...out.matchAll(/<w:(?:ins|del)[^>]*w:date="([^"]+)"/g)].map((m) => m[1]);
+    expect(new Set(dates).size).toBe(1);
+  });
+
+  test("an OLD deletion by the same author is not absorbed into today's edit", () => {
+    const before = part(
+      `<w:p><w:del w:id="5" w:author="Ada Lovelace" w:date="2020-01-01T00:00:00Z">` +
+        `<w:r><w:delText>old</w:delText></w:r></w:del><w:r><w:t>new</w:t></w:r></w:p>`
+    );
+    const after = apply(before, {
+      op: 'deleteText',
+      paragraphId: paragraphId(before),
+      start: 3,
+      end: 6,
+      revision: ADA,
+    });
+    const out = xml(after);
+    // Two decisions. Joining them would backdate today's edit into a revision from 2020 and
+    // make rejecting one reject the other.
+    expect(out.match(/<w:del\b/g)?.length).toBe(2);
+    expect(out).toContain('w:date="2020-01-01T00:00:00Z"');
+    expect(out).toContain(`w:date="${ADA.date}"`);
+  });
+
+  test('a mid-paragraph replacement aimed at the front of the strike lands after it', () => {
+    // The range starts where a run ENDS. That run used to take the words at its end
+    // boundary, so `w:ins` came out in front of `w:del` — the reverse of Word's order, and
+    // read back as an Inserted card and a Deleted card instead of one Replaced.
+    const before = part(
+      '<w:p><w:r><w:t xml:space="preserve">The Receiving Party shall</w:t></w:r></w:p>'
+    );
+    const out = xml(replaced(before, 4, 19, 4, 'Recipient'));
+    expect(out).toMatch(
+      /<w:t xml:space="preserve">The <\/w:t><\/w:r><w:del[^>]*><w:r><w:delText>Receiving Party<\/w:delText><\/w:r><\/w:del><w:ins[^>]*><w:r><w:t>Recipient<\/w:t><\/w:r><\/w:ins><w:r><w:t xml:space="preserve"> shall<\/w:t>/
+    );
+    expect(new Set(revisionIds(out)).size).toBe(2);
+  });
+
+  test('aimed at the front or at the end of the strike, the replacement lands in one place', () => {
+    const before = part(
+      '<w:p><w:r><w:t xml:space="preserve">The Receiving Party shall</w:t></w:r></w:p>'
+    );
+    expect(xml(replaced(before, 4, 19, 4, 'Recipient'))).toBe(
+      xml(replaced(before, 4, 19, 19, 'Recipient'))
+    );
+  });
+
+  test('typing after Backspace keeps the typed text in FRONT of the struck character', () => {
+    // Two transactions, not one: the strike a keystroke ago is adjacent too, but it is not
+    // this edit's replacement. Word keeps the caret before the struck character there, and
+    // the typed text goes where the caret is.
+    const before = part('<w:p><w:r><w:t>abc</w:t></w:r></w:p>');
+    const id = paragraphId(before);
+    const struck = transacted(before, [
+      { op: 'deleteText', paragraphId: id, start: 2, end: 3, revision: ADA },
+    ]);
+    const typed = transacted(struck, [
+      { op: 'insertText', paragraphId: id, offset: 2, text: 'x', revision: ADA },
+    ]);
+    expect(xml(typed)).toMatch(
+      /<w:ins[^>]*><w:r><w:t>x<\/w:t><\/w:r><\/w:ins><w:del[^>]*><w:r><w:delText>c<\/w:delText>/
+    );
+  });
+
+  test('a strike that JOINS one from a moment ago still takes the replacement after it', () => {
+    // The second strike mints no id — it joins the first, and the two merge into one `w:del`.
+    // It is still this transaction's strike, and the words replacing it go after the merged
+    // wrapper, which is also where the keyboard's landing rule puts them.
+    const before = part('<w:p><w:r><w:t>abcdef</w:t></w:r></w:p>');
+    const id = paragraphId(before);
+    const earlier = transacted(before, [
+      { op: 'deleteText', paragraphId: id, start: 3, end: 5, revision: ADA },
+    ]);
+    const out = xml(
+      transacted(earlier, [
+        { op: 'deleteText', paragraphId: id, start: 2, end: 3, revision: ADA },
+        { op: 'insertText', paragraphId: id, offset: 2, text: 'X', revision: ADA },
+      ])
+    );
+    expect(out).toMatch(
+      /<w:del[^>]*><w:r><w:delText>cde<\/w:delText><\/w:r><\/w:del><w:ins[^>]*><w:r><w:t>X<\/w:t>/
+    );
+  });
+
+  test('typing after Backspace goes in FRONT wherever the strike sits in the paragraph', () => {
+    // The same gesture must read the same way at the paragraph's head as in the middle of it.
+    // The boundary rule answered this question separately from the relocation, so a strike the
+    // typed text happened to start on took the words after it and the two disagreed.
+    const before = part('<w:p><w:r><w:t>abcdef</w:t></w:r></w:p>');
+    const id = paragraphId(before);
+    const atHead = transacted(
+      transacted(before, [{ op: 'deleteText', paragraphId: id, start: 0, end: 2, revision: ADA }]),
+      [{ op: 'insertText', paragraphId: id, offset: 0, text: 'X', revision: ADA }]
+    );
+    expect(xml(atHead)).toMatch(
+      /<w:ins[^>]*><w:r><w:t>X<\/w:t><\/w:r><\/w:ins><w:del[^>]*><w:r><w:delText>ab<\/w:delText>/
+    );
+  });
+
+  test("another author's strike under the SAME id does not carry the replacement past it", () => {
+    // `@w:id` comes out of the file and nothing makes it unique, so a foreign `w:del` can
+    // reuse one. Reading the strike's end by id alone dropped the typed words past text this
+    // edit never touched; the full `CT_TrackChange` identity decides membership.
+    const before = part(
+      `<w:p><w:del w:id="0" w:author="Ada Lovelace" w:date="${ADA.date}">` +
+        '<w:r><w:delText>ab</w:delText></w:r></w:del><w:r><w:t>cd</w:t></w:r>' +
+        `<w:del w:id="0" w:author="Grace Hopper" w:date="${ADA.date}">` +
+        '<w:r><w:delText>ef</w:delText></w:r></w:del><w:r><w:t>gh</w:t></w:r></w:p>'
+    );
+    const id = paragraphId(before);
+    const out = xml(
+      transacted(before, [
+        { op: 'deleteText', paragraphId: id, start: 2, end: 4, revision: ADA },
+        { op: 'insertText', paragraphId: id, offset: 2, text: 'X', revision: ADA },
+      ])
+    );
+    // After Ada's own merged strike, and BEFORE Grace's.
+    expect(out).toMatch(
+      /<w:delText>abcd<\/w:delText><\/w:r><\/w:del><w:ins[^>]*><w:r><w:t>X<\/w:t><\/w:r><\/w:ins><w:del[^>]*w:author="Grace Hopper"/
+    );
+  });
+
+  test('retyping your OWN pending insertion beside a strike keeps it where it was', () => {
+    // The range covers only this author's insertion, so it retracts and no `w:del` is
+    // written. Counting the joined id as a strike anyway sent the retyped word to the far
+    // side of the struck words beside it.
+    const before = part(
+      `<w:p><w:ins w:id="1" w:author="Ada Lovelace" w:date="${ADA.date}">` +
+        '<w:r><w:t>abc</w:t></w:r></w:ins>' +
+        `<w:del w:id="0" w:author="Ada Lovelace" w:date="${ADA.date}">` +
+        '<w:r><w:delText>DEF</w:delText></w:r></w:del><w:r><w:t>ghi</w:t></w:r></w:p>'
+    );
+    const id = paragraphId(before);
+    const out = xml(
+      transacted(before, [
+        { op: 'deleteText', paragraphId: id, start: 0, end: 3, revision: ADA },
+        { op: 'insertText', paragraphId: id, offset: 0, text: 'X', revision: ADA },
+      ])
+    );
+    expect(out).toMatch(
+      /<w:ins[^>]*><w:r><w:t>X<\/w:t><\/w:r><\/w:ins><w:del[^>]*><w:r><w:delText>DEF<\/w:delText>/
+    );
+  });
+
+  test('driven straight through the appliers, a replacement still reads in Word order', () => {
+    // No transaction, so no bookkeeping to consult: an adjacent strike by this author IS the
+    // one being replaced, which is what a caller pairing `deleteText` with `insertText` at one
+    // offset means. `applyTreeOp` is public API, and it must not write the reversed order.
+    const before = part(
+      '<w:p><w:r><w:t xml:space="preserve">The Receiving Party shall</w:t></w:r></w:p>'
+    );
+    const id = paragraphId(before);
+    const struck = apply(before, {
+      op: 'deleteText',
+      paragraphId: id,
+      start: 4,
+      end: 19,
+      revision: ADA,
+    });
+    const out = xml(
+      apply(struck, {
+        op: 'insertText',
+        paragraphId: id,
+        offset: 4,
+        text: 'Recipient',
+        revision: ADA,
+      })
+    );
+    expect(out).toMatch(
+      /<w:delText>Receiving Party<\/w:delText><\/w:r><\/w:del><w:ins[^>]*><w:r><w:t>Recipient<\/w:t>/
+    );
+  });
+
+  test('a far piece under the same id, with live words between, is a different decision', () => {
+    // A Word redline reuses one `@w:id` across an editing burst, so two `w:del` under one
+    // identity can have untouched words standing between them. Reading the strike's end as
+    // the paragraph-wide maximum carried the replacement past those words: the accepted text
+    // came out "AAFFXEE" instead of "AAXFFEE".
+    const before = part(
+      '<w:p><w:r><w:t>AA</w:t></w:r>' +
+        `<w:del w:id="3" w:author="Ada Lovelace" w:date="${ADA.date}">` +
+        '<w:r><w:delText>BB</w:delText></w:r></w:del>' +
+        '<w:r><w:t>CCFF</w:t></w:r>' +
+        `<w:del w:id="3" w:author="Ada Lovelace" w:date="${ADA.date}">` +
+        '<w:r><w:delText>DD</w:delText></w:r></w:del>' +
+        '<w:r><w:t>EE</w:t></w:r></w:p>'
+    );
+    const id = paragraphId(before);
+    const out = transacted(before, [
+      { op: 'deleteText', paragraphId: id, start: 4, end: 6, revision: ADA },
+      { op: 'insertText', paragraphId: id, offset: 6, text: 'X', revision: ADA },
+    ]);
+    // The words go after the strike they replace, and BEFORE the untouched "FF".
+    expect(xml(out)).toMatch(
+      /<w:delText>BBCC<\/w:delText><\/w:r><\/w:del><w:ins[^>]*><w:r><w:t>X<\/w:t><\/w:r><\/w:ins><w:r><w:t>FF<\/w:t>/
+    );
+    const accepted = xml(apply(out, { op: 'acceptAllRevisions' }));
+    expect([...accepted.matchAll(/<w:t[^>]*>([^<]*)<\/w:t>/g)].map((m) => m[1]).join('')).toBe(
+      'AAXFFEE'
+    );
+  });
+
+  test('an unrelated op between the halves does not invert them', () => {
+    // The transaction's ID COUNTER goes stale across an op that can import ids, but the
+    // record of what this transaction wrote cannot. Dropping both together made the
+    // insertion stop recognising its own strike, and it came out in front of it.
+    const before = part(
+      '<w:p><w:r><w:t>alpha</w:t></w:r></w:p><w:p><w:r><w:t>x</w:t></w:r></w:p>' +
+        '<w:p><w:r><w:t>y</w:t></w:r></w:p>'
+    );
+    const bodyNode = before.root.children.find((child) => child.kind === 'body');
+    if (!bodyNode || bodyNode.kind === 'textValue') throw new Error('no body');
+    const [first, second, third] = bodyNode.children;
+    const out = xml(
+      transacted(before, [
+        { op: 'deleteText', paragraphId: first!.id, start: 0, end: 5, revision: ADA },
+        { op: 'joinParagraphs', firstId: second!.id, secondId: third!.id },
+        { op: 'insertText', paragraphId: first!.id, offset: 0, text: 'omega', revision: ADA },
+      ])
+    );
+    expect(out).toMatch(
+      /<w:del[^>]*><w:r><w:delText>alpha<\/w:delText><\/w:r><\/w:del><w:ins[^>]*><w:r><w:t>omega<\/w:t>/
+    );
+    // And DISTINCT ids. The counter is dropped across that middle op, and a walk bound to the
+    // part it first saw re-walked that stale snapshot — handing the insertion the id the
+    // strike had already taken, which is the collision this whole change removes.
+    const ids = revisionIds(out);
+    expect(ids).toHaveLength(2);
+    expect(new Set(ids).size).toBe(2);
+  });
+
+  test('with a same-author strike at EACH edge, the words join the one the strike joins', () => {
+    // `applyDeleteTracked` asks about both edges and joins the FIRST deletion in document
+    // order, so the strike touching the range's start wins. A landing rule that asked about
+    // the end alone picked the other one and wrote the words past a deletion this edit never
+    // joined — folding it into the replacement's card, and its Accept with it.
+    const before = part(
+      `<w:p><w:del w:id="1" w:author="Ada Lovelace" w:date="${ADA.date}">` +
+        '<w:r><w:delText>a</w:delText></w:r></w:del><w:r><w:t>bc</w:t></w:r>' +
+        `<w:del w:id="2" w:author="Ada Lovelace" w:date="${ADA.date}">` +
+        '<w:r><w:delText>de</w:delText></w:r></w:del></w:p>'
+    );
+    const id = paragraphId(before);
+    // The landing the surface predicts, from the range the strike will ask about.
+    const paragraph = paragraphNode(before);
+    expect(
+      trackedInsertionLanding(paragraph, { start: 1, end: 3 }, 3, ADA.author, ADA.date)
+    ).toMatchObject({ landing: 3 });
+
+    const out = transacted(before, [
+      { op: 'deleteText', paragraphId: id, start: 1, end: 3, revision: ADA },
+      { op: 'insertText', paragraphId: id, offset: 3, text: 'X', revision: ADA },
+    ]);
+    expect(xml(out)).toMatch(
+      /<w:delText>abc<\/w:delText><\/w:r><\/w:del><w:ins[^>]*><w:r><w:t>X<\/w:t><\/w:r><\/w:ins><w:del[^>]*><w:r><w:delText>de<\/w:delText>/
+    );
+    // Two decisions: the replacement, and the deletion it left alone.
+    const items = revisionItemsOf(out);
+    expect(items.map((item) => item.revisionKind)).toEqual(['replace', 'delete']);
+    expect(items[0]).toMatchObject({ text: 'X', replacedText: 'abc' });
+  });
+
+  test('a strike split by a bookmark edge keeps the replacement after its LAST piece', () => {
+    // Zero-width furniture between two pieces of one deletion is looked past: the words go
+    // after the whole strike, not between its halves.
+    const before = part(
+      '<w:p><w:r><w:t>ab</w:t></w:r><w:bookmarkStart w:id="7" w:name="mark"/>' +
+        '<w:r><w:t>cd</w:t></w:r><w:bookmarkEnd w:id="7"/><w:r><w:t>ef</w:t></w:r></w:p>'
+    );
+    const out = xml(replaced(before, 0, 4, 0, 'X'));
+    // Both pieces first, then the insertion, then the untouched tail.
+    expect(out.indexOf('<w:ins')).toBeGreaterThan(out.lastIndexOf('</w:del>'));
+    expect(out.indexOf('<w:ins')).toBeLessThan(out.indexOf('<w:t>ef</w:t>'));
+  });
+
+  test("a strike interrupted by another author's deletion lands after its LAST piece", () => {
+    // Grace already struck "cd"; Ada's range covers "b", the struck "cd" and "e". Her strike
+    // is two pieces around Grace's, and the replacement follows the second whichever edge
+    // the caller aimed at.
+    const before = part(
+      '<w:p><w:r><w:t>ab</w:t></w:r>' +
+        '<w:del w:id="9" w:author="Grace Hopper" w:date="2020-01-01T00:00:00Z">' +
+        '<w:r><w:delText>cd</w:delText></w:r></w:del><w:r><w:t>ef</w:t></w:r></w:p>'
+    );
+    const atFront = replaced(before, 1, 5, 1, 'Q');
+    expect(xml(atFront)).toBe(xml(replaced(before, 1, 5, 5, 'Q')));
+    expect(xml(atFront)).toMatch(
+      /<w:delText>e<\/w:delText><\/w:r><\/w:del><w:ins[^>]*><w:r><w:t>Q<\/w:t><\/w:r><\/w:ins><w:r><w:t>f<\/w:t>/
+    );
+    // Ada's two pieces share one id and read as one card: one Replaced beside Grace's Deleted.
+    const items = revisionItemsOf(atFront);
+    expect(items.map((item) => item.revisionKind).sort()).toEqual(['delete', 'replace']);
+    expect(items.find((item) => item.revisionKind === 'replace')).toMatchObject({
+      text: 'Q',
+      replacedText: 'be',
+    });
+  });
+
+  test('a replacement inside a formatted run keeps the formatting from either edge', () => {
+    const before = part(
+      '<w:p><w:r><w:rPr><w:b/></w:rPr><w:t xml:space="preserve">The Receiving Party shall</w:t></w:r></w:p>'
+    );
+    const atFront = xml(replaced(before, 4, 19, 4, 'Recipient'));
+    expect(atFront).toBe(xml(replaced(before, 4, 19, 19, 'Recipient')));
+    expect(atFront).toMatch(
+      /<w:ins[^>]*><w:r><w:rPr><w:b\/><\/w:rPr><w:t>Recipient<\/w:t><\/w:r><\/w:ins>/
+    );
+  });
+
+  test('a strike spilling outside a link, aimed at its front, lands after the link', () => {
+    // The replacement stands in for the whole struck range and is not linked, whichever
+    // edge the caller aimed at.
+    const before = part(
+      '<w:p><w:r><w:t xml:space="preserve">word </w:t></w:r>' +
+        '<w:hyperlink w:anchor="x"><w:r><w:t>link</w:t></w:r></w:hyperlink>' +
+        '<w:r><w:t xml:space="preserve"> tail</w:t></w:r></w:p>'
+    );
+    const atFront = xml(replaced(before, 0, 9, 0, 'New'));
+    expect(atFront).toMatch(/<\/w:hyperlink><w:ins[^>]*><w:r><w:t[^>]*>New<\/w:t>/);
+    expect(atFront).toBe(xml(replaced(before, 0, 9, 9, 'New')));
+  });
+
+  test('a strike ending INSIDE a link, aimed at its front, lands inside after the struck text', () => {
+    // "word li" of "word link" is struck: the replacement follows the last struck character,
+    // or the accepted text would read "nk New".
+    const before = part(
+      '<w:p><w:r><w:t xml:space="preserve">word </w:t></w:r>' +
+        '<w:hyperlink w:anchor="x"><w:r><w:t>link</w:t></w:r></w:hyperlink></w:p>'
+    );
+    const out = replaced(before, 0, 7, 0, 'New');
+    expect(xml(out)).toMatch(
+      /<w:delText>li<\/w:delText><\/w:r><\/w:del><w:ins[^>]*><w:r><w:t>New<\/w:t><\/w:r><\/w:ins><w:r><w:t>nk<\/w:t><\/w:r><\/w:hyperlink>/
+    );
+    expect(xml(out)).toBe(xml(replaced(before, 0, 7, 7, 'New')));
+    const accepted = xml(apply(out, { op: 'acceptAllRevisions' }));
+    expect(accepted.indexOf('<w:t>New</w:t>')).toBeLessThan(accepted.indexOf('<w:t>nk</w:t>'));
+  });
+
+  test('a strike that BEGINS inside a link and runs past it lands after its last piece', () => {
+    const before = part(
+      '<w:p><w:hyperlink w:anchor="x"><w:r><w:t>link</w:t></w:r></w:hyperlink>' +
+        '<w:r><w:t xml:space="preserve"> more tail</w:t></w:r></w:p>'
+    );
+    const atFront = xml(replaced(before, 0, 9, 0, 'New'));
+    expect(atFront).toMatch(
+      /<\/w:hyperlink><w:del[^>]*><w:r><w:delText[^>]*> more<\/w:delText><\/w:r><\/w:del><w:ins[^>]*><w:r><w:t>New<\/w:t><\/w:r><\/w:ins><w:r><w:t[^>]*> tail<\/w:t>/
+    );
+    expect(atFront).toBe(xml(replaced(before, 0, 9, 9, 'New')));
+  });
+
+  test("a strike reaching the end of another author's w:ins lands outside it, from either edge", () => {
+    // The replacement is Ada's own, not something Grace can reject with her insertion.
+    const before = part(
+      '<w:p><w:ins w:id="1" w:author="Grace Hopper" w:date="2026-01-02T03:04:05Z">' +
+        '<w:r><w:t>hello</w:t></w:r></w:ins><w:r><w:t xml:space="preserve"> world</w:t></w:r></w:p>'
+    );
+    const atFront = xml(replaced(before, 2, 5, 2, 'XYZ'));
+    expect(atFront).toMatch(
+      /<\/w:del><\/w:ins><w:ins[^>]*w:author="Ada Lovelace"[^>]*><w:r><w:t>XYZ<\/w:t>/
+    );
+    expect(atFront).toBe(xml(replaced(before, 2, 5, 5, 'XYZ')));
+  });
+
+  test('the review lane reads the two ids back as ONE replacement card', () => {
+    // Distinct ids do not split the pair: the reader pairs a deletion with the insertion that
+    // starts where it ends, and hands both addresses to accept and reject.
+    const before = part(
+      '<w:p><w:r><w:t xml:space="preserve">The Receiving Party shall</w:t></w:r></w:p>'
+    );
+    const items = revisionItemsOf(replaced(before, 4, 19, 4, 'Recipient'));
+    expect(items).toHaveLength(1);
+    const card = items[0]!;
+    expect(card.revisionKind).toBe('replace');
+    expect(card.text).toBe('Recipient');
+    expect(card.replacedText).toBe('Receiving Party');
+    expect(card.addresses).toHaveLength(2);
+    expect(new Set(card.addresses.map((address) => address.id)).size).toBe(2);
+  });
+
+  test('a replacement this engine wrote under ONE id still reads as one card', () => {
+    // Files written before the halves were numbered separately share one identity across
+    // both. The address is deduplicated, or accept would refuse the second resolve of one id.
+    const legacy = part(
+      '<w:p><w:r><w:t xml:space="preserve">The </w:t></w:r>' +
+        `<w:del w:id="0" w:author="Ada Lovelace" w:date="${ADA.date}">` +
+        '<w:r><w:delText>old</w:delText></w:r></w:del>' +
+        `<w:ins w:id="0" w:author="Ada Lovelace" w:date="${ADA.date}">` +
+        '<w:r><w:t>new</w:t></w:r></w:ins><w:r><w:t xml:space="preserve"> tail</w:t></w:r></w:p>'
+    );
+    const items = revisionItemsOf(legacy);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({ revisionKind: 'replace', text: 'new', replacedText: 'old' });
+    expect(items[0]!.addresses).toHaveLength(1);
+    const accepted = xml(
+      apply(legacy, {
+        op: 'acceptRevision',
+        revision: { id: '0', author: 'Ada Lovelace', date: ADA.date },
+      })
+    );
+    expect(accepted).toContain('<w:t>new</w:t>');
+    expect(accepted).not.toContain('old');
+  });
+
+  test('a tracked format change and a tracked insertion in one transaction never share an id', () => {
+    // Every tracked lane draws from ONE minter per part per transaction. Two counters, one of
+    // them caching its walk, handed the `w:ins` the id the `w:rPrChange` had just taken.
+    const before = part('<w:p><w:r><w:t>alpha beta</w:t></w:r></w:p>');
+    const id = paragraphId(before);
+    const out = xml(
+      transacted(before, [
+        { op: 'insertText', paragraphId: id, offset: 0, text: 'A', revision: ADA },
+        {
+          op: 'setRunProperties',
+          paragraphId: id,
+          start: 3,
+          end: 6,
+          properties: [{ localName: 'b', namespaceUri: WML, attributes: [] }],
+          revision: ADA,
+        },
+        { op: 'insertText', paragraphId: id, offset: 11, text: 'Z', revision: ADA },
+      ])
+    );
+    const ids = [...out.matchAll(/<w:(?:ins|rPrChange)\b[^>]*w:id="(\d+)"/g)].map((m) => m[1]);
+    expect(ids).toHaveLength(3);
+    expect(new Set(ids).size).toBe(3);
+  });
+
+  test('typing on inside your own insertion mints no id and walks nothing', () => {
+    // The id is minted for the first wrapper only: the second keystroke extends the wrapper
+    // it finds, so the file holds one `w:ins` under one id.
+    let current = part('<w:p><w:r><w:t>alpha</w:t></w:r></w:p>');
+    const id = paragraphId(current);
+    current = apply(current, {
+      op: 'insertText',
+      paragraphId: id,
+      offset: 5,
+      text: 'X',
+      revision: ADA,
+    });
+    current = apply(current, {
+      op: 'insertText',
+      paragraphId: id,
+      offset: 6,
+      text: 'Y',
+      revision: ADA,
+    });
+    const out = xml(current);
+    expect(out.match(/<w:ins /g)).toHaveLength(1);
+    expect(out).toContain('<w:t>XY</w:t>');
+  });
+});

--- a/packages/core/src/store/package/index.ts
+++ b/packages/core/src/store/package/index.ts
@@ -243,6 +243,7 @@ export {
   replaceNode,
   type EditOptions,
   type OoxmlEditResult,
+  type TransactionRevisionIds,
 } from './ooxml-edit.ts';
 export {
   PAGE_BREAK_CHAR,

--- a/packages/core/src/store/package/ooxml-edit.ts
+++ b/packages/core/src/store/package/ooxml-edit.ts
@@ -63,6 +63,39 @@ export interface EditOptions {
    * caller outside a transaction gets.
    */
   readonly revisionIds?: () => string;
+  /**
+   * The transaction's revision-id bookkeeping for the tracked TEXT ops, where `revisionIds`
+   * above hands the property ops one shared id for their whole group.
+   *
+   * Absent means "mint your own and remember nothing", which is what a caller outside a
+   * transaction gets: every applier falls back to its own walk of the part.
+   */
+  readonly trackedRevisionIds?: TransactionRevisionIds;
+}
+
+/**
+ * What one transaction knows about the revision ids its tracked text ops write.
+ *
+ * TWO questions, and they are the same bookkeeping. `nextRevisionId` walks the whole part, so
+ * a replacement — a `deleteText` and an `insertText` in one transaction — walked it twice, and
+ * on a five-hundred-page document that doubled the cost of every one. And an insertion aimed
+ * at the front edge of a deletion relocates past it only when that deletion is THIS
+ * transaction's own: typing over a selection. Backspace, then a keystroke, is two
+ * transactions, and there the typed text belongs in FRONT of the struck character, as Word
+ * writes it. Adjacency alone cannot tell the two apart; the ids can.
+ */
+export interface TransactionRevisionIds {
+  /** A fresh `@w:id`, from this transaction's one walk of the part. */
+  mint(): string;
+  /**
+   * Record a wrapper this transaction wrote, by its FULL `CT_TrackChange` identity — id,
+   * author and date, as `revisionKey` spells it. Not by the id alone: that number comes out
+   * of the file, nothing makes it unique, and a strike joining `w:id="3"` in one paragraph
+   * would otherwise claim an unrelated `w:id="3"` elsewhere as this edit's own.
+   */
+  wrote(key: string): void;
+  /** Whether this transaction wrote a wrapper with that identity. */
+  wroteUnder(key: string): boolean;
 }
 
 /**

--- a/packages/core/src/store/store/review-reads.ts
+++ b/packages/core/src/store/store/review-reads.ts
@@ -267,9 +267,11 @@ function computeRevisionItemsOf(
       if (kind !== 'structural' && existing.revisionKind === 'structural') {
         existing.revisionKind = kind;
       }
-      // An address holding BOTH an insertion and a deletion is one edit that replaced text:
-      // this engine writes a replacement that way on purpose, so the halves cannot drift
-      // apart and one Accept resolves them together.
+      // An address holding BOTH an insertion and a deletion is one edit that replaced text.
+      // Note that the key above carries the ELEMENT NAME, so `w:ins` and `w:del` never reach
+      // this together however they are numbered: a replacement is recognised by ADJACENCY, in
+      // `pairReplacements` below, which is the only thing that works for a file this engine
+      // did not write. This stands for the kinds that do share one element name.
       if (
         (kind === 'insert' && existing.revisionKind === 'delete') ||
         (kind === 'delete' && existing.revisionKind === 'insert') ||
@@ -431,9 +433,10 @@ function pairReplacements(
             id: `replace-${deletion.id}-${insertion.id}`,
             revisionKind: 'replace',
             ...(date === undefined ? {} : { date }),
-            // DEDUPED: when this engine wrote the replacement both halves share one identity,
-            // and applying the same `acceptRevision` twice in one transaction refuses the second
-            // — which refused the whole thing and left the replacement unresolved.
+            // DEDUPED: a replacement this engine wrote before it numbered the halves
+            // separately (#691) shares one identity across both, and applying the same
+            // `acceptRevision` twice in one transaction refuses the second — which refused the
+            // whole thing and left the replacement unresolved.
             addresses: dedupeAddresses([...deletion.addresses, ...insertion.addresses]),
             text: insertion.text,
             replacedText: deletion.text,

--- a/packages/core/src/store/store/tree-op-apply.ts
+++ b/packages/core/src/store/store/tree-op-apply.ts
@@ -29,8 +29,8 @@ import {
 import { wmlFreshNamespaceContextAt } from '../package/wml-namespace.ts';
 import { resolveRevisions } from './tree-op-revisions.ts';
 import { applyInsertCommentMarker } from './tree-op-comments.ts';
+import { applyDeleteTracked } from './tree-op-tracked-delete.ts';
 import {
-  applyDeleteTracked,
   applyInsertTracked,
   applyInsertTrackedElement,
   applyInsertTrackedElements,

--- a/packages/core/src/store/store/tree-op-tracked-adjacency.ts
+++ b/packages/core/src/store/store/tree-op-tracked-adjacency.ts
@@ -1,0 +1,250 @@
+// WHICH DELETION AN EDIT JOINS, and where that deletion ends.
+//
+// One question, asked by both tracked text lanes and by the surface: striking text joins the
+// strike the caret is already working on rather than minting a card per keystroke, and a
+// replacement lands after the words it replaces. Split from `tree-op-tracked.ts`, which owns
+// the appliers; the dependency runs one way, and nothing here writes.
+
+import {
+  WML_NAMESPACE_URI,
+  type OoxmlNode,
+  type OoxmlParagraphNode,
+} from '../package/ooxml-tree.ts';
+import { paragraphOffsetIndex, type ParagraphOffsetIndex } from './tree-op-segments.ts';
+
+/**
+ * Whether an existing revision's timestamp belongs to the edit being made now.
+ *
+ * Coalescing is for a continuous editing run, so the window is small: two keystrokes a
+ * minute apart are still one thought, two edits a month apart are not one revision. Two
+ * dateless wrappers join — a file written with date stamping off has nothing else to go on.
+ */
+export function sameEditingMoment(
+  existing: string | undefined,
+  current: string | undefined
+): boolean {
+  if (existing === undefined || current === undefined) return existing === current;
+  const from = Date.parse(existing);
+  const to = Date.parse(current);
+  if (Number.isNaN(from) || Number.isNaN(to)) return existing === current;
+  return Math.abs(to - from) <= COALESCE_WINDOW_MS;
+}
+
+const COALESCE_WINDOW_MS = 60_000;
+
+/** A deletion wrapper's `@w:id`, or null for anything else. */
+export function deletionId(node: OoxmlNode): string | null {
+  if (node.kind !== 'revisionDelete') return null;
+  return (
+    node.attributes.find(
+      (attribute) => attribute.namespaceUri === WML_NAMESPACE_URI && attribute.localName === 'id'
+    )?.value ?? null
+  );
+}
+
+/** A deletion an edit joins or follows, by its `CT_TrackChange` identity. */
+export interface AdjacentDeletion {
+  readonly id: string;
+  readonly date: string | undefined;
+}
+
+/**
+ * A revision's identity as one string: `@w:id`, `@w:author`, `@w:date`.
+ *
+ * The id alone is not an identity. It comes out of the file, `ST_DecimalNumber` constrains
+ * nothing, and Word reuses one across an editing burst — so two unrelated wrappers can carry
+ * the same number. Everything that remembers a revision across ops keys on this.
+ */
+export function revisionKey(id: string, author: string, date: string | undefined): string {
+  return `${id}\u0000${author}\u0000${date ?? ''}`;
+}
+
+/**
+ * Where a tracked insertion aimed at `aim` actually lands, in the paragraph's offset space.
+ *
+ * THE ONE ANSWER, for the applier that places the words and for the surface that has to say
+ * where they went before the transaction runs. The two computed it separately once, and
+ * disagreed exactly when the strike joined a deletion already standing beside it: the store
+ * put the words after the joined chain and the object model answered a span over the struck
+ * ones, so a script that formatted what it had just written formatted the strike instead.
+ */
+export function trackedInsertionLanding(
+  paragraph: OoxmlParagraphNode,
+  struck: { readonly start: number; readonly end: number },
+  aim: number,
+  author: string,
+  date: string | undefined
+): { readonly past: number; readonly landing: number } {
+  const offsets = paragraphOffsetIndex(paragraph);
+  // PAST A DELETION THE AIM SITS INSIDE, first, and from the paragraph's own tree rather than
+  // from painted pages. The store relocates such an aim whatever the reader is looking at, so
+  // a story with no layout — an unattached header variant, a note nobody references — was
+  // told the words landed where they were aimed while the store put them past the strike.
+  // Strictly interior, matching `positionPastDeletion`: an aim ON either edge is a boundary
+  // the placement rules below own.
+  const past = pastContainingDeletion(paragraph, offsets, aim);
+  // THE RANGE THE STRIKE WILL ASK ABOUT, not the point the words land at. `applyDeleteTracked`
+  // asks with both edges and joins the FIRST deletion in document order, so a strike touching
+  // the range's start wins there. Asking here with the end alone picked the deletion touching
+  // the other edge whenever both edges had one, and the words were then written past a strike
+  // this edit never joined — folding an unrelated deletion into the replacement's card, and
+  // its Accept with it.
+  const replaced = adjacentDeletion(paragraph, offsets, struck.start, struck.end, author, date);
+  const landing =
+    replaced === null
+      ? past
+      : Math.max(past, replacedEnd(paragraph, offsets, replaced, author, past));
+  return { past, landing };
+}
+
+/** `offset` mapped past a `w:del`/`w:moveFrom` that strictly contains it, or unchanged. */
+function pastContainingDeletion(
+  paragraph: OoxmlParagraphNode,
+  offsets: ParagraphOffsetIndex,
+  offset: number
+): number {
+  let mapped = offset;
+  const visit = (node: OoxmlNode): void => {
+    if (node.kind === 'textValue') return;
+    if (node.kind === 'revisionDelete' || node.kind === 'revisionMoveFrom') {
+      const span = offsets.spanOf(node);
+      if (span && mapped > span.start && mapped < span.end) mapped = span.end;
+      return;
+    }
+    for (const child of node.children) visit(child);
+  };
+  for (const child of paragraph.children) visit(child);
+  return mapped;
+}
+
+/**
+ * Where this deletion's LAST piece ends, in the paragraph's offset space.
+ *
+ * One deletion is several `w:del` elements whenever the struck stretch crosses something a
+ * wrapper cannot contain — a field, a note reference, a bookmark edge, another author's
+ * strike — and a replacement aimed at the front of the first belongs after the last. Only the
+ * CONTIGUOUS chain reaching the aim counts: a Word redline reuses one `@w:id` across a whole
+ * editing burst, so two pieces under one identity can have live words standing between them.
+ *
+ * Walked only when the relocation is actually going to happen, which is a replacement and not
+ * an ordinary keystroke. Membership is the FULL `CT_TrackChange` identity, never `@w:id`
+ * alone: the id comes out of the file, nothing makes it unique, and a distant strike by
+ * somebody else carrying the same number would drop the typed words past text this edit never
+ * touched.
+ */
+export function replacedEnd(
+  paragraph: OoxmlParagraphNode,
+  offsets: ParagraphOffsetIndex,
+  replaced: AdjacentDeletion,
+  author: string,
+  aim: number
+): number {
+  const pieces: { start: number; end: number }[] = [];
+  const struck: { start: number; end: number }[] = [];
+  const visit = (node: OoxmlNode): void => {
+    if (node.kind === 'textValue') return;
+    if (node.kind === 'revisionDelete' || node.kind === 'revisionMoveFrom') {
+      const span = offsets.spanOf(node);
+      if (span) {
+        struck.push(span);
+        const read = (localName: string): string | undefined =>
+          node.attributes.find(
+            (attribute) =>
+              attribute.namespaceUri === WML_NAMESPACE_URI && attribute.localName === localName
+          )?.value;
+        if (
+          node.kind === 'revisionDelete' &&
+          deletionId(node) === replaced.id &&
+          read('author') === author &&
+          sameEditingMoment(read('date'), replaced.date)
+        ) {
+          pieces.push(span);
+        }
+      }
+      return;
+    }
+    for (const child of node.children) visit(child);
+  };
+  for (const child of paragraph.children) visit(child);
+  pieces.sort((a, b) => a.start - b.start);
+  struck.sort((a, b) => a.start - b.start);
+
+  /** Whether `[from, to)` holds no LIVE text: every offset in it is inside some strike. */
+  const allStruck = (from: number, to: number): boolean => {
+    let covered = from;
+    for (const span of struck) {
+      if (span.start > covered) break;
+      if (span.end > covered) covered = span.end;
+      if (covered >= to) return true;
+    }
+    return covered >= to;
+  };
+
+  let end = -1;
+  for (const piece of pieces) {
+    if (end < 0) {
+      // The chain starts at the piece the aim touches, not at the first piece in the
+      // paragraph: an earlier burst under the same id is a different decision.
+      if (piece.start <= aim && aim <= piece.end) end = piece.end;
+      continue;
+    }
+    if (piece.start < end) continue;
+    // A later piece joins the chain only when nothing LIVE stands between: markup a `w:del`
+    // cannot contain measures nothing, and another author's strike is struck text too. Live
+    // words between two pieces mean two decisions that happen to share a number, which is
+    // ordinary in a Word redline — it reuses one `@w:id` across an editing burst — and
+    // carrying the replacement past them dropped it on the wrong side of untouched words.
+    if (!allStruck(end, piece.start)) break;
+    end = piece.end;
+  }
+  return end;
+}
+
+/**
+ * The deletion by this author touching `[start, end)`, or null.
+ *
+ * Touching, not overlapping: the run being struck now sits beside the one struck a keystroke
+ * ago, never inside it. Both edges are checked, because Backspace grows a deletion leftwards
+ * and Delete grows it rightwards.
+ */
+export function adjacentDeletion(
+  paragraph: OoxmlParagraphNode,
+  offsets: ParagraphOffsetIndex,
+  start: number,
+  end: number,
+  author: string,
+  /** Only a wrapper from the same moment joins; see the call sites. */
+  within: string | undefined
+): AdjacentDeletion | null {
+  let found: AdjacentDeletion | null = null;
+  const visit = (node: OoxmlNode): void => {
+    if (found !== null || node.kind === 'textValue') return;
+    if (node.kind === 'revisionDelete') {
+      const attributes = node.attributes;
+      const whose = attributes.find(
+        (attribute) =>
+          attribute.namespaceUri === WML_NAMESPACE_URI && attribute.localName === 'author'
+      );
+      const id = attributes.find(
+        (attribute) => attribute.namespaceUri === WML_NAMESPACE_URI && attribute.localName === 'id'
+      );
+      // A wrapper the offset walk never reached has no span, so it cannot be adjacent to
+      // anything: joining it would put this edit under an id at an unknown position.
+      const span = offsets.spanOf(node);
+      if (whose?.value === author && id && span) {
+        if (span.end === start || span.start === end) {
+          const when = attributes.find(
+            (attribute) =>
+              attribute.namespaceUri === WML_NAMESPACE_URI && attribute.localName === 'date'
+          );
+          if (!sameEditingMoment(when?.value, within)) return;
+          found = { id: id.value, date: when?.value };
+          return;
+        }
+      }
+    }
+    for (const child of node.children) visit(child);
+  };
+  for (const child of paragraph.children) visit(child);
+  return found;
+}

--- a/packages/core/src/store/store/tree-op-tracked-delete.ts
+++ b/packages/core/src/store/store/tree-op-tracked-delete.ts
@@ -1,0 +1,283 @@
+// Striking text in SUGGESTING mode: `applyDeleteTracked` and the run surgery it needs.
+//
+// Split out of `tree-op-tracked.ts`, which keeps the insertion appliers and the node builders,
+// wrapper-merging and adjacency rules both lanes share. The dependency runs one way: this
+// module imports the builders; nothing here is imported back.
+
+import type { OoxmlNode, OoxmlParagraphNode, OoxmlPart } from '../package/ooxml-tree.ts';
+import { createNodeIdAllocator, replaceChildren, type EditOptions } from '../package/ooxml-edit.ts';
+import { nextRevisionId } from './tree-op-revision-ids.ts';
+import { TEXT_DEPS, fromEdit } from './tree-op-nodes.ts';
+import { paragraphOffsetIndex, type ParagraphOffsetIndex } from './tree-op-segments.ts';
+import { insertionAuthor, insideDeletion } from './tree-op-retraction.ts';
+import type { RevisionAttributionInput, TreeOpEffect, TreeOpResult } from './tree-op-validate.ts';
+import { adjacentDeletion, revisionKey } from './tree-op-tracked-adjacency.ts';
+import {
+  build,
+  childrenOf,
+  contentOf,
+  copy,
+  type Cursor,
+  isRunProperties,
+  isWmlNamed,
+  mergedRevisions,
+  revisionAttributes,
+  textNode,
+} from './tree-op-tracked.ts';
+
+/**
+ * Delete `[start, end)` as a tracked deletion: the words stay, re-labelled.
+ *
+ * Content already inside a `w:del` is left alone, and content inside the caller's OWN `w:ins`
+ * is removed outright — it was never proposed to anybody else, so there is nothing to strike.
+ */
+export function applyDeleteTracked(
+  part: OoxmlPart,
+  paragraph: OoxmlParagraphNode,
+  start: number,
+  end: number,
+  revision: RevisionAttributionInput,
+  options?: EditOptions
+): TreeOpResult {
+  const mint = createNodeIdAllocator(part);
+  // The transaction's bookkeeping when it lends any: the insertion half of a replacement
+  // draws its own id from the same walk, and asks whether this strike is the one it replaces.
+  const revisionIds = options?.trackedRevisionIds;
+  // The fallback walk is built on FIRST USE, not in the ternary: a range covering only this
+  // author's own pending insertion writes no `w:del`, and outside a transaction it would
+  // otherwise have paid a whole-part walk to mint an id nothing uses.
+  let ownMint: (() => string) | null = null;
+  const mintRevision = (): string =>
+    revisionIds ? revisionIds.mint() : (ownMint ??= nextRevisionId(part))();
+  // Join the deletion the caret is already working on, rather than minting a fresh id per
+  // keystroke. Holding Backspace through a word is ONE decision — Word records it as one
+  // `w:del` and offers one Accept — and a new id per character turned a deleted word into a
+  // column of one-letter cards, the same way untracked insertions did before they coalesced.
+  //
+  // The whole `CT_TrackChange` triple is joined, not just the id: a reader identifies a
+  // revision by (id, author, date), so a fresh timestamp per keystroke split the run back
+  // into one card per character even with the id shared.
+  const offsets = paragraphOffsetIndex(paragraph);
+  const adjacent = adjacentDeletion(paragraph, offsets, start, end, revision.author, revision.date);
+  // Taken LAZILY, on the first wrapper actually written: a range covering only this author's
+  // own pending insertion retracts it and strikes nothing, and minting there left a hole in
+  // the dense sequence Word writes — and, under a collaboration actor, burnt a slot in that
+  // actor's stripe.
+  let minted: string | null = null;
+  const revisionId = (): string => adjacent?.id ?? (minted ??= mintRevision());
+  const attribution: RevisionAttributionInput = adjacent
+    ? { author: revision.author, ...(adjacent.date === undefined ? {} : { date: adjacent.date }) }
+    : revision;
+  const effect: TreeOpEffect = {
+    dirty: [paragraph.id],
+    created: [],
+    deleted: [],
+    dependencyKeys: TEXT_DEPS,
+    impact: 'text-local',
+  };
+  const cursor: Cursor = { offset: 0 };
+  // The nodes of every atom whose single model unit falls INSIDE the struck range. An atom is
+  // one addressable unit, so it goes whole: striking a field's `begin` and leaving its
+  // instruction, separator, result and `end` standing wrote a field no reader can resolve, and
+  // accepting that deletion removed the `begin` and orphaned the rest of it in the file.
+  const struck = new Set<string>();
+  for (const segment of offsets.segments) {
+    if (!segment.removeNodeIds || segment.removeNodeIds.length === 0) continue;
+    if (segment.start < start || segment.end > end) continue;
+    for (const id of segment.removeNodeIds) struck.add(id);
+  }
+  /** A run carrying part of a struck atom, whether or not it carries the offset itself. */
+  const carriesStruckAtom = (node: OoxmlNode): boolean =>
+    node.kind !== 'textValue' && contentOf(node).some((child) => struck.has(child.id));
+
+  const strike = (nodes: readonly OoxmlNode[]): OoxmlNode => {
+    // A JOINED deletion is this transaction's strike too, though it minted nothing — a
+    // replacement over words abutting a strike from a moment ago belongs after all of them.
+    // Recorded HERE rather than beside the join, because a range covering only this author's
+    // own pending insertion writes no `w:del` at all: it retracts. Claiming a strike then let
+    // the replacement for those retracted words jump to the far side of a struck word beside
+    // them.
+    const id = revisionId();
+    revisionIds?.wrote(revisionKey(id, revision.author, attribution.date));
+    return build(mint(), 'revisionDelete', 'del', revisionAttributes(id, attribution), nodes);
+  };
+
+  const rebuild = (nodes: readonly OoxmlNode[], stack: readonly OoxmlNode[]): OoxmlNode[] => {
+    const out: OoxmlNode[] = [];
+    for (const node of nodes) {
+      const length = offsets.lengthOf(node);
+      const from = cursor.offset;
+      const to = from + length;
+
+      // A `w:fldSimple` cannot go inside a `w:del`: `CT_RunTrackChange` takes
+      // `EG_ContentRunContent`, which has no `fldSimple` in it. Word strikes one by putting
+      // the deletion INSIDE the field, around its runs, and so does this.
+      if (struck.has(node.id) && node.kind !== 'textValue' && isWmlNamed(node, 'fldSimple')) {
+        cursor.offset = to;
+        out.push({
+          ...node,
+          children: mergedRevisions(
+            mint,
+            node.children.map((child) =>
+              child.kind === 'run' && !insideDeletion(stack)
+                ? strike([toDeleted(mint, child)])
+                : child
+            )
+          ),
+        } as OoxmlNode);
+        continue;
+      }
+
+      if ((to <= start || from >= end || length === 0) && !carriesStruckAtom(node)) {
+        cursor.offset = to;
+        out.push(node);
+        continue;
+      }
+
+      if (
+        node.kind !== 'textValue' &&
+        (node.kind === 'hyperlink' ||
+          // A content control is a run container too (`w:sdtContent` takes `EG_PContent`,
+          // `w:del` included). Passing it through whole made a suggested deletion over its
+          // text a silent NO-OP: the transaction committed, nothing was struck, and the
+          // reviewer's replacement landed beside words that were never proposed away.
+          node.kind === 'contentControl' ||
+          node.kind === 'contentControlContent' ||
+          node.kind === 'revisionInsert' ||
+          node.kind === 'revisionDelete' ||
+          node.kind === 'revisionMoveFrom' ||
+          node.kind === 'revisionMoveTo')
+      ) {
+        const rebuilt = rebuild(node.children, [...stack, node]);
+        // A wrapper emptied by the removal of our own insertion goes with it; one that
+        // still holds content stays, because it is still saying something about that
+        // content. A CONTROL is not a wrapper: it is document structure the user placed,
+        // so it keeps its (possibly emptied) `w:sdtContent` — dropping it left a `w:sdt`
+        // husk with properties and no content element, a shape Word never writes.
+        const structural = node.kind === 'contentControl' || node.kind === 'contentControlContent';
+        if (rebuilt.length > 0 || structural) {
+          out.push({ ...node, children: rebuilt } as OoxmlNode);
+        }
+        continue;
+      }
+
+      if (node.kind !== 'run') {
+        cursor.offset = to;
+        out.push(node);
+        continue;
+      }
+
+      cursor.offset = to;
+      if (insideDeletion(stack)) {
+        // Already struck. Deleting it again would nest a second `w:del`, which says the same
+        // thing twice and makes accepting it a two-step affair.
+        out.push(node);
+        continue;
+      }
+      const own = insertionAuthor(stack) === revision.author;
+      const covered = { from: Math.max(start, from) - from, to: Math.min(end, to) - from };
+      const pieces = splitRunThree(mint, offsets, node, covered.from, covered.to, struck);
+      if (pieces.before) out.push(pieces.before);
+      if (pieces.covered) {
+        // Our own pending insertion: remove rather than strike. The words were never anyone
+        // else's to see, so there is no proposal to make about taking them away.
+        if (!own) out.push(strike([toDeleted(mint, pieces.covered)]));
+      }
+      if (pieces.after) out.push(pieces.after);
+    }
+    return out;
+  };
+
+  const children = mergedRevisions(mint, rebuild(paragraph.children, []));
+  return fromEdit(replaceChildren(part, paragraph.id, children, options), effect);
+}
+
+/** Split a run into the part before the range, the covered part, and the part after. */
+function splitRunThree(
+  mint: () => string,
+  offsets: ParagraphOffsetIndex,
+  run: OoxmlNode,
+  from: number,
+  to: number,
+  /** Nodes an atom being struck swallows; covered by identity, since they measure nothing. */
+  struckAtomNodes: ReadonlySet<string> = new Set()
+): { before: OoxmlNode | null; covered: OoxmlNode | null; after: OoxmlNode | null } {
+  const properties = childrenOf(run).filter(isRunProperties);
+  const withProperties = (content: readonly OoxmlNode[]): OoxmlNode | null =>
+    content.length === 0
+      ? null
+      : build(
+          mint(),
+          'run',
+          'r',
+          [],
+          [...properties.map((child) => copy(mint, child)), ...content]
+        );
+
+  const before: OoxmlNode[] = [];
+  const covered: OoxmlNode[] = [];
+  const after: OoxmlNode[] = [];
+  let seen = 0;
+  for (const child of childrenOf(run)) {
+    if (isRunProperties(child)) continue;
+    const length = offsets.lengthOf(child);
+    const childFrom = seen;
+    const childTo = seen + length;
+    seen = childTo;
+    // An atom's chrome measures nothing, so no offset comparison can place it. It goes with
+    // the unit it belongs to, which is being struck.
+    if (struckAtomNodes.has(child.id)) {
+      covered.push(child);
+      continue;
+    }
+    if (childTo <= from) {
+      before.push(child);
+      continue;
+    }
+    if (childFrom >= to) {
+      after.push(child);
+      continue;
+    }
+    if (child.kind !== 'text' && child.kind !== 'deletedText') {
+      // A tab or a break is atomic: it is covered or it is not.
+      covered.push(child);
+      continue;
+    }
+    const value = childrenOf(child).find((grand) => grand.kind === 'textValue');
+    const raw = value && value.kind === 'textValue' ? value.value : '';
+    const deleted = child.kind === 'deletedText';
+    const head = raw.slice(0, Math.max(0, from - childFrom));
+    const middle = raw.slice(Math.max(0, from - childFrom), Math.min(raw.length, to - childFrom));
+    const tail = raw.slice(Math.min(raw.length, to - childFrom));
+    if (head) before.push(textNode(mint, head, deleted));
+    if (middle) covered.push(textNode(mint, middle, deleted));
+    if (tail) after.push(textNode(mint, tail, deleted));
+  }
+  return {
+    before: withProperties(before),
+    covered: withProperties(covered),
+    after: withProperties(after),
+  };
+}
+
+/** Re-label a run's text as deleted: `w:t` becomes `w:delText`, everything else stays. */
+function toDeleted(mint: () => string, run: OoxmlNode): OoxmlNode {
+  const children = childrenOf(run).map((child) => {
+    // `w:instrText` becomes `w:delInstrText` inside a deletion, exactly as `w:t` becomes
+    // `w:delText`. The REJECT path already renames it back, so without this the write path
+    // could never produce what the reject path exists to undo.
+    if (child.kind !== 'textValue' && isWmlNamed(child, 'instrText')) {
+      const value = childrenOf(child).find((grand) => grand.kind === 'textValue');
+      const raw = value && value.kind === 'textValue' ? value.value : '';
+      const valueId = mint();
+      return build(mint(), 'generic', 'delInstrText', child.attributes, [
+        { id: valueId, kind: 'textValue', value: raw } as OoxmlNode,
+      ]);
+    }
+    if (child.kind !== 'text') return child;
+    const value = childrenOf(child).find((grand) => grand.kind === 'textValue');
+    const raw = value && value.kind === 'textValue' ? value.value : '';
+    return textNode(mint, raw, true);
+  });
+  return { ...run, id: mint(), children } as OoxmlNode;
+}

--- a/packages/core/src/store/store/tree-op-tracked-marks.ts
+++ b/packages/core/src/store/store/tree-op-tracked-marks.ts
@@ -19,13 +19,8 @@ import {
 } from '../package/ooxml-edit.ts';
 import { nextRevisionId } from './tree-op-revision-ids.ts';
 import { TEXT_DEPS, fromEdit } from './tree-op-nodes.ts';
-import {
-  build,
-  childrenOf,
-  isWmlNamed,
-  revisionAttributes,
-  sameEditingMoment,
-} from './tree-op-tracked.ts';
+import { build, childrenOf, isWmlNamed, revisionAttributes } from './tree-op-tracked.ts';
+import { sameEditingMoment } from './tree-op-tracked-adjacency.ts';
 import type { RevisionAttributionInput, TreeOpEffect, TreeOpResult } from './tree-op-validate.ts';
 
 /**

--- a/packages/core/src/store/store/tree-op-tracked.ts
+++ b/packages/core/src/store/store/tree-op-tracked.ts
@@ -1,4 +1,5 @@
-// Typing and deleting AS TRACKED CHANGES — what suggesting mode writes.
+// Typing AS A TRACKED CHANGE — what suggesting mode writes — and the node builders, wrapper
+// merging and adjacency rules that striking text (`tree-op-tracked-delete.ts`) shares.
 //
 // Two shapes, and they are not symmetrical. An insertion is new content, so it goes into a
 // `w:ins` wrapper the file did not have; a deletion keeps the words exactly where they are
@@ -33,13 +34,20 @@ import {
   type OoxmlParagraphNode,
   type OoxmlPart,
 } from '../package/ooxml-tree.ts';
-import { createNodeIdAllocator, replaceChildren } from '../package/ooxml-edit.ts';
+import { createNodeIdAllocator, replaceChildren, type EditOptions } from '../package/ooxml-edit.ts';
 import { equivalentNodes } from './ooxml-node-equality.ts';
 import { nextRevisionId } from './tree-op-revision-ids.ts';
 import { TEXT_DEPS, fromEdit } from './tree-op-nodes.ts';
 import { paragraphOffsetIndex, type ParagraphOffsetIndex } from './tree-op-segments.ts';
-import { insertionAuthor, insideDeletion } from './tree-op-retraction.ts';
+import { insertionAuthor } from './tree-op-retraction.ts';
 import type { RevisionAttributionInput, TreeOpEffect, TreeOpResult } from './tree-op-validate.ts';
+import {
+  adjacentDeletion,
+  deletionId,
+  replacedEnd,
+  revisionKey,
+  sameEditingMoment,
+} from './tree-op-tracked-adjacency.ts';
 
 function attr(localName: string, value: string) {
   return {
@@ -80,7 +88,7 @@ export function revisionAttributes(id: string, revision: RevisionAttributionInpu
 }
 
 /** A `w:t`, or the `w:delText` the same characters become once struck. */
-function textNode(mint: () => string, value: string, deleted: boolean): OoxmlNode {
+export function textNode(mint: () => string, value: string, deleted: boolean): OoxmlNode {
   const valueId = mint();
   return build(
     mint(),
@@ -96,7 +104,7 @@ function runOf(mint: () => string, children: readonly OoxmlNode[]): OoxmlNode {
   return build(mint(), 'run', 'r', [], children);
 }
 
-function isRunProperties(node: OoxmlNode): boolean {
+export function isRunProperties(node: OoxmlNode): boolean {
   return node.kind !== 'textValue' && node.kind === 'runProperties';
 }
 
@@ -124,51 +132,13 @@ function insertedRunProperties(mint: () => string, run: OoxmlNode): OoxmlNode[] 
 }
 
 /** Deep copy with fresh ids, so a split run's halves are two nodes and not one twice. */
-function copy(mint: () => string, node: OoxmlNode): OoxmlNode {
+export function copy(mint: () => string, node: OoxmlNode): OoxmlNode {
   if (node.kind === 'textValue') return { id: mint(), kind: 'textValue', value: node.value };
   return {
     ...node,
     id: mint(),
     children: node.children.map((child) => copy(mint, child)),
   } as OoxmlNode;
-}
-
-/**
- * Whether an existing revision's timestamp belongs to the edit being made now.
- *
- * Coalescing is for a continuous editing run, so the window is small: two keystrokes a
- * minute apart are still one thought, two edits a month apart are not one revision. Two
- * dateless wrappers join — a file written with date stamping off has nothing else to go on.
- */
-export function sameEditingMoment(
-  existing: string | undefined,
-  current: string | undefined
-): boolean {
-  if (existing === undefined || current === undefined) return existing === current;
-  const from = Date.parse(existing);
-  const to = Date.parse(current);
-  if (Number.isNaN(from) || Number.isNaN(to)) return existing === current;
-  return Math.abs(to - from) <= COALESCE_WINDOW_MS;
-}
-
-const COALESCE_WINDOW_MS = 60_000;
-
-/** A wrapper's `@w:date`, or undefined. */
-function revisionDateOf(node: OoxmlNode): string | undefined {
-  if (node.kind === 'textValue') return undefined;
-  return node.attributes.find(
-    (attribute) => attribute.namespaceUri === WML_NAMESPACE_URI && attribute.localName === 'date'
-  )?.value;
-}
-
-/** A deletion wrapper's `@w:id`, or null for anything else. */
-function deletionId(node: OoxmlNode): string | null {
-  if (node.kind !== 'revisionDelete') return null;
-  return (
-    node.attributes.find(
-      (attribute) => attribute.namespaceUri === WML_NAMESPACE_URI && attribute.localName === 'id'
-    )?.value ?? null
-  );
 }
 
 /** How many deletion wrappers with this `@w:id` live under the node, itself included. */
@@ -179,7 +149,15 @@ function deletionWrappersWithId(node: OoxmlNode, id: string): number {
   return count;
 }
 
-interface Cursor {
+/** A wrapper's `@w:date`, or undefined. */
+function revisionDateOf(node: OoxmlNode): string | undefined {
+  if (node.kind === 'textValue') return undefined;
+  return node.attributes.find(
+    (attribute) => attribute.namespaceUri === WML_NAMESPACE_URI && attribute.localName === 'date'
+  )?.value;
+}
+
+export interface Cursor {
   offset: number;
 }
 
@@ -215,7 +193,7 @@ function atomNodesOf(offsets: ParagraphOffsetIndex): AtomNodes {
 }
 
 /** A run's content — everything but its `w:rPr`. */
-function contentOf(node: OoxmlNode): readonly OoxmlNode[] {
+export function contentOf(node: OoxmlNode): readonly OoxmlNode[] {
   return childrenOf(node).filter((child) => !isRunProperties(child));
 }
 
@@ -268,7 +246,7 @@ export function applyInsertTracked(
   offset: number,
   text: string,
   revision: RevisionAttributionInput,
-  options?: { readonly deferValidation?: boolean }
+  options?: EditOptions
 ): TreeOpResult {
   return applyTrackedInsertion(
     part,
@@ -294,7 +272,7 @@ export function applyInsertTrackedElement(
   offset: number,
   element: (mint: () => string) => OoxmlNode,
   revision: RevisionAttributionInput,
-  options?: { readonly deferValidation?: boolean }
+  options?: EditOptions
 ): TreeOpResult {
   return applyInsertTrackedElements(
     part,
@@ -323,7 +301,7 @@ export function applyInsertTrackedElements(
   elements: (mint: () => string) => readonly OoxmlNode[],
   length: number,
   revision: RevisionAttributionInput,
-  options?: { readonly deferValidation?: boolean }
+  options?: EditOptions
 ): TreeOpResult {
   return applyTrackedInsertion(
     part,
@@ -350,7 +328,7 @@ export function applyInsertTrackedRun(
   offset: number,
   run: (mint: () => string) => OoxmlNode,
   revision: RevisionAttributionInput,
-  options?: { readonly deferValidation?: boolean }
+  options?: EditOptions
 ): TreeOpResult {
   return applyTrackedInsertion(
     part,
@@ -365,10 +343,10 @@ export function applyInsertTrackedRun(
 function applyTrackedInsertion(
   part: OoxmlPart,
   paragraph: OoxmlParagraphNode,
-  offset: number,
+  aim: number,
   payload: TrackedInsertionPayload,
   revision: RevisionAttributionInput,
-  options?: { readonly deferValidation?: boolean }
+  options?: EditOptions
 ): TreeOpResult {
   const mint = createNodeIdAllocator(part);
   const offsets = paragraphOffsetIndex(paragraph);
@@ -385,25 +363,59 @@ function applyTrackedInsertion(
 
   // Typing over a selection arrives as a deletion and an insertion in ONE transaction, the
   // deletion first — so by the time this runs, the struck words are already in the tree at
-  // the caret. Adopting their identity makes the pair one revision in the file, which is
-  // what lets one Accept resolve both halves and one undo take the whole edit back.
+  // the caret. The insertion adopts their DATE, so the pair reads as one moment, and lands
+  // right after them, so the pair reads as one replacement. It does NOT adopt their `@w:id`:
+  // Word numbers every revision element uniquely and writes a replacement as `w:del` then
+  // `w:ins` under two ids, and a reader that keys on the id — the reporter's tooling did —
+  // saw one collided revision where Word writes two. Nothing here needs the shared id: the
+  // review lane pairs the halves on adjacency (the only thing that works for a file this
+  // engine did not write) and resolves both addresses in one transaction, and undo is the
+  // transaction's, not the id's.
   // Only a deletion from THIS edit joins: `adjacentDeletion` matches on author alone, and a
   // deletion the same author made last month is also adjacent. Adopting its date would
   // backdate today's edit into last month's revision and make rejecting one reject both.
-  const replaced = adjacentDeletion(
-    paragraph,
-    offsets,
-    offset,
-    offset,
-    revision.author,
-    revision.date
-  );
+  const replaced = adjacentDeletion(paragraph, offsets, aim, aim, revision.author, revision.date);
   const attribution: RevisionAttributionInput = replaced
     ? { author: revision.author, ...(replaced.date === undefined ? {} : { date: replaced.date }) }
     : revision;
-  // Minted LAZILY: `nextRevisionId` walks the whole part, and an insertion that adopts the
-  // adjacent deletion's id — every replace-typing keystroke — would pay that walk for nothing.
-  const insertionId = replaced?.id ?? nextRevisionId(part)();
+  // THE REPLACEMENT FOLLOWS THE WORDS IT REPLACES. The struck text keeps its offsets, so a
+  // caller that aims at the front edge of THIS TRANSACTION's own strike — where the range
+  // began — is placing the same edit the keyboard places when it aims past the strike.
+  // Normalized HERE, once, so every rule below sees one aim: struck text first, then what
+  // takes its place, which is Word's arrangement, the order that reads as a sentence, and the
+  // adjacency the review lane pairs into one card. Aimed at the front, the run before the
+  // strike used to take the words at its end boundary, and every mid-paragraph replacement
+  // came out `w:ins` then `w:del`.
+  // Only a strike THIS transaction wrote qualifies (`TransactionRevisionIds.wroteUnder`). The
+  // deletion a keystroke ago is adjacent too, and typing after Backspace or Delete belongs in
+  // FRONT of the struck character — Word's order for that gesture — not after it.
+  // ONE predicate for the whole placement, because the question is asked three times: here,
+  // at the boundary rule that puts the words after a `w:del` they start on, and at the rule
+  // that follows them into the link or control holding the struck words. Two answers to it
+  // put the same gesture on either side of the strike depending on what preceded it.
+  //
+  // WITHOUT a transaction's bookkeeping there is no opinion to consult, and the reading is
+  // that an adjacent strike by this author IS the one being replaced — which is what every
+  // caller driving the appliers directly means by a `deleteText` and an `insertText` at one
+  // offset, and what the note lifecycle means when it writes its reference over a selection.
+  // Only a transaction can tell that gesture apart from Backspace-then-type, and only a
+  // transaction has to: the keyboard's two gestures are two transactions.
+  const replacesThisEdit =
+    replaced !== null &&
+    (options?.trackedRevisionIds?.wroteUnder(
+      revisionKey(replaced.id, revision.author, replaced.date)
+    ) ??
+      true);
+  const offset = replacesThisEdit
+    ? Math.max(aim, replacedEnd(paragraph, offsets, replaced!, revision.author, aim))
+    : aim;
+  // Minted LAZILY, on the first wrapper actually built: `nextRevisionId` walks the whole
+  // part, and typing on inside your own `w:ins` — every keystroke after the first — extends
+  // the existing wrapper and builds none, so it must not pay that walk. A transaction lends
+  // its own bookkeeping so a replacement's two halves share one walk.
+  let insertionId: string | null = null;
+  const mintedInsertionId = (): string =>
+    (insertionId ??= options?.trackedRevisionIds?.mint() ?? nextRevisionId(part)());
 
   // Counted lazily and ONCE: the paragraph-wide count only matters when a container holds
   // part of the adopted deletion, and it cannot change during the rebuild.
@@ -422,7 +434,7 @@ function applyTrackedInsertion(
       mint(),
       'revisionInsert',
       'ins',
-      revisionAttributes(insertionId, attribution),
+      revisionAttributes(mintedInsertionId(), attribution),
       payload.nodes ? [runOf(mint, [...properties, ...payload.nodes(mint)])] : [payload.run!(mint)]
     );
 
@@ -511,9 +523,13 @@ function applyTrackedInsertion(
         (node.kind === 'hyperlink' ||
           node.kind === 'contentControl' ||
           node.kind === 'contentControlContent');
+      // `replacesThisEdit`, not merely "a deletion is adjacent": this is the THIRD place the
+      // same question is asked, and an ungated answer followed the words into a link whose
+      // text a previous gesture had struck — where the relocation above had already declined
+      // to send them.
       const wrappersInside =
-        followable && replaced !== null && offset >= start && offset <= end
-          ? deletionWrappersWithId(node, replaced.id)
+        followable && replacesThisEdit && offset >= start && offset <= end
+          ? deletionWrappersWithId(node, replaced!.id)
           : 0;
       const holdsReplaced = wrappersInside > 0 && wrappersInside === wrappersWithReplacedId();
       if (
@@ -562,9 +578,13 @@ function applyTrackedInsertion(
         // Before them would read as "omega alpha" with alpha struck, which inverts the
         // sentence. It also puts the two halves side by side, which is what lets a reader
         // see them as one replacement.
-        const isReplacedText =
-          replaced !== null && node.kind === 'revisionDelete' && deletionId(node) === replaced.id;
-        if (isReplacedText) {
+        // The SAME gate as the relocation above: a strike from an earlier transaction is
+        // adjacent too, and typing after Backspace belongs in front of the struck character.
+        if (
+          replacesThisEdit &&
+          node.kind === 'revisionDelete' &&
+          deletionId(node) === replaced!.id
+        ) {
           cursor.offset = end;
           out.push(node, wrap([]));
           placed = true;
@@ -724,151 +744,6 @@ export function childrenOf(node: OoxmlNode): readonly OoxmlNode[] {
 }
 
 /**
- * Delete `[start, end)` as a tracked deletion: the words stay, re-labelled.
- *
- * Content already inside a `w:del` is left alone, and content inside the caller's OWN `w:ins`
- * is removed outright — it was never proposed to anybody else, so there is nothing to strike.
- */
-export function applyDeleteTracked(
-  part: OoxmlPart,
-  paragraph: OoxmlParagraphNode,
-  start: number,
-  end: number,
-  revision: RevisionAttributionInput,
-  options?: { readonly deferValidation?: boolean }
-): TreeOpResult {
-  const mint = createNodeIdAllocator(part);
-  const mintRevision = nextRevisionId(part);
-  // Join the deletion the caret is already working on, rather than minting a fresh id per
-  // keystroke. Holding Backspace through a word is ONE decision — Word records it as one
-  // `w:del` and offers one Accept — and a new id per character turned a deleted word into a
-  // column of one-letter cards, the same way untracked insertions did before they coalesced.
-  //
-  // The whole `CT_TrackChange` triple is joined, not just the id: a reader identifies a
-  // revision by (id, author, date), so a fresh timestamp per keystroke split the run back
-  // into one card per character even with the id shared.
-  const offsets = paragraphOffsetIndex(paragraph);
-  const adjacent = adjacentDeletion(paragraph, offsets, start, end, revision.author, revision.date);
-  const revisionId = adjacent?.id ?? mintRevision();
-  const attribution: RevisionAttributionInput = adjacent
-    ? { author: revision.author, ...(adjacent.date === undefined ? {} : { date: adjacent.date }) }
-    : revision;
-  const effect: TreeOpEffect = {
-    dirty: [paragraph.id],
-    created: [],
-    deleted: [],
-    dependencyKeys: TEXT_DEPS,
-    impact: 'text-local',
-  };
-  const cursor: Cursor = { offset: 0 };
-  // The nodes of every atom whose single model unit falls INSIDE the struck range. An atom is
-  // one addressable unit, so it goes whole: striking a field's `begin` and leaving its
-  // instruction, separator, result and `end` standing wrote a field no reader can resolve, and
-  // accepting that deletion removed the `begin` and orphaned the rest of it in the file.
-  const struck = new Set<string>();
-  for (const segment of offsets.segments) {
-    if (!segment.removeNodeIds || segment.removeNodeIds.length === 0) continue;
-    if (segment.start < start || segment.end > end) continue;
-    for (const id of segment.removeNodeIds) struck.add(id);
-  }
-  /** A run carrying part of a struck atom, whether or not it carries the offset itself. */
-  const carriesStruckAtom = (node: OoxmlNode): boolean =>
-    node.kind !== 'textValue' && contentOf(node).some((child) => struck.has(child.id));
-
-  const strike = (nodes: readonly OoxmlNode[]): OoxmlNode =>
-    build(mint(), 'revisionDelete', 'del', revisionAttributes(revisionId, attribution), nodes);
-
-  const rebuild = (nodes: readonly OoxmlNode[], stack: readonly OoxmlNode[]): OoxmlNode[] => {
-    const out: OoxmlNode[] = [];
-    for (const node of nodes) {
-      const length = offsets.lengthOf(node);
-      const from = cursor.offset;
-      const to = from + length;
-
-      // A `w:fldSimple` cannot go inside a `w:del`: `CT_RunTrackChange` takes
-      // `EG_ContentRunContent`, which has no `fldSimple` in it. Word strikes one by putting
-      // the deletion INSIDE the field, around its runs, and so does this.
-      if (struck.has(node.id) && node.kind !== 'textValue' && isWmlNamed(node, 'fldSimple')) {
-        cursor.offset = to;
-        out.push({
-          ...node,
-          children: mergedRevisions(
-            mint,
-            node.children.map((child) =>
-              child.kind === 'run' && !insideDeletion(stack)
-                ? strike([toDeleted(mint, child)])
-                : child
-            )
-          ),
-        } as OoxmlNode);
-        continue;
-      }
-
-      if ((to <= start || from >= end || length === 0) && !carriesStruckAtom(node)) {
-        cursor.offset = to;
-        out.push(node);
-        continue;
-      }
-
-      if (
-        node.kind !== 'textValue' &&
-        (node.kind === 'hyperlink' ||
-          // A content control is a run container too (`w:sdtContent` takes `EG_PContent`,
-          // `w:del` included). Passing it through whole made a suggested deletion over its
-          // text a silent NO-OP: the transaction committed, nothing was struck, and the
-          // reviewer's replacement landed beside words that were never proposed away.
-          node.kind === 'contentControl' ||
-          node.kind === 'contentControlContent' ||
-          node.kind === 'revisionInsert' ||
-          node.kind === 'revisionDelete' ||
-          node.kind === 'revisionMoveFrom' ||
-          node.kind === 'revisionMoveTo')
-      ) {
-        const rebuilt = rebuild(node.children, [...stack, node]);
-        // A wrapper emptied by the removal of our own insertion goes with it; one that
-        // still holds content stays, because it is still saying something about that
-        // content. A CONTROL is not a wrapper: it is document structure the user placed,
-        // so it keeps its (possibly emptied) `w:sdtContent` — dropping it left a `w:sdt`
-        // husk with properties and no content element, a shape Word never writes.
-        const structural = node.kind === 'contentControl' || node.kind === 'contentControlContent';
-        if (rebuilt.length > 0 || structural) {
-          out.push({ ...node, children: rebuilt } as OoxmlNode);
-        }
-        continue;
-      }
-
-      if (node.kind !== 'run') {
-        cursor.offset = to;
-        out.push(node);
-        continue;
-      }
-
-      cursor.offset = to;
-      if (insideDeletion(stack)) {
-        // Already struck. Deleting it again would nest a second `w:del`, which says the same
-        // thing twice and makes accepting it a two-step affair.
-        out.push(node);
-        continue;
-      }
-      const own = insertionAuthor(stack) === revision.author;
-      const covered = { from: Math.max(start, from) - from, to: Math.min(end, to) - from };
-      const pieces = splitRunThree(mint, offsets, node, covered.from, covered.to, struck);
-      if (pieces.before) out.push(pieces.before);
-      if (pieces.covered) {
-        // Our own pending insertion: remove rather than strike. The words were never anyone
-        // else's to see, so there is no proposal to make about taking them away.
-        if (!own) out.push(strike([toDeleted(mint, pieces.covered)]));
-      }
-      if (pieces.after) out.push(pieces.after);
-    }
-    return out;
-  };
-
-  const children = mergedRevisions(mint, rebuild(paragraph.children, []));
-  return fromEdit(replaceChildren(part, paragraph.id, children, options), effect);
-}
-
-/**
  * Fold adjacent revision wrappers that are the same revision into one.
  *
  * Striking a character at a time leaves `<w:del id=0/><w:del id=0/><w:del id=0/>` — one
@@ -876,7 +751,7 @@ export function applyDeleteTracked(
  * and three more on the next keystroke. Same id, same author, same date, side by side: one
  * wrapper holding all their runs.
  */
-function mergedRevisions(mint: () => string, nodes: readonly OoxmlNode[]): OoxmlNode[] {
+export function mergedRevisions(mint: () => string, nodes: readonly OoxmlNode[]): OoxmlNode[] {
   const out: OoxmlNode[] = [];
   for (const node of nodes) {
     const previous = out[out.length - 1];
@@ -948,145 +823,6 @@ function sameRevision(a: OoxmlElement, b: OoxmlElement): boolean {
     read(a, 'author') === read(b, 'author') &&
     read(a, 'date') === read(b, 'date')
   );
-}
-
-/**
- * The `@w:id` of a deletion by this author touching `[start, end)`, or null.
- *
- * Touching, not overlapping: the run being struck now sits beside the one struck a keystroke
- * ago, never inside it. Both edges are checked, because Backspace grows a deletion leftwards
- * and Delete grows it rightwards.
- */
-function adjacentDeletion(
-  paragraph: OoxmlParagraphNode,
-  offsets: ParagraphOffsetIndex,
-  start: number,
-  end: number,
-  author: string,
-  /** Only a wrapper from the same moment joins; see the call sites. */
-  within: string | undefined
-): { readonly id: string; readonly date: string | undefined } | null {
-  let found: { readonly id: string; readonly date: string | undefined } | null = null;
-  const visit = (node: OoxmlNode): void => {
-    if (found !== null || node.kind === 'textValue') return;
-    if (node.kind === 'revisionDelete') {
-      const attributes = node.attributes;
-      const whose = attributes.find(
-        (attribute) =>
-          attribute.namespaceUri === WML_NAMESPACE_URI && attribute.localName === 'author'
-      );
-      const id = attributes.find(
-        (attribute) => attribute.namespaceUri === WML_NAMESPACE_URI && attribute.localName === 'id'
-      );
-      // A wrapper the offset walk never reached has no span, so it cannot be adjacent to
-      // anything: joining it would put this edit under an id at an unknown position.
-      const span = offsets.spanOf(node);
-      if (whose?.value === author && id && span) {
-        if (span.end === start || span.start === end) {
-          const when = attributes.find(
-            (attribute) =>
-              attribute.namespaceUri === WML_NAMESPACE_URI && attribute.localName === 'date'
-          );
-          if (!sameEditingMoment(when?.value, within)) return;
-          found = { id: id.value, date: when?.value };
-          return;
-        }
-      }
-    }
-    for (const child of node.children) visit(child);
-  };
-  for (const child of paragraph.children) visit(child);
-  return found;
-}
-
-/** Split a run into the part before the range, the covered part, and the part after. */
-function splitRunThree(
-  mint: () => string,
-  offsets: ParagraphOffsetIndex,
-  run: OoxmlNode,
-  from: number,
-  to: number,
-  /** Nodes an atom being struck swallows; covered by identity, since they measure nothing. */
-  struckAtomNodes: ReadonlySet<string> = new Set()
-): { before: OoxmlNode | null; covered: OoxmlNode | null; after: OoxmlNode | null } {
-  const properties = childrenOf(run).filter(isRunProperties);
-  const withProperties = (content: readonly OoxmlNode[]): OoxmlNode | null =>
-    content.length === 0
-      ? null
-      : build(
-          mint(),
-          'run',
-          'r',
-          [],
-          [...properties.map((child) => copy(mint, child)), ...content]
-        );
-
-  const before: OoxmlNode[] = [];
-  const covered: OoxmlNode[] = [];
-  const after: OoxmlNode[] = [];
-  let seen = 0;
-  for (const child of childrenOf(run)) {
-    if (isRunProperties(child)) continue;
-    const length = offsets.lengthOf(child);
-    const childFrom = seen;
-    const childTo = seen + length;
-    seen = childTo;
-    // An atom's chrome measures nothing, so no offset comparison can place it. It goes with
-    // the unit it belongs to, which is being struck.
-    if (struckAtomNodes.has(child.id)) {
-      covered.push(child);
-      continue;
-    }
-    if (childTo <= from) {
-      before.push(child);
-      continue;
-    }
-    if (childFrom >= to) {
-      after.push(child);
-      continue;
-    }
-    if (child.kind !== 'text' && child.kind !== 'deletedText') {
-      // A tab or a break is atomic: it is covered or it is not.
-      covered.push(child);
-      continue;
-    }
-    const value = childrenOf(child).find((grand) => grand.kind === 'textValue');
-    const raw = value && value.kind === 'textValue' ? value.value : '';
-    const deleted = child.kind === 'deletedText';
-    const head = raw.slice(0, Math.max(0, from - childFrom));
-    const middle = raw.slice(Math.max(0, from - childFrom), Math.min(raw.length, to - childFrom));
-    const tail = raw.slice(Math.min(raw.length, to - childFrom));
-    if (head) before.push(textNode(mint, head, deleted));
-    if (middle) covered.push(textNode(mint, middle, deleted));
-    if (tail) after.push(textNode(mint, tail, deleted));
-  }
-  return {
-    before: withProperties(before),
-    covered: withProperties(covered),
-    after: withProperties(after),
-  };
-}
-
-/** Re-label a run's text as deleted: `w:t` becomes `w:delText`, everything else stays. */
-function toDeleted(mint: () => string, run: OoxmlNode): OoxmlNode {
-  const children = childrenOf(run).map((child) => {
-    // `w:instrText` becomes `w:delInstrText` inside a deletion, exactly as `w:t` becomes
-    // `w:delText`. The REJECT path already renames it back, so without this the write path
-    // could never produce what the reject path exists to undo.
-    if (child.kind !== 'textValue' && isWmlNamed(child, 'instrText')) {
-      const value = childrenOf(child).find((grand) => grand.kind === 'textValue');
-      const raw = value && value.kind === 'textValue' ? value.value : '';
-      const valueId = mint();
-      return build(mint(), 'generic', 'delInstrText', child.attributes, [
-        { id: valueId, kind: 'textValue', value: raw } as OoxmlNode,
-      ]);
-    }
-    if (child.kind !== 'text') return child;
-    const value = childrenOf(child).find((grand) => grand.kind === 'textValue');
-    const raw = value && value.kind === 'textValue' ? value.value : '';
-    return textNode(mint, raw, true);
-  });
-  return { ...run, id: mint(), children } as OoxmlNode;
 }
 
 /** Shared with `tree-op-tracked-marks.ts`, which writes the paragraph-mark wrappers. */

--- a/packages/core/src/store/store/tree-store.ts
+++ b/packages/core/src/store/store/tree-store.ts
@@ -24,6 +24,31 @@ import { ORIGIN_IDS } from '../registry/frozen-ids.ts';
 import { formsProtectionRefusal } from './tree-op-content-controls.ts';
 import { nextRevisionId } from './tree-op-revision-ids.ts';
 import { PROPERTY_CHANGE_WRAPPER_OF_OP } from './tree-op-tracked-properties.ts';
+import type { TransactionRevisionIds } from '../package/ooxml-edit.ts';
+
+/**
+ * The ops whose tracked appliers write a revision wrapper. They get the transaction's
+ * bookkeeping — the shared counter, and the record of what it has written, which is what
+ * tells a replacement's insertion from a keystroke after Backspace.
+ */
+const TRACKED_WRAPPER_OPS: ReadonlySet<string> = new Set([
+  'insertText',
+  'insertTab',
+  'insertHardBreak',
+  'insertPageBreak',
+  'insertPageField',
+  'insertDrawing',
+  'deleteText',
+]);
+
+/**
+ * Of those, the ones whose content comes from the CALLER and can carry revision ids in with
+ * it: an anchored text box holds `w:txbxContent` paragraphs that may already be revised. They
+ * still get the record — they write a wrapper, and the next op has to know it — but the
+ * counter is dropped around them, so nothing after them draws from a walk taken before the
+ * content arrived.
+ */
+const IMPORTS_REVISION_IDS: ReadonlySet<string> = new Set(['insertDrawing']);
 import { applyTreeOp, type ImpactClass, type TreeDocOp, type TreeOpRejection } from './tree-ops.ts';
 
 /** A selection the caller wants restored when an entry is undone or redone. */
@@ -458,8 +483,46 @@ export class TreeDocumentStore {
      * including `applyPackage`. Those ops MINT ids and never import one, so an id taken before
      * the first of them is still free when the last lands. A paste carries its own revision
      * ids, so an id that survived one would be an address the document had just started using.
+     * The id itself comes from the per-part minter below, which every tracked lane shares.
      */
     const revisionIdOfGroup = new Map<string, { id: string | null }>();
+    /**
+     * ONE `nextRevisionId` walk per part per transaction, shared by every tracked lane. The
+     * property groups above and the text ops below draw from the same counter, so an id a
+     * `w:rPrChange` took is never handed to the `w:ins` written next — two counters, each
+     * walking the part for itself, did exactly that once one of them cached its walk. What it
+     * hands out is remembered, which is the other half of `TransactionRevisionIds`.
+     */
+    const revisionIdsOfPart = new Map<
+      string,
+      { mint: (() => string) | null; readonly written: Set<string> }
+    >();
+    /**
+     * The bookkeeping for one part, bound to the part AS IT STANDS FOR THIS OP.
+     *
+     * The counter is memoized in the map, the closure over it is not: an applier is handed a
+     * new part after every op, and a walk that captured the first one it ever saw re-walked
+     * that stale snapshot whenever the counter was dropped — handing back an id the same
+     * transaction had already used, which is the very collision this is here to prevent.
+     */
+    const revisionIdsFor = (part: OoxmlPart): TransactionRevisionIds => {
+      let held = revisionIdsOfPart.get(part.name);
+      if (!held) {
+        held = { mint: null, written: new Set<string>() };
+        revisionIdsOfPart.set(part.name, held);
+      }
+      const state = held;
+      return {
+        // The walk itself is LAZY: an untracked transaction never pays for one.
+        mint: (): string => (state.mint ??= nextRevisionId(part))(),
+        wrote: (key: string): void => void state.written.add(key),
+        wroteUnder: (key: string): boolean => state.written.has(key),
+      };
+    };
+    /** Drop the counters; the next mint walks the part it is given. The record stays. */
+    const resetRevisionCounters = (): void => {
+      for (const held of revisionIdsOfPart.values()) held.mint = null;
+    };
     const sharedRevisionIds = (op: TreeDocOp, part: OoxmlPart): (() => string) | null => {
       const wrapper = PROPERTY_CHANGE_WRAPPER_OF_OP.get(op.op);
       if (wrapper === undefined) {
@@ -473,12 +536,27 @@ export class TreeDocumentStore {
         revisionIdOfGroup.set(key, group);
       }
       // Taken LAZILY on the first record actually written, so an untracked format — the
-      // common case — never pays the walk at all. AGAINST THIS OP'S OWN PART, not the one
-      // that happened to open the group: an op that records nothing (a run inside this
-      // author's own `w:ins`) opens it against a part that does not yet hold the other
-      // wrapper's id, and minting from that snapshot later handed both wrappers one address.
+      // common case — never pays the walk at all.
       const held = group;
-      return (): string => (held.id ??= nextRevisionId(part)());
+      return (): string => (held.id ??= revisionIdsFor(part).mint());
+    };
+
+    /**
+     * The tracked TEXT ops' bookkeeping. The COUNTER is dropped, like the property group, the
+     * moment anything else runs (`applyPackage` included): a paste re-mints the ids it carries
+     * against the part as it stands, and a walk taken before it would hand out an id the paste
+     * just used. What this transaction WROTE survives all of it — a record of the past cannot
+     * go stale, and the replacement rule reads it after ops that mint nothing.
+     */
+    const trackedRevisionIdsFor = (
+      op: TreeDocOp,
+      part: OoxmlPart
+    ): TransactionRevisionIds | null => {
+      const writes = TRACKED_WRAPPER_OPS.has(op.op);
+      // A property op keeps the counter: its group takes one id and imports none.
+      if (!writes && PROPERTY_CHANGE_WRAPPER_OF_OP.get(op.op) !== undefined) return null;
+      if (!writes || IMPORTS_REVISION_IDS.has(op.op)) resetRevisionCounters();
+      return writes ? revisionIdsFor(part) : null;
     };
 
     const applyToPart = (partName: string, op: TreeDocOp): boolean => {
@@ -505,14 +583,21 @@ export class TreeDocumentStore {
       // commit can observe the intermediate parts. Op-level input validation still runs
       // inside `applyTreeOp` before any tree work.
       const revisionIds = sharedRevisionIds(op, target);
+      const trackedRevisionIds = trackedRevisionIdsFor(op, target);
       const result = applyTreeOp(target, op, {
         deferValidation: true,
         ...(revisionIds ? { revisionIds } : {}),
+        ...(trackedRevisionIds ? { trackedRevisionIds } : {}),
       });
       if (!result.ok) {
         failure = { reason: result.reason, ...(result.detail ? { detail: result.detail } : {}) };
         return false;
       }
+      // AFTER an importing op, not only before it: the op writes a wrapper of its own, so it
+      // re-establishes the counter while it runs — against the part as it stood before its
+      // own content arrived. Left standing, the next op would mint from a walk that never saw
+      // the ids that came in with it.
+      if (IMPORTS_REVISION_IDS.has(op.op)) resetRevisionCounters();
       working = withPart(working, result.part);
       const identityNoOp =
         result.part === target &&
@@ -549,6 +634,7 @@ export class TreeDocumentStore {
         // its own revision ids. The shared id is taken from the part it first saw, so it goes
         // here for the same reason a non-property op drops it.
         revisionIdOfGroup.clear();
+        resetRevisionCounters();
         const next = edit(working);
         if (next === working) return true;
         for (const [name, part] of next.parts) {


### PR DESCRIPTION
In suggesting mode, replacing text wrote the insertion and the deletion under one revision id, and a replacement that did not start at the paragraph's first character wrote the insertion in front of the deletion. Word numbers every revision element uniquely and writes the deletion first. A reader that keys on the id, and the engine's own review lane on reopen, saw the wrong shape.

The insertion half now takes its own id and keeps only the deletion's date. An insertion aimed at the front edge of the strike it replaces is normalized to the end of that strike, so the file reads `w:del` then `w:ins` wherever the replaced text sits, and typing and `Range.insertText(…, 'Replace')` write the same markup. Only a strike from the same transaction counts, so typing after Backspace still puts the new text in front of the struck character.

The object model asks the editor where a tracked replacement lands, through a new `replacementLanding` member on the surface and the automation port, rather than inferring it. It inserts there and answers that span, so a script that formats or comments on the returned range acts on the text it just wrote.

Verified against Word and against the reported case. Word writes the same replacement as `w:del` with id 0 followed by `w:ins` with id 1 on one timestamp, and it lists the engine's earlier shared-id output as two separate revisions. Running the reporter's document and edit on this branch now produces that same shape, and the object model answers the span holding the new text.

A transaction now shares one revision-id walk across its tracked ops, so a replacement no longer scans the part twice.

The delete applier moves to `tree-op-tracked-delete.ts`, the content-control input vocabulary to `content-control-input.ts`, and the surface options record to `paginated-surface-options.ts`, all to stay under the line caps. No behavior changes there.

Fixes #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6NxccdmDgf5AY9LFgd7Jp

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/722"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791107562&installation_model_id=422592&pr_number=722&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F722&signature=eb0fb97d8b13757f17cd07e8e6502bd910569c657ea185c8d30683e1bf6e00c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->