### PR TITLE
fix: render JPEG photos with large metadata and EXIF orientation

### DIFF
--- a/.changeset/jpeg-metadata-orientation.md
+++ b/.changeset/jpeg-metadata-orientation.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Render JPEG photos with large metadata segments and validate their EXIF-oriented dimensions without changing the original media.

--- a/docs/site/content/guides/images.mdx
+++ b/docs/site/content/guides/images.mdx
@@ -19,6 +19,10 @@ DrawingML pictures (`w:drawing` with `pic:pic`) lay out, paint, and round-trip t
 
 Insert accepts PNG/JPEG/GIF only. Other payloads stay in the package and affect pagination through their authored extent.
 
+JPEG validation accepts large EXIF and ICC metadata segments before the frame header.
+Intrinsic dimensions account for EXIF orientation, matching the browser's decoded image.
+The original photo bytes and the authored drawing extent remain unchanged.
+
 BMP and WebP decode in the browser and paint like PNG or JPEG. BMP support includes top-down
 bitmaps and the 12-byte `BITMAPCOREHEADER`. WebP support includes lossy, lossless, and extended
 containers.

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -468,7 +468,7 @@ export const wordFeatures: WordFeature[] = [
     tier: 'community',
     docsLink: '/docs/2.x/guides/images',
     notes:
-      'The engine lays out and paints embedded PNG, JPEG, and GIF at the authored size. Both adapters ship insert and overlay authoring: the Insert menu, toolbar, properties dialog, and keyboard resize through the shared engine commands. An inserted image keeps its natural size when it fits and scales down proportionally to its cell, column, or page content box when it does not.',
+      'The engine lays out and paints embedded PNG, JPEG, and GIF at the authored size. JPEG validation accepts large metadata segments and accounts for EXIF-oriented intrinsic dimensions without rewriting the photo. Both adapters ship insert and overlay authoring: the Insert menu, toolbar, properties dialog, and keyboard resize through the shared engine commands. An inserted image keeps its natural size when it fits and scales down proportionally to its cell, column, or page content box when it does not.',
   },
   {
     id: 'images.anchored',

--- a/packages/core/src/store/__tests__/jpeg-metadata.test.ts
+++ b/packages/core/src/store/__tests__/jpeg-metadata.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from 'bun:test';
+import { strToU8, unzipSync, zipSync } from 'fflate';
+import { createImageResourceCache, validateJpegHeader } from '../package/image-resources.ts';
+import { readOoxmlPackage, writeOoxmlPackage } from '../package/ooxml-package.ts';
+
+// Synthetic headers, not a decodable photograph. The decode-port tests below
+// independently return the browser's orientation-adjusted dimensions.
+function join(parts: readonly Uint8Array[]): Uint8Array {
+  const result = new Uint8Array(parts.reduce((size, part) => size + part.length, 0));
+  let offset = 0;
+  for (const part of parts) {
+    result.set(part, offset);
+    offset += part.length;
+  }
+  return result;
+}
+
+function segment(marker: number, payload: Uint8Array): Uint8Array {
+  const length = payload.length + 2;
+  return join([Uint8Array.of(0xff, marker, length >> 8, length & 255), payload]);
+}
+
+function frame(marker = 0xc0): Uint8Array {
+  return segment(marker, Uint8Array.of(8, 0, 20, 0, 40, 1, 1, 0x11, 0));
+}
+
+function jpeg(parts: readonly Uint8Array[]): Uint8Array {
+  return join([Uint8Array.of(0xff, 0xd8), ...parts, Uint8Array.of(0xff, 0xd9)]);
+}
+
+function exif(orientation: number, little = true): Uint8Array {
+  const bytes = new Uint8Array(32);
+  bytes.set([0x45, 0x78, 0x69, 0x66, 0, 0]);
+  const view = new DataView(bytes.buffer);
+  view.setUint16(6, little ? 0x4949 : 0x4d4d);
+  view.setUint16(8, 42, little);
+  view.setUint32(10, 8, little);
+  view.setUint16(14, 1, little);
+  view.setUint16(16, 0x112, little);
+  view.setUint16(18, 3, little);
+  view.setUint32(20, 1, little);
+  view.setUint16(24, orientation, little);
+  return bytes;
+}
+
+const landscape = { pixelWidth: 40, pixelHeight: 20 };
+const portrait = { pixelWidth: 20, pixelHeight: 40 };
+
+describe('JPEG metadata before the frame header', () => {
+  test('skips large APP/ICC payloads beyond the former 64 KiB prefix', () => {
+    const bytes = jpeg([
+      segment(0xe2, new Uint8Array(65_533)),
+      segment(0xe2, new Uint8Array(65_533)),
+      frame(),
+    ]);
+    expect(validateJpegHeader(bytes)).toEqual(landscape);
+  });
+
+  for (const little of [true, false]) {
+    for (let orientation = 1; orientation <= 8; orientation += 1) {
+      test(`reads ${little ? 'little' : 'big'}-endian EXIF orientation ${orientation}`, () => {
+        expect(
+          validateJpegHeader(jpeg([segment(0xe1, exif(orientation, little)), frame()]))
+        ).toEqual(orientation >= 5 ? portrait : landscape);
+      });
+    }
+  }
+
+  test('reads progressive frames and byte-offset views', () => {
+    const bytes = jpeg([segment(0xe1, exif(6)), frame(0xc2)]);
+    const padded = join([new Uint8Array(7), bytes, new Uint8Array(11)]);
+    expect(validateJpegHeader(padded.subarray(7, 7 + bytes.length))).toEqual(portrait);
+  });
+
+  test('does not read orientation outside its APP1 segment', () => {
+    const malformed: Uint8Array[] = [];
+    for (const [offset, value, width] of [
+      [8, 41, 2], // TIFF magic
+      [10, 0xfffffff0, 4], // IFD offset
+      [14, 4097, 2], // excessive entry count
+      [14, 2, 2], // truncated entries
+      [18, 4, 2], // wrong orientation type
+      [20, 2, 4], // wrong orientation count
+      [24, 9, 2], // invalid orientation value
+    ]) {
+      const bytes = exif(6);
+      const view = new DataView(bytes.buffer);
+      if (width === 4) view.setUint32(offset!, value!, true);
+      else view.setUint16(offset!, value!, true);
+      malformed.push(bytes);
+    }
+    malformed.push(exif(6).subarray(0, 18));
+    for (const bytes of malformed) {
+      expect(validateJpegHeader(jpeg([segment(0xe1, bytes), frame()]))).toEqual(landscape);
+    }
+  });
+
+  test('ignores non-EXIF APP1 and finds a subsequent valid orientation', () => {
+    expect(
+      validateJpegHeader(jpeg([segment(0xe1, strToU8('XMP')), segment(0xe1, exif(8)), frame()]))
+    ).toEqual(portrait);
+  });
+
+  test('rejects invalid marker lengths, truncated frames, and zero dimensions', () => {
+    const zero = frame();
+    zero[8] = 0;
+    const invalidComponents = frame();
+    invalidComponents[9] = 2;
+    for (const bytes of [
+      Uint8Array.of(0xff, 0xe1, 0, 1),
+      Uint8Array.of(0xff, 0xe1, 0xff, 0xff),
+      segment(0xc0, Uint8Array.of(8, 0, 20, 0, 40)),
+      zero,
+      invalidComponents,
+    ]) {
+      expect(validateJpegHeader(jpeg([bytes]))).toBeNull();
+    }
+  });
+
+  test('does not search compressed scan data for a frame', () => {
+    for (const marker of [0, 0xda, 0xd9]) {
+      expect(validateJpegHeader(jpeg([Uint8Array.of(0xff, marker, 0, 2), frame()]))).toBeNull();
+    }
+  });
+
+  test('bounds marker count and padding separately from payload size', () => {
+    const small = Array.from({ length: 4096 }, () => segment(0xe0, new Uint8Array(0)));
+    expect(validateJpegHeader(jpeg(small.concat([frame()])))).toBeNull();
+    expect(validateJpegHeader(jpeg([new Uint8Array(4098).fill(255), frame()]))).toBeNull();
+    expect(validateJpegHeader(jpeg([Uint8Array.of(255, 255, 1), frame()]))).toEqual(landscape);
+  });
+
+  test('an oriented embedded photo resolves once and saves its original bytes', async () => {
+    const bytes = jpeg([segment(0xe2, new Uint8Array(65_533)), segment(0xe1, exif(6)), frame()]);
+    const rel = 'http://schemas.openxmlformats.org/package/2006/relationships';
+    const officeRel = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+    const loaded = readOoxmlPackage(
+      zipSync(
+        {
+          '[Content_Types].xml': strToU8(
+            '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+              '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+              '<Default Extension="jpg" ContentType="image/jpeg"/>' +
+              '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>'
+          ),
+          '_rels/.rels': strToU8(
+            `<Relationships xmlns="${rel}"><Relationship Id="doc" Type="${officeRel}/officeDocument" Target="word/document.xml"/></Relationships>`
+          ),
+          'word/document.xml': strToU8(
+            '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p/></w:body></w:document>'
+          ),
+          'word/_rels/document.xml.rels': strToU8(
+            `<Relationships xmlns="${rel}"><Relationship Id="photo" Type="${officeRel}/image" Target="media/photo.jpg"/></Relationships>`
+          ),
+          'word/media/photo.jpg': bytes,
+        },
+        { level: 0 }
+      )
+    );
+    if (!loaded.ok) throw new Error(loaded.reason);
+    let calls = 0;
+    const cache = createImageResourceCache(loaded.package, {
+      decodePort: {
+        decode: async (input) => {
+          calls += 1;
+          expect(input).toEqual(bytes);
+          return { ...portrait, dpiX: 96, dpiY: 96 };
+        },
+      },
+    });
+    const state = await cache.resolveEmbedded('/word/document.xml', 'photo');
+    expect(state).toMatchObject({ kind: 'ready', ...portrait });
+    expect(await cache.resolveEmbedded('/word/document.xml', 'photo')).toBe(state);
+    expect(calls).toBe(1);
+    const saved = writeOoxmlPackage(loaded.package);
+    expect(unzipSync(saved)['word/media/photo.jpg']).toEqual(bytes);
+    cache.dispose();
+  });
+});

--- a/packages/core/src/store/package/image-resources.ts
+++ b/packages/core/src/store/package/image-resources.ts
@@ -18,6 +18,7 @@ import {
 import { projectDrawingsInPackage, type DrawingProjection } from './drawing-projection.ts';
 import type { OoxmlPackage } from './ooxml-package.ts';
 import { readPngPhysicalDensity } from './png-physical-density.ts';
+import { validateJpegHeader as readJpegHeader } from './jpeg-header.ts';
 import {
   IMAGE_RESOURCE_HARD_CEILINGS,
   resolveImageResourceLimits,
@@ -142,7 +143,6 @@ export interface ImageResourceLookup {
 
 const PNG_SIGNATURE = Object.freeze([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 const DEFAULT_DPI = 96;
-const MAX_JPEG_MARKER_SCAN = 65_536;
 /** Maximum prefix inspected for SVG root detection (exported for bounded-scan tests). */
 export const MAX_SVG_SNIFF_BYTES = 512;
 /** Maximum prefix inspected for the SVG root element's sizing attributes. */
@@ -386,46 +386,9 @@ export function validateGifHeader(bytes: Uint8Array): ValidatedRasterHeader | nu
   return { pixelWidth, pixelHeight };
 }
 
-function isJpegSofMarker(marker: number): boolean {
-  return (
-    (marker >= 0xc0 && marker <= 0xc3) ||
-    (marker >= 0xc5 && marker <= 0xc7) ||
-    (marker >= 0xc9 && marker <= 0xcb) ||
-    (marker >= 0xcd && marker <= 0xcf)
-  );
-}
-
 /** Bounded JPEG marker scan through the first supported SOF marker. */
 export function validateJpegHeader(bytes: Uint8Array): ValidatedRasterHeader | null {
-  if (bytes.length < 4 || bytes[0] !== 0xff || bytes[1] !== 0xd8) return null;
-  let offset = 2;
-  const scanLimit = Math.min(bytes.length, MAX_JPEG_MARKER_SCAN);
-  while (offset + 1 < scanLimit) {
-    if (bytes[offset] !== 0xff) return null;
-    let marker = bytes[offset + 1]!;
-    offset += 2;
-    while (marker === 0xff && offset < scanLimit) {
-      marker = bytes[offset]!;
-      offset += 1;
-    }
-    if (marker === 0xd8) continue;
-    if (marker === 0xd9) return null;
-    if (marker === 0x01 || (marker >= 0xd0 && marker <= 0xd7)) continue;
-    if (offset + 1 >= scanLimit) return null;
-    const segmentLength = (bytes[offset]! << 8) | bytes[offset + 1]!;
-    if (segmentLength < 2) return null;
-    const segmentEnd = offset + segmentLength;
-    if (segmentEnd > scanLimit) return null;
-    if (isJpegSofMarker(marker)) {
-      if (segmentLength < 7 || offset + 6 >= scanLimit) return null;
-      const pixelHeight = (bytes[offset + 3]! << 8) | bytes[offset + 4]!;
-      const pixelWidth = (bytes[offset + 5]! << 8) | bytes[offset + 6]!;
-      if (pixelWidth === 0 || pixelHeight === 0) return null;
-      return { pixelWidth, pixelHeight };
-    }
-    offset = segmentEnd;
-  }
-  return null;
+  return readJpegHeader(bytes);
 }
 
 /** `BITMAPCOREHEADER` is 12 bytes and 16-bit; every later DIB header is 40 or more and 32-bit. */

--- a/packages/core/src/store/package/jpeg-header.ts
+++ b/packages/core/src/store/package/jpeg-header.ts
@@ -1,0 +1,83 @@
+// Skip JPEG metadata payloads by their declared lengths, not by scanning their bytes.
+// Large EXIF/ICC blocks are valid; work is bounded independently of their total size.
+const MAX_MARKERS = 4096;
+const MAX_PADDING_BYTES = 4096;
+const MAX_EXIF_ENTRIES = 4096;
+
+function exifOrientation(bytes: Uint8Array, start: number, end: number): number | null {
+  if (
+    end - start < 14 ||
+    bytes[start] !== 0x45 ||
+    bytes[start + 1] !== 0x78 ||
+    bytes[start + 2] !== 0x69 ||
+    bytes[start + 3] !== 0x66 ||
+    bytes[start + 4] !== 0 ||
+    bytes[start + 5] !== 0
+  )
+    return null;
+  const tiff = start + 6;
+  const little = bytes[tiff] === 0x49 && bytes[tiff + 1] === 0x49;
+  if (!little && !(bytes[tiff] === 0x4d && bytes[tiff + 1] === 0x4d)) return null;
+  // The view is confined to this APP1 segment, including for subarray inputs.
+  const view = new DataView(bytes.buffer, bytes.byteOffset + tiff, end - tiff);
+  if (view.getUint16(2, little) !== 42) return null;
+  const ifd = view.getUint32(4, little);
+  if (ifd < 8 || ifd + 2 > view.byteLength) return null;
+  const entries = view.getUint16(ifd, little);
+  if (entries > MAX_EXIF_ENTRIES || ifd + 2 + entries * 12 > view.byteLength) return null;
+  for (let index = 0; index < entries; index += 1) {
+    const entry = ifd + 2 + index * 12;
+    if (view.getUint16(entry, little) !== 0x112) continue;
+    if (view.getUint16(entry + 2, little) !== 3 || view.getUint32(entry + 4, little) !== 1) {
+      return null;
+    }
+    const orientation = view.getUint16(entry + 8, little);
+    return orientation >= 1 && orientation <= 8 ? orientation : null;
+  }
+  return null;
+}
+
+/** Bounded header validation, with the extent a browser reports after EXIF orientation. */
+export function validateJpegHeader(
+  bytes: Uint8Array
+): Readonly<{ pixelWidth: number; pixelHeight: number }> | null {
+  if (bytes.length < 4 || bytes[0] !== 0xff || bytes[1] !== 0xd8) return null;
+  let offset = 2;
+  let padding = 0;
+  let orientation: number | null = null;
+  for (let markers = 0; markers < MAX_MARKERS && offset + 1 < bytes.length; markers += 1) {
+    if (bytes[offset++] !== 0xff) return null;
+    while (bytes[offset] === 0xff) {
+      if (++padding > MAX_PADDING_BYTES) return null;
+      offset += 1;
+    }
+    if (offset >= bytes.length) return null;
+    const marker = bytes[offset++]!;
+    // Never interpret entropy-coded scan data as marker metadata.
+    if (marker === 0 || marker === 0xd9 || marker === 0xda) return null;
+    if (marker === 0xd8 || marker === 1 || (marker >= 0xd0 && marker <= 0xd7)) continue;
+    if (offset + 2 > bytes.length) return null;
+    const length = (bytes[offset]! << 8) | bytes[offset + 1]!;
+    const end = offset + length;
+    if (length < 2 || end > bytes.length) return null;
+    if (marker === 0xe1 && orientation === null) {
+      orientation = exifOrientation(bytes, offset + 2, end);
+    }
+    const isFrame =
+      marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc;
+    if (isFrame) {
+      if (length < 8) return null;
+      const components = bytes[offset + 7]!;
+      if (components === 0 || length !== 8 + 3 * components) return null;
+      const pixelHeight = (bytes[offset + 3]! << 8) | bytes[offset + 4]!;
+      const pixelWidth = (bytes[offset + 5]! << 8) | bytes[offset + 6]!;
+      if (pixelWidth === 0 || pixelHeight === 0) return null;
+      // Do not rotate or rewrite the payload: the decoder/painter applies EXIF once.
+      return orientation !== null && orientation >= 5
+        ? { pixelWidth: pixelHeight, pixelHeight: pixelWidth }
+        : { pixelWidth, pixelHeight };
+    }
+    offset = end;
+  }
+  return null;
+}


### PR DESCRIPTION
JPEG photos with large EXIF/ICC segments can be rejected before decoding, and EXIF orientations 5–8 can fail the decoded-dimension check. Validate metadata by bounded marker/IFD counts and use orientation-adjusted dimensions, retaining the original media bytes and existing resource limits.

Regression coverage includes both TIFF byte orders, all eight orientations, progressive frames, truncated metadata, scan-data boundaries, resource caching, and unchanged media on save. Store and layout suites: 4,981 tests passed. Core typecheck, DOM-free store/layout checks, scoped lint/format, core build, and API snapshots passed. Full monorepo and browser E2E suites were not run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/733"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791165099&installation_model_id=422592&pr_number=733&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F733&signature=aca0351d8d9a9a0cfcb87c6aab7bec20e34f70ed85795e50494cf3671eeff629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->