### PR TITLE
test: budget the export's live heap instead of its resident set

### DIFF
--- a/packages/docx-to-markdown/test/browser-node-parity.test.ts
+++ b/packages/docx-to-markdown/test/browser-node-parity.test.ts
@@ -186,8 +186,11 @@ function performanceMeasurement(
   readonly markdownLength: number;
   readonly hasDom: boolean;
   readonly peakRssBytes: number;
+  readonly liveHeapBytes: number;
 } {
-  const result = spawnSync('node', [...nodeArguments, nodeWorker.path], {
+  // `--expose-gc` only adds `globalThis.gc`; it leaves the collection policy alone, so it changes
+  // neither the peak this run reaches nor what the constrained arguments below constrain.
+  const result = spawnSync('node', ['--expose-gc', ...nodeArguments, nodeWorker.path], {
     cwd: nodeWorker.repositoryRoot,
     env: childEnvironment({
       DOCX_EDITOR_WORKER_MODE: mode,
@@ -224,31 +227,50 @@ function expectProductionFixture(
   expect(measurement.hasDom).toBe(false);
 }
 
-test('a real 500-page shaped export stays below the default Node peak-memory budget', () => {
+// Sweeping this fixture over macOS arm64 and Linux arm64/x64 on Node 20, 22, 24 and 25 reads
+// 199 MiB at the widest for the one-shot export and 336 MiB for a caller holding the settled
+// layout, with Node 20 the high reader in both. These ceilings clear those by 28% and 33%, wide
+// enough that a runner the suite has not run on before does not move them and tight enough to
+// still catch the 1.8+ GiB class of regression they exist for.
+const ONE_SHOT_LIVE_HEAP_CEILING = 256 * 1024 * 1024;
+const RETAINED_LAYOUT_LIVE_HEAP_CEILING = 448 * 1024 * 1024;
+
+// Resident set size gets a loose backstop instead of a budget: across the same sweep one set of
+// constrained arguments spans 532 MiB to 676 MiB, because resident size also counts allocator and
+// committed-page overhead. The default-heap run reaches 1034 MiB on Linux x64, which is why a
+// 1 GiB ceiling here was not survivable. Only a gross regression clears this.
+const RESIDENT_BACKSTOP = 1536 * 1024 * 1024;
+
+test('a real 500-page shaped export holds a bounded live set on a default heap', () => {
   const measurement = performanceMeasurement();
   expectProductionFixture(measurement);
-  // Default V8 deliberately keeps reclaimed old-space pages committed. This ceiling measures
-  // an ordinary invocation and catches the original 1.8+ GiB regression without treating
-  // committed-but-reusable heap as the live set.
-  expect(measurement.peakRssBytes).toBeLessThan(1024 * 1024 * 1024);
+  // Default V8 grows old space freely and keeps reclaimed pages committed, so an ordinary
+  // invocation is where retention shows up first: nothing here forces a collection the way the
+  // constrained runs below do. The live set is the assertion that means something; resident size
+  // only has to stay off the backstop.
+  expect(measurement.liveHeapBytes).toBeLessThan(RETAINED_LAYOUT_LIVE_HEAP_CEILING);
+  expect(measurement.peakRssBytes).toBeLessThan(RESIDENT_BACKSTOP);
 }, 120_000);
 
-// The bound these two tests prove is the heap cap itself: under a 364 MiB old space V8 must
-// collect rather than retain transient layout allocations, so a working set that no longer fits
-// aborts the worker and fails the `status` assertion in `performanceMeasurement`. A peak-RSS
-// ceiling used to sit on top of that, but resident size also carries allocator and
-// committed-page overhead that swings by roughly 200 MiB across platforms for the same live
-// set, which made the ceiling fail on CI while passing everywhere it was calibrated. The
-// default-heap test above keeps a resident-size ceiling, where the headroom is wide enough for
-// that spread to be noise.
+// A 364 MiB old space is itself an assertion: V8 has to collect rather than retain transient
+// layout allocations, and a working set that no longer fits aborts the worker, which the exit
+// status in `performanceMeasurement` catches. On top of that the one-shot run gets a live-heap
+// ceiling, because how far under the cap it settles is the evidence that it releases the layout.
 const CONSTRAINED_NODE_ARGUMENTS = ['--max-old-space-size=364', '--max-semi-space-size=8'] as const;
 
 test('the one-shot 500-page export fits a constrained 364 MiB heap', () => {
   const measurement = performanceMeasurement(CONSTRAINED_NODE_ARGUMENTS, 'one-shot-performance');
   expectProductionFixture(measurement, { inspectLayout: false });
+  // The one-shot entry point returns markdown and drops the layout, so it settles well below the
+  // retained-layout ceiling. That gap is the point: it proves the export does not pin the layout.
+  expect(measurement.liveHeapBytes).toBeLessThan(ONE_SHOT_LIVE_HEAP_CEILING);
 }, 120_000);
 
 test('the shared core session fits the same constrained 364 MiB heap', () => {
   const measurement = performanceMeasurement(CONSTRAINED_NODE_ARGUMENTS);
   expectProductionFixture(measurement);
+  // Guard the exporter-neutral workflow used by PDF and future projections, including callers
+  // that intentionally retain the settled layout while translating it. No live-heap ceiling of
+  // its own: the 364 MiB cap is already below the one the default-heap run answers to, so this
+  // aborts on the cap before any ceiling worth writing here could fire.
 }, 120_000);

--- a/packages/docx-to-markdown/test/literal-node-worker-entry.ts
+++ b/packages/docx-to-markdown/test/literal-node-worker-entry.ts
@@ -3,6 +3,19 @@ import { readFile } from 'node:fs/promises';
 import { exportMarkdown, exportMarkdownFrom, openDocumentForExport } from '../src/index.ts';
 import { canonicalLayout } from './canonical-layout.ts';
 
+// Resident set size counts allocator and committed-page overhead that swings by more than 100 MiB
+// across platforms for an identical live set, so it cannot carry a tight budget. The live heap
+// after a forced full collection can: this export settles inside a 2% band across macOS arm64,
+// Linux arm64 and Linux x64 for a given Node major, and the majors themselves sit 40 MiB apart at
+// the widest. Collect repeatedly because one pass leaves objects that only become unreachable
+// once the previous pass has finalized weak references.
+function liveHeapBytes(): number {
+  const collect = (globalThis as { gc?: () => void }).gc;
+  if (!collect) throw new Error('export test worker requires --expose-gc');
+  for (let pass = 0; pass < 4; pass += 1) collect();
+  return process.memoryUsage().heapUsed;
+}
+
 if (process.release.name !== 'node') throw new Error('export test worker requires Node');
 const fixturePath = process.env.DOCX_EDITOR_WORKER_FIXTURE;
 if (!fixturePath) throw new Error('DOCX_EDITOR_WORKER_FIXTURE is required');
@@ -17,6 +30,7 @@ if (mode === 'one-shot-performance') {
       markdownLength: translated.markdown.length,
       hasDom: typeof document !== 'undefined',
       peakRssBytes: process.resourceUsage().maxRSS * 1024,
+      liveHeapBytes: liveHeapBytes(),
     })
   );
 } else {
@@ -62,6 +76,9 @@ if (mode === 'one-shot-performance') {
           hasDom: typeof document !== 'undefined',
           // Node reports maxRSS in KiB on every supported platform.
           peakRssBytes: process.resourceUsage().maxRSS * 1024,
+          // Read before the `finally` disposes the session, so this is the set a caller retains
+          // while it holds the settled layout.
+          liveHeapBytes: liveHeapBytes(),
         })
       );
     } else {


### PR DESCRIPTION
Follow-up to #721, which unblocked the release by dropping the peak-resident
ceilings from the constrained 500-page export tests. This restores a budget, on a
measurement that holds still across hosts.

## Why resident size cannot carry a budget

A sweep of the 521-page fixture across macOS arm64, Linux arm64 and Linux x64 on
Node 20, 22, 24 and 25, 27 runs in total:

| Measurement | Spread across the sweep | Spread within one Node major |
| --- | --- | --- |
| Live heap, one-shot export | 191-200 MiB | 2% |
| Live heap, caller retains the layout | 287-336 MiB | 2% |
| Peak resident set | 532-1034 MiB | 20% |

Resident size swings 20% for a byte-identical live set, because it also counts
allocator and committed-page overhead. Live heap after a forced full collection
does not.

## What this changes

The worker now forces a collection and reports `heapUsed` alongside
`peakRssBytes`, and the tests spawn it with `--expose-gc`. The ceilings sit at
256 MiB for the one-shot export and 448 MiB for a caller holding the settled
layout, clearing the widest readings by 28% and 33%. Both still catch the
1.8+ GiB class of regression they exist for.

The constrained shared-session test gets no ceiling of its own. Its
`--max-old-space-size=364` cap already sits below any ceiling worth writing, so
the worker aborts on the cap first and the existing exit-status assertion is what
enforces it.

## The default-heap test was the next one to go

Its resident ceiling of 1 GiB survived #721. The sweep reads **1034 MiB** on
Linux x64, so it was already over the line on a combination the suite had not run
on yet. It becomes a 1.5 GiB backstop, and the live-set assertion carries the
meaning.

## Verified

`bun run format`, `bun run lint` (0 errors), `bun run typecheck`, and the full
suite: 11468 pass, 0 fail across 907 files.

## Not included

`release.yml` pins Node 24 through `actions/setup-node`, while `ci.yml` has no
setup-node step and runs whatever the runner ships. PR CI therefore never
exercises the Node version the release gate uses, which is how a runner-specific
failure first appeared during a publish. Closing that gap belongs in its own
change, since aligning the versions can surface unrelated failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vecpoa78ufmKRMwdbkHQt
