### PR TITLE
fix(pro): keep review balloons inside viewport

### DIFF
--- a/.changeset/quiet-balloons-stay-visible.md
+++ b/.changeset/quiet-balloons-stay-visible.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/pro': patch
+---
+
+Keep click-opened review balloons inside an embedded editor's visible scroll viewport.

--- a/packages/pro/src/__tests__/review-balloon-geometry.test.ts
+++ b/packages/pro/src/__tests__/review-balloon-geometry.test.ts
@@ -1,0 +1,50 @@
+/*
+Copyright (c) 2026 EigenPal, Inc. All rights reserved.
+Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/pro/LICENSE.md.
+Production use requires a commercial agreement: licensing@eigenpal.com
+*/
+
+import { describe, expect, test } from 'bun:test';
+import { placeReviewBalloon, type BalloonRect } from '../review/balloon-geometry.ts';
+
+const rail: BalloonRect = { left: 500, right: 800, top: 0, bottom: 1000 };
+const viewport: BalloonRect = { left: 100, right: 600, top: 50, bottom: 450 };
+
+describe('review balloon geometry', () => {
+  test('keeps the full card inside an embedded scroll viewport', () => {
+    const rightEdge = placeReviewBalloon(
+      { left: 550, right: 570, top: 200, bottom: 220 },
+      rail,
+      viewport
+    );
+    expect(rightEdge.left).toBe(-192);
+
+    const leftEdge = placeReviewBalloon(
+      { left: 0, right: 20, top: 200, bottom: 220 },
+      rail,
+      viewport
+    );
+    expect(leftEdge.left).toBe(-388);
+  });
+
+  test('uses the editor viewport to select the vertical side', () => {
+    expect(
+      placeReviewBalloon({ left: 300, right: 320, top: 300, bottom: 320 }, rail, viewport).above
+    ).toBe(true);
+
+    expect(
+      placeReviewBalloon({ left: 300, right: 320, top: 80, bottom: 100 }, rail, viewport).above
+    ).toBe(false);
+  });
+
+  test('uses the roomier side when neither side fits the estimate', () => {
+    expect(
+      placeReviewBalloon({ left: 300, right: 320, top: 170, bottom: 190 }, rail, {
+        left: 100,
+        right: 600,
+        top: 100,
+        bottom: 280,
+      }).above
+    ).toBe(false);
+  });
+});

--- a/packages/pro/src/react/DocxEditorReview.tsx
+++ b/packages/pro/src/react/DocxEditorReview.tsx
@@ -65,6 +65,7 @@ import {
   type ReviewAuthorInfo,
   type ToolbarTranslate,
 } from '@docx-editor.dev/react';
+import { placeReviewBalloonInViewport } from '../review/balloon-geometry';
 import { cloneReviewCard, partitionReviewChildren } from './review-composition';
 import {
   COMPACT_CARD_WIDTH,
@@ -1224,7 +1225,7 @@ function ReviewBalloon({ className, hidden }: ReviewPartProps) {
     const open = (element: HTMLElement, structuralSite: boolean): void => {
       const railRect = rail.getBoundingClientRect();
       const rect = element.getBoundingClientRect();
-      const viewportBottom = element.ownerDocument.defaultView?.innerHeight ?? Infinity;
+      const placement = placeReviewBalloonInViewport(rect, railRect, scroller);
       const start = Number(element.dataset.start);
       const end = Number(element.dataset.end);
       setAnchor({
@@ -1242,12 +1243,11 @@ function ReviewBalloon({ className, hidden }: ReviewPartProps) {
           : {}),
         ...(Number.isFinite(start) ? { start } : {}),
         ...(Number.isFinite(end) ? { end } : {}),
-        left: rect.left - railRect.left,
+        left: placement.left,
         top: rect.top - railRect.top,
         bottom: rect.bottom - railRect.top,
-        // Opens upward when there is no room below — a change on the last visible line
-        // would otherwise push its balloon under the fold.
-        above: rect.bottom + 220 > viewportBottom,
+        // Opens on the side with enough room, or the roomier side in a short editor.
+        above: placement.above,
       });
     };
 

--- a/packages/pro/src/review/balloon-geometry.ts
+++ b/packages/pro/src/review/balloon-geometry.ts
@@ -1,0 +1,81 @@
+/*
+Copyright (c) 2026 EigenPal, Inc. All rights reserved.
+Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/pro/LICENSE.md.
+Production use requires a commercial agreement: licensing@eigenpal.com
+*/
+
+/** The part of a client rect needed to position a review balloon. */
+export interface BalloonRect {
+  readonly left: number;
+  readonly right: number;
+  readonly top: number;
+  readonly bottom: number;
+}
+
+/** The balloon position in rail-local coordinates. */
+export interface BalloonPlacement {
+  readonly left: number;
+  readonly above: boolean;
+}
+
+/** A scroll viewport that can publish its visible client box. */
+export interface BalloonViewport {
+  readonly clientLeft: number;
+  readonly clientTop: number;
+  readonly clientWidth: number;
+  readonly clientHeight: number;
+  getBoundingClientRect(): BalloonRect;
+}
+
+/** Matches `.docx-review__balloon` in the shared editor stylesheet. */
+const BALLOON_WIDTH = 280;
+/** Keeps the floating card clear of the scroll viewport's edges. */
+const BALLOON_INSET = 12;
+/** Approximate card height used only to select the better vertical side. */
+const BALLOON_ESTIMATED_HEIGHT = 220;
+
+/**
+ * Place a review balloon inside an editor's visible scroll viewport.
+ *
+ * The rail and anchor can extend outside that viewport. This is common in embedded editors
+ * that cannot reserve the full review column. The horizontal clamp keeps the complete card
+ * visible. The vertical choice uses the editor viewport, not the browser window.
+ */
+export function placeReviewBalloon(
+  anchor: BalloonRect,
+  rail: BalloonRect,
+  viewport: BalloonRect
+): BalloonPlacement {
+  const minimumLeft = viewport.left - rail.left + BALLOON_INSET;
+  const maximumLeft = viewport.right - rail.left - BALLOON_INSET - BALLOON_WIDTH;
+  const desiredLeft = anchor.left - rail.left;
+  const left =
+    maximumLeft < minimumLeft
+      ? minimumLeft
+      : Math.min(Math.max(desiredLeft, minimumLeft), maximumLeft);
+
+  const roomAbove = anchor.top - viewport.top;
+  const roomBelow = viewport.bottom - anchor.bottom;
+  const above =
+    roomBelow < BALLOON_ESTIMATED_HEIGHT &&
+    (roomAbove >= BALLOON_ESTIMATED_HEIGHT || roomAbove > roomBelow);
+
+  return { left, above };
+}
+
+/** Place a review balloon from a scroll element's visible client box. */
+export function placeReviewBalloonInViewport(
+  anchor: BalloonRect,
+  rail: BalloonRect,
+  viewport: BalloonViewport
+): BalloonPlacement {
+  const box = viewport.getBoundingClientRect();
+  const left = box.left + viewport.clientLeft;
+  const top = box.top + viewport.clientTop;
+  return placeReviewBalloon(anchor, rail, {
+    left,
+    right: left + viewport.clientWidth,
+    top,
+    bottom: top + viewport.clientHeight,
+  });
+}

--- a/packages/pro/src/vue/review-rail-parts.tsx
+++ b/packages/pro/src/vue/review-rail-parts.tsx
@@ -18,6 +18,7 @@ import {
   type VNode,
 } from 'vue';
 import { Slot } from '@docx-editor.dev/vue';
+import { placeReviewBalloonInViewport } from '../review/balloon-geometry.ts';
 import { cloneReviewCard, partitionReviewChildren } from './review-composition.ts';
 import {
   MARKER_STEP,
@@ -322,7 +323,7 @@ export const ReviewBalloon = markPart(
         const openAt = (element: HTMLElement, structuralSite: boolean): void => {
           const railRect = railEl.getBoundingClientRect();
           const rect = element.getBoundingClientRect();
-          const viewportBottom = element.ownerDocument.defaultView?.innerHeight ?? Infinity;
+          const placement = placeReviewBalloonInViewport(rect, railRect, scroller);
           const start = Number(element.dataset.start);
           const end = Number(element.dataset.end);
           anchor.value = {
@@ -340,10 +341,10 @@ export const ReviewBalloon = markPart(
               : {}),
             ...(Number.isFinite(start) ? { start } : {}),
             ...(Number.isFinite(end) ? { end } : {}),
-            left: rect.left - railRect.left,
+            left: placement.left,
             top: rect.top - railRect.top,
             bottom: rect.bottom - railRect.top,
-            above: rect.bottom + 220 > viewportBottom,
+            above: placement.above,
           };
           instance?.proxy?.$forceUpdate();
         };


### PR DESCRIPTION
## Summary

- Clamp click-opened review balloons to the editor scroll viewport.
- Use embedded viewport bounds when choosing the vertical side.
- Keep React and Vue behavior aligned through shared geometry.

## Verification

- 53 focused review tests pass.
- Type checks, parity gates, formatting, lint, API checks, and package builds pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791139882&installation_model_id=422592&pr_number=731&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F731&signature=fbc28f31f886b7ac70fdb0af7607b566fca28183a7ab32c6b1754f3b42dc2ce4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->