### PR TITLE
fix: preserve open DrawingML connectors and triangular line ends

### DIFF
--- a/.changeset/drawingml-open-connectors.md
+++ b/.changeset/drawingml-open-connectors.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': minor
+---
+
+Project flipped DrawingML vector paths and straight connectors, preserve open versus closed paths, and render bounded triangular line ends without changing canonical XML.

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -4236,6 +4236,10 @@ export function utf16OffsetToGrapheme(text: string, utf16Offset: number): number
 
 // @public (undocumented)
 export interface VectorShapeComponent {
+    readonly arrowheadsEmu?: readonly (readonly Readonly<{
+        x: number;
+        y: number;
+    }>[])[];
     // (undocumented)
     readonly fillAlpha: number;
     // (undocumented)
@@ -4246,6 +4250,7 @@ export interface VectorShapeComponent {
     readonly strokeHex: string | null;
     // (undocumented)
     readonly strokeWidthEmu: number;
+    readonly subpathsClosed?: readonly boolean[];
     // (undocumented)
     readonly subpathsEmu: readonly (readonly Readonly<{
         x: number;

--- a/packages/core/src/output/__tests__/drawing-connectors.test.ts
+++ b/packages/core/src/output/__tests__/drawing-connectors.test.ts
@@ -1,0 +1,136 @@
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+import { expect, test } from 'bun:test';
+import { readOoxmlPart, serializeOoxmlPart } from '../../store/package/ooxml-tree.ts';
+import { indexInlineDrawingProjectionsInPart } from '../../store/package/drawing-projection.ts';
+import { buildInlineDrawingRecord } from '../../layout/drawing-layout.ts';
+import { paintDrawingRecord, DEFAULT_DRAWING_PAINT_STRINGS } from '../semantic-paint-drawings.ts';
+
+function fixture(
+  options: {
+    flip?: string;
+    geom?: string;
+    ends?: string;
+    commands?: string;
+    closed?: boolean;
+    wrap?: boolean;
+  } = {}
+) {
+  const geometry = options.geom
+    ? `<a:prstGeom prst="${options.geom}"><a:avLst/></a:prstGeom>`
+    : `<a:custGeom><a:pathLst><a:path w="1000" h="1000"><a:moveTo><a:pt x="0" y="0"/></a:moveTo>${options.commands ?? '<a:lnTo><a:pt x="1000" y="1000"/></a:lnTo>'}${options.closed ? '<a:close/>' : ''}</a:path></a:pathLst></a:custGeom>`;
+  let drawing = `<w:drawing><wp:inline><wp:extent cx="1270000" cy="635000"/><wp:docPr id="1" name="Synthetic connector"/><a:graphic><a:graphicData uri="http://schemas.microsoft.com/office/word/2010/wordprocessingShape"><wps:wsp><wps:spPr><a:xfrm ${options.flip ?? ''}><a:off x="0" y="0"/><a:ext cx="1270000" cy="635000"/></a:xfrm>${geometry}<a:noFill/><a:ln w="12700"><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill>${options.ends ?? '<a:tailEnd type="triangle" w="sm" len="lg"/>'}</a:ln></wps:spPr></wps:wsp></a:graphicData></a:graphic></wp:inline></w:drawing>`;
+  if (options.wrap)
+    drawing = `<mc:AlternateContent><mc:Choice Requires="wps">${drawing}</mc:Choice><mc:Fallback><w:pict><v:shape id="unchanged-fallback"/></w:pict></mc:Fallback></mc:AlternateContent>`;
+  const xml = `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:v="urn:schemas-microsoft-com:vml"><w:body><w:p><w:r>${drawing}</w:r></w:p></w:body></w:document>`;
+  const parsed = readOoxmlPart(xml, {
+    name: '/word/document.xml',
+    contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml',
+  });
+  if (!parsed.ok) throw new Error(parsed.reason);
+  const before = serializeOoxmlPart(parsed.part);
+  const projections = [...indexInlineDrawingProjectionsInPart(parsed.part).values()];
+  expect(projections).toHaveLength(1);
+  expect(serializeOoxmlPart(parsed.part)).toBe(before);
+  return { projection: projections[0]!, part: parsed.part };
+}
+
+test('a flipped MC two-point connector and its triangle share projected coordinates', () => {
+  const { projection, part } = fixture({ flip: 'flipH="1"', wrap: true });
+  const component = projection.vectorShape!.components[0]!;
+  expect(component.subpathsEmu).toEqual([
+    [
+      { x: 1270000, y: 0 },
+      { x: 0, y: 635000 },
+    ],
+  ]);
+  expect(component.subpathsClosed).toEqual([false]);
+  expect(component.arrowheadsEmu).toHaveLength(1);
+  expect(component.arrowheadsEmu![0]![0]).toEqual({ x: 0, y: 635000 });
+  expect(component.arrowheadsEmu![0]![1]!.x).toBeGreaterThan(0);
+  expect(Object.isFrozen(component.subpathsClosed)).toBe(true);
+  expect(Object.isFrozen(component.arrowheadsEmu![0]![0])).toBe(true);
+  expect(serializeOoxmlPart(part)).toContain('unchanged-fallback');
+});
+
+test('straight connector presets stay open and double flips mirror both axes', () => {
+  for (const geom of ['line', 'straightConnector1']) {
+    const component = fixture({ geom, flip: 'flipH="true" flipV="1"', ends: '' }).projection
+      .vectorShape!.components[0]!;
+    expect(component.subpathsEmu).toEqual([
+      [
+        { x: 1270000, y: 635000 },
+        { x: 0, y: 0 },
+      ],
+    ]);
+    expect(component.subpathsClosed).toEqual([false]);
+    expect(component.arrowheadsEmu).toBeUndefined();
+  }
+});
+
+test('close commands keep closed shapes and do not add open-line decorations', () => {
+  const component = fixture({ closed: true }).projection.vectorShape!.components[0]!;
+  expect(component.subpathsClosed).toEqual([true]);
+  expect(component.arrowheadsEmu).toBeUndefined();
+});
+
+test('unsupported visible ends, invalid flips and unknown presets remain refused', () => {
+  for (const options of [
+    { flip: 'flipH="yes"' },
+    { geom: 'bentConnector3' },
+    { ends: '<a:tailEnd type="stealth"/>' },
+    { ends: '<a:tailEnd type="triangle" w="url(x)"/>' },
+  ]) {
+    expect(fixture(options).projection.vectorShape).toBeNull();
+  }
+});
+
+test('repeated terminal vertices use the last nonzero tangent and stay finite', () => {
+  const { projection } = fixture({
+    commands:
+      '<a:lnTo><a:pt x="1000" y="1000"/></a:lnTo><a:lnTo><a:pt x="1000" y="1000"/></a:lnTo>',
+    ends: '<a:headEnd type="triangle"/><a:tailEnd type="triangle"/>',
+  });
+  const arrows = projection.vectorShape!.components[0]!.arrowheadsEmu!;
+  expect(arrows).toHaveLength(2);
+  expect(arrows.flat().every((p) => Number.isFinite(p.x) && Number.isFinite(p.y))).toBe(true);
+});
+
+test('semantic painter leaves an open path open and fills its separate arrowhead', () => {
+  const { projection } = fixture({ flip: 'flipH="1"' });
+  const record = buildInlineDrawingRecord({
+    input: {
+      drawingNodeId: projection.drawingNodeId,
+      ownerPartName: projection.ownerPartName,
+      projection,
+      resource: { kind: 'missing', partName: null, reason: 'no-resource' },
+    },
+    paragraphId: 'p',
+    start: 0,
+    slotX: 0,
+    y: 0,
+    baseline: 50,
+    contentLeft: 0,
+    contentRight: 200,
+  });
+  const element = paintDrawingRecord(
+    document,
+    record,
+    { scale: 1, strings: DEFAULT_DRAWING_PAINT_STRINGS, imageUrlPort: null, inertLinks: true },
+    null
+  )!;
+  expect(element.querySelector('path')!.getAttribute('d')).toBe('M1270000 0L0 635000');
+  const arrow = element.querySelector('[data-docx-line-end]')!;
+  expect(arrow.getAttribute('fill')).toBe('#FF0000');
+  expect(element.querySelectorAll('path')).toHaveLength(2);
+  expect(element.querySelector('image')).toBeNull();
+});
+
+test('generated arrowhead vertices count against the existing per-drawing point budget', () => {
+  const commands = '<a:lnTo><a:pt x="1000" y="1000"/></a:lnTo>'.repeat(1020);
+  expect(fixture({ commands, ends: '' }).projection.vectorShape).not.toBeNull();
+  expect(
+    fixture({ commands, ends: '<a:headEnd type="triangle"/><a:tailEnd type="triangle"/>' })
+      .projection.vectorShape
+  ).toBeNull();
+});

--- a/packages/core/src/output/semantic-paint-drawings.ts
+++ b/packages/core/src/output/semantic-paint-drawings.ts
@@ -555,8 +555,8 @@ function paintVectorShape(
     const path = document.createElementNS(SVG_NAMESPACE, 'path');
     const d = component.subpathsEmu
       .map(
-        (points) =>
-          `M${points.map((point) => `${finiteStyle(point.x)} ${finiteStyle(point.y)}`).join('L')}Z`
+        (points, index) =>
+          `M${points.map((point) => `${finiteStyle(point.x)} ${finiteStyle(point.y)}`).join('L')}${component.subpathsClosed?.[index] === false ? '' : 'Z'}`
       )
       .join('');
     path.setAttribute('d', d);
@@ -574,6 +574,22 @@ function paintVectorShape(
       }
     }
     svg.append(path);
+    if (component.strokeHex !== null) {
+      for (const points of component.arrowheadsEmu ?? []) {
+        const arrow = document.createElementNS(SVG_NAMESPACE, 'path');
+        arrow.setAttribute(
+          'd',
+          `M${points.map((point) => `${finiteStyle(point.x)} ${finiteStyle(point.y)}`).join('L')}Z`
+        );
+        arrow.setAttribute('fill', `#${component.strokeHex}`);
+        arrow.setAttribute(
+          'fill-opacity',
+          finiteStyle(Math.max(0, Math.min(1, component.strokeAlpha)))
+        );
+        arrow.setAttribute('data-docx-line-end', 'triangle');
+        svg.append(arrow);
+      }
+    }
   }
   frame.append(svg);
   outer.append(frame);

--- a/packages/core/src/store/__tests__/drawing-fixture-oracles.ts
+++ b/packages/core/src/store/__tests__/drawing-fixture-oracles.ts
@@ -309,7 +309,7 @@ export const FIXTURE_ORACLES: Readonly<Record<string, FixtureLayoutPaintOracle>>
     // textboxes (PAGE / NUMPAGES with stale cached results). Per-page field projection is
     // asserted in layout/__tests__/textbox-story-layout.test.ts; this oracle pins the
     // package-wide projection census and body-only paint.
-    drawingCount: 14,
+    drawingCount: 15,
     pageCount: 62,
     readyCount: 2,
     placeholderCount: 0,
@@ -322,7 +322,17 @@ export const FIXTURE_ORACLES: Readonly<Record<string, FixtureLayoutPaintOracle>>
         '/word/footer4.xml',
       ]);
       expect(projections.filter((p) => p.picture !== null)).toHaveLength(2);
-      expect(projections.filter((p) => p.vectorShape !== null)).toHaveLength(9);
+      expect(projections.filter((p) => p.vectorShape !== null)).toHaveLength(10);
+      // The authored Group 7 consists of three open two-point rules, now supported.
+      const rules = projections.find(
+        (p) => p.drawingNodeId === '/word/document.xml#0.0.33.1.1.0.0'
+      )!.vectorShape!;
+      expect(rules.components.map((component) => component.subpathsClosed)).toEqual([
+        [false],
+        [false],
+        [false],
+      ]);
+      expect(rules.subpathsEmu.map((points) => points.length)).toEqual([2, 2, 2]);
     },
   },
 };

--- a/packages/core/src/store/__tests__/drawing-vector-shape.test.ts
+++ b/packages/core/src/store/__tests__/drawing-vector-shape.test.ts
@@ -484,14 +484,13 @@ describe('wps vector shape projection', () => {
     }
   });
 
-  // `flipH`/`flipV` are `xsd:boolean`. The engine cannot paint a flip, so a set flag refuses
-  // the shape — and a spelling the schema does not allow must refuse too, not fall through
-  // to "unset" and paint the shape the wrong way round.
+  // `flipH`/`flipV` are `xsd:boolean`. Shapes now honor legal flips, while group-level
+  // transforms remain narrower. Invalid spellings refuse instead of painting unflipped.
   //
   // Four call sites read a flip: `flipH` and `flipV` on a shape's own `a:xfrm`, and the same
   // pair on a group's `wpg:grpSpPr/a:xfrm`. The group pair is the lane this file exists for,
   // so every spelling runs against all four.
-  test('an unset flip paints and any other spelling refuses, at all four sites', () => {
+  test('legal shape flips paint; group flips and schema-invalid spellings still refuse', () => {
     const spellings = [
       // Legal `xsd:boolean` false, including the forms the fixed `whiteSpace="collapse"`
       // facet makes valid. The XML reader does not trim, so the helper has to.
@@ -500,7 +499,7 @@ describe('wps vector shape projection', () => {
       ['false', true],
       [' 0 ', true],
       ['\nfalse\n', true],
-      // Legal true — the engine cannot paint a flip, so it refuses.
+      // Legal true — supported for shapes, but still refused at group level below.
       ['1', false],
       ['true', false],
       [' 1 ', false],
@@ -552,7 +551,11 @@ describe('wps vector shape projection', () => {
           }).values(),
         ][0]?.vectorShape;
         const label = `${site.name}=${JSON.stringify(value)}`;
-        expect(`${label}: ${shape !== null && shape !== undefined}`).toBe(`${label}: ${paints}`);
+        const supportedShapeFlip =
+          site.name.startsWith('shape ') && ['1', 'true'].includes(value?.trim() ?? '');
+        expect(`${label}: ${shape !== null && shape !== undefined}`).toBe(
+          `${label}: ${paints || supportedShapeFlip}`
+        );
       }
     }
   });
@@ -778,7 +781,7 @@ describe('wps vector shape projection', () => {
           resolveSchemeColor: () => '4472C4',
         }).values(),
       ][0]!.vectorShape
-    ).toBeNull();
+    ).not.toBeNull();
 
     const withMetadata = parsePart(
       `<w:p><w:r>${drawing.replace('<wpg:wgp>', '<wpg:wgp><wpg:cNvPr id="1"/>')}</w:r></w:p>`

--- a/packages/core/src/store/package/drawing-line-arrowheads.ts
+++ b/packages/core/src/store/package/drawing-line-arrowheads.ts
@@ -1,0 +1,59 @@
+import { schemaAttributeValue } from './ooxml-drawing-rules.ts';
+import { DRAWINGML_MAIN_NAMESPACE_URI, type OoxmlElement } from './ooxml-tree.ts';
+
+type Point = Readonly<{ x: number; y: number }>;
+type End = { width: number; length: number };
+
+/** Bounded solid triangular line ends. Unknown visible decorations refuse the shape. */
+export function projectLineArrowheads(
+  paths: readonly (readonly Point[])[],
+  closed: readonly boolean[],
+  line: OoxmlElement | null,
+  strokeWidth: number
+): readonly (readonly Point[])[] | null {
+  const ends: { head?: End; tail?: End } = {};
+  const size = (value: string | undefined) =>
+    value === 'sm' ? 2 : value === 'lg' ? 5 : value === 'med' || value === undefined ? 3 : null;
+  for (const child of line?.children ?? []) {
+    if (
+      child.kind !== 'generic' ||
+      child.namespaceUri !== DRAWINGML_MAIN_NAMESPACE_URI ||
+      (child.localName !== 'headEnd' && child.localName !== 'tailEnd')
+    )
+      continue;
+    const type = schemaAttributeValue(child.attributes, 'type') ?? 'none';
+    if (type === 'none') continue;
+    if (type !== 'triangle') return null;
+    const width = size(schemaAttributeValue(child.attributes, 'w'));
+    const length = size(schemaAttributeValue(child.attributes, 'len'));
+    if (width === null || length === null) return null;
+    ends[child.localName === 'headEnd' ? 'head' : 'tail'] = { width, length };
+  }
+  const arrows: Point[][] = [];
+  if (!(strokeWidth > 0)) return arrows;
+  for (const [index, points] of paths.entries()) {
+    if (closed[index] || points.length < 2) continue;
+    for (const side of ['head', 'tail'] as const) {
+      const end = ends[side];
+      if (!end) continue;
+      const ordered = side === 'head' ? points : [...points].reverse();
+      const tip = ordered[0]!;
+      const next = ordered.find((point) => point.x !== tip.x || point.y !== tip.y);
+      if (!next) continue;
+      const distance = Math.hypot(tip.x - next.x, tip.y - next.y);
+      const ux = (tip.x - next.x) / distance;
+      const uy = (tip.y - next.y) / distance;
+      const length = end.length * strokeWidth;
+      const half = (end.width * strokeWidth) / 2;
+      const arrow = [
+        tip,
+        { x: tip.x - ux * length - uy * half, y: tip.y - uy * length + ux * half },
+        { x: tip.x - ux * length + uy * half, y: tip.y - uy * length - ux * half },
+      ];
+      if (!arrow.every((point) => Number.isFinite(point.x) && Number.isFinite(point.y)))
+        return null;
+      arrows.push(arrow);
+    }
+  }
+  return arrows;
+}

--- a/packages/core/src/store/package/drawing-projection.ts
+++ b/packages/core/src/store/package/drawing-projection.ts
@@ -4,6 +4,7 @@
 // projection-only — every authored branch stays in the tree on save.
 
 import { sanitizeHref } from './sinks.ts';
+import { freezeVectorShapeComponent } from './drawing-vector-freeze.ts';
 import { HYPERLINK_RELATIONSHIP_TYPE, type RelationshipTargetResolver } from './hyperlink.ts';
 import { resolveRelationship } from './relationships.ts';
 import {
@@ -1290,16 +1291,7 @@ function freezeDrawingProjection(projection: DrawingProjection): DrawingProjecti
           // `components` is required and non-empty: paint iterates it, so a conditional
           // spread that ever took the empty branch would strip the field and throw.
           components: Object.freeze(
-            projection.vectorShape.components.map((component) =>
-              Object.freeze({
-                ...component,
-                subpathsEmu: Object.freeze(
-                  component.subpathsEmu.map((points) =>
-                    Object.freeze(points.map((point) => Object.freeze({ ...point })))
-                  )
-                ),
-              })
-            )
+            projection.vectorShape.components.map(freezeVectorShapeComponent)
           ),
         })
       : null,

--- a/packages/core/src/store/package/drawing-shape-projection.ts
+++ b/packages/core/src/store/package/drawing-shape-projection.ts
@@ -5,6 +5,8 @@
 import { findDirectKind, isElement } from './drawing-projection-walk.ts';
 import { schemaAttributeValue } from './ooxml-drawing-rules.ts';
 import { WML_NAMESPACE_URI } from './ooxml-shared.ts';
+import { projectLineArrowheads } from './drawing-line-arrowheads.ts';
+import { readShapePathPolygons } from './drawing-vector-paths.ts';
 import { DRAWINGML_MAIN_NAMESPACE_URI, type OoxmlElement, type OoxmlNode } from './ooxml-tree.ts';
 
 const WPS_NAMESPACE_URI = 'http://schemas.microsoft.com/office/word/2010/wordprocessingShape';
@@ -12,11 +14,9 @@ const WPG_NAMESPACE_URI = 'http://schemas.microsoft.com/office/word/2010/wordpro
 const WPS_GRAPHIC_DATA_URI = 'http://schemas.microsoft.com/office/word/2010/wordprocessingShape';
 const WPG_GRAPHIC_DATA_URI = 'http://schemas.microsoft.com/office/word/2010/wordprocessingGroup';
 const SHAPE_HEX_RE = /^[0-9A-Fa-f]{6}$/;
-const MAX_VECTOR_SHAPE_SUBPATHS = 64;
 const MAX_VECTOR_SHAPE_POINTS = 1024;
 const MAX_GROUP_SHAPE_CHILDREN = 128;
 const ELLIPSE_POINTS = 32;
-const CUBIC_BEZIER_SEGMENTS = 8;
 
 export type ShapeSchemeColorResolver = (scheme: string) => string | null;
 export type ShapeStyleMatrixResolver = (
@@ -59,7 +59,7 @@ function schemaFlagIsUnset(value: string | undefined): boolean {
  * The complement of {@link schemaFlagIsUnset}: an `xsd:boolean` that legally reads true.
  *
  * A value is neither set nor unset when it is schema-invalid, and the two callers want
- * opposite things there. A flag the engine cannot HONOUR (a flipped vector shape) refuses
+ * opposite things there. A flag the engine cannot HONOUR (a flipped vector group) refuses
  * through `schemaFlagIsUnset`, because painting it unflipped would be a wrong render. A flag
  * the engine can honour (a flipped picture) reads through here and treats anything invalid
  * as unset, because refusing would drop the picture entirely — a worse outcome than a
@@ -157,6 +157,10 @@ export interface VectorShapeProjection {
 
 export interface VectorShapeComponent {
   readonly subpathsEmu: readonly (readonly Readonly<{ x: number; y: number }>[])[];
+  /** Authored close commands; omitted by older consumers means closed polygons. */
+  readonly subpathsClosed?: readonly boolean[];
+  /** Filled line-end polygons in the same projected coordinate space. */
+  readonly arrowheadsEmu?: readonly (readonly Readonly<{ x: number; y: number }>[])[];
   readonly fillHex: string | null;
   readonly fillAlpha: number;
   readonly strokeHex: string | null;
@@ -478,86 +482,6 @@ function readStyleReference(
   };
 }
 
-/** Polygon subpaths of one `a:path` — move/line/close verbs only; anything else refuses. */
-function readShapePathPolygons(
-  path: OoxmlElement,
-  scaleX: number,
-  scaleY: number,
-  sink: { x: number; y: number }[][],
-  pointBudget: { remaining: number }
-): boolean {
-  let current: { x: number; y: number }[] | null = null;
-  for (const verb of path.children) {
-    if (!isElement(verb)) continue;
-    if (verb.namespaceUri !== DRAWINGML_MAIN_NAMESPACE_URI) return false;
-    if (verb.localName === 'close') {
-      current = null;
-      continue;
-    }
-    if (verb.localName === 'cubicBezTo') {
-      if (current === null || pointBudget.remaining < CUBIC_BEZIER_SEGMENTS) return false;
-      const controls = verb.children.filter(isElement);
-      if (
-        controls.length !== 3 ||
-        controls.some(
-          (point) => point.namespaceUri !== DRAWINGML_MAIN_NAMESPACE_URI || point.localName !== 'pt'
-        )
-      ) {
-        return false;
-      }
-      const parsed = controls.map((point) => {
-        const x = parseEmu(schemaAttributeValue(point.attributes, 'x'), false);
-        const y = parseEmu(schemaAttributeValue(point.attributes, 'y'), false);
-        return x === null || y === null ? null : { x: x * scaleX, y: y * scaleY };
-      });
-      if (parsed.some((point) => point === null)) return false;
-      const start = current[current.length - 1]!;
-      const control1 = parsed[0]!;
-      const control2 = parsed[1]!;
-      const end = parsed[2]!;
-      for (let index = 1; index <= CUBIC_BEZIER_SEGMENTS; index += 1) {
-        const t = index / CUBIC_BEZIER_SEGMENTS;
-        const inverse = 1 - t;
-        current.push({
-          x:
-            inverse ** 3 * start.x +
-            3 * inverse ** 2 * t * control1.x +
-            3 * inverse * t ** 2 * control2.x +
-            t ** 3 * end.x,
-          y:
-            inverse ** 3 * start.y +
-            3 * inverse ** 2 * t * control1.y +
-            3 * inverse * t ** 2 * control2.y +
-            t ** 3 * end.y,
-        });
-      }
-      pointBudget.remaining -= CUBIC_BEZIER_SEGMENTS;
-      continue;
-    }
-    if (verb.localName !== 'moveTo' && verb.localName !== 'lnTo') return false;
-    const pt = findDirectChild(verb.children, {
-      namespaceUri: DRAWINGML_MAIN_NAMESPACE_URI,
-      localName: 'pt',
-    });
-    if (!pt) return false;
-    const x = parseEmu(schemaAttributeValue(pt.attributes, 'x'), false);
-    const y = parseEmu(schemaAttributeValue(pt.attributes, 'y'), false);
-    if (x === null || y === null) return false;
-    const scaled = { x: x * scaleX, y: y * scaleY };
-    if (!Number.isFinite(scaled.x) || !Number.isFinite(scaled.y)) return false;
-    if (pointBudget.remaining <= 0) return false;
-    pointBudget.remaining -= 1;
-    if (verb.localName === 'moveTo' || current === null) {
-      if (sink.length >= MAX_VECTOR_SHAPE_SUBPATHS) return false;
-      current = [scaled];
-      sink.push(current);
-    } else {
-      current.push(scaled);
-    }
-  }
-  return true;
-}
-
 function findGraphicData(anchor: OoxmlElement): OoxmlElement | null {
   // Non-picture graphic payloads demote to generic nodes even under a typed
   // `drawingGraphic`, so the generic lookup is always in play here.
@@ -611,8 +535,10 @@ function projectWspComponent(
   });
   if (xfrm) {
     if (!schemaAngleIsZero(schemaAttributeValue(xfrm.attributes, 'rot'))) return null;
-    if (!schemaFlagIsUnset(schemaAttributeValue(xfrm.attributes, 'flipH'))) return null;
-    if (!schemaFlagIsUnset(schemaAttributeValue(xfrm.attributes, 'flipV'))) return null;
+    for (const name of ['flipH', 'flipV']) {
+      const value = schemaAttributeValue(xfrm.attributes, name);
+      if (!schemaFlagIsUnset(value) && !schemaFlagIsSet(value)) return null;
+    }
   }
 
   const authoredFill = directFill(spPr, resolveSchemeColor);
@@ -640,6 +566,7 @@ function projectWspComponent(
   if (fill === null && stroke === null) return null;
 
   const subpaths: { x: number; y: number }[][] = [];
+  const closed: boolean[] = [];
   const custGeom = findDirectChild(spPr.children, {
     namespaceUri: DRAWINGML_MAIN_NAMESPACE_URI,
     localName: 'custGeom',
@@ -659,7 +586,14 @@ function projectWspComponent(
       const pathH = parseEmu(schemaAttributeValue(child.attributes, 'h')) ?? extent.cy;
       if (pathW <= 0 || pathH <= 0) return null;
       if (
-        !readShapePathPolygons(child, extent.cx / pathW, extent.cy / pathH, subpaths, pointBudget)
+        !readShapePathPolygons(
+          child,
+          extent.cx / pathW,
+          extent.cy / pathH,
+          subpaths,
+          pointBudget,
+          closed
+        )
       ) {
         return null;
       }
@@ -670,7 +604,15 @@ function projectWspComponent(
       localName: 'prstGeom',
     });
     const preset = prstGeom ? schemaAttributeValue(prstGeom.attributes, 'prst') : undefined;
-    if (preset === 'rect') {
+    if (preset === 'line' || preset === 'straightConnector1') {
+      if (pointBudget.remaining < 2) return null;
+      subpaths.push([
+        { x: 0, y: 0 },
+        { x: extent.cx, y: extent.cy },
+      ]);
+      closed.push(false);
+      pointBudget.remaining -= 2;
+    } else if (preset === 'rect') {
       if (pointBudget.remaining < 4) return null;
       subpaths.push([
         { x: 0, y: 0 },
@@ -679,6 +621,7 @@ function projectWspComponent(
         { x: 0, y: extent.cy },
       ]);
       pointBudget.remaining -= 4;
+      closed.push(true);
     } else if (preset === 'ellipse' && pointBudget.remaining >= ELLIPSE_POINTS) {
       const ellipse: { x: number; y: number }[] = [];
       for (let index = 0; index < ELLIPSE_POINTS; index += 1) {
@@ -690,14 +633,31 @@ function projectWspComponent(
       }
       pointBudget.remaining -= ELLIPSE_POINTS;
       subpaths.push(ellipse);
+      closed.push(true);
     } else {
       return null;
     }
   }
-  const polygons = subpaths.filter((points) => points.length >= 3);
+  const polygons = subpaths.filter(
+    (points) => points.length >= 3 || (points.length === 2 && stroke !== null)
+  );
   if (polygons.length === 0) return null;
+  const subpathsClosed = subpaths.flatMap((points, index) =>
+    polygons.includes(points) ? [closed[index]!] : []
+  );
+  const arrowheads = projectLineArrowheads(polygons, subpathsClosed, ln, strokeWidthEmu);
+  if (arrowheads === null || arrowheads.length * 3 > pointBudget.remaining) return null;
+  pointBudget.remaining -= arrowheads.length * 3;
+  const flipH = xfrm !== null && schemaFlagIsSet(schemaAttributeValue(xfrm.attributes, 'flipH'));
+  const flipV = xfrm !== null && schemaFlagIsSet(schemaAttributeValue(xfrm.attributes, 'flipV'));
+  const flip = (point: Readonly<{ x: number; y: number }>) => ({
+    x: flipH ? extent.cx - point.x : point.x,
+    y: flipV ? extent.cy - point.y : point.y,
+  });
   return {
-    subpathsEmu: polygons,
+    subpathsEmu: polygons.map((points) => points.map(flip)),
+    subpathsClosed,
+    ...(arrowheads.length ? { arrowheadsEmu: arrowheads.map((points) => points.map(flip)) } : {}),
     fillHex: fill?.hex ?? null,
     fillAlpha: fill?.alpha ?? 1,
     strokeHex: stroke?.hex ?? null,
@@ -721,6 +681,16 @@ function transformComponent(
       }))
     ),
     strokeWidthEmu: component.strokeWidthEmu * ((Math.abs(scaleX) + Math.abs(scaleY)) / 2),
+    ...(component.arrowheadsEmu
+      ? {
+          arrowheadsEmu: component.arrowheadsEmu.map((path) =>
+            path.map((point) => ({
+              x: offset.x + point.x * scaleX,
+              y: offset.y + point.y * scaleY,
+            }))
+          ),
+        }
+      : {}),
   };
 }
 

--- a/packages/core/src/store/package/drawing-vector-freeze.ts
+++ b/packages/core/src/store/package/drawing-vector-freeze.ts
@@ -1,0 +1,17 @@
+import type { VectorShapeComponent } from './drawing-shape-projection.ts';
+
+const freezePaths = (paths: VectorShapeComponent['subpathsEmu']) =>
+  Object.freeze(
+    paths.map((points) => Object.freeze(points.map((point) => Object.freeze({ ...point }))))
+  );
+
+export function freezeVectorShapeComponent(component: VectorShapeComponent): VectorShapeComponent {
+  return Object.freeze({
+    ...component,
+    subpathsEmu: freezePaths(component.subpathsEmu),
+    ...(component.subpathsClosed
+      ? { subpathsClosed: Object.freeze([...component.subpathsClosed]) }
+      : {}),
+    ...(component.arrowheadsEmu ? { arrowheadsEmu: freezePaths(component.arrowheadsEmu) } : {}),
+  });
+}

--- a/packages/core/src/store/package/drawing-vector-paths.ts
+++ b/packages/core/src/store/package/drawing-vector-paths.ts
@@ -1,0 +1,93 @@
+import { isElement } from './drawing-projection-walk.ts';
+import { schemaAttributeValue } from './ooxml-drawing-rules.ts';
+import { DRAWINGML_MAIN_NAMESPACE_URI, type OoxmlElement } from './ooxml-tree.ts';
+
+const MAX_VECTOR_SHAPE_SUBPATHS = 64;
+const CUBIC_BEZIER_SEGMENTS = 8;
+const readCoordinate = (value: string | undefined): number | null =>
+  value !== undefined && /^-?\d{1,15}$/.test(value) ? Number(value) : null;
+
+/** Polygon subpaths of one `a:path` — move/line/close verbs only; anything else refuses. */
+export function readShapePathPolygons(
+  path: OoxmlElement,
+  scaleX: number,
+  scaleY: number,
+  sink: { x: number; y: number }[][],
+  pointBudget: { remaining: number },
+  closed: boolean[]
+): boolean {
+  let current: { x: number; y: number }[] | null = null;
+  for (const verb of path.children) {
+    if (!isElement(verb)) continue;
+    if (verb.namespaceUri !== DRAWINGML_MAIN_NAMESPACE_URI) return false;
+    if (verb.localName === 'close') {
+      if (current !== null) closed[sink.length - 1] = true;
+      current = null;
+      continue;
+    }
+    if (verb.localName === 'cubicBezTo') {
+      if (current === null || pointBudget.remaining < CUBIC_BEZIER_SEGMENTS) return false;
+      const controls = verb.children.filter(isElement);
+      if (
+        controls.length !== 3 ||
+        controls.some(
+          (point) => point.namespaceUri !== DRAWINGML_MAIN_NAMESPACE_URI || point.localName !== 'pt'
+        )
+      ) {
+        return false;
+      }
+      const parsed = controls.map((point) => {
+        const x = readCoordinate(schemaAttributeValue(point.attributes, 'x'));
+        const y = readCoordinate(schemaAttributeValue(point.attributes, 'y'));
+        return x === null || y === null ? null : { x: x * scaleX, y: y * scaleY };
+      });
+      if (parsed.some((point) => point === null)) return false;
+      const start = current[current.length - 1]!;
+      const control1 = parsed[0]!;
+      const control2 = parsed[1]!;
+      const end = parsed[2]!;
+      for (let index = 1; index <= CUBIC_BEZIER_SEGMENTS; index += 1) {
+        const t = index / CUBIC_BEZIER_SEGMENTS;
+        const inverse = 1 - t;
+        current.push({
+          x:
+            inverse ** 3 * start.x +
+            3 * inverse ** 2 * t * control1.x +
+            3 * inverse * t ** 2 * control2.x +
+            t ** 3 * end.x,
+          y:
+            inverse ** 3 * start.y +
+            3 * inverse ** 2 * t * control1.y +
+            3 * inverse * t ** 2 * control2.y +
+            t ** 3 * end.y,
+        });
+      }
+      pointBudget.remaining -= CUBIC_BEZIER_SEGMENTS;
+      continue;
+    }
+    if (verb.localName !== 'moveTo' && verb.localName !== 'lnTo') return false;
+    const pt = verb.children.find(
+      (node) =>
+        node.kind === 'generic' &&
+        node.namespaceUri === DRAWINGML_MAIN_NAMESPACE_URI &&
+        node.localName === 'pt'
+    );
+    if (!pt || !isElement(pt)) return false;
+    const x = readCoordinate(schemaAttributeValue(pt.attributes, 'x'));
+    const y = readCoordinate(schemaAttributeValue(pt.attributes, 'y'));
+    if (x === null || y === null) return false;
+    const scaled = { x: x * scaleX, y: y * scaleY };
+    if (!Number.isFinite(scaled.x) || !Number.isFinite(scaled.y)) return false;
+    if (pointBudget.remaining <= 0) return false;
+    pointBudget.remaining -= 1;
+    if (verb.localName === 'moveTo' || current === null) {
+      if (sink.length >= MAX_VECTOR_SHAPE_SUBPATHS) return false;
+      current = [scaled];
+      sink.push(current);
+      closed.push(false);
+    } else {
+      current.push(scaled);
+    }
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary

Render a bounded subset of DrawingML connectors that previously disappeared: open two-point custom paths, `line` / `straightConnector1` presets, legal shape-level horizontal/vertical flips, and solid triangular line ends. Authored `close` commands remain distinct from open polylines, so the painter no longer invents a closing diagonal.

Arrowhead geometry is calculated in the projection coordinate space, transformed with grouped components, and deeply frozen with the rest of the drawing. Generated vertices count against the existing per-drawing point budget. The painter consumes validated paths and colors; canonical XML and unselected MC fallback branches stay unchanged.

This remains deliberately bounded: group-level flips, rotations, other connector presets and other visible line-end styles are not implemented. Unknown decorations remain refused instead of being silently painted as plain lines. The optional path-closure and arrowhead fields are covered by a minor changeset and a regenerated API snapshot.

## Validation

- Seven new synthetic regression tests cover flips, MC selection/preservation, open/closed paths, triangle geometry, repeated endpoints, retained canonical XML, immutability, point budgets and semantic SVG paint.
- Existing sanitized `footer-textbox-page-fields.docx` now correctly projects one additional group containing three two-point rules. Its oracle was updated from 14 to 15 drawings, with specific assertions for those three open paths; the fixture bytes, page count and other objects are unchanged.
- All 5,347 core store/layout/binding/output tests pass (2,558 / 2,399 / 172 / 218). Core and DOM-free store/layout typechecks, scoped lint/format, line caps, ESM/CJS/declaration build and core API checks pass (15 entries, zero errors, 1,905 existing warnings).
- Synthetic Chromium pixel checks exercise canonical projection, layout and semantic painting, and compare our application backport: both produce matching red line/arrow pixels, no invented diagonal, no external requests or page errors, and unchanged canonical XML.
- No private reports, annotations, photos or customer text are included. Full monorepo and full browser E2E suites were not run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/738"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791194292&installation_model_id=422592&pr_number=738&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F738&signature=bb5c08120eaa99dfa4547605c696c6aab31a40fc200520dff594bdb29237f6fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->