### PR TITLE
fix: preserve floating image bounds in cells and continuous sections

### DIFF
--- a/.changeset/floating-image-clipping.md
+++ b/.changeset/floating-image-clipping.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Keep floating overlays visible beyond their anchor cells and clip page-relative images to the physical sheet instead of a shortened continuous-section band.

--- a/docs/site/content/guides/images.mdx
+++ b/docs/site/content/guides/images.mdx
@@ -79,6 +79,10 @@ editor.snapshot().image; // reference-stable until selection or image fields mov
 | `behind`       | Places the picture behind document content      | `wrapNone`, `@behindDoc="1"` |
 | `inFront`      | Places the picture in front of document content | `wrapNone`, `@behindDoc="0"` |
 
+Images in front of or behind text can paint beyond their anchor cells. Their cell-relative
+position is preserved, but the cell does not crop these overlays. Page-relative images
+are clipped to the physical sheet, including below a shortened continuous-section band.
+
 The `resourceStatus` field reports image availability:
 
 | Status         | Meaning                                                                     |

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -480,7 +480,7 @@ export const wordFeatures: WordFeature[] = [
     tier: 'community',
     docsLink: '/docs/2.x/guides/images',
     notes:
-      'Nine wrap modes, exclusion reflow, z-order, and drag and resize in both adapters. Both share setImageWrapType and toolbarCommandState.',
+      'Nine wrap modes, exclusion reflow, z-order, and drag and resize in both adapters. In-front and behind-text overlays can paint beyond their anchor cells. Page-relative images clip to the physical sheet rather than a shortened continuous-section band. Both share setImageWrapType and toolbarCommandState.',
   },
   {
     id: 'images.bmp-webp',

--- a/packages/core/src/layout/__tests__/floating-image-clipping.test.ts
+++ b/packages/core/src/layout/__tests__/floating-image-clipping.test.ts
@@ -1,0 +1,84 @@
+import { expect, test } from 'bun:test';
+import { readOoxmlPart, WML_NAMESPACE_URI } from '../../store/package/ooxml-tree.ts';
+import { indexInlineDrawingProjectionsInPart } from '../../store/package/drawing-projection.ts';
+import { pageClipRegion } from '../drawing-layout.ts';
+import { createFixedMeasurer, layoutSemanticDocument } from '../semantic-layout.ts';
+
+const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
+const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+const PIC = 'http://schemas.openxmlformats.org/drawingml/2006/picture';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+
+function inCell(wrap: string, behind = false, layoutInCell = true) {
+  const xml = `<w:document xmlns:w="${WML_NAMESPACE_URI}" xmlns:wp="${WP}" xmlns:a="${A}" xmlns:pic="${PIC}" xmlns:r="${R}"><w:body>
+    <w:tbl><w:tblPr><w:tblW w:w="2000" w:type="dxa"/><w:tblLayout w:type="fixed"/></w:tblPr>
+    <w:tblGrid><w:gridCol w:w="2000"/></w:tblGrid><w:tr><w:tc><w:tcPr><w:tcW w:w="2000" w:type="dxa"/></w:tcPr><w:p><w:r><w:drawing>
+    <wp:anchor simplePos="0" behindDoc="${behind ? 1 : 0}" layoutInCell="${layoutInCell ? 1 : 0}" allowOverlap="1" locked="0" relativeHeight="1">
+      <wp:simplePos x="0" y="0"/>
+      <wp:positionH relativeFrom="column"><wp:posOffset>0</wp:posOffset></wp:positionH>
+      <wp:positionV relativeFrom="paragraph"><wp:posOffset>0</wp:posOffset></wp:positionV>
+      <wp:extent cx="2540000" cy="1143000"/>${wrap}<wp:docPr id="1" name="photo"/>
+      <a:graphic><a:graphicData uri="${PIC}"><pic:pic>
+      <pic:nvPicPr><pic:cNvPr id="1" name="photo"/><pic:cNvPicPr/></pic:nvPicPr>
+      <pic:blipFill><a:blip r:embed="photo"/></pic:blipFill><pic:spPr/>
+      </pic:pic></a:graphicData></a:graphic>
+    </wp:anchor></w:drawing></w:r></w:p></w:tc></w:tr></w:tbl><w:p/>
+    <w:sectPr><w:cols w:num="2" w:space="720"/></w:sectPr></w:body></w:document>`;
+  const loaded = readOoxmlPart(xml, {
+    name: '/word/document.xml',
+    contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml',
+  });
+  if (!loaded.ok) throw new Error(loaded.reason);
+  const projections = indexInlineDrawingProjectionsInPart(loaded.part);
+  const result = layoutSemanticDocument(loaded.part, 1, {
+    measurer: createFixedMeasurer(6, 14),
+    inlineDrawingLayout: {
+      ownerPartName: loaded.part.name,
+      projectionForAtom: (id) => projections.get(id) ?? null,
+      project: (node) => projections.get(node.id) ?? null,
+      resourceOf: () => ({ kind: 'missing', relationshipId: 'photo' }),
+    },
+  });
+  const drawing = result.pages.flatMap((page) => page.anchoredDrawings ?? [])[0];
+  expect(drawing).toBeDefined();
+  return drawing!;
+}
+
+for (const behind of [false, true]) {
+  test(`wrapNone ${behind ? 'behind' : 'in front of'} text is not cropped to its short anchor cell`, () => {
+    const drawing = inCell('<wp:wrapNone/>', behind);
+    expect(drawing.layoutInCell).toBe(true);
+    expect(drawing.width).toBe(200);
+    expect(drawing.height).toBe(90);
+    expect(drawing.paintBounds.width).toBeCloseTo(200, 4);
+    expect(drawing.paintBounds.height).toBeCloseTo(90, 4);
+  });
+}
+
+test('square wrapping retains cell clipping', () => {
+  const drawing = inCell('<wp:wrapSquare wrapText="bothSides"/>');
+  expect(drawing.paintBounds.width).toBeGreaterThan(0);
+  expect(drawing.paintBounds.width).toBeLessThan(drawing.width);
+});
+
+test('layoutInCell=false still permits overflow', () => {
+  const drawing = inCell('<wp:wrapNone/>', false, false);
+  expect(drawing.layoutInCell).toBe(false);
+  expect(drawing.paintBounds.width).toBeCloseTo(drawing.width, 4);
+});
+
+test('physical page height outlives a short continuous-section band', () => {
+  const frame = {
+    pageWidth: 600,
+    pageHeight: 900,
+    marginLeft: 40,
+    contentInsetTop: 50,
+    contentInsetBottom: 60,
+    contentBandHeight: 420,
+  };
+  expect(pageClipRegion(frame)).toEqual({ x: -40, y: -50, width: 600, height: 900 });
+  // Callers with no physical height keep the existing full-band fallback.
+  for (const pageHeight of [undefined, NaN, 0, -1]) {
+    expect(pageClipRegion({ ...frame, pageHeight }).height).toBe(530);
+  }
+});

--- a/packages/core/src/layout/drawing-layout.ts
+++ b/packages/core/src/layout/drawing-layout.ts
@@ -18,6 +18,8 @@ import {
   isRunLevelMcAlternateContent,
 } from '../store/package/drawing-projection.ts';
 import type { OoxmlNode } from '../store/package/ooxml-tree.ts';
+import { pageClipRegion } from './drawing-page-clip.ts';
+export { pageClipRegion } from './drawing-page-clip.ts';
 import type { ImageResourceState } from '../store/package/image-resources.ts';
 import {
   DEFAULT_REVISION_DISPLAY_MODE,
@@ -829,29 +831,6 @@ function positionFromVertical(
   return edges.top + offset;
 }
 
-/**
- * Full page clip including margin bands — page-relative anchors may paint into margins.
- *
- * Width MUST be {@link DrawingAnchorFrameContext.pageWidth}, not `contentWidth`: in a
- * multi-column section `contentWidth` is the active column, and page-relative drawings that
- * sit outside that column must still paint. Height stays the physical content band plus
- * margin bands (furniture-shrunk `contentHeight` must not clip page-relative paint).
- */
-export function pageClipRegion(
-  frameBase: Pick<
-    DrawingAnchorFrameContext,
-    'pageWidth' | 'marginLeft' | 'contentInsetTop' | 'contentInsetBottom' | 'contentBandHeight'
-  >
-): LayoutBox {
-  const bandHeight = frameBase.contentBandHeight;
-  return Object.freeze({
-    x: -frameBase.marginLeft,
-    y: -frameBase.contentInsetTop,
-    width: frameBase.pageWidth,
-    height: bandHeight + frameBase.contentInsetTop + frameBase.contentInsetBottom,
-  });
-}
-
 /** Resolve anchored x/y in page-content coordinates. */
 export function resolveAnchoredDrawingPosition(
   projection: DrawingProjection,
@@ -1296,6 +1275,8 @@ export function publishAnchoredDrawingsForParagraph(options: {
     });
     const resolved = resolveAnchoredDrawingPosition(projection, frameContext);
     const clipToCell =
+      projection.wrap !== 'inFront' &&
+      projection.wrap !== 'behind' &&
       layoutInCell &&
       options.cellBox !== null &&
       Number.isFinite(options.cellBox.height) &&

--- a/packages/core/src/layout/drawing-page-clip.ts
+++ b/packages/core/src/layout/drawing-page-clip.ts
@@ -1,0 +1,26 @@
+import type { DrawingAnchorFrameContext } from './drawing-layout.ts';
+import type { LayoutBox } from './semantic-records.ts';
+
+/**
+ * Full physical page clip, including margins and all columns. A continuous section's
+ * content band can end before the sheet does; it must not crop page-relative artwork.
+ * Callers without physical height retain the full-band fallback.
+ */
+export function pageClipRegion(
+  frameBase: Pick<
+    DrawingAnchorFrameContext,
+    'pageWidth' | 'marginLeft' | 'contentInsetTop' | 'contentInsetBottom' | 'contentBandHeight'
+  > &
+    Partial<Pick<DrawingAnchorFrameContext, 'pageHeight'>>
+): LayoutBox {
+  const height = frameBase.pageHeight;
+  return Object.freeze({
+    x: -frameBase.marginLeft,
+    y: -frameBase.contentInsetTop,
+    width: frameBase.pageWidth,
+    height:
+      height !== undefined && Number.isFinite(height) && height > 0
+        ? height
+        : frameBase.contentBandHeight + frameBase.contentInsetTop + frameBase.contentInsetBottom,
+  });
+}


### PR DESCRIPTION
Floating pictures with `wrapNone` were cropped to short anchor cells, even when placed in front of or behind text. Keep their cell-relative positioning without applying the cell as a paint clip. Page-relative drawings also retain the full physical page clip below a shortened continuous-section band.

Regression tests reproduce both overlay modes and the shortened page clip; square-wrap clipping and `layoutInCell=false` remain covered. All 2,404 layout tests pass, including existing multi-column drawing tests. Core typecheck, DOM-free layout check, scoped lint/format, core build, and API snapshots pass. Full monorepo and browser E2E suites were not run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791165988&installation_model_id=422592&pr_number=734&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F734&signature=776cffc5d905316805abbf2b526fffbd700bbb77b5b0a92747445304f94dcde7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->