### PR TITLE
fix: render DrawingML bilevel picture color mode

### DIFF
--- a/.changeset/picture-bilevel-color-mode.md
+++ b/.changeset/picture-bilevel-color-mode.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': minor
+---
+
+Project the optional DrawingML bilevel threshold and paint black/white picture colour mode with a bounded SVG filter. Preserve image alpha and original media, and invalidate retained image paint when the threshold changes or is removed.

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -1439,11 +1439,7 @@ export interface InlineDrawingRecord {
     // (undocumented)
     readonly drawingNodeId: string;
     // (undocumented)
-    readonly effects: Readonly<{
-        readonly brightness: number;
-        readonly contrast: number;
-        readonly grayscale: boolean;
-    }>;
+    readonly effects: DrawingProjection['effects'];
     // (undocumented)
     readonly geometry: DrawingGeometry;
     // (undocumented)

--- a/docs/api/docx-editor-docx-to-markdown/index.api.md
+++ b/docs/api/docx-editor-docx-to-markdown/index.api.md
@@ -366,11 +366,7 @@ export interface InlineDrawingRecord {
     // (undocumented)
     readonly drawingNodeId: string;
     // (undocumented)
-    readonly effects: Readonly<{
-        readonly brightness: number;
-        readonly contrast: number;
-        readonly grayscale: boolean;
-    }>;
+    readonly effects: DrawingProjection['effects'];
     // (undocumented)
     readonly geometry: DrawingGeometry;
     // (undocumented)

--- a/packages/core/src/layout/drawing-layout.ts
+++ b/packages/core/src/layout/drawing-layout.ts
@@ -63,11 +63,7 @@ const EMPTY_CROP: SourceCrop = Object.freeze({ left: 0, top: 0, right: 0, bottom
 
 function drawingPaintFields(projection: DrawingProjection): {
   readonly hyperlinkHref: string | null;
-  readonly effects: Readonly<{
-    readonly grayscale: boolean;
-    readonly brightness: number;
-    readonly contrast: number;
-  }>;
+  readonly effects: DrawingProjection['effects'];
   readonly crop: SourceCrop;
   readonly transform: DrawingTransform;
   readonly placeholderGraphicKind: string | null;
@@ -319,11 +315,7 @@ export interface InlineDrawingRecord {
   readonly accessibility: DrawingAccessibility;
   /** Sanitized external hyperlink projection; inert until an explicit gesture activates it. */
   readonly hyperlinkHref: string | null;
-  readonly effects: Readonly<{
-    readonly grayscale: boolean;
-    readonly brightness: number;
-    readonly contrast: number;
-  }>;
+  readonly effects: DrawingProjection['effects'];
   readonly crop: SourceCrop;
   readonly transform: DrawingTransform;
   /** Fixed non-picture graphic kind for refusal labels (`chart`, `group`, …); null for pictures. */

--- a/packages/core/src/output/__tests__/semantic-paint-drawings.test.ts
+++ b/packages/core/src/output/__tests__/semantic-paint-drawings.test.ts
@@ -81,6 +81,7 @@ function inlinePictureXml(
     readonly flipV?: boolean;
     readonly lum?: string;
     readonly grayscale?: boolean;
+    readonly bilevel?: string;
     readonly preset?: string;
   } = {}
 ): string {
@@ -94,6 +95,7 @@ function inlinePictureXml(
   const flipV = options.flipV ? ' flipV="1"' : '';
   const lum = options.lum ?? '';
   const grayscale = options.grayscale ? '<a:grayscl/>' : '';
+  const bilevel = options.bilevel === undefined ? '' : `<a:biLevel thresh="${options.bilevel}"/>`;
   const preset = options.preset ?? 'rect';
   return (
     `<w:document xmlns:w="${WML_NAMESPACE_URI}" xmlns:wp="${WP}" xmlns:a="${A}" xmlns:pic="${PIC}" xmlns:r="${R}">` +
@@ -104,7 +106,7 @@ function inlinePictureXml(
     '<wp:cNvGraphicFramePr/>' +
     `<a:graphic><a:graphicData uri="${PIC_URI}">` +
     '<pic:pic><pic:nvPicPr><pic:cNvPr id="1" name=""/><pic:cNvPicPr/></pic:nvPicPr>' +
-    `<pic:blipFill><a:blip r:embed="rId14">${grayscale}${lum}</a:blip><a:srcRect ${srcRect}/>` +
+    `<pic:blipFill><a:blip r:embed="rId14">${bilevel}${grayscale}${lum}</a:blip><a:srcRect ${srcRect}/>` +
     `<a:stretch/></pic:blipFill>` +
     `<pic:spPr><a:xfrm${rot}${flipH}${flipV}><a:off x="0" y="0"/><a:ext cx="914400" cy="457200"/></a:xfrm>` +
     `<a:prstGeom prst="${preset}"><a:avLst/></a:prstGeom></pic:spPr>` +
@@ -321,6 +323,75 @@ describe('paints validated raster records', () => {
     expect(second.dataset.revisionKind).toBeUndefined();
     expect(second.dataset.revisionId).toBeUndefined();
     expect(second.dataset.reviewAuthor).toBeUndefined();
+  });
+
+  test('validates bilevel thresholds and paints a bounded alpha-preserving filter', () => {
+    for (const value of ['0', '25000', '50000', '100000']) {
+      const record = readyRecordFromXml(inlinePictureXml({ bilevel: value }));
+      expect(record.effects.bilevel).toBe(Number(value) / 100_000);
+      const painted = paintRecord(record, fakeUrlPort().port);
+      expect(painted.querySelector('filter')?.getAttribute('color-interpolation-filters')).toBe(
+        'sRGB'
+      );
+      expect(painted.querySelectorAll('feFuncA')).toHaveLength(0);
+      expect(painted.querySelectorAll('feComponentTransfer')).toHaveLength(1);
+      const table = painted
+        .querySelector('feFuncR')!
+        .getAttribute('tableValues')!
+        .split(' ')
+        .map(Number);
+      expect(table).toHaveLength(256);
+      expect(
+        table.every((v, index) => v === (index / 255 >= Number(value) / 100_000 ? 1 : 0))
+      ).toBe(true);
+    }
+    for (const value of ['', '-1', '100001', 'NaN', 'Infinity', '0.5', 'url(x)']) {
+      const record = readyRecordFromXml(inlinePictureXml({ bilevel: value }));
+      expect(record.effects.bilevel).toBeUndefined();
+      expect(paintRecord(record, fakeUrlPort().port).querySelector('filter')).toBeNull();
+    }
+  });
+
+  test('changing or removing bilevel invalidates a retained paint frame', () => {
+    const { port } = fakeUrlPort();
+    const registry = drawingUrlRegistryFor(document.createElement('div'), port);
+    const ctx = { scale: 1, strings: DEFAULT_DRAWING_PAINT_STRINGS, imageUrlPort: port };
+    const firstRecord = readyRecordFromXml(
+      inlinePictureXml({
+        bilevel: '50000',
+        grayscale: true,
+        lum: '<a:lum bright="-30000" contrast="66000"/>',
+      })
+    );
+    const first = paintDrawingRecord(document, firstRecord, ctx, registry)!;
+    const id = first.querySelector('filter')!.id;
+    expect(paintDrawingRecord(document, firstRecord, ctx, registry)).toBe(first);
+    expect(first.querySelector('filter')!.id).toBe(id);
+    const second = paintDrawingRecord(
+      document,
+      readyRecordFromXml(inlinePictureXml({ bilevel: '75000' })),
+      ctx,
+      registry
+    )!;
+    expect(second).toBe(first);
+    expect(second.querySelector('filter')!.id).not.toBe(id);
+    expect(
+      second
+        .querySelector('feFuncR')!
+        .getAttribute('tableValues')!
+        .split(' ')
+        .filter((v) => v === '1')
+    ).toHaveLength(64);
+    const third = paintDrawingRecord(
+      document,
+      readyRecordFromXml(inlinePictureXml()),
+      ctx,
+      registry
+    )!;
+    expect(third).toBe(first);
+    expect(third.querySelector('filter')).toBeNull();
+    expect(third.querySelector<HTMLElement>('.docx-drawing-image-frame')!.style.filter).toBe('');
+    registry.revokeAll();
   });
 });
 

--- a/packages/core/src/output/drawing-bilevel-filter.ts
+++ b/packages/core/src/output/drawing-bilevel-filter.ts
@@ -1,0 +1,38 @@
+let nextFilterId = 0;
+
+/** Apply the final black/white colour mode without changing source image bytes. */
+export function applyDrawingBilevelFilter(
+  document: Document,
+  outer: HTMLElement,
+  frame: HTMLElement,
+  threshold: number | undefined
+): void {
+  if (threshold === undefined || !Number.isFinite(threshold) || threshold < 0 || threshold > 1)
+    return;
+  const ns = 'http://www.w3.org/2000/svg';
+  const node = (name: string, attributes: Record<string, string>) => {
+    const element = document.createElementNS(ns, name);
+    for (const [key, value] of Object.entries(attributes)) element.setAttribute(key, value);
+    return element;
+  };
+  const id = `docx-bilevel-${++nextFilterId}`;
+  const svg = node('svg', { width: '0', height: '0', 'aria-hidden': 'true' });
+  svg.style.position = 'absolute';
+  svg.style.pointerEvents = 'none';
+  const filter = node('filter', { id, 'color-interpolation-filters': 'sRGB' });
+  filter.append(node('feColorMatrix', { type: 'saturate', values: '0' }));
+  const step = node('feComponentTransfer', {});
+  // One fixed-size lookup avoids rounding an intermediate threshold shift
+  // down by one channel value, especially at the inclusive 0 and 1 endpoints.
+  // Alpha is intentionally untouched.
+  const table = Array.from({ length: 256 }, (_, value) => (value / 255 >= threshold ? 1 : 0)).join(
+    ' '
+  );
+  for (const channel of ['R', 'G', 'B']) {
+    step.append(node(`feFunc${channel}`, { type: 'discrete', tableValues: table }));
+  }
+  filter.append(step);
+  svg.append(filter);
+  outer.append(svg);
+  frame.style.filter = `${frame.style.filter} url(#${id})`.trim();
+}

--- a/packages/core/src/output/semantic-paint-drawings.ts
+++ b/packages/core/src/output/semantic-paint-drawings.ts
@@ -9,6 +9,7 @@ import type {
   ValidatedImageBytesHandle,
 } from '../store/package/image-resources.ts';
 import type { AnchoredDrawingRecord, InlineDrawingRecord } from '../layout/drawing-layout.ts';
+import { applyDrawingBilevelFilter } from './drawing-bilevel-filter.ts';
 import type { DrawingPoint } from '../layout/drawing-geometry.ts';
 import { cssTransformForDrawingImage } from '../layout/drawing-geometry.ts';
 import type {
@@ -367,6 +368,7 @@ function readyImagePaintSignature(
     content.height,
     cssClipPathFromPolygon(drawing.geometry.clipPolygon ?? [], paint) ?? '',
     filterStyleOf(drawing) ?? '',
+    drawing.effects.bilevel ?? '',
     imagePaintTransformStyle(drawing) ?? '',
     crop.width,
     crop.height,
@@ -495,6 +497,7 @@ function paintReadyImage(
   transformStage.append(cropViewport);
   inner.append(transformStage);
   outer.replaceChildren(inner);
+  applyDrawingBilevelFilter(document, outer, inner, drawing.effects.bilevel);
 
   if (drawing.hyperlinkHref && !ctx.inertLinks) {
     outer.dataset.docxDrawingLink = drawing.drawingNodeId;

--- a/packages/core/src/store/package/drawing-image-effects.ts
+++ b/packages/core/src/store/package/drawing-image-effects.ts
@@ -1,0 +1,40 @@
+import { schemaAttributeValue } from './ooxml-drawing-rules.ts';
+import { DRAWINGML_MAIN_NAMESPACE_URI, type OoxmlElement } from './ooxml-tree.ts';
+
+function parseLumPercent(value: string | undefined): number | null {
+  if (value === undefined || !/^-?\d+$/.test(value)) return null;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed)) return null;
+  return parsed / 1000;
+}
+
+/** Bounded picture colour modes; projection never rewrites source media. */
+export function readBlipEffects(
+  blip: OoxmlElement
+): Readonly<{ grayscale: boolean; brightness: number; contrast: number; bilevel?: number }> {
+  let grayscale = false;
+  let brightness = 0;
+  let contrast = 0;
+  let bilevel: number | undefined;
+  for (const child of blip.children) {
+    if (child.kind !== 'generic' || child.namespaceUri !== DRAWINGML_MAIN_NAMESPACE_URI) continue;
+    if (child.localName === 'biLevel') {
+      const raw = schemaAttributeValue(child.attributes, 'thresh');
+      const value = raw !== undefined && /^\d+$/.test(raw) ? Number(raw) : NaN;
+      if (Number.isInteger(value) && value >= 0 && value <= 100_000) bilevel = value / 100_000;
+    } else if (child.localName === 'grayscl') {
+      grayscale = true;
+    } else if (child.localName === 'lum') {
+      const bright = parseLumPercent(schemaAttributeValue(child.attributes, 'bright'));
+      const contrastRaw = parseLumPercent(schemaAttributeValue(child.attributes, 'contrast'));
+      if (bright !== null) brightness = bright;
+      if (contrastRaw !== null) contrast = contrastRaw;
+    }
+  }
+  return Object.freeze({
+    grayscale,
+    brightness,
+    contrast,
+    ...(bilevel === undefined ? {} : { bilevel }),
+  });
+}

--- a/packages/core/src/store/package/drawing-projection.ts
+++ b/packages/core/src/store/package/drawing-projection.ts
@@ -4,6 +4,7 @@
 // projection-only — every authored branch stays in the tree on save.
 
 import { sanitizeHref } from './sinks.ts';
+import { readBlipEffects } from './drawing-image-effects.ts';
 import { HYPERLINK_RELATIONSHIP_TYPE, type RelationshipTargetResolver } from './hyperlink.ts';
 import { resolveRelationship } from './relationships.ts';
 import {
@@ -214,7 +215,12 @@ export interface DrawingProjection {
   readonly vectorShape: VectorShapeProjection | null;
   readonly textboxStory: TextboxStoryProjection | null;
   readonly locks: DrawingLocks;
-  readonly effects: Readonly<{ grayscale: boolean; brightness: number; contrast: number }>;
+  readonly effects: Readonly<{
+    grayscale: boolean;
+    brightness: number;
+    contrast: number;
+    bilevel?: number;
+  }>;
   readonly compatibilityBranchNodeId: string | null;
   readonly diagnostics: readonly DrawingDiagnostic[];
 }
@@ -1076,36 +1082,6 @@ function readDocPrMetadata(
   });
 }
 
-function parseLumPercent(value: string | undefined): number | null {
-  if (value === undefined || !/^-?\d+$/.test(value)) return null;
-  const parsed = Number(value);
-  if (!Number.isInteger(parsed)) return null;
-  return parsed / 1000;
-}
-
-function readBlipEffects(
-  blip: OoxmlElement
-): Readonly<{ grayscale: boolean; brightness: number; contrast: number }> {
-  let grayscale = false;
-  let brightness = 0;
-  let contrast = 0;
-  for (const child of blip.children) {
-    if (!isElement(child) || child.kind !== 'generic') continue;
-    if (child.namespaceUri !== DRAWINGML_MAIN_NAMESPACE_URI) continue;
-    if (child.localName === 'grayscl') {
-      grayscale = true;
-      continue;
-    }
-    if (child.localName === 'lum') {
-      const bright = parseLumPercent(schemaAttributeValue(child.attributes, 'bright'));
-      const contrastRaw = parseLumPercent(schemaAttributeValue(child.attributes, 'contrast'));
-      if (bright !== null) brightness = bright;
-      if (contrastRaw !== null) contrast = contrastRaw;
-    }
-  }
-  return Object.freeze({ grayscale, brightness, contrast });
-}
-
 function projectPicture(
   anchor: OoxmlElement,
   state: WalkState,
@@ -1115,7 +1091,12 @@ function projectPicture(
 ): {
   readonly picture: PictureProjection | null;
   readonly relationshipId: string | null;
-  readonly effects: Readonly<{ grayscale: boolean; brightness: number; contrast: number }>;
+  readonly effects: Readonly<{
+    grayscale: boolean;
+    brightness: number;
+    contrast: number;
+    bilevel?: number;
+  }>;
   readonly diagnostic: DrawingDiagnostic | null;
 } {
   if (!visitNode(state, ctx.limits)) {

--- a/scripts/lib/packages.mjs
+++ b/scripts/lib/packages.mjs
@@ -251,6 +251,7 @@ export const PACKAGES = [
           'DrawingClipFallback',
           'DrawingInsets',
           'DrawingPoint',
+          'DrawingProjection',
           'FontOrigin',
           'HeaderFooterParts',
           'HeaderFooterSectionResolution',


### PR DESCRIPTION
## Summary

Render the DrawingML `a:biLevel` black/white picture colour mode, which was previously ignored. A bounded integer threshold is projected through the image layout record, and a fixed-size sRGB SVG filter applies the final colour mode while leaving source image bytes and alpha untouched. Existing grayscale, brightness and contrast filters stay in place. Retained image paint keys include the threshold so changing/removing it updates the painted image.

The threshold endpoints are inclusive on the white side: zero produces white and one keeps only full-white luminance white. A 256-entry transfer table avoids the off-by-one endpoint rounding seen with an intermediate linear shift in Chromium. Invalid and foreign-namespace effects are ignored; no authored strings become SVG markup or external filter URLs.

This is a focused missing-effect fix, not a claim of complete Office picture-effect parity. In particular it does not change the existing brightness/contrast algorithm, implement arbitrary effect ordering, or fix unsupported connector shapes. A minor changeset and regenerated core layout API snapshot cover the additive optional effect field.

## Validation

- 5,342 core store/layout/binding/output tests pass (2,558 / 2,399 / 172 / 213), including threshold validation, fixed filter structure, alpha preservation and retained-paint updates.
- Core and DOM-free store/layout typechecks, scoped lint/format, line caps, ESM/CJS/declaration build and core API checks pass (15 entries, zero errors, 1,905 existing warnings).
- Separate synthetic Chromium pixel checks cover thresholds 0, 0.25, 0.5 and 1 for both the original-source implementation and our application backport, including values adjacent to the cutoff and partially transparent pixels; zero external requests or page errors.
- No private documents, photos or customer data are included. Full monorepo and full browser E2E suites were not run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/737"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791192540&installation_model_id=422592&pr_number=737&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F737&signature=595d52e80b8ac4bf5832de279b789e9672e3175243b2a865bff7ca9a4262988a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->