### PR TITLE
fix(fonts): survive the bundler rewrite of packaged asset URLs

### DIFF
--- a/.changeset/plenty-donuts-repeat.md
+++ b/.changeset/plenty-donuts-repeat.md
@@ -9,9 +9,17 @@ Those bundlers replace `new URL('../assets/<face>', import.meta.url)` with a bar
 relative path string for the asset they emitted. Deriving the asset root from one entry
 with a single-argument `new URL()` therefore threw `URL constructor:
 /_next/static/media/Caladea-Bold.<hash>.ttf is not a valid URL` while the module was
-still evaluating, where nothing can catch it. In a bundled build the root now reports a
-non-`file:` URL, which is what consumers already gate on before using it as a
-`createPackagedFileFetch` trusted root.
+still evaluating, where nothing can catch it.
 
-Registering a packaged face by URL no longer reads `.href` off that same string, which
-had been producing the literal source `url(undefined)` and silently losing the face.
+In a bundled build the root now reports a non-`file:` URL, which is what consumers
+already gate on before using it as a `createPackagedFileFetch` trusted root. That holds
+even when the page itself was opened from disk, as in an Electron renderer or a static
+export: the bundler moved the faces, so no local directory holds them, and a bundle
+serving assets from the path root would otherwise have resolved to the filesystem root,
+which `createPackagedFileFetch` rejects by throwing.
+
+Two ways a packaged face could silently fail to register are also fixed. The `FontFace`
+URL source read `.href` off the bundler's string, which is `undefined`, emitting the
+literal `url(undefined)`. And the source was unquoted, so an install path containing
+characters an unquoted CSS `url()` token forbids, parentheses among them, produced a
+token the browser could not parse.

--- a/.changeset/plenty-donuts-repeat.md
+++ b/.changeset/plenty-donuts-repeat.md
@@ -1,0 +1,17 @@
+---
+'@docx-editor.dev/fonts': patch
+---
+
+Stop `FONT_ASSET_ROOT` from throwing at module scope under webpack and Turbopack, which
+took down the whole client bundle of any app that imported this package.
+
+Those bundlers replace `new URL('../assets/<face>', import.meta.url)` with a bare
+relative path string for the asset they emitted. Deriving the asset root from one entry
+with a single-argument `new URL()` therefore threw `URL constructor:
+/_next/static/media/Caladea-Bold.<hash>.ttf is not a valid URL` while the module was
+still evaluating, where nothing can catch it. In a bundled build the root now reports a
+non-`file:` URL, which is what consumers already gate on before using it as a
+`createPackagedFileFetch` trusted root.
+
+Registering a packaged face by URL no longer reads `.href` off that same string, which
+had been producing the literal source `url(undefined)` and silently losing the face.

--- a/packages/fonts/scripts/check-built-assets.mjs
+++ b/packages/fonts/scripts/check-built-assets.mjs
@@ -4,7 +4,8 @@
 
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
-import { readFileSync, readdirSync } from 'node:fs';
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
@@ -59,6 +60,55 @@ for (const url of requestedUrls) {
   assert.equal(new URL('./', url).href, expectedRoot.href);
 }
 
+// The ESM build must survive a bundler, and "survive" means IMPORTING AT ALL.
+//
+// webpack and Turbopack do not leave `new URL('../assets/x.ttf', import.meta.url)` alone.
+// They emit the asset and replace the whole expression with a bare RELATIVE path string
+// for it. Any module-scope code that then treats an entry as a `URL` throws while the
+// module is still evaluating, which is uncatchable: it takes down the entire client
+// bundle rather than degrading font loading.
+//
+// That shipped once. `@docx-editor.dev/fonts@2.15.0` derived an asset root with a
+// single-argument `new URL()` and answered every page of a production site with
+// "URL constructor: /_next/static/media/Caladea-Bold.d6e01b80.ttf is not a valid URL".
+//
+// So: rewrite the built ESM exactly the way those bundlers do, then import it.
+const bundlerScratch = mkdtempSync(join(tmpdir(), 'docx-fonts-bundler-'));
+try {
+  const rewritten = [];
+  for (const file of readdirSync(distDir).filter((name) => name.endsWith('.js'))) {
+    const source = readFileSync(join(distDir, file), 'utf8').replace(
+      /new URL\(\s*['"]\.\.\/assets\/([^'"]+\.(?:ttf|otf))['"]\s*,\s*import\.meta\.url\s*\)/g,
+      (_match, asset) => {
+        rewritten.push(asset);
+        return JSON.stringify(
+          `/_next/static/media/${asset.replace(/\.(ttf|otf)$/, '.d6e01b80.$1')}`
+        );
+      }
+    );
+    writeFileSync(join(bundlerScratch, file), source);
+  }
+  assert.deepEqual(
+    rewritten.sort(),
+    assetFiles,
+    'the bundler simulation must rewrite every packaged face, or it is testing nothing'
+  );
+
+  const bundled = await import(pathToFileURL(join(bundlerScratch, 'index.js')).href);
+
+  // Importing without throwing IS the assertion. The rest pins why the value is safe to
+  // hand to `createPackagedFileFetch`: a bundler moved the faces, so there is no trusted
+  // LOCAL directory, and every consumer gates on exactly this.
+  assert.notEqual(
+    bundled.FONT_ASSET_ROOT.protocol,
+    'file:',
+    'a bundled build must not claim a local asset directory it cannot have'
+  );
+} finally {
+  rmSync(bundlerScratch, { recursive: true, force: true });
+}
+
 console.log(
-  `built font assets OK (${assetFiles.length} ESM URLs, ${requestedUrls.length} CJS reads)`
+  `built font assets OK (${assetFiles.length} ESM URLs, ${requestedUrls.length} CJS reads, ` +
+    `${assetFiles.length} bundler-rewritten URLs import cleanly)`
 );

--- a/packages/fonts/scripts/check-built-assets.mjs
+++ b/packages/fonts/scripts/check-built-assets.mjs
@@ -75,6 +75,11 @@ for (const url of requestedUrls) {
 // So: rewrite the built ESM exactly the way those bundlers do, then import it.
 const bundlerScratch = mkdtempSync(join(tmpdir(), 'docx-fonts-bundler-'));
 try {
+  // `dist/*.js` is ESM, and a directory with no `package.json` is CommonJS to Node.
+  // Without this the import fails with "Cannot use import statement outside a module" on
+  // any Node before 22.7, which reads as a broken check rather than a broken package.
+  writeFileSync(join(bundlerScratch, 'package.json'), '{"type":"module"}\n');
+
   const rewritten = [];
   for (const file of readdirSync(distDir).filter((name) => name.endsWith('.js'))) {
     const source = readFileSync(join(distDir, file), 'utf8').replace(

--- a/packages/fonts/scripts/generate-manifest.mjs
+++ b/packages/fonts/scripts/generate-manifest.mjs
@@ -56,13 +56,21 @@ const body =
     .join('\n') +
   '\n];\n\n' +
   '/**\n' +
-  ' * Bundler-visible URL for every packaged face. Each `new URL` argument is deliberately\n' +
+  ' * Bundler-visible location of every packaged face. Each `new URL` argument is deliberately\n' +
   ' * a literal so Vite, webpack, and Turbopack emit the matching asset instead of collapsing\n' +
   ' * a dynamic template to one arbitrary file.\n' +
   ' *\n' +
+  ' * The value type is `URL | string`, not `URL`, because that is what the expression\n' +
+  ' * actually evaluates to once a bundler has seen it. Node, Bun, and Vite leave a `URL`.\n' +
+  ' * webpack and Turbopack replace the whole expression with a bare path STRING for the\n' +
+  ' * asset they emitted (`/_next/static/media/Caladea-Bold.d6e01b80.ttf`). Typing it as\n' +
+  ' * `URL` reads as a promise this package cannot keep, and let a single-argument `URL`\n' +
+  ' * construction over a relative string ship that threw at module scope in every browser\n' +
+  ' * build.\n' +
+  ' *\n' +
   ' * @internal\n' +
   ' */\n' +
-  'export const FONT_ASSET_URLS: Readonly<Record<string, URL>> = {\n' +
+  'export const FONT_ASSET_URLS: Readonly<Record<string, URL | string>> = {\n' +
   entries
     .map((entry) => `  '${entry.file}': new URL('../assets/${entry.file}', import.meta.url),`)
     .join('\n') +

--- a/packages/fonts/src/__tests__/default-fonts.test.ts
+++ b/packages/fonts/src/__tests__/default-fonts.test.ts
@@ -233,43 +233,63 @@ describe('loadDefaultFonts', () => {
   // so importing this package took down the whole client bundle with
   // "URL constructor: /_next/static/media/Caladea-Bold.<hash>.ttf is not a valid URL"
   // instead of degrading font loading.
-  test('the asset root survives every shape a bundler leaves a face entry in', () => {
+  const REWRITTEN = '/_next/static/media/Caladea-Bold.d6e01b80.ttf';
+
+  test('a URL entry keeps its own directory, file: included', () => {
+    // Node, Bun, and Vite leave the expression alone. `file:` is the right answer here:
+    // it is the directory headless exporters confine their reads to.
     const packagedRoot = new URL('../../assets/', import.meta.url);
+    const root = resolvePackagedAssetRoot(new URL('Caladea-Bold.ttf', packagedRoot));
+    expect(root.href).toBe(packagedRoot.href);
+    expect(root.protocol).toBe('file:');
+  });
 
-    // Node, Bun, Vite: the expression stays a real URL.
-    expect(resolvePackagedAssetRoot(new URL('Caladea-Bold.ttf', packagedRoot)).href).toBe(
-      packagedRoot.href
+  test('a bundler-rewritten entry resolves against the page origin', () => {
+    // The arm that runs in a real webpack or Turbopack browser bundle. `origin` is a
+    // parameter precisely so this is reachable: the suite's own `location` is
+    // `about:blank`, and Node has none at all.
+    expect(resolvePackagedAssetRoot(REWRITTEN, 'https://site.example/docs/').href).toBe(
+      'https://site.example/_next/static/media/'
     );
-
-    // A bundler that emits an absolute URL string resolves the same way.
     expect(
       resolvePackagedAssetRoot('https://cdn.example/static/Caladea-Bold.abc123.ttf').href
     ).toBe('https://cdn.example/static/');
+  });
 
-    // webpack and Turbopack emit a RELATIVE path string. This is the shape that threw.
-    const rewritten = '/_next/static/media/Caladea-Bold.d6e01b80.ttf';
-    expect(() => resolvePackagedAssetRoot(rewritten)).not.toThrow();
+  test('a bundler-rewritten entry never resolves to a file: directory', () => {
+    // A `file:` document origin is real: an Electron renderer, a static export opened
+    // from disk, Capacitor. The bundler moved the faces, so that directory does not hold
+    // them, and `createPackagedFileFetch` REJECTS a broad filesystem root by throwing.
+    // An asset path at the root would otherwise yield `file:///` and crash
+    // `@docx-editor.dev/docx-to-markdown` at module scope, reintroducing exactly the
+    // uncatchable failure this module exists to prevent.
+    for (const origin of ['file:///Users/x/out/index.html', 'file:///out/index.html']) {
+      expect(resolvePackagedAssetRoot(REWRITTEN, origin).protocol).not.toBe('file:');
+      expect(resolvePackagedAssetRoot('/Caladea-Bold.d6e01b80.ttf', origin).protocol).not.toBe(
+        'file:'
+      );
+    }
+  });
 
-    const fallback = resolvePackagedAssetRoot(rewritten);
-    expect(fallback.pathname.endsWith('/')).toBe(true);
-    // Never a `file:` guess. Reaching this branch means a bundler moved the faces, so a
-    // made-up local directory would widen the `trustedRoot` confinement it feeds.
-    expect(fallback.protocol).not.toBe('file:');
-
-    // This suite runs under happy-dom, whose `location.href` is `about:blank`. That is
-    // also what a sandboxed or srcdoc iframe reports, and it cannot base a URL, so this
-    // case covers an unusable origin rather than a missing one. Asserting it keeps the
-    // coverage deliberate: if the preload ever supplies a real origin, this line fails
-    // instead of the branch quietly going untested.
-    expect(() => new URL(rewritten, globalThis.location?.href)).toThrow();
-    expect(fallback.href).toBe('https://bundled.invalid/_next/static/media/');
+  test('a bundler-rewritten entry survives an origin that cannot base a URL', () => {
+    // `about:blank` and `about:srcdoc` are what a sandboxed or srcdoc iframe reports.
+    // This is also the suite's own origin under happy-dom.
+    for (const origin of ['about:blank', 'about:srcdoc', '', undefined]) {
+      expect(() => resolvePackagedAssetRoot(REWRITTEN, origin)).not.toThrow();
+      expect(resolvePackagedAssetRoot(REWRITTEN, origin).href).toBe(
+        'https://bundled.invalid/_next/static/media/'
+      );
+    }
+    expect(() => new URL(REWRITTEN, globalThis.location?.href)).toThrow();
   });
 
   test('no packaged face href is built by reading .href off a bundler string', () => {
     // `.href` on the string webpack and Turbopack emit is undefined, which renders as
     // the literal `url(undefined)` in a FontFace source and silently loses the face.
+    // `assetHref` is the only sanctioned reader; it narrows the union first.
     const moduleSource = readFileSync(new URL('../index.ts', import.meta.url), 'utf8');
     expect(moduleSource).not.toContain('assetUrl(file).href');
+    expect(moduleSource).not.toMatch(/assetUrl\([^)]*\)\.href/);
   });
 });
 

--- a/packages/fonts/src/__tests__/default-fonts.test.ts
+++ b/packages/fonts/src/__tests__/default-fonts.test.ts
@@ -25,6 +25,7 @@ import {
   WORD_DOCUMENT_DEFAULT_FAMILIES,
   loadDefaultFonts,
 } from '../index.ts';
+import { resolvePackagedAssetRoot } from '../asset-root.ts';
 import { FONT_ASSET_URLS } from '../manifest.generated.ts';
 
 const assetsDir = new URL('../../assets/', import.meta.url);
@@ -219,13 +220,56 @@ describe('loadDefaultFonts', () => {
     expect(FONT_ASSET_ROOT.protocol).toBe('file:');
     expect(FONT_ASSET_ROOT.pathname.endsWith('/')).toBe(true);
     expect(FONT_ASSET_ROOT.href).toBe(
-      new URL('./', FONT_ASSET_URLS[FONT_ASSET_MANIFEST[0]!.file]).href
+      new URL('./', FONT_ASSET_URLS[FONT_ASSET_MANIFEST[0]!.file]!).href
     );
     for (const entry of FONT_ASSET_MANIFEST) {
-      const url = FONT_ASSET_URLS[entry.file];
+      const url = new URL(String(FONT_ASSET_URLS[entry.file]));
       expect(new URL('./', url).href).toBe(FONT_ASSET_ROOT.href);
       expect(new URL(entry.file, FONT_ASSET_ROOT).href).toBe(url.href);
     }
+  });
+
+  // Regression: a bundler-shaped entry threw here at MODULE SCOPE, which is uncatchable,
+  // so importing this package took down the whole client bundle with
+  // "URL constructor: /_next/static/media/Caladea-Bold.<hash>.ttf is not a valid URL"
+  // instead of degrading font loading.
+  test('the asset root survives every shape a bundler leaves a face entry in', () => {
+    const packagedRoot = new URL('../../assets/', import.meta.url);
+
+    // Node, Bun, Vite: the expression stays a real URL.
+    expect(resolvePackagedAssetRoot(new URL('Caladea-Bold.ttf', packagedRoot)).href).toBe(
+      packagedRoot.href
+    );
+
+    // A bundler that emits an absolute URL string resolves the same way.
+    expect(
+      resolvePackagedAssetRoot('https://cdn.example/static/Caladea-Bold.abc123.ttf').href
+    ).toBe('https://cdn.example/static/');
+
+    // webpack and Turbopack emit a RELATIVE path string. This is the shape that threw.
+    const rewritten = '/_next/static/media/Caladea-Bold.d6e01b80.ttf';
+    expect(() => resolvePackagedAssetRoot(rewritten)).not.toThrow();
+
+    const fallback = resolvePackagedAssetRoot(rewritten);
+    expect(fallback.pathname.endsWith('/')).toBe(true);
+    // Never a `file:` guess. Reaching this branch means a bundler moved the faces, so a
+    // made-up local directory would widen the `trustedRoot` confinement it feeds.
+    expect(fallback.protocol).not.toBe('file:');
+
+    // This suite runs under happy-dom, whose `location.href` is `about:blank`. That is
+    // also what a sandboxed or srcdoc iframe reports, and it cannot base a URL, so this
+    // case covers an unusable origin rather than a missing one. Asserting it keeps the
+    // coverage deliberate: if the preload ever supplies a real origin, this line fails
+    // instead of the branch quietly going untested.
+    expect(() => new URL(rewritten, globalThis.location?.href)).toThrow();
+    expect(fallback.href).toBe('https://bundled.invalid/_next/static/media/');
+  });
+
+  test('no packaged face href is built by reading .href off a bundler string', () => {
+    // `.href` on the string webpack and Turbopack emit is undefined, which renders as
+    // the literal `url(undefined)` in a FontFace source and silently loses the face.
+    const moduleSource = readFileSync(new URL('../index.ts', import.meta.url), 'utf8');
+    expect(moduleSource).not.toContain('assetUrl(file).href');
   });
 });
 

--- a/packages/fonts/src/__tests__/install-font-faces.test.ts
+++ b/packages/fonts/src/__tests__/install-font-faces.test.ts
@@ -120,7 +120,10 @@ describe('installDefaultFontFaces', () => {
       'string',
     ]);
     for (const entry of capture.registered) {
-      expect(String(entry.source)).toMatch(/^url\(.*Carlito-.*\)$/);
+      // QUOTED. An unquoted CSS `url()` token forbids characters the URL parser leaves
+      // alone, `(` and `)` among them, so a checkout under a path like `My (Docs)` built
+      // a token that failed to parse and silently dropped the face.
+      expect(String(entry.source)).toMatch(/^url\("[^"]*Carlito-[^"]*"\)$/);
     }
   });
 

--- a/packages/fonts/src/asset-root.ts
+++ b/packages/fonts/src/asset-root.ts
@@ -1,60 +1,62 @@
 // Resolving the directory of the packaged font assets.
 //
-// Split out of `index.ts` so its own test can reach it directly. Everything here runs at
-// MODULE SCOPE in `index.ts`, where a throw is uncatchable: it takes down the whole
-// bundle that imported this package rather than degrading font loading. That is not
-// hypothetical. A single-argument `new URL()` over a bundler-rewritten face entry
-// shipped once and answered every page of a production site with
+// Its own module so its test can reach it directly. This runs at MODULE SCOPE in
+// `index.ts`, where a throw is uncatchable: it takes down the whole bundle that imported
+// this package rather than degrading font loading. That is not hypothetical. A
+// single-argument `new URL()` over a bundler-rewritten face entry shipped once and
+// answered every page of a production site with
 // "URL constructor: /_next/static/media/Caladea-Bold.<hash>.ttf is not a valid URL".
 
 /**
- * Base for a face entry a bundler rewrote to a RELATIVE path. A page resolves such a
- * path against its own origin, so `location` is the truthful base. Off the main thread
- * and outside a browser there is no origin to speak of, and the reserved `.invalid` TLD
- * says so in a value that is still a well-formed URL.
+ * Base for a face entry a bundler rewrote to a RELATIVE path, when no page origin can
+ * serve as one. The reserved `.invalid` TLD says exactly that, in a value that parses.
  */
 const BUNDLED_FACE_BASE = 'https://bundled.invalid/';
 
 /**
  * Directory of the packaged assets, given whatever shape a bundler left one face in.
  *
- * Its own module so the test can reach it without widening the package's public API:
- * `index.ts` imports it and does not re-export it.
+ * A `URL` entry is Node, Bun, or Vite leaving the expression alone, and its directory is
+ * the real asset directory even under Yarn PnP or a nested install, so a `file:` answer
+ * there is correct and is what headless exporters need.
+ *
+ * A `string` entry means webpack or Turbopack replaced the expression with a path for an
+ * asset they emitted, and a relative one cannot base a URL on its own. Every answer in
+ * that case is REJECTED IF IT IS `file:`, including one derived from a `file:` page
+ * origin, because two things then go wrong at once. The directory would not hold the
+ * faces, since the bundler moved them. And consumers pass this to
+ * `createPackagedFileFetch` as `trustedRoot`, which rejects a broad filesystem root by
+ * THROWING: a bundle whose assets sit at the path root would resolve to `file:///` and
+ * crash `@docx-editor.dev/docx-to-markdown` at module scope, which is the very failure
+ * this module exists to prevent. A non-`file:` answer instead reads correctly as "no
+ * trusted local directory", while the loaders keep fetching each face by the emitted
+ * path.
+ *
+ * `origin` is a parameter so the page-origin arm is testable. Production always takes
+ * the default.
  */
-export const resolvePackagedAssetRoot = (face: URL | string): URL => {
-  // Ordered most-truthful first. Each entry can fail, so each is tried in turn; the
-  // trailing `return` is what makes the function total, and total is the property that
-  // matters here. This runs at module scope, where a throw is uncatchable and takes down
-  // the whole bundle that imported this package rather than degrading font loading.
-  const bases: readonly (string | undefined)[] = [
-    // Node, Bun, and Vite leave a real URL, whose directory is the real asset directory
-    // even under Yarn PnP or a nested install. A bundler that emits an ABSOLUTE string
-    // lands here too, and resolves the same way.
-    undefined,
-    // webpack and Turbopack emit a RELATIVE path string, which a page resolves against
-    // its own origin. `location` is therefore the truthful base, when there is one.
-    // There is not always one: `about:blank` and `about:srcdoc` are real values of
-    // `location.href` in a sandboxed or srcdoc iframe, and neither can base a URL.
-    globalThis.location?.href,
-    // No usable origin. The reserved `.invalid` TLD says exactly that, in a value that
-    // still parses.
-    //
-    // Deliberately not `new URL('../assets/', import.meta.url)`. That resolves, but it
-    // answers with a `file:` directory, and reaching this point means a bundler moved
-    // the faces somewhere of its own choosing, so the guess would be wrong by
-    // construction. It would also be wrong in the dangerous direction: consumers pass
-    // this to `createPackagedFileFetch` as `trustedRoot`, so a made-up local directory
-    // widens a confinement boundary instead of closing it. Every consumer gates on
-    // `protocol === 'file:'`, so a non-`file:` answer correctly reads as "no trusted
-    // local directory", while the loaders keep fetching each face by the path the
-    // bundler emitted.
-    BUNDLED_FACE_BASE,
-  ];
-  for (const base of bases) {
+export const resolvePackagedAssetRoot = (
+  face: URL | string,
+  origin: string | undefined = globalThis.location?.href
+): URL => {
+  if (typeof face !== 'string') {
     try {
-      return new URL('./', base === undefined ? face : new URL(face, base));
+      return new URL('./', face);
     } catch {
-      // Unusable base or unusable entry. Fall through to the next.
+      // A `URL` cannot fail to base one, so this is unreachable in practice. Falling
+      // through rather than throwing is what makes this function total.
+    }
+  } else {
+    // Bases, most truthful first. `about:blank` and `about:srcdoc` are real values of
+    // `location.href` in a sandboxed or srcdoc iframe and cannot base a URL, so a bad
+    // origin falls through instead of failing.
+    for (const base of [undefined, origin, BUNDLED_FACE_BASE]) {
+      try {
+        const root = new URL('./', base === undefined ? face : new URL(face, base));
+        if (root.protocol !== 'file:') return root;
+      } catch {
+        // Unusable base. Try the next.
+      }
     }
   }
   return new URL(BUNDLED_FACE_BASE);

--- a/packages/fonts/src/asset-root.ts
+++ b/packages/fonts/src/asset-root.ts
@@ -1,0 +1,61 @@
+// Resolving the directory of the packaged font assets.
+//
+// Split out of `index.ts` so its own test can reach it directly. Everything here runs at
+// MODULE SCOPE in `index.ts`, where a throw is uncatchable: it takes down the whole
+// bundle that imported this package rather than degrading font loading. That is not
+// hypothetical. A single-argument `new URL()` over a bundler-rewritten face entry
+// shipped once and answered every page of a production site with
+// "URL constructor: /_next/static/media/Caladea-Bold.<hash>.ttf is not a valid URL".
+
+/**
+ * Base for a face entry a bundler rewrote to a RELATIVE path. A page resolves such a
+ * path against its own origin, so `location` is the truthful base. Off the main thread
+ * and outside a browser there is no origin to speak of, and the reserved `.invalid` TLD
+ * says so in a value that is still a well-formed URL.
+ */
+const BUNDLED_FACE_BASE = 'https://bundled.invalid/';
+
+/**
+ * Directory of the packaged assets, given whatever shape a bundler left one face in.
+ *
+ * Its own module so the test can reach it without widening the package's public API:
+ * `index.ts` imports it and does not re-export it.
+ */
+export const resolvePackagedAssetRoot = (face: URL | string): URL => {
+  // Ordered most-truthful first. Each entry can fail, so each is tried in turn; the
+  // trailing `return` is what makes the function total, and total is the property that
+  // matters here. This runs at module scope, where a throw is uncatchable and takes down
+  // the whole bundle that imported this package rather than degrading font loading.
+  const bases: readonly (string | undefined)[] = [
+    // Node, Bun, and Vite leave a real URL, whose directory is the real asset directory
+    // even under Yarn PnP or a nested install. A bundler that emits an ABSOLUTE string
+    // lands here too, and resolves the same way.
+    undefined,
+    // webpack and Turbopack emit a RELATIVE path string, which a page resolves against
+    // its own origin. `location` is therefore the truthful base, when there is one.
+    // There is not always one: `about:blank` and `about:srcdoc` are real values of
+    // `location.href` in a sandboxed or srcdoc iframe, and neither can base a URL.
+    globalThis.location?.href,
+    // No usable origin. The reserved `.invalid` TLD says exactly that, in a value that
+    // still parses.
+    //
+    // Deliberately not `new URL('../assets/', import.meta.url)`. That resolves, but it
+    // answers with a `file:` directory, and reaching this point means a bundler moved
+    // the faces somewhere of its own choosing, so the guess would be wrong by
+    // construction. It would also be wrong in the dangerous direction: consumers pass
+    // this to `createPackagedFileFetch` as `trustedRoot`, so a made-up local directory
+    // widens a confinement boundary instead of closing it. Every consumer gates on
+    // `protocol === 'file:'`, so a non-`file:` answer correctly reads as "no trusted
+    // local directory", while the loaders keep fetching each face by the path the
+    // bundler emitted.
+    BUNDLED_FACE_BASE,
+  ];
+  for (const base of bases) {
+    try {
+      return new URL('./', base === undefined ? face : new URL(face, base));
+    } catch {
+      // Unusable base or unusable entry. Fall through to the next.
+    }
+  }
+  return new URL(BUNDLED_FACE_BASE);
+};

--- a/packages/fonts/src/index.ts
+++ b/packages/fonts/src/index.ts
@@ -163,6 +163,16 @@ const assetHref = (file: string): string => {
 };
 
 /**
+ * A `FontFace` source naming one packaged face.
+ *
+ * The href is QUOTED. An unquoted CSS `url()` token forbids characters the URL parser
+ * leaves alone, `(` and `)` among them, so a checkout under a path like `My (Docs)`
+ * produced a token that failed to parse and silently dropped the face.
+ */
+const assetFontFaceSource = (file: string): string =>
+  `url("${assetHref(file).replace(/[\\"]/g, '\\$&').replace(/\n/g, '\\A ')}")`;
+
+/**
  * Directory URL of the packaged font files this package serves.
  *
  * Headless exporters pass this to Core `createPackagedFileFetch` as `trustedRoot`.
@@ -398,7 +408,7 @@ export async function installDefaultFontFaces(
             // That request is the one `fetcher` cannot intercept.
             const source: string | ArrayBuffer = bytes
               ? (bytes.slice().buffer as ArrayBuffer)
-              : `url(${assetHref(file)})`;
+              : assetFontFaceSource(file);
             const fontFace = new FontFace(family, source, {
               weight: String(face.weight),
               style: face.style,

--- a/packages/fonts/src/index.ts
+++ b/packages/fonts/src/index.ts
@@ -63,6 +63,7 @@
 
 import { FACES, FAMILY_PLANS, planFaceFile, planLineBox } from './family-plans.ts';
 import type { WordDefaultFamily } from './family-plans.ts';
+import { resolvePackagedAssetRoot } from './asset-root.ts';
 import { FONT_ASSET_MANIFEST, FONT_ASSET_URLS } from './manifest.generated.ts';
 
 export type { WordDefaultFamily } from './family-plans.ts';
@@ -143,22 +144,44 @@ export interface LoadDefaultFontsOptions {
 
 const manifestByFile = new Map(FONT_ASSET_MANIFEST.map((entry) => [entry.file, entry]));
 
-/** Bundler-visible asset URL for one packaged face. */
-const assetUrl = (file: string): URL => FONT_ASSET_URLS[file];
+/**
+ * Bundler-visible asset location for one packaged face.
+ *
+ * The return type is `URL | string` because bundlers disagree, and the disagreement is
+ * not observable from this file. Node, Bun, and Vite leave the `new URL(literal,
+ * import.meta.url)` expression as a real `URL`. webpack and Turbopack replace the whole
+ * expression with a bare path STRING for the asset they emitted, such as
+ * `/_next/static/media/Caladea-Bold.d6e01b80.ttf`. Anything that needs a `URL` here has
+ * to cope with both; see {@link assetHref} and {@link FONT_ASSET_ROOT}.
+ */
+const assetUrl = (file: string): URL | string => FONT_ASSET_URLS[file]!;
 
-const firstPackagedFace = FONT_ASSET_URLS[FONT_ASSET_MANIFEST[0]!.file];
+/** Absolute-or-relative href for one packaged face, whatever shape the bundler left. */
+const assetHref = (file: string): string => {
+  const value = assetUrl(file);
+  return typeof value === 'string' ? value : value.href;
+};
 
 /**
  * Directory URL of the packaged font files this package serves.
  *
  * Headless exporters pass this to Core `createPackagedFileFetch` as `trustedRoot`.
  * The value comes from the same packaged face URLs the loaders fetch, so the trusted
- * directory matches Node, Bun, pnpm, Yarn PnP, and nested installs. Browser bundlers
- * rewrite those face URLs to HTTP; HTTP fetches do not use this directory.
+ * directory matches Node, Bun, pnpm, Yarn PnP, and nested installs.
+ *
+ * In a browser bundle this resolves to an HTTP URL rather than a `file:` one. That is
+ * why every consumer gates on `FONT_ASSET_ROOT.protocol === 'file:'`: HTTP fetches do
+ * not use a trusted directory, and confining them to one would be meaningless.
+ *
+ * Deriving this MUST NOT throw. It runs at module scope, so a throw here is
+ * uncatchable and takes down the whole bundle that imported this package rather than
+ * degrading font loading.
  *
  * @public
  */
-export const FONT_ASSET_ROOT: URL = new URL('./', firstPackagedFace);
+export const FONT_ASSET_ROOT: URL = resolvePackagedAssetRoot(
+  assetUrl(FONT_ASSET_MANIFEST[0]!.file)
+);
 
 /**
  * The families Word applies to a document by DEFAULT, and what
@@ -375,7 +398,7 @@ export async function installDefaultFontFaces(
             // That request is the one `fetcher` cannot intercept.
             const source: string | ArrayBuffer = bytes
               ? (bytes.slice().buffer as ArrayBuffer)
-              : `url(${assetUrl(file).href})`;
+              : `url(${assetHref(file)})`;
             const fontFace = new FontFace(family, source, {
               weight: String(face.weight),
               style: face.style,

--- a/packages/fonts/src/manifest.generated.ts
+++ b/packages/fonts/src/manifest.generated.ts
@@ -145,13 +145,21 @@ export const FONT_ASSET_MANIFEST: readonly FontAssetManifestEntry[] = [
 ];
 
 /**
- * Bundler-visible URL for every packaged face. Each `new URL` argument is deliberately
+ * Bundler-visible location of every packaged face. Each `new URL` argument is deliberately
  * a literal so Vite, webpack, and Turbopack emit the matching asset instead of collapsing
  * a dynamic template to one arbitrary file.
  *
+ * The value type is `URL | string`, not `URL`, because that is what the expression
+ * actually evaluates to once a bundler has seen it. Node, Bun, and Vite leave a `URL`.
+ * webpack and Turbopack replace the whole expression with a bare path STRING for the
+ * asset they emitted (`/_next/static/media/Caladea-Bold.d6e01b80.ttf`). Typing it as
+ * `URL` reads as a promise this package cannot keep, and let a single-argument `URL`
+ * construction over a relative string ship that threw at module scope in every browser
+ * build.
+ *
  * @internal
  */
-export const FONT_ASSET_URLS: Readonly<Record<string, URL>> = {
+export const FONT_ASSET_URLS: Readonly<Record<string, URL | string>> = {
   'Caladea-Bold.ttf': new URL('../assets/Caladea-Bold.ttf', import.meta.url),
   'Caladea-BoldItalic.ttf': new URL('../assets/Caladea-BoldItalic.ttf', import.meta.url),
   'Caladea-Italic.ttf': new URL('../assets/Caladea-Italic.ttf', import.meta.url),


### PR DESCRIPTION
## What broke

`@docx-editor.dev/fonts@2.15.0` crashes every page of any app that imports it, in every browser. It took down https://www.docx-editor.dev until the version bump was reverted there.

```
Uncaught TypeError: URL constructor: /_next/static/media/Caladea-Bold.d6e01b80.ttf is not a valid URL
```

## Why

`FONT_ASSET_URLS` entries are authored as `new URL('../assets/<face>', import.meta.url)` and typed `URL`. That type is only true for some consumers:

| Consumer | What the expression evaluates to |
| --- | --- |
| Node, Bun, Vite | a real `URL` |
| webpack, Turbopack | a bare **relative path string** for the emitted asset |

`FONT_ASSET_ROOT` derived its directory from one entry with a single-argument `new URL()`:

```js
var v = FONT_ASSET_URLS[FONT_ASSET_MANIFEST[0].file],
    j = new URL('./', v);   // throws on a relative string
```

That runs at **module scope**, so the throw is uncatchable. It takes the whole client bundle down instead of degrading font loading.

## The fix

**Type `FONT_ASSET_URLS` as `URL | string`.** This is the root cause. The old type read as a promise the package cannot keep, and it is what let both bugs past the compiler.

**Move the root derivation to `asset-root.ts` and make it total.** It tries the entry as-is, then `location.href`, then a `https://bundled.invalid/` base, and returns a constant if every one fails.

It deliberately does *not* fall back to `new URL('../assets/', import.meta.url)`. That resolves, but reaching the fallback means a bundler moved the faces, so a `file:` answer would be wrong by construction, and wrong in the dangerous direction: consumers pass this to `createPackagedFileFetch` as `trustedRoot`, and a made-up local directory widens that confinement instead of closing it. Consumers already gate on `protocol === 'file:'`, so a non-`file:` answer correctly reads as "no trusted local directory" while the loaders keep fetching each face by the emitted path.

`location.href` is tried but not trusted. `about:blank` and `about:srcdoc` are real values in a sandboxed or srcdoc iframe and cannot base a URL. The fonts suite runs under happy-dom, which reports `about:blank`, so that path is covered rather than assumed.

**Fix the same mistake one level down.** Installing a face by URL read `.href` off that same value. On a string that is `undefined`, so it emitted the literal `url(undefined)` as a `FontFace` source and silently lost the face. It sits inside a `try`/`catch`, so it degraded rather than crashed, and would have outlived the visible bug.

## Guard

`check-built-assets.mjs` now rewrites the built ESM the way webpack and Turbopack do, then imports the result. Importing without throwing is the assertion, so the build fails if any module-scope code goes back to assuming a `URL`.

Verified in both directions:

- reintroducing the 2.15.0 shape fails the build with `TypeError: Invalid URL`
- the published 2.15.0 tarball fails the same simulation with `"./" cannot be parsed as a URL against "/_next/static/media/Caladea-Bold.d6e01b80.ttf"`
- this branch passes, and reports `24 bundler-rewritten URLs import cleanly`

## Surface

Unchanged. `asset-root.ts` is imported by `index.ts` and not re-exported, so the resolver keeps a direct unit test without appearing in the public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fnc8gywGE1Gipuxjd7YGVG

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791129689&installation_model_id=422592&pr_number=726&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F726&signature=fa189ac27daab0e3f59beeb0a3e4a8a94e695f2f86807e2be7f6c990bdbb9676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->