### PR TITLE
fix: preserve centered legacy PAGE footer frames

### DIFF
--- a/.changeset/legacy-footer-page-frame.md
+++ b/.changeset/legacy-footer-page-frame.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': patch
 ---
 
-Center legacy PAGE footer frames over their empty or centered middle-dot anchor paragraph without adding an extra footer line or changing the original document structure.
+Position supported legacy PAGE footer frames without adding an extra footer line. Clip fixed-width frames while preserving fields, selections, and document structure.

--- a/.changeset/legacy-footer-page-frame.md
+++ b/.changeset/legacy-footer-page-frame.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': patch
 ---
 
-Position supported legacy PAGE footer frames without adding an extra footer line. Clip fixed-width frames while preserving fields, selections, and document structure.
+Position supported legacy PAGE footer frames without adding an extra footer line. Clip fixed-width frames above empty or PAGE anchors while preserving fields, selections, and document structure.

--- a/.changeset/legacy-footer-page-frame.md
+++ b/.changeset/legacy-footer-page-frame.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Center legacy PAGE footer frames over their empty anchor paragraph without adding an extra footer line or changing the original document structure.

--- a/.changeset/legacy-footer-page-frame.md
+++ b/.changeset/legacy-footer-page-frame.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': patch
 ---
 
-Center legacy PAGE footer frames over their empty anchor paragraph without adding an extra footer line or changing the original document structure.
+Center legacy PAGE footer frames over their empty or centered middle-dot anchor paragraph without adding an extra footer line or changing the original document structure.

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -2370,6 +2370,7 @@ export interface ParagraphFragmentRecord {
     readonly bottomBorder?: ParagraphBottomBorderRecord;
     // (undocumented)
     readonly box: LayoutBox;
+    readonly clipToBox?: true;
     readonly fragmentIndex: number;
     // (undocumented)
     readonly id: string;

--- a/docs/site/content/guides/headers-footers.mdx
+++ b/docs/site/content/guides/headers-footers.mdx
@@ -42,6 +42,11 @@ a grouping comma, and literal text.
 Other fields use separate evaluation rules. See
 [Fields and cross-references](/docs/2.x/guides/fields).
 
+Legacy footers can store a centered `PAGE` field in an auto-sized `w:framePr` over an
+empty paragraph of the same style. This two-paragraph form renders in one footer band,
+and page values are re-centered per page. Both original paragraphs and the frame survive save.
+Frames with other positions, wrapping, spacing, or additional content stay in ordinary flow.
+
 ## Per-section headers and footers
 
 The OOXML model attaches header and footer references to sections, and the editor implements that model:

--- a/docs/site/content/guides/headers-footers.mdx
+++ b/docs/site/content/guides/headers-footers.mdx
@@ -48,11 +48,11 @@ render in one footer band. Page values are re-centered per page, and the source 
 survives save.
 
 A supported fixed-width frame uses a page-relative X position and text-relative vertical
-centering over a second `PAGE` paragraph. A leading tab can place its value outside the
-frame. The editor clips that value but retains both fields and their source ranges.
+centering over an empty anchor or a second `PAGE` paragraph. A leading tab can place its value outside the
+frame. The editor clips that value but retains all fields, paragraphs, and source ranges.
 Selections and pointer hits use the same clip rectangle.
 
-This support covers two simple, single-line `PAGE` paragraphs. Values must fit completely
+This support covers a simple, single-line `PAGE` frame and a single-line empty or `PAGE` anchor. Values must fit completely
 inside the frame or lie completely beyond it. Partial wrapping, other positions,
 paragraph spacing, and additional content keep the ordinary flow behavior.
 

--- a/docs/site/content/guides/headers-footers.mdx
+++ b/docs/site/content/guides/headers-footers.mdx
@@ -43,9 +43,18 @@ Other fields use separate evaluation rules. See
 [Fields and cross-references](/docs/2.x/guides/fields).
 
 Legacy footers can store a centered `PAGE` field in an auto-sized `w:framePr` over an
-empty paragraph of the same style. This two-paragraph form renders in one footer band,
-and page values are re-centered per page. Both original paragraphs and the frame survive save.
-Frames with other positions, wrapping, spacing, or additional content stay in ordinary flow.
+empty paragraph of the same style or a centered middle-dot decoration. Both paragraphs
+render in one footer band. Page values are re-centered per page, and the source structure
+survives save.
+
+A supported fixed-width frame uses a page-relative X position and text-relative vertical
+centering over a second `PAGE` paragraph. A leading tab can place its value outside the
+frame. The editor clips that value but retains both fields and their source ranges.
+Selections and pointer hits use the same clip rectangle.
+
+This support covers two simple, single-line `PAGE` paragraphs. Values must fit completely
+inside the frame or lie completely beyond it. Partial wrapping, other positions,
+paragraph spacing, and additional content keep the ordinary flow behavior.
 
 ## Per-section headers and footers
 

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -291,7 +291,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'A centered, auto-sized PAGE footer frame over one empty paragraph of the same style renders without charging a second footer line. Both paragraphs and framePr remain intact on save. Other frames and drop caps stay in ordinary text flow.',
+      'A centered, auto-sized PAGE footer frame can overlay an empty or centered middle-dot anchor without adding a footer line. Supported single-line fixed-width PAGE frames use their page-relative horizontal position and clip overflow above a second PAGE paragraph. Both fields and paragraphs survive save. Frames that need text wrapping, unsupported positions, and drop caps stay in ordinary flow.',
   },
   {
     id: 'paragraphs.hyphenation',

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -287,11 +287,11 @@ export const wordFeatures: WordFeature[] = [
     name: 'Drop caps & text frames (framePr)',
     category: 'paragraphs',
     editing: 'none',
-    rendering: 'none',
+    rendering: 'partial',
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'Parsed and round-tripped; text flows inline rather than as a drop cap or positioned frame.',
+      'A centered, auto-sized PAGE footer frame over one empty paragraph of the same style renders without charging a second footer line. Both paragraphs and framePr remain intact on save. Other frames and drop caps stay in ordinary text flow.',
   },
   {
     id: 'paragraphs.hyphenation',

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -291,7 +291,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'A centered, auto-sized PAGE footer frame can overlay an empty or centered middle-dot anchor without adding a footer line. Supported single-line fixed-width PAGE frames use their page-relative horizontal position and clip overflow above a second PAGE paragraph. Both fields and paragraphs survive save. Frames that need text wrapping, unsupported positions, and drop caps stay in ordinary flow.',
+      'A centered, auto-sized PAGE footer frame can overlay an empty or centered middle-dot anchor without adding a footer line. Supported single-line fixed-width PAGE frames use their page-relative horizontal position and clip overflow above an empty anchor or a second PAGE paragraph. All fields and paragraphs survive save. Frames that need text wrapping, unsupported positions, and drop caps stay in ordinary flow.',
   },
   {
     id: 'paragraphs.hyphenation',

--- a/packages/core/src/layout/__tests__/legacy-footer-fixed-frame.test.ts
+++ b/packages/core/src/layout/__tests__/legacy-footer-fixed-frame.test.ts
@@ -1,0 +1,270 @@
+import { expect, test } from 'bun:test';
+import {
+  readOoxmlPart,
+  serializeOoxmlPart,
+  WML_NAMESPACE_URI,
+} from '../../store/package/ooxml-tree.ts';
+import { createFixedMeasurer } from '../fixed-measurer.ts';
+import { layoutHeaderFooterStory } from '../hf-layout.ts';
+import { buildStyleCascadeTable } from '../style-cascade.ts';
+import { shiftParagraphFragment } from '../note-fragment-geometry.ts';
+import { fragmentSignature } from '../semantic-fragment-signature.ts';
+import type { ParagraphFragmentRecord, SemanticLayout } from '../semantic-records.ts';
+import { caretAt, caretStopsForBlocks, spansInSelection } from '../semantic-interaction.ts';
+import { presenceSelectionRects } from '../selection-rects.ts';
+import { hitTestFragments } from '../semantic-hit-test.ts';
+
+const frame =
+  '<w:framePr w:w="400" w:wrap="around" w:vAnchor="text" w:hAnchor="page" w:x="4000" w:yAlign="center"/>';
+const field =
+  '<w:r><w:fldChar w:fldCharType="begin"/></w:r><w:r><w:instrText> PAGE </w:instrText></w:r><w:r><w:fldChar w:fldCharType="separate"/></w:r><w:r><w:t>1</w:t></w:r><w:r><w:fldChar w:fldCharType="end"/></w:r>';
+const decorated =
+  '<w:r><w:t xml:space="preserve">- </w:t></w:r>' +
+  field +
+  '<w:r><w:t xml:space="preserve"> -</w:t></w:r>';
+const body = `<w:p><w:pPr><w:pStyle w:val="Footer"/>${frame}</w:pPr><w:r><w:tab/></w:r>${decorated}</w:p><w:p><w:pPr><w:pStyle w:val="Footer"/><w:ind w:right="360"/><w:jc w:val="center"/></w:pPr>${decorated}</w:p>`;
+function part(xml: string, kind = 'ftr') {
+  const loaded = readOoxmlPart(
+    `<w:${kind} xmlns:w="${WML_NAMESPACE_URI}" xmlns:x="urn:foreign">${xml}</w:${kind}>`,
+    { name: '/word/footer1.xml', contentType: 'application/xml' }
+  );
+  if (!loaded.ok) throw new Error(loaded.reason);
+  return loaded.part;
+}
+const stylesWith = (extra = '') =>
+  buildStyleCascadeTable(
+    part(
+      `<w:style w:type="paragraph" w:styleId="Footer"><w:pPr><w:tabs><w:tab w:val="center" w:pos="4000"/></w:tabs>${extra}</w:pPr><w:rPr><w:sz w:val="22"/></w:rPr></w:style>`,
+      'styles'
+    ).root
+  );
+const styles = stylesWith();
+const measurer = createFixedMeasurer(6, 14);
+const geometry = {
+  pageNumber: 1,
+  pageWidth: 612,
+  pageHeight: 792,
+  marginLeft: 72,
+  marginRight: 72,
+  marginTop: 72,
+  marginBottom: 72,
+};
+const layout = (content = body, pageGeometry = geometry, kind = 'ftr', cascade = styles) =>
+  layoutHeaderFooterStory(
+    part(content, kind),
+    468,
+    measurer,
+    'fixed-frame',
+    undefined,
+    cascade,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    pageGeometry
+  );
+const paragraphs = (story: ReturnType<typeof layout>) =>
+  story.fragments.map((p) => {
+    if (p.kind !== 'paragraph') throw Error('paragraph required');
+    return p;
+  });
+function documentOf(story: ReturnType<typeof layout>): SemanticLayout {
+  return {
+    revision: 0,
+    pages: [
+      {
+        index: 0,
+        box: { x: 0, y: 0, width: 612, height: 792 },
+        contentBox: { x: 72, y: 72, width: 468, height: 648 },
+        fragments: [],
+        footer: {
+          kind: 'footer',
+          variant: 'default',
+          partName: story.partName,
+          part: story.part,
+          box: { x: 72, y: 730, width: 468, height: story.flowHeight },
+          fragments: story.fragments,
+        },
+      },
+    ],
+  } as SemanticLayout;
+}
+
+test('positions and clips a fixed PAGE frame while preserving both authored fields', () => {
+  const source = part(body),
+    before = serializeOoxmlPart(source);
+  const initial = layout();
+  const projected = initial.withPageContext({ pageNumber: 5, pageCount: 5, sectionPageCount: 5 });
+  const [framed, anchor] = paragraphs(projected);
+  expect(framed!.clipToBox).toBe(true);
+  expect(framed!.box).toEqual({ x: 128, y: 0, width: 20, height: 14 });
+  expect(anchor!.box.y).toBe(0);
+  expect(projected.flowHeight).toBe(14);
+  expect(framed!.lines[0]!.spans.map((s) => s.text).join('')).toBe('\t- 5 -');
+  expect(anchor!.lines[0]!.spans.map((s) => s.text).join('')).toBe('- 5 -');
+  expect(framed!.lines[0]!.spans.find((s) => s.projected)!.box.x).toBeGreaterThan(
+    framed!.box.x + framed!.box.width
+  );
+  expect(serializeOoxmlPart(source)).toBe(before);
+  expect(serializeOoxmlPart(projected.part).match(/fldCharType="begin"/g)).toHaveLength(2);
+  const saved = serializeOoxmlPart(projected.part);
+  const reopened = readOoxmlPart(saved, { name: source.name, contentType: source.contentType });
+  expect(reopened.ok).toBe(true);
+  if (reopened.ok) expect(serializeOoxmlPart(reopened.part)).toBe(saved);
+});
+
+test('recomputes PAGE and page-X conversion without sharing a stale clipping origin', () => {
+  const narrow = layout(),
+    widerMargin = layout(body, { ...geometry, marginLeft: 90 });
+  expect(paragraphs(widerMargin)[0]!.box.x).toBe(110);
+  for (const pageNumber of [1, 12, 123]) {
+    const value = narrow.withPageContext({ pageNumber, pageCount: 200, sectionPageCount: 200 });
+    expect(
+      paragraphs(value)[0]!
+        .lines[0]!.spans.map((s) => s.text)
+        .join('')
+    ).toBe(`\t- ${pageNumber} -`);
+    expect(paragraphs(value)[0]!.box.width).toBe(20);
+    expect(value.flowHeight).toBe(14);
+  }
+});
+
+test('supports fully contained fields and independent valid anchor decoration', () => {
+  const contained = layout(body.replace('w:w="400"', 'w:w="5000"'));
+  const [framed] = paragraphs(contained);
+  expect(framed!.clipToBox).toBe(true);
+  const last = framed!.lines[0]!.spans.at(-1)!;
+  expect(last.box.x + last.box.width).toBeLessThan(framed!.box.x + framed!.box.width);
+  const differentDecoration =
+    body.slice(0, body.indexOf('</w:p>') + 6) +
+    body.slice(body.indexOf('</w:p>') + 6).replace(decorated, field);
+  expect(paragraphs(layout(differentDecoration))[0]!.clipToBox).toBe(true);
+});
+
+test('defers partial-width reflow and rejects unknown or unsafe frame structures', () => {
+  const variants = [
+    body.replace('w:w="400"', 'w:w="4000"'),
+    body.replace('w:w="400"', 'w:w="0"'),
+    body.replace('w:x="4000"', 'w:x="99999"'),
+    body.replace('w:w="400"', 'w:w="NaN"'),
+    body.replace('w:x="4000"', 'x:x="4000"'),
+    body.replace('w:yAlign="center"', 'w:yAlign="top"'),
+    body.replace('w:hAnchor="page"', 'w:hAnchor="margin"'),
+    body.replace('w:w="400"', 'w:w="400" w:h="200"'),
+    body.replace(frame, frame + frame),
+    body.replace(' PAGE ', ' NUMPAGES '),
+    body.replace('<w:tab/>', '<w:br/>'),
+    body.replace(frame, frame + '<w:bidi/>'),
+    body.replace(frame, frame + '<w:spacing w:after="20"/>'),
+    body.replace(frame, ''),
+    body.replace('w:w="400"', 'w:w="400" x:w="400"'),
+  ];
+  for (const xml of variants) {
+    const [framed, anchor] = paragraphs(layout(xml));
+    expect(framed!.clipToBox).toBeUndefined();
+    expect(anchor!.box.y).toBeGreaterThan(0);
+  }
+  expect(
+    paragraphs(layout(body, { ...geometry, pageWidth: Infinity }))[0]!.clipToBox
+  ).toBeUndefined();
+  expect(paragraphs(layout(body, { ...geometry, pageWidth: 1585 }))[0]!.clipToBox).toBeUndefined();
+  expect(paragraphs(layout(body, geometry, 'hdr'))[0]!.clipToBox).toBeUndefined();
+});
+
+test('refuses inherited direction, frame, spacing and unknown layout properties', () => {
+  for (const inherited of [
+    '<w:bidi/>',
+    '<w:textDirection w:val="tbRl"/>',
+    frame,
+    '<w:spacing w:before="40"/>',
+    '<w:unknownLayout/>',
+  ]) {
+    expect(
+      paragraphs(layout(body, geometry, 'ftr', stylesWith(inherited)))[0]!.clipToBox
+    ).toBeUndefined();
+  }
+  expect(
+    paragraphs(layout(body, geometry, 'ftr', stylesWith('<w:widowControl w:val="0"/>')))[0]!
+      .clipToBox
+  ).toBe(true);
+});
+
+test('clipping participates in signatures and follows vertical fragment translations', () => {
+  const [framed] = paragraphs(layout());
+  expect(fragmentSignature(framed!)).not.toBe(
+    fragmentSignature({ ...framed!, clipToBox: undefined } as unknown as ParagraphFragmentRecord)
+  );
+  const shifted = shiftParagraphFragment(framed!, 30);
+  expect(shifted.clipToBox).toBe(true);
+  expect(shifted.box.y).toBe(30);
+  expect(shifted.lines[0]!.spans[0]!.box.y).toBe(30);
+});
+
+test('hidden PAGE glyphs have no floating caret, presence highlight or outside-frame hit', () => {
+  const story = layout().withPageContext({ pageNumber: 5, pageCount: 5, sectionPageCount: 5 });
+  const model = documentOf(story),
+    [framed, anchor] = paragraphs(story);
+  const fieldSpan = framed!.lines[0]!.spans.find((s) => s.projected)!;
+  const start = { paragraphId: framed!.paragraphId, offset: fieldSpan.range.start };
+  const end = { ...start, offset: fieldSpan.range.end };
+  expect(caretAt(model, start)).toBeNull();
+  expect(
+    presenceSelectionRects(model, { anchor: start, head: end }, [
+      framed!.paragraphId,
+      anchor!.paragraphId,
+    ])
+  ).toEqual([]);
+  expect(
+    caretStopsForBlocks(model, 0, story.fragments)
+      .filter((s) => s.position.paragraphId === framed!.paragraphId)
+      .every((s) => s.x >= framed!.box.x && s.x <= framed!.box.x + framed!.box.width)
+  ).toBe(true);
+  expect(
+    hitTestFragments(model, 0, story.fragments, { x: fieldSpan.box.x + 1, y: 3 })?.position
+      .paragraphId
+  ).toBe(anchor!.paragraphId);
+  expect(framed!.range.end).toBe(6);
+  const hit = hitTestFragments(model, 0, [framed!], { x: framed!.box.x + 15, y: 3 });
+  expect(
+    hit === null ||
+      (hit.caret.x >= framed!.box.x && hit.caret.x <= framed!.box.x + framed!.box.width)
+  ).toBe(true);
+  expect(
+    spansInSelection(model, { anchor: start, head: end }, [
+      framed!.paragraphId,
+      anchor!.paragraphId,
+    ])
+  ).toContain(fieldSpan);
+});
+
+test('presence uses footer story order without highlighting another PAGE field', () => {
+  const story = layout(body.replace(frame, ''));
+  const model = documentOf(story),
+    [first, second] = paragraphs(story);
+  const fieldSpan = first!.lines[0]!.spans.find((span) => span.projected)!;
+  const start = { paragraphId: first!.paragraphId, offset: fieldSpan.range.start };
+  const end = { ...start, offset: fieldSpan.range.end };
+  const order = [first!.paragraphId, second!.paragraphId];
+  const onlyFirst = presenceSelectionRects(model, { anchor: start, head: end }, order);
+  expect(onlyFirst).toHaveLength(1);
+  expect(onlyFirst[0]!.y).toBe(658);
+  expect(onlyFirst[0]!.x).toBe(fieldSpan.box.x);
+  const secondField = second!.lines[0]!.spans.find((span) => span.projected)!;
+  const throughSecond = { paragraphId: second!.paragraphId, offset: secondField.range.end };
+  expect(presenceSelectionRects(model, { anchor: throughSecond, head: start }, order)).toHaveLength(
+    2
+  );
+  expect(
+    presenceSelectionRects(
+      model,
+      {
+        anchor: { paragraphId: 'missing', offset: 0 },
+        head: { paragraphId: 'missing', offset: 1 },
+      },
+      order
+    )
+  ).toEqual([]);
+});

--- a/packages/core/src/layout/__tests__/legacy-footer-fixed-frame.test.ts
+++ b/packages/core/src/layout/__tests__/legacy-footer-fixed-frame.test.ts
@@ -144,6 +144,68 @@ test('supports fully contained fields and independent valid anchor decoration', 
   expect(paragraphs(layout(differentDecoration))[0]!.clipToBox).toBe(true);
 });
 
+test('an empty anchor retains its line and clips the fixed frame without deleting its PAGE field', () => {
+  const split = body.indexOf('</w:p>') + 6;
+  const empty = body.slice(0, split) + body.slice(split).replace(decorated, '');
+  const source = part(empty),
+    before = serializeOoxmlPart(source);
+  for (const pageNumber of [1, 49, 123]) {
+    const projected = layout(empty).withPageContext({
+      pageNumber,
+      pageCount: 200,
+      sectionPageCount: 200,
+    });
+    const [framed, anchor] = paragraphs(projected);
+    expect(framed!.clipToBox).toBe(true);
+    expect(framed!.box.width).toBe(20);
+    expect(anchor!.box.y).toBe(0);
+    expect(anchor!.box.height).toBe(14);
+    expect(projected.flowHeight).toBe(14);
+    expect(anchor!.lines[0]!.spans).toHaveLength(0);
+    expect(framed!.lines[0]!.spans.map((span) => span.text).join('')).toBe(`\t- ${pageNumber} -`);
+    expect(
+      framed!.lines[0]!.spans.filter((span) => span.text.trim()).every(
+        (span) => span.box.x >= framed!.box.x + framed!.box.width
+      )
+    ).toBe(true);
+    expect(
+      caretAt(documentOf(projected), { paragraphId: anchor!.paragraphId, offset: 0 })
+    ).not.toBeNull();
+    expect(serializeOoxmlPart(projected.part)).toBe(before);
+  }
+  expect(serializeOoxmlPart(source)).toBe(before);
+  expect(before.match(/fldCharType="begin"/g)).toHaveLength(1);
+});
+
+test('empty formatting runs do not turn an empty anchor into visible content', () => {
+  const split = body.indexOf('</w:p>') + 6;
+  for (const emptyContent of ['', '<w:r/>', '<w:r><w:rPr><w:b/></w:rPr></w:r>']) {
+    const empty = body.slice(0, split) + body.slice(split).replace(decorated, emptyContent);
+    expect(paragraphs(layout(empty))[0]!.clipToBox).toBe(true);
+    const contained = paragraphs(layout(empty.replace('w:w="400"', 'w:w="5000"')))[0]!;
+    expect(contained.clipToBox).toBe(true);
+    expect(contained.lines[0]!.spans.at(-1)!.box.x).toBeLessThan(
+      contained.box.x + contained.box.width
+    );
+  }
+});
+
+test('unknown, hidden, whitespace and non-PAGE anchors are not mistaken for an empty anchor', () => {
+  const split = body.indexOf('</w:p>') + 6;
+  for (const content of [
+    '<w:r><w:t> </w:t></w:r>',
+    '<w:r><w:tab/></w:r>',
+    '<w:r><w:br/></w:r>',
+    '<w:r><w:rPr><w:vanish/></w:rPr><w:t>hidden</w:t></w:r>',
+    '<w:bookmarkStart w:id="1" w:name="kept"/><w:bookmarkEnd w:id="1"/>',
+    '<x:r/>',
+    field.replace(' PAGE ', ' NUMPAGES '),
+  ]) {
+    const variant = body.slice(0, split) + body.slice(split).replace(decorated, content);
+    expect(paragraphs(layout(variant))[0]!.clipToBox).toBeUndefined();
+  }
+});
+
 test('defers partial-width reflow and rejects unknown or unsafe frame structures', () => {
   const variants = [
     body.replace('w:w="400"', 'w:w="4000"'),

--- a/packages/core/src/layout/__tests__/legacy-footer-page-frame.test.ts
+++ b/packages/core/src/layout/__tests__/legacy-footer-page-frame.test.ts
@@ -1,0 +1,83 @@
+import { expect, test } from 'bun:test';
+import {
+  readOoxmlPart,
+  serializeOoxmlPart,
+  WML_NAMESPACE_URI,
+} from '../../store/package/ooxml-tree.ts';
+import { createFixedMeasurer } from '../fixed-measurer.ts';
+import { layoutHeaderFooterStory } from '../hf-layout.ts';
+
+const frame =
+  '<w:framePr w:wrap="around" w:vAnchor="text" w:hAnchor="margin" w:xAlign="center" w:y="1"/>';
+const field =
+  '<w:r><w:fldChar w:fldCharType="begin"/></w:r><w:r><w:instrText xml:space="preserve"> PAGE </w:instrText></w:r><w:r><w:fldChar w:fldCharType="separate"/></w:r><w:r><w:t>1</w:t></w:r><w:r><w:fldChar w:fldCharType="end"/></w:r>';
+const body = `<w:p><w:pPr><w:pStyle w:val="Footer"/>${frame}</w:pPr>${field}</w:p><w:p><w:pPr><w:pStyle w:val="Footer"/></w:pPr></w:p>`;
+const measurer = createFixedMeasurer(6, 14);
+
+function partOf(content = body, header = false) {
+  const kind = header ? 'header' : 'footer';
+  const root = header ? 'hdr' : 'ftr';
+  const parsed = readOoxmlPart(`<w:${root} xmlns:w="${WML_NAMESPACE_URI}">${content}</w:${root}>`, {
+    name: `/word/${kind}1.xml`,
+    contentType: `application/vnd.openxmlformats-officedocument.wordprocessingml.${kind}+xml`,
+  });
+  if (!parsed.ok) throw new Error(parsed.reason);
+  return parsed.part;
+}
+
+test('centers the legacy PAGE frame without charging its empty anchor paragraph twice', () => {
+  const part = partOf();
+  const before = serializeOoxmlPart(part);
+  const story = layoutHeaderFooterStory(part, 400, measurer, 'test');
+  expect(story.fragments).toHaveLength(2);
+  const first = story.fragments[0]!;
+  const second = story.fragments[1]!;
+  if (first.kind !== 'paragraph' || second.kind !== 'paragraph')
+    throw new Error('paragraphs required');
+  expect(story.flowHeight).toBeCloseTo(first.box.height + 0.05, 3);
+  expect(first.alignment).toBe('center');
+  const span = first.lines[0]!.spans[0]!;
+  expect(span.box.x + span.box.width / 2).toBeCloseTo(200, 4);
+  expect(first.lines[0]!.contentX).toBe(span.box.x);
+  expect(second.box.y).toBeCloseTo(0, 4);
+  expect(first.paragraphId).not.toBe(second.paragraphId);
+  expect(story.part).toBe(part);
+  expect(serializeOoxmlPart(part)).toBe(before);
+});
+
+test('re-evaluates and re-centers multi-digit PAGE results per page', () => {
+  const story = layoutHeaderFooterStory(partOf(), 400, measurer, 'test');
+  for (const pageNumber of [1, 12, 123]) {
+    const projected = story.withPageContext({ pageNumber, pageCount: 200, sectionPageCount: 200 });
+    const paragraph = projected.fragments[0]!;
+    if (paragraph.kind !== 'paragraph') throw new Error('paragraph required');
+    const spans = paragraph.lines[0]!.spans;
+    expect(spans.map((span) => span.text).join('')).toBe(String(pageNumber));
+    expect(spans[0]!.box.x + spans.reduce((sum, span) => sum + span.box.width, 0) / 2).toBeCloseTo(
+      200,
+      4
+    );
+    expect(projected.flowHeight).toBeCloseTo(story.flowHeight, 4);
+  }
+});
+
+test('leaves other frame structures in ordinary flow', () => {
+  const samples = [
+    body.replace('w:xAlign="center"', 'w:xAlign="right"'),
+    body.replace('w:y="1"', 'w:y="200"'),
+    body.replace('w:y="1"', 'w:y="1" w:w="200"'),
+    body.replace(' PAGE ', ' NUMPAGES '),
+    body.replace('</w:pPr></w:p>', '</w:pPr><w:r><w:t>not empty</w:t></w:r></w:p>'),
+    body.replace('<w:t>1</w:t>', '<w:t>Page 1</w:t>'),
+    body.replace(frame, frame + '<w:spacing w:after="200"/>'),
+    body.replace(frame, frame + frame),
+    body.replace('w:xAlign="center"', 'xAlign="center"'),
+    body.replace('<w:t>1</w:t>', '<w:t>' + '1'.repeat(257) + '</w:t>'),
+  ];
+  for (const content of samples) {
+    const story = layoutHeaderFooterStory(partOf(content), 400, measurer, 'test');
+    expect(story.fragments[1]!.box.y).toBeGreaterThan(0);
+  }
+  const header = layoutHeaderFooterStory(partOf(body, true), 400, measurer, 'test');
+  expect(header.fragments[1]!.box.y).toBeGreaterThan(0);
+});

--- a/packages/core/src/layout/__tests__/legacy-footer-page-frame.test.ts
+++ b/packages/core/src/layout/__tests__/legacy-footer-page-frame.test.ts
@@ -81,3 +81,47 @@ test('leaves other frame structures in ordinary flow', () => {
   const header = layoutHeaderFooterStory(partOf(body, true), 400, measurer, 'test');
   expect(header.fragments[1]!.box.y).toBeGreaterThan(0);
 });
+
+test('centers PAGE over a middle-dot anchor without moving or merging its text', () => {
+  const decorated = body.replace(
+    '</w:pPr></w:p>',
+    '<w:jc w:val="center"/><w:rPr><w:rFonts w:hint="eastAsia"/></w:rPr></w:pPr><w:r><w:t xml:space="preserve">·   ·</w:t></w:r></w:p>'
+  );
+  const part = partOf(decorated),
+    before = serializeOoxmlPart(part);
+  const story = layoutHeaderFooterStory(part, 400, measurer, 'decorated');
+  for (const pageNumber of [1, 12, 123]) {
+    const projected = story.withPageContext({ pageNumber, pageCount: 200, sectionPageCount: 200 });
+    const [first, second] = projected.fragments;
+    if (first?.kind !== 'paragraph' || second?.kind !== 'paragraph')
+      throw new Error('paragraphs required');
+    expect(first.lines[0]!.spans.map((span) => span.text).join('')).toBe(String(pageNumber));
+    expect(second.lines[0]!.spans.map((span) => span.text).join('')).toBe('·   ·');
+    expect(first.paragraphId).not.toBe(second.paragraphId);
+    const start = first.lines[0]!.spans[0]!.box,
+      end = first.lines[0]!.spans.at(-1)!.box;
+    expect((start.x + end.x + end.width) / 2).toBeCloseTo(200, 4);
+    expect(second.box.y).toBe(0);
+    expect(projected.flowHeight).toBeCloseTo(first.box.height + 0.05, 3);
+  }
+  expect(serializeOoxmlPart(part)).toBe(before);
+});
+
+test('does not overlay meaningful, left-aligned or field-bearing anchor content', () => {
+  for (const [content, align] of [
+    ['· note ·', 'center'],
+    ['·   ·', 'left'],
+    ['·'.repeat(40), 'center'],
+  ]) {
+    const decorated = body.replace(
+      '</w:pPr></w:p>',
+      `<w:jc w:val="${align}"/></w:pPr><w:r><w:t>${content}</w:t></w:r></w:p>`
+    );
+    const story = layoutHeaderFooterStory(partOf(decorated), 400, measurer, 'refused');
+    expect(story.fragments[1]!.box.y).toBeGreaterThan(0);
+  }
+  const fieldAnchor = body.replace('</w:pPr></w:p>', `</w:pPr>${field}</w:p>`);
+  expect(
+    layoutHeaderFooterStory(partOf(fieldAnchor), 400, measurer, 'field-anchor').fragments[1]!.box.y
+  ).toBeGreaterThan(0);
+});

--- a/packages/core/src/layout/__tests__/paragraph-frame-clip.test.ts
+++ b/packages/core/src/layout/__tests__/paragraph-frame-clip.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from 'bun:test';
+import { readOoxmlPart } from '../../store/package/ooxml-tree.ts';
+import { createFixedMeasurer, layoutSemanticDocument } from '../semantic-layout.ts';
+import type { ParagraphFragmentRecord, SemanticLayout } from '../semantic-records.ts';
+import { caretAt, caretStops, spansInSelection } from '../semantic-interaction.ts';
+import { selectionRects, keyedRangeRects } from '../selection-rects.ts';
+import { hitTestFragments } from '../semantic-hit-test.ts';
+import { clipParagraphBox } from '../paragraph-frame-clip.ts';
+
+function fixture() {
+  const parsed = readOoxmlPart(
+    '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:rPr><w:sz w:val="22"/></w:rPr><w:t>abcdef</w:t></w:r></w:p></w:body></w:document>',
+    { name: '/word/document.xml', contentType: 'application/xml' }
+  );
+  if (!parsed.ok) throw Error(parsed.reason);
+  const initial = layoutSemanticDocument(parsed.part, 0, { measurer: createFixedMeasurer(6, 14) });
+  const original = initial.pages[0]!.fragments[0] as ParagraphFragmentRecord;
+  const clipped: ParagraphFragmentRecord = {
+    ...original,
+    clipToBox: true,
+    box: { x: 12, y: 4, width: 12, height: 6 },
+  };
+  const layout: SemanticLayout = {
+    ...initial,
+    pages: [{ ...initial.pages[0]!, fragments: [clipped] }],
+  };
+  const position = (offset: number) => ({ paragraphId: clipped.paragraphId, offset });
+  return { layout, clipped, position };
+}
+
+test('clips selection, review and caret geometry while retaining the complete model text', () => {
+  const { layout, clipped, position } = fixture();
+  const selection = { anchor: position(0), head: position(6) },
+    order = [clipped.paragraphId];
+  const expected = [{ pageIndex: 0, ...clipped.box }];
+  expect(selectionRects(layout, selection, order)).toEqual(expected);
+  expect(
+    keyedRangeRects(layout, [{ key: 'review', from: selection.anchor, to: selection.head }]).get(
+      'review'
+    )
+  ).toEqual(expected);
+  expect(caretAt(layout, position(0))).toBeNull();
+  expect(caretAt(layout, position(3))).toMatchObject({ x: 18, y: 4, height: 6 });
+  expect(caretStops(layout).map((stop) => stop.position.offset)).toEqual([2, 3, 4]);
+  expect(caretStops(layout).every((stop) => stop.y === 4 && stop.height === 6)).toBe(true);
+  expect(
+    spansInSelection(layout, selection, order)
+      .map((span) => span.text)
+      .join('')
+  ).toBe('abcdef');
+});
+
+test('frame hit results stay inside the clip rectangle', () => {
+  const { layout, clipped } = fixture();
+  expect(hitTestFragments(layout, 0, [clipped], { x: 13, y: 5 })?.caret).toMatchObject({
+    x: 12,
+    y: 4,
+    height: 6,
+  });
+  expect(hitTestFragments(layout, 0, [clipped], { x: 25, y: 5 })).toBeNull();
+  expect(hitTestFragments(layout, 0, [clipped], { x: 15, y: 11 })).toBeNull();
+});
+
+test('clip intersections preserve zero-width caret edges and leave ordinary geometry unchanged', () => {
+  const frame = { x: 10, y: 10, width: 20, height: 20 };
+  const caret = { x: 30, y: 5, width: 0, height: 15 };
+  expect(clipParagraphBox(caret, frame)).toEqual({ x: 30, y: 10, width: 0, height: 10 });
+  expect(clipParagraphBox({ ...caret, x: 31 }, frame)).toBeNull();
+  expect(clipParagraphBox(caret, undefined)).toBe(caret);
+});

--- a/packages/core/src/layout/hf-layout.ts
+++ b/packages/core/src/layout/hf-layout.ts
@@ -55,6 +55,7 @@ import type {
 } from './semantic-records.ts';
 import type { StyleCascadeTable } from './style-cascade.ts';
 import { storyBlocks } from './story-roots.ts';
+import { positionLegacyFooterPageFrame } from './legacy-footer-page-frame.ts';
 
 /**
  * Distinct PAGE-dependent contexts retained before LRU eviction.
@@ -500,6 +501,7 @@ export function layoutHeaderFooterStory(
       });
     }
 
+    flow = positionLegacyFooterPageFrame(part, flow, contentWidth);
     const story: HeaderFooterStoryLayout = {
       partName: part.name,
       part,

--- a/packages/core/src/layout/hf-layout.ts
+++ b/packages/core/src/layout/hf-layout.ts
@@ -501,7 +501,7 @@ export function layoutHeaderFooterStory(
       });
     }
 
-    flow = positionLegacyFooterPageFrame(part, flow, contentWidth);
+    flow = positionLegacyFooterPageFrame(part, flow, contentWidth, hfPageContext);
     const story: HeaderFooterStoryLayout = {
       partName: part.name,
       part,

--- a/packages/core/src/layout/legacy-footer-fixed-frame.ts
+++ b/packages/core/src/layout/legacy-footer-fixed-frame.ts
@@ -94,6 +94,16 @@ function simple(fragment: BlockFragmentRecord): fragment is ParagraphFragmentRec
   );
 }
 
+function emptyAnchor(paragraph: OoxmlElement, fragment: ParagraphFragmentRecord): boolean {
+  return (
+    fragment.lines[0]!.spans.length === 0 &&
+    elements(paragraph).every(
+      (node) =>
+        isW(node, 'pPr') || (isW(node, 'r') && elements(node).every((child) => isW(child, 'rPr')))
+    )
+  );
+}
+
 function supportedProperties(fragment: ParagraphFragmentRecord, framed: boolean): boolean {
   const allowed = new Set([
     'pStyle',
@@ -169,7 +179,11 @@ export function positionFixedFooterPageFrame<
   )
     return flow;
   const decoration = pageText(paragraphs[0]!, true);
-  if (decoration === undefined || pageText(paragraphs[1]!, false) === undefined) return flow;
+  if (
+    decoration === undefined ||
+    (pageText(paragraphs[1]!, false) === undefined && !emptyAnchor(paragraphs[1]!, anchor))
+  )
+    return flow;
   const frame = one(firstProps, 'framePr');
   const allowed = new Set(['w', 'wrap', 'vAnchor', 'hAnchor', 'x', 'yAlign']);
   if (

--- a/packages/core/src/layout/legacy-footer-fixed-frame.ts
+++ b/packages/core/src/layout/legacy-footer-fixed-frame.ts
@@ -1,0 +1,225 @@
+import {
+  WML_NAMESPACE_URI,
+  type OoxmlElement,
+  type OoxmlNode,
+  type OoxmlPart,
+} from '../store/package/ooxml-tree.ts';
+import { shiftParagraphFragment } from './note-fragment-geometry.ts';
+import type { BlockFragmentRecord, ParagraphFragmentRecord } from './semantic-records.ts';
+
+const MAX_PT = 31_680 / 20;
+const isElement = (node: OoxmlNode): node is OoxmlElement => node.kind !== 'textValue';
+const isW = (node: OoxmlNode, name: string): boolean =>
+  isElement(node) && node.namespaceUri === WML_NAMESPACE_URI && node.localName === name;
+const elements = (node: OoxmlElement): OoxmlElement[] =>
+  (node.children as readonly OoxmlNode[]).filter(isElement);
+const attr = (node: OoxmlElement, name: string): string | undefined => {
+  const matches = node.attributes.filter((item) => item.localName === name);
+  return matches.length === 1 && matches[0]!.namespaceUri === WML_NAMESPACE_URI
+    ? matches[0]!.value
+    : undefined;
+};
+function one(node: OoxmlElement, name: string): OoxmlElement | undefined {
+  const matches = elements(node).filter((child) => child.localName === name);
+  return matches.length === 1 && isW(matches[0]!, name) ? matches[0] : undefined;
+}
+function twips(value: string | undefined): number | undefined {
+  if (value === undefined || !/^\d{1,5}$/.test(value)) return undefined;
+  const pt = Number(value) / 20;
+  return pt <= MAX_PT ? pt : undefined;
+}
+
+/** Bounded only-PAGE paragraphs; decoration is content, never a deduplication key. */
+function pageText(paragraph: OoxmlElement, leadingTab: boolean): string | undefined {
+  let state = 0,
+    instruction = '',
+    prefix = '',
+    suffix = '',
+    tabs = 0;
+  for (const run of elements(paragraph)) {
+    if (isW(run, 'pPr')) continue;
+    if (!isW(run, 'r')) return undefined;
+    for (const node of elements(run)) {
+      if (isW(node, 'rPr')) continue;
+      if (
+        isW(node, 'tab') &&
+        state === 0 &&
+        !prefix &&
+        !tabs &&
+        leadingTab &&
+        !node.children.length
+      ) {
+        tabs++;
+        continue;
+      }
+      if (isW(node, 'fldChar') && !node.children.length) {
+        const type = attr(node, 'fldCharType');
+        if (state === 0 && type === 'begin') state = 1;
+        else if (state === 1 && type === 'separate' && instruction.trim() === 'PAGE') state = 2;
+        else if (state === 2 && type === 'end') state = 3;
+        else return undefined;
+        continue;
+      }
+      if (node.children.some(isElement)) return undefined;
+      const value = node.children
+        .map((child) => (child.kind === 'textValue' ? child.value : ''))
+        .join('');
+      if (isW(node, 'instrText') && state === 1) instruction += value;
+      else if (isW(node, 't') && state === 0) prefix += value;
+      else if (isW(node, 't') && state === 3) suffix += value;
+      else if (!(isW(node, 't') && state === 2 && /^\d*$/.test(value))) return undefined;
+    }
+  }
+  return state === 3 &&
+    instruction.trim() === 'PAGE' &&
+    tabs === Number(leadingTab) &&
+    ((!prefix && !suffix) || (prefix === '- ' && suffix === ' -'))
+    ? prefix + suffix
+    : undefined;
+}
+
+function simple(fragment: BlockFragmentRecord): fragment is ParagraphFragmentRecord {
+  return (
+    fragment.kind === 'paragraph' &&
+    fragment.lines.length === 1 &&
+    !fragment.marker &&
+    !fragment.borders?.length &&
+    !fragment.shading &&
+    !fragment.lines[0]!.drawings?.length &&
+    fragment.spacing.before === 0 &&
+    fragment.spacing.after === 0 &&
+    fragment.indent.left === 0 &&
+    fragment.indent.firstLine === 0 &&
+    fragment.indent.hanging === 0
+  );
+}
+
+function supportedProperties(fragment: ParagraphFragmentRecord, framed: boolean): boolean {
+  const allowed = new Set([
+    'pStyle',
+    'tabs',
+    'jc',
+    'rPr',
+    'ind',
+    'spacing',
+    'widowControl',
+    'contextualSpacing',
+    'snapToGrid',
+    ...(framed ? ['framePr'] : []),
+  ]);
+  return (
+    fragment.props.length <= 64 &&
+    fragment.props.every((property) => allowed.has(property.localName)) &&
+    fragment.props.filter((property) => property.localName === 'framePr').length === Number(framed)
+  );
+}
+
+/**
+ * Fixed-width, page-X/text-center footer frames. The caller bounds the entire source tree.
+ * This lane preserves both fields, including text outside the frame's clipping rectangle.
+ * It does not support multi-paragraph frames, arbitrary text wrapping or partial-line reflow.
+ */
+export function positionFixedFooterPageFrame<
+  T extends { blocks: BlockFragmentRecord[]; bottom: number },
+>(
+  part: OoxmlPart,
+  flow: T,
+  geometry: { readonly marginLeft: number; readonly pageWidth: number } | undefined
+): T {
+  if (
+    !geometry ||
+    !isW(part.root, 'ftr') ||
+    flow.blocks.length !== 2 ||
+    !Number.isFinite(geometry.pageWidth) ||
+    geometry.pageWidth <= 0 ||
+    geometry.pageWidth > MAX_PT ||
+    !Number.isFinite(geometry.marginLeft) ||
+    geometry.marginLeft < 0 ||
+    geometry.marginLeft > geometry.pageWidth
+  )
+    return flow;
+  const paragraphs = elements(part.root);
+  const [first, anchor] = flow.blocks;
+  if (
+    paragraphs.length !== 2 ||
+    paragraphs.some((p) => p.kind !== 'paragraph') ||
+    !first ||
+    !anchor ||
+    !simple(first) ||
+    !simple(anchor) ||
+    !supportedProperties(first, true) ||
+    !supportedProperties(anchor, false) ||
+    first.paragraphId !== paragraphs[0]!.id ||
+    anchor.paragraphId !== paragraphs[1]!.id ||
+    first.alignment !== 'left' ||
+    first.indent.right !== 0 ||
+    anchor.indent.right < 0 ||
+    anchor.indent.right > MAX_PT
+  )
+    return flow;
+  const firstProps = one(paragraphs[0]!, 'pPr'),
+    anchorProps = one(paragraphs[1]!, 'pPr');
+  if (
+    !firstProps ||
+    !anchorProps ||
+    elements(firstProps).some(
+      (p) => !['framePr', 'pStyle', 'tabs', 'jc', 'rPr'].some((name) => isW(p, name))
+    ) ||
+    elements(anchorProps).some((p) => !['pStyle', 'jc', 'ind', 'rPr'].some((name) => isW(p, name)))
+  )
+    return flow;
+  const decoration = pageText(paragraphs[0]!, true);
+  if (decoration === undefined || pageText(paragraphs[1]!, false) === undefined) return flow;
+  const frame = one(firstProps, 'framePr');
+  const allowed = new Set(['w', 'wrap', 'vAnchor', 'hAnchor', 'x', 'yAlign']);
+  if (
+    !frame ||
+    frame.children.length ||
+    frame.attributes.some(
+      (a) => a.namespaceUri !== WML_NAMESPACE_URI || !allowed.has(a.localName)
+    ) ||
+    attr(frame, 'wrap') !== 'around' ||
+    attr(frame, 'vAnchor') !== 'text' ||
+    attr(frame, 'hAnchor') !== 'page' ||
+    attr(frame, 'yAlign') !== 'center'
+  )
+    return flow;
+  const width = twips(attr(frame, 'w')),
+    x = twips(attr(frame, 'x'));
+  if (width === undefined || width <= 0 || x === undefined || x + width > geometry.pageWidth)
+    return flow;
+  const line = first.lines[0]!;
+  let left = Infinity,
+    right = -Infinity;
+  for (const span of line.spans) {
+    if (span.box.width <= 0 || span.text === '\t' || span.text.trim() === '') continue;
+    left = Math.min(left, span.box.x - first.box.x);
+    right = Math.max(right, span.box.x + span.box.width - first.box.x);
+  }
+  // A tab can place the entire value past the frame (Word keeps the value but clips its ink).
+  // If it instead straddles the edge, wrapping requires a frame-width text-flow pass; defer it.
+  if (
+    !Number.isFinite(left) ||
+    !Number.isFinite(right) ||
+    left < 0 ||
+    !(right <= width || left >= width)
+  )
+    return flow;
+  const shiftedAnchor = shiftParagraphFragment(anchor, -anchor.box.y);
+  const y = (anchor.box.height - first.box.height) / 2;
+  if (y < 0) return flow;
+  const shifted = shiftParagraphFragment(first, y - first.box.y);
+  const dx = x - geometry.marginLeft - first.box.x;
+  const clipped: ParagraphFragmentRecord = {
+    ...shifted,
+    clipToBox: true,
+    box: { ...shifted.box, x: first.box.x + dx, width },
+    lines: shifted.lines.map((item) => ({
+      ...item,
+      box: { ...item.box, x: item.box.x + dx },
+      contentX: item.contentX + dx,
+      spans: item.spans.map((span) => ({ ...span, box: { ...span.box, x: span.box.x + dx } })),
+    })),
+  };
+  return { ...flow, blocks: [clipped, shiftedAnchor], bottom: shiftedAnchor.box.height };
+}

--- a/packages/core/src/layout/legacy-footer-page-frame.ts
+++ b/packages/core/src/layout/legacy-footer-page-frame.ts
@@ -5,6 +5,7 @@ import {
   type OoxmlPart,
 } from '../store/package/ooxml-tree.ts';
 import { shiftParagraphFragment } from './note-fragment-geometry.ts';
+import { positionFixedFooterPageFrame } from './legacy-footer-fixed-frame.ts';
 import type { BlockFragmentRecord, ParagraphFragmentRecord } from './semantic-records.ts';
 
 const isElement = (node: OoxmlNode): node is OoxmlElement => node.kind !== 'textValue';
@@ -159,9 +160,15 @@ function simpleLine(fragment: BlockFragmentRecord): fragment is ParagraphFragmen
 /** Position the narrowly supported PAGE/empty-paragraph footer pair in derived geometry only. */
 export function positionLegacyFooterPageFrame<
   T extends { blocks: BlockFragmentRecord[]; bottom: number },
->(part: OoxmlPart, flow: T, contentWidth: number): T {
+>(
+  part: OoxmlPart,
+  flow: T,
+  contentWidth: number,
+  pageGeometry?: { readonly marginLeft: number; readonly pageWidth: number }
+): T {
   const pair = framePair(part);
-  if (!pair || flow.blocks.length !== 2) return flow;
+  if (!pair) return bounded(part) ? positionFixedFooterPageFrame(part, flow, pageGeometry) : flow;
+  if (flow.blocks.length !== 2) return flow;
   const [first, empty] = flow.blocks;
   if (
     !first ||

--- a/packages/core/src/layout/legacy-footer-page-frame.ts
+++ b/packages/core/src/layout/legacy-footer-page-frame.ts
@@ -79,30 +79,49 @@ function containsOnlyPageField(paragraph: OoxmlElement): boolean {
   return state === 3 && instruction === 'PAGE';
 }
 
-function framePair(part: OoxmlPart): { first: string; empty: string; y: number } | null {
+function framePair(
+  part: OoxmlPart
+): { first: string; empty: string; y: number; decoration: string } | null {
   if (!isW(part.root, 'ftr') || !bounded(part)) return null;
   const paragraphs = elements(part.root);
   if (paragraphs.length !== 2 || paragraphs.some((node) => node.kind !== 'paragraph')) return null;
   const [first, empty] = paragraphs as [OoxmlElement, OoxmlElement];
   const props = elements(first).find((node) => isW(node, 'pPr'));
-  const emptyChildren = elements(empty);
-  if (!props || emptyChildren.length !== 1 || !isW(emptyChildren[0]!, 'pPr')) return null;
-  const properties = elements(props);
+  const emptyProps = elements(empty).find((node) => isW(node, 'pPr'));
+  if (!props || !emptyProps) return null;
+  const properties = elements(props),
+    anchorProperties = elements(emptyProps);
   if (
     properties.filter((node) => isW(node, 'framePr')).length !== 1 ||
-    properties.filter((node) => isW(node, 'pStyle')).length !== 1
+    properties.filter((node) => isW(node, 'pStyle')).length !== 1 ||
+    anchorProperties.filter((node) => isW(node, 'pStyle')).length !== 1
   )
     return null;
   if (
-    properties.some((node) => !['pStyle', 'framePr', 'jc', 'rPr'].some((name) => isW(node, name)))
+    properties.some(
+      (node) => !['pStyle', 'framePr', 'jc', 'rPr'].some((name) => isW(node, name))
+    ) ||
+    anchorProperties.some((node) => !['pStyle', 'jc', 'rPr'].some((name) => isW(node, name)))
   )
     return null;
-  const style = properties.find((node) => isW(node, 'pStyle'));
-  const frame = properties.find((node) => isW(node, 'framePr'));
-  const emptyProperties = elements(emptyChildren[0]!);
-  if (!style || !frame || emptyProperties.length !== 1 || !isW(emptyProperties[0]!, 'pStyle'))
-    return null;
-  if (!attr(style, 'val') || attr(style, 'val') !== attr(emptyProperties[0]!, 'val')) return null;
+  const style = properties.find((node) => isW(node, 'pStyle'))!;
+  const anchorStyle = anchorProperties.find((node) => isW(node, 'pStyle'))!;
+  const frame = properties.find((node) => isW(node, 'framePr'))!;
+  if (!attr(style, 'val') || attr(style, 'val') !== attr(anchorStyle, 'val')) return null;
+  let decoration = '';
+  for (const run of elements(empty)) {
+    if (isW(run, 'pPr')) continue;
+    if (!isW(run, 'r')) return null;
+    for (const node of elements(run)) {
+      if (isW(node, 'rPr')) continue;
+      if (!isW(node, 't')) return null;
+      const value = text(node);
+      if (value === null) return null;
+      decoration += value;
+    }
+  }
+  // Preserve a centered middle-dot decoration as authored; do not merge or delete runs.
+  if (decoration && !/^· {1,15}·$/.test(decoration)) return null;
   const allowed = new Set(['wrap', 'vAnchor', 'hAnchor', 'xAlign', 'y']);
   if (
     frame.children.length ||
@@ -120,7 +139,7 @@ function framePair(part: OoxmlPart): { first: string; empty: string; y: number }
     return null;
   const y = attr(frame, 'y') ?? '0';
   if (!['0', '1'].includes(y) || !containsOnlyPageField(first)) return null;
-  return { first: first.id, empty: empty.id, y: Number(y) / 20 };
+  return { first: first.id, empty: empty.id, y: Number(y) / 20, decoration };
 }
 
 function simpleLine(fragment: BlockFragmentRecord): fragment is ParagraphFragmentRecord {
@@ -151,7 +170,10 @@ export function positionLegacyFooterPageFrame<
     !simpleLine(empty) ||
     first.paragraphId !== pair.first ||
     empty.paragraphId !== pair.empty ||
-    empty.lines[0]!.spans.length
+    (pair.decoration
+      ? empty.alignment !== 'center' ||
+        empty.lines[0]!.spans.map((span) => span.text).join('') !== pair.decoration
+      : empty.lines[0]!.spans.length > 0)
   )
     return flow;
   const framed = shiftParagraphFragment(first, pair.y - first.box.y);

--- a/packages/core/src/layout/legacy-footer-page-frame.ts
+++ b/packages/core/src/layout/legacy-footer-page-frame.ts
@@ -1,0 +1,182 @@
+import {
+  WML_NAMESPACE_URI,
+  type OoxmlElement,
+  type OoxmlNode,
+  type OoxmlPart,
+} from '../store/package/ooxml-tree.ts';
+import { shiftParagraphFragment } from './note-fragment-geometry.ts';
+import type { BlockFragmentRecord, ParagraphFragmentRecord } from './semantic-records.ts';
+
+const isElement = (node: OoxmlNode): node is OoxmlElement => node.kind !== 'textValue';
+const isW = (node: OoxmlNode, name: string): boolean =>
+  isElement(node) && node.namespaceUri === WML_NAMESPACE_URI && node.localName === name;
+const attr = (node: OoxmlElement, name: string) =>
+  node.attributes.find((item) => item.namespaceUri === WML_NAMESPACE_URI && item.localName === name)
+    ?.value;
+function elements(node: OoxmlElement): OoxmlElement[] {
+  const children: readonly OoxmlNode[] = node.children;
+  return children.filter(isElement);
+}
+
+function bounded(part: OoxmlPart): boolean {
+  const stack = [{ node: part.root as OoxmlNode, depth: 0 }];
+  let visited = 0;
+  while (stack.length) {
+    const { node, depth } = stack.pop()!;
+    if (++visited > 512 || depth > 16) return false;
+    if (node.kind === 'textValue') {
+      if (node.value.length > 256) return false;
+    } else {
+      if (visited + stack.length + node.children.length > 512 || node.attributes.length > 32)
+        return false;
+      if (node.attributes.some((item) => item.value.length > 1024)) return false;
+      for (const child of node.children) {
+        if (
+          child.kind === 'textValue' &&
+          child.value.trim() &&
+          !isW(node, 't') &&
+          !isW(node, 'instrText')
+        )
+          return false;
+        stack.push({ node: child, depth: depth + 1 });
+      }
+    }
+  }
+  return true;
+}
+
+function text(node: OoxmlElement): string | null {
+  let value = '';
+  for (const child of node.children) {
+    if (child.kind !== 'textValue') return null;
+    value += child.value;
+  }
+  return value;
+}
+
+function containsOnlyPageField(paragraph: OoxmlElement): boolean {
+  let state = 0;
+  let instruction: string | null = null;
+  for (const run of elements(paragraph)) {
+    if (isW(run, 'pPr')) continue;
+    if (!isW(run, 'r')) return false;
+    for (const node of elements(run)) {
+      if (isW(node, 'rPr')) continue;
+      if (isW(node, 'fldChar') && node.children.length === 0) {
+        const kind = attr(node, 'fldCharType');
+        if (state === 0 && kind === 'begin') state = 1;
+        else if (state === 1 && kind === 'separate' && instruction === 'PAGE') state = 2;
+        else if (state === 2 && kind === 'end') state = 3;
+        else return false;
+      } else if (isW(node, 'instrText') && state === 1 && instruction === null) {
+        instruction = text(node)?.trim() ?? null;
+      } else if (isW(node, 't') && state === 2) {
+        const value = text(node);
+        if (value === null || !/^\d*$/.test(value)) return false;
+      } else return false;
+    }
+  }
+  return state === 3 && instruction === 'PAGE';
+}
+
+function framePair(part: OoxmlPart): { first: string; empty: string; y: number } | null {
+  if (!isW(part.root, 'ftr') || !bounded(part)) return null;
+  const paragraphs = elements(part.root);
+  if (paragraphs.length !== 2 || paragraphs.some((node) => node.kind !== 'paragraph')) return null;
+  const [first, empty] = paragraphs as [OoxmlElement, OoxmlElement];
+  const props = elements(first).find((node) => isW(node, 'pPr'));
+  const emptyChildren = elements(empty);
+  if (!props || emptyChildren.length !== 1 || !isW(emptyChildren[0]!, 'pPr')) return null;
+  const properties = elements(props);
+  if (
+    properties.filter((node) => isW(node, 'framePr')).length !== 1 ||
+    properties.filter((node) => isW(node, 'pStyle')).length !== 1
+  )
+    return null;
+  if (
+    properties.some((node) => !['pStyle', 'framePr', 'jc', 'rPr'].some((name) => isW(node, name)))
+  )
+    return null;
+  const style = properties.find((node) => isW(node, 'pStyle'));
+  const frame = properties.find((node) => isW(node, 'framePr'));
+  const emptyProperties = elements(emptyChildren[0]!);
+  if (!style || !frame || emptyProperties.length !== 1 || !isW(emptyProperties[0]!, 'pStyle'))
+    return null;
+  if (!attr(style, 'val') || attr(style, 'val') !== attr(emptyProperties[0]!, 'val')) return null;
+  const allowed = new Set(['wrap', 'vAnchor', 'hAnchor', 'xAlign', 'y']);
+  if (
+    frame.children.length ||
+    frame.attributes.some(
+      (item) => item.namespaceUri !== WML_NAMESPACE_URI || !allowed.has(item.localName)
+    )
+  )
+    return null;
+  if (
+    attr(frame, 'wrap') !== 'around' ||
+    attr(frame, 'vAnchor') !== 'text' ||
+    attr(frame, 'hAnchor') !== 'margin' ||
+    attr(frame, 'xAlign') !== 'center'
+  )
+    return null;
+  const y = attr(frame, 'y') ?? '0';
+  if (!['0', '1'].includes(y) || !containsOnlyPageField(first)) return null;
+  return { first: first.id, empty: empty.id, y: Number(y) / 20 };
+}
+
+function simpleLine(fragment: BlockFragmentRecord): fragment is ParagraphFragmentRecord {
+  return (
+    fragment.kind === 'paragraph' &&
+    fragment.lines.length === 1 &&
+    !fragment.marker &&
+    !fragment.borders?.length &&
+    !fragment.shading &&
+    !fragment.lines[0]!.drawings?.length &&
+    fragment.spacing.before === 0 &&
+    fragment.spacing.after === 0 &&
+    Object.values(fragment.indent).every((value) => value === 0)
+  );
+}
+
+/** Position the narrowly supported PAGE/empty-paragraph footer pair in derived geometry only. */
+export function positionLegacyFooterPageFrame<
+  T extends { blocks: BlockFragmentRecord[]; bottom: number },
+>(part: OoxmlPart, flow: T, contentWidth: number): T {
+  const pair = framePair(part);
+  if (!pair || flow.blocks.length !== 2) return flow;
+  const [first, empty] = flow.blocks;
+  if (
+    !first ||
+    !empty ||
+    !simpleLine(first) ||
+    !simpleLine(empty) ||
+    first.paragraphId !== pair.first ||
+    empty.paragraphId !== pair.empty ||
+    empty.lines[0]!.spans.length
+  )
+    return flow;
+  const framed = shiftParagraphFragment(first, pair.y - first.box.y);
+  const anchor = shiftParagraphFragment(empty, -empty.box.y);
+  const line = framed.lines[0]!;
+  const left = line.spans[0]?.box.x ?? line.contentX;
+  const last = line.spans.at(-1);
+  const right = last ? last.box.x + last.box.width : left;
+  const dx = (contentWidth - (right - left)) / 2 - left;
+  const centered: ParagraphFragmentRecord = {
+    ...framed,
+    alignment: 'center',
+    lines: [
+      {
+        ...line,
+        contentX: line.contentX + dx,
+        spans: line.spans.map((span) => ({ ...span, box: { ...span.box, x: span.box.x + dx } })),
+      },
+    ],
+  };
+  // Both canonical paragraph identities remain addressable, even though the empty
+  // anchor occupies the same band. Never delete it or rewrite framePr to fake pagination.
+  return {
+    ...flow,
+    blocks: [centered, anchor],
+    bottom: Math.max(centered.box.y + centered.box.height, anchor.box.y + anchor.box.height),
+  };
+}

--- a/packages/core/src/layout/line-segments.ts
+++ b/packages/core/src/layout/line-segments.ts
@@ -131,12 +131,20 @@ export function segmentOverlap(
   layout: SemanticLayout,
   segment: LineSegment,
   from: SemanticPosition,
-  to: SemanticPosition
+  to: SemanticPosition,
+  index: ReadonlyMap<string, number> = documentOrderIndex(layout)
 ): { start: number; end: number } | null {
-  const index = documentOrderIndex(layout);
-  const lineParagraph = index.get(segment.paragraphId) ?? -1;
-  const fromParagraph = index.get(from.paragraphId) ?? -1;
-  const toParagraph = index.get(to.paragraphId) ?? -1;
+  if (from.paragraphId === to.paragraphId) {
+    if (segment.paragraphId !== from.paragraphId) return null;
+    const start = Math.max(segment.start, from.offset),
+      end = Math.min(segment.end, to.offset);
+    return end > start ? { start, end } : null;
+  }
+  const lineParagraph = index.get(segment.paragraphId);
+  const fromParagraph = index.get(from.paragraphId);
+  const toParagraph = index.get(to.paragraphId);
+  if (lineParagraph === undefined || fromParagraph === undefined || toParagraph === undefined)
+    return null;
   if (lineParagraph < fromParagraph || lineParagraph > toParagraph) return null;
 
   const start =

--- a/packages/core/src/layout/paragraph-frame-clip.ts
+++ b/packages/core/src/layout/paragraph-frame-clip.ts
@@ -1,0 +1,15 @@
+import type { LayoutBox } from './semantic-records.ts';
+
+/** Intersect ink/selection geometry with a text frame without changing model ranges. */
+export function clipParagraphBox<T extends LayoutBox>(
+  value: T,
+  frame: LayoutBox | undefined
+): T | null {
+  if (!frame) return value;
+  const x = Math.max(value.x, frame.x),
+    y = Math.max(value.y, frame.y);
+  const right = Math.min(value.x + value.width, frame.x + frame.width);
+  const bottom = Math.min(value.y + value.height, frame.y + frame.height);
+  if (bottom <= y || (value.width === 0 ? right < x : right <= x)) return null;
+  return { ...value, x, y, width: right - x, height: bottom - y };
+}

--- a/packages/core/src/layout/paragraph-lines.ts
+++ b/packages/core/src/layout/paragraph-lines.ts
@@ -5,7 +5,7 @@
 // memoized per revision, with no knowledge of stops or selections.
 
 import { lineSegments } from './line-segments.ts';
-import type { LineRecord, PageRecord, SemanticLayout } from './semantic-records.ts';
+import type { LayoutBox, LineRecord, PageRecord, SemanticLayout } from './semantic-records.ts';
 import { lineAtPosition, paragraphFragmentsOf } from './semantic-records.ts';
 import type { SemanticPosition } from './semantic-interaction.ts';
 
@@ -21,6 +21,7 @@ import type { SemanticPosition } from './semantic-interaction.ts';
 export interface PlacedLine {
   readonly line: LineRecord;
   readonly pageIndex: number;
+  readonly clipBox?: LayoutBox;
 }
 
 const paragraphLinesCache = new WeakMap<SemanticLayout, Map<string, PlacedLine[]>>();
@@ -60,9 +61,9 @@ function pageLines(page: PageRecord): ReadonlyMap<string, readonly PlacedLine[]>
    * A merged line belongs to two paragraphs, and a caret walking either of them has to find
    * it. An ordinary line has one segment and lands in exactly the one bucket it always did.
    */
-  const indexLine = (line: LineRecord, pageIndex: number): void => {
+  const indexLine = (line: LineRecord, pageIndex: number, clipBox?: LayoutBox): void => {
     for (const segment of lineSegments(line)) {
-      const placed = { line, pageIndex };
+      const placed = { line, pageIndex, ...(clipBox ? { clipBox } : {}) };
       const entry = index.get(segment.paragraphId);
       if (entry) entry.push(placed);
       else index.set(segment.paragraphId, [placed]);
@@ -77,7 +78,8 @@ function pageLines(page: PageRecord): ReadonlyMap<string, readonly PlacedLine[]>
     ): void => {
       for (const block of blocks) {
         if (block.kind === 'paragraph') {
-          for (const line of block.lines) indexLine(line, pageIndex);
+          for (const line of block.lines)
+            indexLine(line, pageIndex, block.clipToBox ? block.box : undefined);
           continue;
         }
         for (const row of block.rows) {
@@ -90,7 +92,8 @@ function pageLines(page: PageRecord): ReadonlyMap<string, readonly PlacedLine[]>
   };
   // Body first — primary story for caret stops built elsewhere via paragraphFragmentsOf.
   for (const fragment of paragraphFragmentsOf(page)) {
-    for (const line of fragment.lines) indexLine(line, page.index);
+    for (const line of fragment.lines)
+      indexLine(line, page.index, fragment.clipToBox ? fragment.box : undefined);
   }
   // Furniture paragraphs share this index so formatting / paragraphTextFromLayout can
   // resolve an open header/footer selection. documentOrder and caretStops stay body-only.

--- a/packages/core/src/layout/selection-rects.ts
+++ b/packages/core/src/layout/selection-rects.ts
@@ -6,6 +6,7 @@
 
 import { lineSegments, segmentOverlap } from './line-segments.ts';
 import { xWithinLine } from './line-geometry.ts';
+import { clipParagraphBox } from './paragraph-frame-clip.ts';
 import { paragraphFragmentsOf, paragraphFragmentsOfBlocks } from './semantic-records.ts';
 import type {
   BlockFragmentRecord,
@@ -168,15 +169,18 @@ function rangeRects(
           );
           const startX = Math.min(...edges);
           const endX = Math.max(...edges);
-          rects.push(
-            bottomToTopRectInLayout(layout, segment.paragraphId, {
+          const clipped = clipParagraphBox(
+            {
               pageIndex: page.index,
               x: startX,
               y: line.box.y,
               width: endX - startX,
               height: line.box.height,
-            })
+            },
+            fragment.clipToBox ? fragment.box : undefined
           );
+          if (!clipped) continue;
+          rects.push(bottomToTopRectInLayout(layout, segment.paragraphId, clipped));
         }
       }
     }
@@ -227,15 +231,18 @@ export function keyedRangeRects(
             const startX = xWithinLine(line, overlap.start, measurer, segment);
             const endX = xWithinLine(line, overlap.end, measurer, segment);
             const rects = found.get(range.key) ?? [];
-            rects.push(
-              bottomToTopRectInLayout(layout, segment.paragraphId, {
+            const clipped = clipParagraphBox(
+              {
                 pageIndex: page.index,
                 x: Math.min(startX, endX),
                 y: line.box.y,
                 width: Math.abs(endX - startX),
                 height: line.box.height,
-              })
+              },
+              fragment.clipToBox ? fragment.box : undefined
             );
+            if (!clipped) continue;
+            rects.push(bottomToTopRectInLayout(layout, segment.paragraphId, clipped));
             found.set(range.key, rects);
           }
       }
@@ -381,6 +388,7 @@ export function presenceRangeRects(
     if (pair) ordered.push({ key: range.key, from: pair.from, to: pair.to });
   }
   if (ordered.length === 0) return found;
+  const orderIndex = indexesOf(order);
   const take = (
     blocks: readonly BlockFragmentRecord[],
     pageIndex: number,
@@ -392,18 +400,23 @@ export function presenceRangeRects(
         presenceWalkLines += 1;
         for (const segment of lineSegments(line)) {
           for (const range of ordered) {
-            const overlap = segmentOverlap(layout, segment, range.from, range.to);
+            const overlap = segmentOverlap(layout, segment, range.from, range.to, orderIndex);
             if (!overlap) continue;
             const startX = xWithinLine(line, overlap.start, measurer, segment);
             const endX = xWithinLine(line, overlap.end, measurer, segment);
             const rects = found.get(range.key) ?? [];
-            rects.push({
-              pageIndex,
-              x: Math.min(startX, endX) + offsetX,
-              y: line.box.y + offsetY,
-              width: Math.abs(endX - startX),
-              height: line.box.height,
-            });
+            const clipped = clipParagraphBox(
+              {
+                pageIndex,
+                x: Math.min(startX, endX),
+                y: line.box.y,
+                width: Math.abs(endX - startX),
+                height: line.box.height,
+              },
+              fragment.clipToBox ? fragment.box : undefined
+            );
+            if (!clipped) continue;
+            rects.push({ ...clipped, x: clipped.x + offsetX, y: clipped.y + offsetY });
             found.set(range.key, rects);
           }
         }

--- a/packages/core/src/layout/semantic-caret-line.ts
+++ b/packages/core/src/layout/semantic-caret-line.ts
@@ -1,0 +1,98 @@
+import type { LineSegment } from './line-segments.ts';
+import type { LineRecord, SemanticLayout } from './semantic-records.ts';
+import { paragraphLinesIndex } from './paragraph-lines.ts';
+import { PAGE_BREAK_CHAR } from '../store/package/hard-break.ts';
+
+/**
+ * Whether a LATER line of the same paragraph starts at this offset, and so owns it.
+ *
+ * Asked across the whole paragraph rather than the current fragment: a paragraph split by a
+ * page boundary continues on the next page, and the line that owns the position may live in
+ * a different fragment. `caretAt` resolves against the same paragraph-wide index, so both
+ * lanes answer with the same line. When nothing later claims it — a layout that produced no
+ * line after the break — the break's own line keeps the stop rather than losing the position.
+ */
+export function laterLineOwns(layout: SemanticLayout, line: LineRecord, offset: number): boolean {
+  const lines = paragraphLinesIndex(layout).get(line.range.paragraphId) ?? [];
+  let seen = false;
+  for (const placed of lines) {
+    if (placed.line === line) {
+      seen = true;
+      continue;
+    }
+    if (seen && placed.line.range.start === offset) return true;
+  }
+  return false;
+}
+
+/** The continuation line when a soft wrap opens on an inline drawing atom. */
+export function laterLineWithDrawingAt(
+  layout: SemanticLayout,
+  paragraphId: string,
+  offset: number
+): LineRecord | null {
+  for (const { line } of paragraphLinesIndex(layout).get(paragraphId) ?? []) {
+    if (line.range.start !== offset) continue;
+    if (line.drawings?.some((drawing) => drawing.start === offset)) return line;
+  }
+  return null;
+}
+
+/**
+ * True when `offset` sits strictly inside a span that is not a 1:1 model↔paint mapping
+ * (projected PAGE digits, leaders) — those interiors are not navigable caret stops.
+ * Tabs keep a 1:1 `\t` range; their wide box is still only two stops (before/after).
+ */
+export function isNonNavigableInterior(
+  line: LineRecord,
+  offset: number,
+  segment?: LineSegment
+): boolean {
+  for (const span of segment ? segment.spans : line.spans) {
+    if (offset <= span.range.start || offset >= span.range.end) continue;
+    if (span.projected) return true;
+    if (span.text.length !== span.range.end - span.range.start) return true;
+  }
+  return false;
+}
+
+/**
+ * Whether an authored break is what ended this line.
+ *
+ * The break OCCUPIES a model offset and is published as a zero-width span, so a line that a
+ * Shift+Enter terminated carries it as its last span. That is the one case where a position
+ * shared by two lines is not ambiguous — see `caretAt`.
+ *
+ * A PAGE break counts for exactly the same reason, and leaving it out was worse than the
+ * hard-break case rather than milder: the line it opens is on the NEXT PAGE, so reporting
+ * the end of the line the break closed put the caret on a different page from the text that
+ * would be typed at it. Click below the last line, type, and the letters appear a page
+ * later. A column break already arrives here as `\n` — only `w:type="page"` projects its
+ * own character.
+ */
+export function endsWithLineBreak(line: {
+  readonly spans: readonly { readonly text: string }[];
+}): boolean {
+  const last = line.spans[line.spans.length - 1]?.text;
+  return last === '\n' || last === PAGE_BREAK_CHAR;
+}
+
+/**
+ * Whether this paragraph's slice of the line is ONE inline drawing and nothing else — a
+ * picture too wide to share its line, painted as a block in text clothing.
+ *
+ * That is the other case where the position shared by two lines is not ambiguous, and it is
+ * the hard-break case wearing an image: the drawing is what ended the line, so the caret at
+ * the offset after it belongs before the text that follows. Painting it at the picture's
+ * right edge instead meant a click before that text resolved the right offset but drew the
+ * caret a full picture away — the caret looked stuck beside the following words, and there
+ * was no click that showed one at the text's start.
+ */
+export function isDrawingOnlySegment(line: LineRecord, segment: LineSegment): boolean {
+  if (segment.end - segment.start !== 1) return false;
+  if (!line.drawings?.some((drawing) => drawing.start === segment.start)) return false;
+  for (const span of segment.spans) {
+    if (span.range.end > span.range.start) return false;
+  }
+  return true;
+}

--- a/packages/core/src/layout/semantic-fragment-signature.ts
+++ b/packages/core/src/layout/semantic-fragment-signature.ts
@@ -39,6 +39,7 @@ const PARAGRAPH_FIELDS = {
   // `id` is `${paragraphId}#f${fragmentIndex}`, so both are already in it.
   paragraphId: 'covered',
   fragmentIndex: 'covered',
+  clipToBox: 'hashed',
   range: 'hashed',
   // A paragraph-property change that layout does not read moves no geometry. Without this
   // the freshly built fragment converged against the old one and was discarded, leaving a

--- a/packages/core/src/layout/semantic-hit-test.ts
+++ b/packages/core/src/layout/semantic-hit-test.ts
@@ -42,6 +42,7 @@ import type {
 } from './semantic-records.ts';
 import type { InlineDrawingRecord, AnchoredDrawingRecord } from './drawing-layout.ts';
 import { pointInDrawingClip } from './drawing-wrap.ts';
+import { clipParagraphBox } from './paragraph-frame-clip.ts';
 import { bottomToTopCaretInLayout, pointInBottomToTopCell } from './table-cell-text-direction.ts';
 
 /** A point in the coordinate space named by the function taking it. */
@@ -562,6 +563,7 @@ function resolveParagraph(
   cell: TableCellAddress | null,
   insideBox: boolean
 ): SemanticHit | null {
+  if (fragment.clipToBox && !insideBox) return null;
   const line = lineAtY(fragment.lines, point.y);
   if (!line) return null;
   const resolved = offsetOnLine(line, point.x, point.y, context);
@@ -576,13 +578,18 @@ function resolveParagraph(
   const offset = Math.min(Math.max(resolved.offset, segment.start), segment.end);
   const position: SemanticPosition = { paragraphId: segment.paragraphId, offset };
   const box = caretBoxOnLine(line, offset, context.measurer, segment);
+  const caretBox = clipParagraphBox(
+    { ...box, x: resolved.x, width: 0 },
+    fragment.clipToBox ? fragment.box : undefined
+  );
+  if (!caretBox) return null;
   return {
     position,
     caret: {
       position,
-      x: resolved.x,
-      y: box.y,
-      height: box.height,
+      x: caretBox.x,
+      y: caretBox.y,
+      height: caretBox.height,
       lineId: line.id,
       pageIndex: context.pageIndex,
     },

--- a/packages/core/src/layout/semantic-interaction.ts
+++ b/packages/core/src/layout/semantic-interaction.ts
@@ -13,11 +13,13 @@ import { documentOrder, documentOrderIndex } from './document-order.ts';
 export { documentOrder, everyStoryOrder } from './document-order.ts';
 export { selectionRects, keyedRangeRects, type KeyedRange } from './selection-rects.ts';
 import { xWithinLine } from './line-geometry.ts';
+import { clipParagraphBox } from './paragraph-frame-clip.ts';
 import { lineSegmentFor, lineSegments, segmentOverlap, type LineSegment } from './line-segments.ts';
 import type {
   BlockFragmentRecord,
   ContentControlBoundaryRecord,
   LineRecord,
+  LayoutBox,
   SemanticLayout,
   StyleSpanRecord,
   TextMeasurer,
@@ -42,7 +44,13 @@ import {
   paragraphLinesIndex,
 } from './paragraph-lines.ts';
 import { wordBoundary } from './semantic-word-navigation.ts';
-import { PAGE_BREAK_CHAR } from '../store/package/hard-break.ts';
+import {
+  laterLineOwns,
+  laterLineWithDrawingAt,
+  isNonNavigableInterior,
+  endsWithLineBreak,
+  isDrawingOnlySegment,
+} from './semantic-caret-line.ts';
 import { bottomToTopCaretInLayout } from './table-cell-text-direction.ts';
 
 export { wordBoundary } from './semantic-word-navigation.ts';
@@ -86,96 +94,6 @@ export interface SelectionRect {
   readonly height: number;
 }
 
-/**
- * Whether a LATER line of the same paragraph starts at this offset, and so owns it.
- *
- * Asked across the whole paragraph rather than the current fragment: a paragraph split by a
- * page boundary continues on the next page, and the line that owns the position may live in
- * a different fragment. `caretAt` resolves against the same paragraph-wide index, so both
- * lanes answer with the same line. When nothing later claims it — a layout that produced no
- * line after the break — the break's own line keeps the stop rather than losing the position.
- */
-function laterLineOwns(layout: SemanticLayout, line: LineRecord, offset: number): boolean {
-  const lines = paragraphLinesIndex(layout).get(line.range.paragraphId) ?? [];
-  let seen = false;
-  for (const placed of lines) {
-    if (placed.line === line) {
-      seen = true;
-      continue;
-    }
-    if (seen && placed.line.range.start === offset) return true;
-  }
-  return false;
-}
-
-/** The continuation line when a soft wrap opens on an inline drawing atom. */
-function laterLineWithDrawingAt(
-  layout: SemanticLayout,
-  paragraphId: string,
-  offset: number
-): LineRecord | null {
-  for (const { line } of paragraphLinesIndex(layout).get(paragraphId) ?? []) {
-    if (line.range.start !== offset) continue;
-    if (line.drawings?.some((drawing) => drawing.start === offset)) return line;
-  }
-  return null;
-}
-
-/**
- * True when `offset` sits strictly inside a span that is not a 1:1 model↔paint mapping
- * (projected PAGE digits, leaders) — those interiors are not navigable caret stops.
- * Tabs keep a 1:1 `\t` range; their wide box is still only two stops (before/after).
- */
-function isNonNavigableInterior(line: LineRecord, offset: number, segment?: LineSegment): boolean {
-  for (const span of segment ? segment.spans : line.spans) {
-    if (offset <= span.range.start || offset >= span.range.end) continue;
-    if (span.projected) return true;
-    if (span.text.length !== span.range.end - span.range.start) return true;
-  }
-  return false;
-}
-
-/**
- * Whether an authored break is what ended this line.
- *
- * The break OCCUPIES a model offset and is published as a zero-width span, so a line that a
- * Shift+Enter terminated carries it as its last span. That is the one case where a position
- * shared by two lines is not ambiguous — see `caretAt`.
- *
- * A PAGE break counts for exactly the same reason, and leaving it out was worse than the
- * hard-break case rather than milder: the line it opens is on the NEXT PAGE, so reporting
- * the end of the line the break closed put the caret on a different page from the text that
- * would be typed at it. Click below the last line, type, and the letters appear a page
- * later. A column break already arrives here as `\n` — only `w:type="page"` projects its
- * own character.
- */
-function endsWithLineBreak(line: {
-  readonly spans: readonly { readonly text: string }[];
-}): boolean {
-  const last = line.spans[line.spans.length - 1]?.text;
-  return last === '\n' || last === PAGE_BREAK_CHAR;
-}
-
-/**
- * Whether this paragraph's slice of the line is ONE inline drawing and nothing else — a
- * picture too wide to share its line, painted as a block in text clothing.
- *
- * That is the other case where the position shared by two lines is not ambiguous, and it is
- * the hard-break case wearing an image: the drawing is what ended the line, so the caret at
- * the offset after it belongs before the text that follows. Painting it at the picture's
- * right edge instead meant a click before that text resolved the right offset but drew the
- * caret a full picture away — the caret looked stuck beside the following words, and there
- * was no click that showed one at the text's start.
- */
-function isDrawingOnlySegment(line: LineRecord, segment: LineSegment): boolean {
-  if (segment.end - segment.start !== 1) return false;
-  if (!line.drawings?.some((drawing) => drawing.start === segment.start)) return false;
-  for (const span of segment.spans) {
-    if (span.range.end > span.range.start) return false;
-  }
-  return true;
-}
-
 function pushLineCaretStops(
   stops: CaretGeometry[],
   layout: SemanticLayout,
@@ -183,11 +101,21 @@ function pushLineCaretStops(
   pageIndex: number,
   fragmentStart: number,
   measurer?: TextMeasurer,
-  only?: string
+  only?: string,
+  clipBox?: LayoutBox
 ): void {
   for (const segment of lineSegments(line)) {
     if (only !== undefined && segment.paragraphId !== only) continue;
-    pushSegmentCaretStops(stops, layout, line, segment, pageIndex, fragmentStart, measurer);
+    pushSegmentCaretStops(
+      stops,
+      layout,
+      line,
+      segment,
+      pageIndex,
+      fragmentStart,
+      measurer,
+      clipBox
+    );
   }
 }
 
@@ -198,7 +126,8 @@ function pushSegmentCaretStops(
   segment: LineSegment,
   pageIndex: number,
   fragmentStart: number,
-  measurer?: TextMeasurer
+  measurer?: TextMeasurer,
+  clipBox?: LayoutBox
 ): void {
   const mixed = lineSegments(line).length > 1;
   // Paragraph-wide, not this line's own slices: a deletion that wraps is clipped per line,
@@ -242,12 +171,22 @@ function pushSegmentCaretStops(
     // at invisible positions. Derived from the spans rather than from the mode, so the rule
     // holds in any mode that suppresses them.
     if (insideDeletedContent(deleted, offset) && !painted(offset)) continue;
+    const visible = clipParagraphBox(
+      {
+        x: xWithinLine(line, offset, measurer, segment),
+        y: line.box.y,
+        width: 0,
+        height: line.box.height,
+      },
+      clipBox
+    );
+    if (!visible) continue;
     stops.push(
       bottomToTopCaretInLayout(layout, {
         position: { paragraphId: segment.paragraphId, offset },
-        x: xWithinLine(line, offset, measurer, segment),
-        y: line.box.y,
-        height: line.box.height,
+        x: visible.x,
+        y: visible.y,
+        height: visible.height,
         lineId: line.id,
         pageIndex,
       })
@@ -265,7 +204,16 @@ function visitParagraphFragments(
   for (const block of blocks) {
     if (block.kind === 'paragraph') {
       for (const line of block.lines) {
-        pushLineCaretStops(stops, layout, line, pageIndex, block.range.start, measurer);
+        pushLineCaretStops(
+          stops,
+          layout,
+          line,
+          pageIndex,
+          block.range.start,
+          measurer,
+          undefined,
+          block.clipToBox ? block.box : undefined
+        );
       }
       continue;
     }
@@ -292,7 +240,16 @@ export function caretStops(layout: SemanticLayout, measurer?: TextMeasurer): Car
   for (const page of layout.pages) {
     for (const fragment of paragraphFragmentsOf(page)) {
       for (const line of fragment.lines) {
-        pushLineCaretStops(stops, layout, line, page.index, fragment.range.start, measurer);
+        pushLineCaretStops(
+          stops,
+          layout,
+          line,
+          page.index,
+          fragment.range.start,
+          measurer,
+          undefined,
+          fragment.clipToBox ? fragment.box : undefined
+        );
       }
     }
   }
@@ -317,7 +274,16 @@ function mergedLineCaretStops(
   });
   if (!found || lineSegments(found.line).length < 2) return null;
   const stops: CaretGeometry[] = [];
-  pushLineCaretStops(stops, layout, found.line, found.pageIndex, 0, measurer);
+  pushLineCaretStops(
+    stops,
+    layout,
+    found.line,
+    found.pageIndex,
+    0,
+    measurer,
+    undefined,
+    found.clipBox
+  );
   return indexCaretStops(stops);
 }
 
@@ -328,8 +294,8 @@ function paragraphCaretStops(
 ): IndexedCaretStops<CaretGeometry> {
   return paragraphCaretStopCache.get(layout, paragraphId, measurer, () => {
     const stops: CaretGeometry[] = [];
-    for (const { line, pageIndex } of paragraphLinesIndex(layout).get(paragraphId) ?? []) {
-      pushLineCaretStops(stops, layout, line, pageIndex, 0, measurer, paragraphId);
+    for (const { line, pageIndex, clipBox } of paragraphLinesIndex(layout).get(paragraphId) ?? []) {
+      pushLineCaretStops(stops, layout, line, pageIndex, 0, measurer, paragraphId, clipBox);
     }
     return indexCaretStops(stops);
   });
@@ -388,13 +354,14 @@ function headerRepeatLinesOnPage(
   layout: SemanticLayout,
   pageIndex: number,
   paragraphId: string
-): { line: LineRecord; pageIndex: number }[] {
+): { line: LineRecord; pageIndex: number; clipBox?: LayoutBox }[] {
   const page = layout.pages[pageIndex];
   if (!page) return [];
-  const found: { line: LineRecord; pageIndex: number }[] = [];
+  const found: { line: LineRecord; pageIndex: number; clipBox?: LayoutBox }[] = [];
   for (const fragment of paragraphFragmentsOf(page, true)) {
     if (fragment.paragraphId !== paragraphId) continue;
-    for (const line of fragment.lines) found.push({ line, pageIndex });
+    for (const line of fragment.lines)
+      found.push({ line, pageIndex, ...(fragment.clipToBox ? { clipBox: fragment.box } : {}) });
   }
   return found;
 }
@@ -427,8 +394,8 @@ export function caretAt(
   // just opened — not a break's width to the right of the last glyph on the line above,
   // which is what a Shift+Enter looked like. Soft wraps stay on the first match, where the
   // offset is genuinely shared and the end of the visual line is the conventional answer.
-  let afterBreak: { line: LineRecord; pageIndex: number } | null = null;
-  for (const { line, pageIndex } of ordered) {
+  let afterBreak: { line: LineRecord; pageIndex: number; clipBox?: LayoutBox } | null = null;
+  for (const { line, pageIndex, clipBox } of ordered) {
     // The part of the line this paragraph owns. On a merged line that is half of it, and the
     // other half counts its offsets in a different paragraph entirely.
     const segment = lineSegmentFor(line, position.paragraphId);
@@ -444,7 +411,7 @@ export function caretAt(
       // keeps a caret placed rather than lost if no such line was laid out — for the
       // drawing-only line, that fallback is exactly the picture-ends-its-paragraph case,
       // where the right edge of the picture IS the answer.
-      afterBreak ??= { line, pageIndex };
+      afterBreak ??= { line, pageIndex, clipBox };
       continue;
     }
     if (
@@ -454,7 +421,11 @@ export function caretAt(
     ) {
       continue;
     }
-    const box = caretBoxOnLine(line, position.offset, options.measurer, segment);
+    const box = clipParagraphBox(
+      { ...caretBoxOnLine(line, position.offset, options.measurer, segment), width: 0 },
+      clipBox
+    );
+    if (!box) continue;
     return bottomToTopCaretInLayout(layout, {
       position,
       x: box.x,
@@ -465,12 +436,19 @@ export function caretAt(
     });
   }
   if (afterBreak) {
-    const box = caretBoxOnLine(
-      afterBreak.line,
-      position.offset,
-      options.measurer,
-      lineSegmentFor(afterBreak.line, position.paragraphId)
+    const box = clipParagraphBox(
+      {
+        ...caretBoxOnLine(
+          afterBreak.line,
+          position.offset,
+          options.measurer,
+          lineSegmentFor(afterBreak.line, position.paragraphId)
+        ),
+        width: 0,
+      },
+      afterBreak.clipBox
     );
+    if (!box) return null;
     return bottomToTopCaretInLayout(layout, {
       position,
       x: box.x,
@@ -542,7 +520,7 @@ export function contentControlsInLayout(
  */
 const orderIndexes = new WeakMap<readonly string[], Map<string, number>>();
 
-function positionIn(order: readonly string[], paragraphId: string): number {
+function indexPositions(order: readonly string[]): ReadonlyMap<string, number> {
   let index = orderIndexes.get(order);
   if (!index) {
     index = new Map();
@@ -551,7 +529,11 @@ function positionIn(order: readonly string[], paragraphId: string): number {
     });
     orderIndexes.set(order, index);
   }
-  return index.get(paragraphId) ?? -1;
+  return index;
+}
+
+function positionIn(order: readonly string[], paragraphId: string): number {
+  return indexPositions(order).get(paragraphId) ?? -1;
 }
 
 /**
@@ -970,7 +952,13 @@ export function spansInSelection(
     for (const { line } of lines.get(order[at]!) ?? []) {
       const segment = lineSegmentFor(line, order[at]!);
       if (!segment) continue;
-      const overlap = segmentOverlap(layout, segment, ordered.from, ordered.to);
+      const overlap = segmentOverlap(
+        layout,
+        segment,
+        ordered.from,
+        ordered.to,
+        indexPositions(order)
+      );
       if (!overlap) continue;
       for (const span of segment.spans) {
         if (span.range.end > overlap.start && span.range.start < overlap.end) spans.push(span);

--- a/packages/core/src/layout/semantic-records.ts
+++ b/packages/core/src/layout/semantic-records.ts
@@ -342,6 +342,8 @@ export interface ParagraphFragmentRecord {
   readonly paragraphId: string;
   /** 0 for the first fragment of the paragraph, 1 for its continuation, and so on. */
   readonly fragmentIndex: number;
+  /** A fixed text frame clips its painted ink to this fragment's box; source ranges remain intact. */
+  readonly clipToBox?: true;
   readonly range: SourceRange;
   readonly props: readonly OoxmlProperty[];
   /** Resolved paragraph style after the style/default cascade, or null when none applies. */

--- a/packages/core/src/output/__tests__/paragraph-frame-clip.test.ts
+++ b/packages/core/src/output/__tests__/paragraph-frame-clip.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from 'bun:test';
+import { readOoxmlPart, serializeOoxmlPart } from '@docx-editor.dev/core/store';
+import { createFixedMeasurer, layoutSemanticDocument } from '../../layout/semantic-layout.ts';
+import type { ParagraphFragmentRecord, SemanticLayout } from '../../layout/semantic-records.ts';
+import { paintSemanticLayout } from '../semantic-paint.ts';
+
+function fixture() {
+  const parsed = readOoxmlPart(
+    '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>0123456789</w:t></w:r></w:p></w:body></w:document>',
+    { name: '/word/document.xml', contentType: 'application/xml' }
+  );
+  if (!parsed.ok) throw Error(parsed.reason);
+  const layout = layoutSemanticDocument(parsed.part, 0, { measurer: createFixedMeasurer(6, 14) });
+  const original = layout.pages[0]!.fragments[0] as ParagraphFragmentRecord;
+  const framed: ParagraphFragmentRecord = {
+    ...original,
+    clipToBox: true,
+    box: { ...original.box, width: 20 },
+  };
+  const withFragment = (fragment: ParagraphFragmentRecord): SemanticLayout => ({
+    ...layout,
+    pages: [{ ...layout.pages[0]!, fragments: [fragment] }],
+  });
+  return { source: parsed.part, original, framed, withFragment };
+}
+
+test('fixed paragraph clips ink without deleting text nodes or changing source ranges', () => {
+  const { source, original, framed, withFragment } = fixture();
+  const before = serializeOoxmlPart(source),
+    container = document.createElement('div');
+  paintSemanticLayout(container, withFragment(framed), { scale: 2 });
+  const paragraph = container.querySelector<HTMLElement>('.docx-paragraph-fragment')!;
+  expect(paragraph.style.overflow).toBe('hidden');
+  expect(paragraph.style.width).toBe('40px');
+  expect(paragraph.textContent).toBe('0123456789');
+  expect(framed.lines).toBe(original.lines);
+  expect(framed.range).toBe(original.range);
+  expect(serializeOoxmlPart(source)).toBe(before);
+});
+
+test('retained paint notices clip-only changes and ordinary paragraphs remain unclipped', () => {
+  const { original, framed, withFragment } = fixture();
+  const sameBox: ParagraphFragmentRecord = { ...original, box: framed.box };
+  const container = document.createElement('div');
+  paintSemanticLayout(container, withFragment(sameBox), { scale: 1 });
+  expect(container.querySelector<HTMLElement>('.docx-paragraph-fragment')!.style.overflow).not.toBe(
+    'hidden'
+  );
+  paintSemanticLayout(container, withFragment(framed), { scale: 1 });
+  expect(container.querySelector<HTMLElement>('.docx-paragraph-fragment')!.style.overflow).toBe(
+    'hidden'
+  );
+  paintSemanticLayout(container, withFragment(sameBox), { scale: 1 });
+  expect(container.querySelector<HTMLElement>('.docx-paragraph-fragment')!.style.overflow).not.toBe(
+    'hidden'
+  );
+});

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -1624,6 +1624,7 @@ function paintFragment(
   const scale = ctx.scale;
   const element = positioned(document, 'div', fragment.box, scale);
   element.className = 'docx-paragraph-fragment layout-paragraph';
+  if (fragment.clipToBox) element.style.overflow = 'hidden';
   element.dataset.paragraphId = fragment.paragraphId;
   element.dataset.fragmentIndex = String(fragment.fragmentIndex);
   if (ctx.readOnlyParagraphIds?.has(fragment.paragraphId)) {

--- a/packages/docx-to-markdown/src/markdown-semantic-policy.ts
+++ b/packages/docx-to-markdown/src/markdown-semantic-policy.ts
@@ -142,6 +142,7 @@ const MARKDOWN_SEMANTIC_POLICY_RATCHETS = Object.freeze({
     tabStops: 'layout-only',
     lines: 'represented',
     box: 'layout-only',
+    clipToBox: 'layout-only',
   } satisfies Record<keyof ParagraphFragmentRecord, MarkdownFieldPolicy>,
   listMarker: {
     text: 'explicitly-omitted',


### PR DESCRIPTION
Legacy PAGE frames incorrectly add a footer line. Centered auto-sized frames now overlay their empty or centered middle-dot anchor.

Supported fixed-width frames also use their page-relative X position and clip overflow above an empty anchor or a second PAGE paragraph. All fields, paragraphs, and source ranges remain intact. Empty anchors retain their original line height and caret. The clip also bounds pointer hits, carets, and local or remote selections.

This covers simple single-line frames, not general paragraph-frame layout. Partial wrapping, unsupported properties, and malformed inputs keep the existing behavior.

Validation passes: 2,558 store, 2,418 layout, 172 binding, 213 output, and 26 scoped header/footer host tests (5,387 total). Three new empty-anchor cases cover field/paragraph preservation, contained and overflowing values, formatting-only runs, and rejection of hidden/whitespace/unknown content. Core and DOM-free typechecks, scoped lint/format, line caps, core builds, and API snapshots pass. Full monorepo and upstream browser E2E suites were not run. Fixtures contain synthetic XML only, without private documents or report data.
