### PR TITLE
fix: honor East Asian font hints for Latin-1 symbols

### DIFF
--- a/.changeset/east-asia-symbol-font-hints.md
+++ b/.changeset/east-asia-symbol-font-hints.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Honor explicit East Asian font hints for Latin-1 symbols, including middle dots, degree signs, multiplication and division signs. Keep ASCII text, model offsets and canonical run formatting unchanged.

--- a/packages/core/src/layout/__tests__/east-asia-symbol-hint.test.ts
+++ b/packages/core/src/layout/__tests__/east-asia-symbol-hint.test.ts
@@ -1,0 +1,101 @@
+import { expect, test } from 'bun:test';
+import { hasEastAsiaSymbolHint, isEastAsiaHintSymbol } from '../east-asia-symbol-hint.ts';
+import { applyEastAsiaFontSlots, type FieldAwarePiece } from '../field-pieces.ts';
+import { resolveRunStyle } from '../run-style.ts';
+import type { OoxmlProperty } from '@docx-editor.dev/core/store';
+
+const fonts: OoxmlProperty = {
+  localName: 'rFonts',
+  attributes: { ascii: 'Times New Roman', eastAsia: 'SimSun', hint: 'eastAsia' },
+};
+function piece(text: string, props: OoxmlProperty[] = [fonts], projected = false): FieldAwarePiece {
+  return {
+    text,
+    props,
+    style: resolveRunStyle(props),
+    start: 0,
+    end: projected ? 1 : text.length,
+    ...(projected ? { projected: true } : {}),
+  };
+}
+test('the Latin-1 hint table accepts exactly the unconditional symbols, not accented letters', () => {
+  const expected = [
+    0xa1, 0xa4, 0xa7, 0xa8, 0xaa, 0xad, 0xaf, 0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb6, 0xb7, 0xb8, 0xb9,
+    0xba, 0xbc, 0xbd, 0xbe, 0xbf, 0xd7, 0xf7,
+  ];
+  for (let code = 0; code <= 0x2ff; code++)
+    expect(isEastAsiaHintSymbol(code)).toBe(expected.includes(code));
+});
+test('hinted middle dots keep their East Asian face without changing ASCII or offsets', () => {
+  const input = piece('·   · 1×2÷3 20°C'),
+    before = JSON.stringify(input);
+  const out = applyEastAsiaFontSlots([input]);
+  expect(out.map((p) => p.text).join('')).toBe(input.text);
+  let offset = 0;
+  for (const item of out) {
+    expect(item.start).toBe(offset);
+    offset = item.end;
+    expect(item.style).toBe(input.style);
+    expect(item.props).toBe(input.props);
+    for (const char of item.text)
+      expect(item.fontSlot === 'eastAsia').toBe(isEastAsiaHintSymbol(char.codePointAt(0)!));
+  }
+  expect(offset).toBe(input.text.length);
+  expect(JSON.stringify(input)).toBe(before);
+});
+test('hint inheritance follows last specified value, not last rFonts element', () => {
+  expect(
+    hasEastAsiaSymbolHint([fonts, { localName: 'rFonts', attributes: { ascii: 'Arial' } }])
+  ).toBe(true);
+  expect(
+    hasEastAsiaSymbolHint([fonts, { localName: 'rFonts', attributes: { hint: 'default' } }])
+  ).toBe(false);
+  expect(
+    hasEastAsiaSymbolHint([{ localName: 'rFonts', attributes: { hint: 'default' } }, fonts])
+  ).toBe(true);
+  expect(hasEastAsiaSymbolHint([{ ...fonts, attributes: { hint: 'EastAsia' } }])).toBe(false);
+});
+test('unhinted Latin symbols and explicitly complex-script runs gain no new slot', () => {
+  for (const props of [
+    [{ ...fonts, attributes: { ascii: 'Arial', eastAsia: 'SimSun' } }],
+    [fonts, { localName: 'rtl' }],
+    [fonts, { localName: 'cs', attributes: { val: '1' } }],
+  ]) {
+    const input = piece('·×÷', props);
+    expect(applyEastAsiaFontSlots([input])).toEqual([input]);
+  }
+  expect(
+    hasEastAsiaSymbolHint([
+      fonts,
+      { localName: 'cs' },
+      { localName: 'cs', attributes: { val: '0' } },
+    ])
+  ).toBe(true);
+});
+test('projected results retain one model atom; only uniform-symbol projections take the slot', () => {
+  const symbol = piece('··', [fonts], true),
+    mixed = piece('1·', [fonts], true);
+  const out = applyEastAsiaFontSlots([symbol, mixed]);
+  expect(out).toHaveLength(2);
+  expect(out[0]!.fontSlot).toBe('eastAsia');
+  expect(out[0]!.end).toBe(1);
+  expect(out[1]).toBe(mixed);
+});
+test('a hint without a distinct East Asian face leaves the original piece untouched', () => {
+  const input = piece('·', [
+    { localName: 'rFonts', attributes: { ascii: 'Arial', hint: 'eastAsia' } },
+  ]);
+  expect(applyEastAsiaFontSlots([input])[0]).toBe(input);
+  const fallback = piece('·', [
+    {
+      localName: 'rFonts',
+      attributes: {
+        ascii: 'Arial',
+        hAnsi: 'Arial',
+        eastAsia: 'Times New Roman',
+        hint: 'eastAsia',
+      },
+    },
+  ]);
+  expect(applyEastAsiaFontSlots([fallback])[0]).toBe(fallback);
+});

--- a/packages/core/src/layout/east-asia-symbol-hint.ts
+++ b/packages/core/src/layout/east-asia-symbol-hint.ts
@@ -1,0 +1,38 @@
+import type { OoxmlProperty } from '@docx-editor.dev/core/store';
+
+/** Last specified hint wins across the already-cascaded run properties. */
+export function hasEastAsiaSymbolHint(properties: readonly OoxmlProperty[]): boolean {
+  let hint: string | undefined;
+  let cs = false;
+  let rtl = false;
+  for (const property of properties) {
+    if (property.localName === 'rFonts' && property.attributes?.hint !== undefined) {
+      hint = property.attributes.hint;
+    } else if (property.localName === 'cs' || property.localName === 'rtl') {
+      const enabled = !['0', 'false', 'off'].includes(property.attributes?.val ?? '1');
+      if (property.localName === 'cs') cs = enabled;
+      else rtl = enabled;
+    }
+  }
+  return hint === 'eastAsia' && !cs && !rtl;
+}
+
+/**
+ * MS-OI29500 2.1.88: the unconditional Latin-1 symbol exceptions for hint=eastAsia.
+ * ASCII and language/charset-dependent accented letters are deliberately excluded.
+ */
+export function isEastAsiaHintSymbol(codePoint: number): boolean {
+  return (
+    codePoint === 0xa1 ||
+    codePoint === 0xa4 ||
+    (codePoint >= 0xa7 && codePoint <= 0xa8) ||
+    codePoint === 0xaa ||
+    codePoint === 0xad ||
+    codePoint === 0xaf ||
+    (codePoint >= 0xb0 && codePoint <= 0xb4) ||
+    (codePoint >= 0xb6 && codePoint <= 0xba) ||
+    (codePoint >= 0xbc && codePoint <= 0xbf) ||
+    codePoint === 0xd7 ||
+    codePoint === 0xf7
+  );
+}

--- a/packages/core/src/layout/field-pieces.ts
+++ b/packages/core/src/layout/field-pieces.ts
@@ -13,6 +13,7 @@ import type { HardBreakKind } from '@docx-editor.dev/core/store';
 import type { LegacyFormFieldData } from '../store/package/field-nodes.ts';
 import type { InlineDrawingLayoutInput } from './drawing-layout.ts';
 import { eastAsiaRunsOfSegments, type FontSlot } from './script-itemization.ts';
+import { hasEastAsiaSymbolHint } from './east-asia-symbol-hint.ts';
 import type { ButtonFieldSpec } from './field-button.ts';
 import type { DocPropertyField } from './field-doc-property.ts';
 import type { FormFieldKind } from './field-form.ts';
@@ -440,6 +441,7 @@ export function applyEastAsiaFontSlots(pieces: FieldAwarePiece[]): FieldAwarePie
   /** Indices of the pieces whose text joins the classification, in paragraph order. */
   const streamed: number[] = [];
   const segments: string[] = [];
+  const hintedSegments: boolean[] = [];
   for (let index = 0; index < pieces.length; index += 1) {
     const piece = pieces[index]!;
     if (piece.positionalTab || piece.breakKind || piece.inlineDrawing) continue;
@@ -447,8 +449,13 @@ export function applyEastAsiaFontSlots(pieces: FieldAwarePiece[]): FieldAwarePie
     if (piece.text.length === 0) continue;
     streamed.push(index);
     segments.push(piece.text);
+    // Leave the special Times New Roman East Asian fallback to existing resolution.
+    hintedSegments.push(
+      piece.style.fontFamilyEastAsia?.toLowerCase() !== 'times new roman' &&
+        hasEastAsiaSymbolHint(piece.props)
+    );
   }
-  const ranges = eastAsiaRunsOfSegments(segments);
+  const ranges = eastAsiaRunsOfSegments(segments, hintedSegments);
   if (ranges.length === 0) return pieces;
 
   const rangesBySegment = new Map<number, { from: number; to: number }[]>();

--- a/packages/core/src/layout/script-itemization.ts
+++ b/packages/core/src/layout/script-itemization.ts
@@ -1,6 +1,7 @@
 import type { BidiEmbeddingLevels } from './bidi.ts';
 import type { TextDirection } from './shaped-run.ts';
 import { withFontFamily, type ResolvedRunStyle } from './run-style.ts';
+import { isEastAsiaHintSymbol } from './east-asia-symbol-hint.ts';
 
 /**
  * Which `w:rFonts` slot a character resolves its face through.
@@ -314,7 +315,10 @@ const pureAscii = (text: string): boolean => {
  * whose docDefaults author an East Asian face pay two compares per character, not a
  * classifier call.
  */
-export function eastAsiaRunsOfSegments(segments: readonly string[]): readonly SegmentSlotRange[] {
+export function eastAsiaRunsOfSegments(
+  segments: readonly string[],
+  hintedSegments: readonly boolean[] = []
+): readonly SegmentSlotRange[] {
   const out: SegmentSlotRange[] = [];
   const addEastAsia = (segment: number, from: number, to: number): void => {
     const previous = out.at(-1);
@@ -350,7 +354,10 @@ export function eastAsiaRunsOfSegments(segments: readonly string[]): readonly Se
     for (let from = 0; from < text.length; ) {
       const codePoint = text.codePointAt(from)!;
       const to = from + (codePoint > 0xffff ? 2 : 1);
-      const slotClass = slotClassOf(codePoint);
+      const slotClass =
+        hintedSegments[segment] && isEastAsiaHintSymbol(codePoint)
+          ? 'eastAsia'
+          : slotClassOf(codePoint);
       if (slotClass === 'common') {
         if (precedingStrong === null) {
           pending.push({ segment, from, to, ascii: codePoint <= 0x7f });

--- a/packages/core/src/output/__tests__/semantic-paint-font-hints.test.ts
+++ b/packages/core/src/output/__tests__/semantic-paint-font-hints.test.ts
@@ -1,0 +1,32 @@
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+import { expect, test } from 'bun:test';
+import { readOoxmlPart, serializeOoxmlPart } from '@docx-editor.dev/core/store';
+import { createFixedMeasurer, layoutSemanticDocument } from '@docx-editor.dev/core/layout';
+import { paintSemanticLayout } from '../semantic-paint.ts';
+
+test('East Asian hinted symbols reach the semantic painter without restyling adjacent ASCII', () => {
+  const source =
+    '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:rPr><w:rFonts w:ascii="Times New Roman" w:eastAsia="SimSun" w:hint="eastAsia"/></w:rPr><w:t>· 1 ·</w:t></w:r></w:p></w:body></w:document>';
+  const parsed = readOoxmlPart(source, { name: '/word/document.xml', contentType: 'app/xml' });
+  if (!parsed.ok) throw new Error(parsed.reason);
+  const before = serializeOoxmlPart(parsed.part);
+  const layout = layoutSemanticDocument(parsed.part, 1, { measurer: createFixedMeasurer(6, 14) });
+  const container = document.createElement('div');
+  paintSemanticLayout(container, layout, { scale: 1 });
+  const text = Array.from(container.querySelectorAll<HTMLElement>('.layout-run-text'));
+  expect(text.map((node) => node.textContent).join('')).toBe('· 1 ·');
+  const family = (node: HTMLElement) =>
+    node.style.fontFamily || node.parentElement!.style.fontFamily;
+  expect(
+    text
+      .filter((node) => node.textContent?.includes('·'))
+      .every((node) => family(node).includes('SimSun'))
+  ).toBe(true);
+  expect(
+    text
+      .filter((node) => node.textContent?.includes('1'))
+      .every((node) => family(node).includes('Times New Roman'))
+  ).toBe(true);
+  expect(serializeOoxmlPart(parsed.part)).toBe(before);
+});


### PR DESCRIPTION
## Problem

Runs containing only ambiguous Latin-1 symbols ignored `w:rFonts w:hint="eastAsia"`. A middle-dot footer decoration, degree sign, or multiplication/division sign therefore used the Latin face even when the run explicitly requested a distinct East Asian font. This changes glyph shape and measured width.

## Changes

- Carry the effective per-run hint into the existing paragraph-wide font-slot pass; the last specified hint wins across cascaded properties.
- Recognize only the unconditional Latin-1 symbol exceptions documented in [MS-OI29500 section 2.1.88](https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oi29500/aef3c9a6-5d6c-434b-90b7-85e761fd8e62).
- Keep ASCII, language-dependent accented letters, explicit complex-script runs, and the special Times New Roman fallback on their existing paths. This does not implement the entire Word font-selection table.
- Preserve canonical run properties, style-object identity, text and offsets. Projected field results stay atomic; mixed projected text is not split.

## Validation

- 7 new synthetic regressions: exact symbol table, inherited/overridden hints, ASCII and model offsets, complex-script controls, projected atoms, fallback fonts, and actual semantic DOM paint.
- Full core store/layout/binding/output tests: 2,558 + 2,405 + 172 + 212 = 5,347 passing.
- Core and DOM-free layout typechecks, scoped ESLint/Prettier, file-size caps, ESM/CJS/DTS core build, and 15 API snapshots pass.
- Chromium 152 rendered the native semantic painter's synthetic output with SimSun for the hinted symbols and Times New Roman for adjacent ASCII; no external requests or page errors, unchanged canonical XML.

Private report comparisons motivated the fix but no private reports, images, fonts, or other customer data are included. Full monorepo and upstream browser E2E suites were not run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/739"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791197119&installation_model_id=422592&pr_number=739&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F739&signature=d6d0b975bd001b973edc2295c1659bdd2fd412962516577002de21ce651ad6d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->