### PR TITLE
fix: keep wrapping space runs at the line end

### DIFF
--- a/.changeset/hang-wrapped-space-runs.md
+++ b/.changeset/hang-wrapped-space-runs.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Keep overflowing whitespace-only runs at the end of their current line instead of indenting the next line, preserving their canonical text and caret ranges.

--- a/packages/core/src/layout/__tests__/wrapped-space-run.test.ts
+++ b/packages/core/src/layout/__tests__/wrapped-space-run.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, serializeOoxmlPart } from '@docx-editor.dev/core/store';
+import { createFixedMeasurer, layoutSemanticDocument, linesOf } from '../index.ts';
+import { spanOffsetX } from '../semantic-hit-test.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const run = (text: string, bold = false) =>
+  `<w:r><w:rPr><w:sz w:val="22"/>${bold ? '<w:b/>' : ''}</w:rPr><w:t xml:space="preserve">${text}</w:t></w:r>`;
+const measurer = createFixedMeasurer(10, 12);
+function layout(body: string, width = 25) {
+  const parsed = readOoxmlPart(
+    `<w:document xmlns:w="${W}"><w:body><w:p>${body}</w:p></w:body></w:document>`,
+    { name: '/word/document.xml', contentType: 'app/xml' }
+  );
+  if (!parsed.ok) throw new Error(parsed.reason);
+  const original = serializeOoxmlPart(parsed.part);
+  const result = layoutSemanticDocument(parsed.part, 1, {
+    measurer,
+    geometry: { width, height: 300, margin: { top: 0, right: 0, bottom: 0, left: 0 } },
+  });
+  expect(serializeOoxmlPart(parsed.part)).toBe(original);
+  return linesOf(result);
+}
+const texts = (lines: ReturnType<typeof layout>) =>
+  lines.map((line) => line.spans.map((span) => span.text).join(''));
+
+describe('separate whitespace runs at a soft-wrap margin', () => {
+  test('retains the separator on its old line without indenting the next word', () => {
+    const lines = layout(run('AB') + run(' ', true) + run('CD'));
+    expect(texts(lines)).toEqual(['AB ', 'CD']);
+    const space = lines[0]!.spans.at(-1)!;
+    expect(space.range).toMatchObject({ start: 2, end: 3 });
+    expect(space.box.width).toBe(5);
+    expect(spanOffsetX(space, 3, measurer)).toBe(25);
+    expect(lines[1]!.spans[0]!.box.x).toBe(0);
+  });
+  test('keeps long and producer-split space runs in the same line', () => {
+    const spaces = run('  ', true) + run('  ');
+    expect(texts(layout(run('AB') + spaces + run('CD', true)))).toEqual(['AB    ', 'CD']);
+  });
+  test('ordinary spaces that fit retain their measured advance', () => {
+    const lines = layout(run('A') + run(' ', true) + run('B'), 40);
+    expect(texts(lines)).toEqual(['A B']);
+    expect(lines[0]!.spans[1]!.box.width).toBe(10);
+  });
+  test('does not drop an authored paragraph indent made from spaces', () => {
+    const lines = layout(run(' ', true) + run('A'));
+    expect(texts(lines)).toEqual([' A']);
+    expect(lines[0]!.spans.at(-1)!.box.x).toBe(10);
+  });
+  test('does not collapse leading spaces after a hard break', () => {
+    const lines = layout(run('AB') + '<w:r><w:br/></w:r>' + run(' ', true) + run('C'));
+    expect(texts(lines)).toEqual(['AB\n', ' C']);
+    expect(lines[1]!.spans.at(-1)!.box.x).toBe(10);
+  });
+  test('keeps nonbreaking spaces non-collapsible', () => {
+    const lines = layout(run('AB') + run('\u00a0', true) + run('C'));
+    expect(
+      lines.flatMap((line) => line.spans).find((span) => span.text === '\u00a0')!.box.width
+    ).toBe(10);
+  });
+});

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -1,9 +1,4 @@
-// Paragraph measuring and breaking, shared between the body flow and table cells.
-//
-// Extracted from `semantic-layout.ts` unchanged so a cell paragraph breaks exactly like a
-// body paragraph: same pieces, same word boundaries, same cache discipline. The BREAK is
-// position-independent — span x offsets are relative to the paragraph origin — which is
-// what lets one cached break serve the same content at any x (body or any cell).
+// Shared body/cell line breaking. Paragraph-relative spans keep cached breaks position-independent.
 
 import {
   PAGE_BREAK_CHAR,
@@ -1550,9 +1545,13 @@ export function breakParagraph(
         wordStartEnd = line.end;
       }
       advancePastAnchorExclusionForPlacement(piece.start + consumed);
-      // Trailing fill spaces occupy the remaining band but never open continuation lines.
+      // Hang overflowing space runs on this line, preserving text/ranges and authored leading spaces.
       const lineEndWhitespace =
-        isCollapsibleLineEndWhitespace(candidate) && placeableSuffixes[pieceIndex]![boundary] !== 1;
+        isCollapsibleLineEndWhitespace(candidate) &&
+        (placeableSuffixes[pieceIndex]![boundary] !== 1 ||
+          (!layoutOwned &&
+            line.spans.length > 0 &&
+            line.width + width > lineAvailable() + OVERFLOW_TOLERANCE_PT));
       if (lineEndWhitespace) {
         width = Math.min(width, Math.max(0, lineAvailable() - line.width));
       }


### PR DESCRIPTION
## Problem

A whitespace-only run that no longer fits at a line end is currently moved onto the next line, even when it is just the separator before the next word. Its advance then indents that word and can create an additional line or page. Producer-split runs make this visible in both body paragraphs and narrow table cells.

## Changes

- Keep overflowing literal space-only runs on the current line and cap their advance at the remaining line width.
- Reuse the existing line-end-whitespace representation so paint and caret positions agree with the clipped advance.
- Preserve canonical text, run properties, UTF-16 ranges and authored leading spaces. Nonbreaking spaces and projected field atoms do not enter this new path.
- Add six synthetic regression tests, including multiple runs, fitting spaces, paragraph-leading and hard-break-leading spaces, nonbreaking spaces, canonical serialization and caret positions.

This follows the default trailing-space behavior described by [ISO/IEC 29500's wrapTrailSpaces documentation](https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.wordprocessing.wraptrailspaces?view=openxml-3.0.1). This bounded fix does not add a document-level compatibility-settings reader or implement the explicit legacy wrapTrailSpaces override, which is not currently wired into paragraph flow.

## Validation

- Full layout suite: 2,405 passing; full output suite: 211 passing.
- Core and DOM-free layout TypeScript checks, scoped ESLint/Prettier, file-size caps, ESM/CJS/DTS core build and 15 core API entry-point checks pass.
- The application backport passes 161 local DOCX regressions. A private WPS comparison that motivated the fix now has 33 rather than 34 editor pages, matching its 33-page reference; the displaced paragraph returns to the correct page. Editing, save/reopen, undo, text coverage and overflow checks pass. Other visual differences remain, so this is not a claim of whole-document fidelity.

Only synthetic tests are included. No private reports, PDFs, photographs or customer data are uploaded. Full monorepo and upstream browser E2E suites were not run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791199111&installation_model_id=422592&pr_number=740&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F740&signature=8705f74b6008c06bc966e5bfe92845afcfdbe44a57ba8bde8a84726e44d836d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->