### PR TITLE
test: budget the export's external memory too

### DIFF
--- a/packages/docx-to-markdown/test/browser-node-parity.test.ts
+++ b/packages/docx-to-markdown/test/browser-node-parity.test.ts
@@ -187,6 +187,7 @@ function performanceMeasurement(
   readonly hasDom: boolean;
   readonly peakRssBytes: number;
   readonly liveHeapBytes: number;
+  readonly externalBytes: number;
 } {
   // `--expose-gc` only adds `globalThis.gc`; it leaves the collection policy alone, so it changes
   // neither the peak this run reaches nor what the constrained arguments below constrain.
@@ -235,10 +236,17 @@ function expectProductionFixture(
 const ONE_SHOT_LIVE_HEAP_CEILING = 256 * 1024 * 1024;
 const RETAINED_LAYOUT_LIVE_HEAP_CEILING = 448 * 1024 * 1024;
 
-// Resident set size gets a loose backstop instead of a budget: across the same sweep one set of
-// constrained arguments spans 532 MiB to 676 MiB, because resident size also counts allocator and
-// committed-page overhead. The default-heap run reaches 1034 MiB on Linux x64, which is why a
-// 1 GiB ceiling here was not survivable. Only a gross regression clears this.
+// External memory is the steadiest reading of the three: the same sweep puts every retained-layout
+// run within 0.1 MiB of 33 MiB on Node 20 and 39 MiB on Node 24, on all three platforms. It is
+// also the only place a HarfBuzz or image-buffer regression can show, since `heapUsed` does not
+// count it. One ceiling covers both shapes.
+const EXTERNAL_MEMORY_CEILING = 64 * 1024 * 1024;
+
+// Resident set size keeps a backstop rather than a budget, because it is the only reading that
+// sees growth outside V8 at all. It cannot be tight: across the same sweep one set of constrained
+// arguments spans 532 MiB to 676 MiB on allocator and committed-page overhead alone, and the
+// default-heap run reaches 1034 MiB on Linux x64, which is why the 1 GiB ceiling this replaces
+// was never survivable. Only a runaway clears it.
 const RESIDENT_BACKSTOP = 1536 * 1024 * 1024;
 
 test('a real 500-page shaped export holds a bounded live set on a default heap', () => {
@@ -246,9 +254,10 @@ test('a real 500-page shaped export holds a bounded live set on a default heap',
   expectProductionFixture(measurement);
   // Default V8 grows old space freely and keeps reclaimed pages committed, so an ordinary
   // invocation is where retention shows up first: nothing here forces a collection the way the
-  // constrained runs below do. The live set is the assertion that means something; resident size
-  // only has to stay off the backstop.
+  // constrained runs below do. The live set and external memory are the assertions that mean
+  // something; resident size only has to stay off the backstop.
   expect(measurement.liveHeapBytes).toBeLessThan(RETAINED_LAYOUT_LIVE_HEAP_CEILING);
+  expect(measurement.externalBytes).toBeLessThan(EXTERNAL_MEMORY_CEILING);
   expect(measurement.peakRssBytes).toBeLessThan(RESIDENT_BACKSTOP);
 }, 120_000);
 
@@ -264,6 +273,7 @@ test('the one-shot 500-page export fits a constrained 364 MiB heap', () => {
   // The one-shot entry point returns markdown and drops the layout, so it settles well below the
   // retained-layout ceiling. That gap is the point: it proves the export does not pin the layout.
   expect(measurement.liveHeapBytes).toBeLessThan(ONE_SHOT_LIVE_HEAP_CEILING);
+  expect(measurement.externalBytes).toBeLessThan(EXTERNAL_MEMORY_CEILING);
 }, 120_000);
 
 test('the shared core session fits the same constrained 364 MiB heap', () => {
@@ -272,5 +282,7 @@ test('the shared core session fits the same constrained 364 MiB heap', () => {
   // Guard the exporter-neutral workflow used by PDF and future projections, including callers
   // that intentionally retain the settled layout while translating it. No live-heap ceiling of
   // its own: the 364 MiB cap is already below the one the default-heap run answers to, so this
-  // aborts on the cap before any ceiling worth writing here could fire.
+  // aborts on the cap before any ceiling worth writing here could fire. External memory sits
+  // outside that cap, so it still needs asserting here.
+  expect(measurement.externalBytes).toBeLessThan(EXTERNAL_MEMORY_CEILING);
 }, 120_000);

--- a/packages/docx-to-markdown/test/literal-node-worker-entry.ts
+++ b/packages/docx-to-markdown/test/literal-node-worker-entry.ts
@@ -4,16 +4,20 @@ import { exportMarkdown, exportMarkdownFrom, openDocumentForExport } from '../sr
 import { canonicalLayout } from './canonical-layout.ts';
 
 // Resident set size counts allocator and committed-page overhead that swings by more than 100 MiB
-// across platforms for an identical live set, so it cannot carry a tight budget. The live heap
-// after a forced full collection can: this export settles inside a 2% band across macOS arm64,
-// Linux arm64 and Linux x64 for a given Node major, and the majors themselves sit 40 MiB apart at
-// the widest. Collect repeatedly because one pass leaves objects that only become unreachable
-// once the previous pass has finalized weak references.
-function liveHeapBytes(): number {
+// across platforms for an identical live set, so it cannot carry a tight budget. These two
+// readings can. After a forced full collection the live heap settles inside a 2% band across
+// macOS arm64, Linux arm64 and Linux x64 for a given Node major, and external memory matches to
+// 0.1 MiB across the same three. Collect repeatedly because one pass leaves objects that only
+// become unreachable once the previous pass has finalized weak references.
+function settledMemory(): { readonly liveHeapBytes: number; readonly externalBytes: number } {
   const collect = (globalThis as { gc?: () => void }).gc;
   if (!collect) throw new Error('export test worker requires --expose-gc');
   for (let pass = 0; pass < 4; pass += 1) collect();
-  return process.memoryUsage().heapUsed;
+  const usage = process.memoryUsage();
+  // `external` is the half `heapUsed` cannot see: the HarfBuzz wasm heap, decoded image buffers,
+  // and every other ArrayBuffer. A shaper cache or buffer that stops being released grows here
+  // and nowhere else, so the two readings together cover what a retention regression can move.
+  return { liveHeapBytes: usage.heapUsed, externalBytes: usage.external };
 }
 
 if (process.release.name !== 'node') throw new Error('export test worker requires Node');
@@ -30,7 +34,7 @@ if (mode === 'one-shot-performance') {
       markdownLength: translated.markdown.length,
       hasDom: typeof document !== 'undefined',
       peakRssBytes: process.resourceUsage().maxRSS * 1024,
-      liveHeapBytes: liveHeapBytes(),
+      ...settledMemory(),
     })
   );
 } else {
@@ -78,7 +82,7 @@ if (mode === 'one-shot-performance') {
           peakRssBytes: process.resourceUsage().maxRSS * 1024,
           // Read before the `finally` disposes the session, so this is the set a caller retains
           // while it holds the settled layout.
-          liveHeapBytes: liveHeapBytes(),
+          ...settledMemory(),
         })
       );
     } else {


### PR DESCRIPTION
Follow-up to #724, which budgeted the export's live heap. `heapUsed` does not
count external memory, so the HarfBuzz wasm heap and decoded image buffers sit
outside that ceiling entirely. A shaper cache or a buffer that stops being
released would clear it untouched, and only the 1.5 GiB resident backstop would
notice, at 20% noise.

`external` measures that directly, and across the same sweep it is the steadiest
reading of the three:

| Reading | Spread across 27 runs | Spread within one Node major |
| --- | --- | --- |
| `external` | 21.5-38.7 MiB | 0.1 MiB |
| `heapUsed` | 191-337 MiB | 2% |
| Peak resident set | 530-1032 MiB | 20% |

Every retained-layout run lands within 0.1 MiB of 33 MiB on Node 20 and 39 MiB on
Node 24, on macOS arm64, Linux arm64 and Linux x64 alike. One 64 MiB ceiling
covers both shapes with 65% headroom.

The gap between the two shapes is itself evidence: the one-shot export settles at
21 MiB external and 1.5 MiB of ArrayBuffers, against 33 MiB and 13 MiB when the
caller holds the layout. It demonstrably releases both the layout and its buffers.

The constrained shared-session test asserts this even though it has no live-heap
ceiling of its own, because external memory sits outside the
`--max-old-space-size` cap that otherwise bounds that run.

The resident backstop stays. It is the only reading that sees growth outside V8
at all, so it still earns a place; it just cannot be tight.

## Verified

All 27 sweep runs pass every ceiling, with the widest usage at 78% (`heapUsed`,
one-shot on Node 20), 61% (`external`, Node 24) and 67% (resident, Linux x64).
Locally: `bun run format`, `bun run lint` (0 errors), `bun run typecheck`, and
the full suite at 11468 pass, 0 fail across 907 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vecpoa78ufmKRMwdbkHQt

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/725"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791121670&installation_model_id=422592&pr_number=725&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F725&signature=51b4f7efcc5431e31fe1763cb66cec0bec9b8517383471a4366165def30a10e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->