### PR TITLE
fix: render solid Word 2010 text outlines

### DIFF
--- a/.changeset/solid-text-outline.md
+++ b/.changeset/solid-text-outline.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Read opaque solid Word 2010 run text outlines through the style cascade and paint their width and colour without changing font weight, text advances, model ranges or saved XML. Gradient/theme/alpha, dashed/compound/inset outlines are not supported; glyph joins use the browser's native text-stroke rasterization.

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -2796,6 +2796,10 @@ export interface ResolvedRunStyle {
     readonly smallCaps: boolean;
     // (undocumented)
     readonly strike: boolean;
+    readonly textOutline?: {
+        readonly color: string;
+        readonly widthPt: number;
+    };
     // (undocumented)
     readonly underline: ResolvedUnderline | null;
     // (undocumented)

--- a/packages/core/src/layout/__tests__/run-text-outline.test.ts
+++ b/packages/core/src/layout/__tests__/run-text-outline.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, serializeOoxmlPart } from '@docx-editor.dev/core/store';
+import { propertiesOfRunContainer } from '../field-run-text.ts';
+import { resolveRunStyle, runStylesEqual } from '../run-style.ts';
+import { buildStyleCascadeTable } from '../style-cascade.ts';
+import { createFixedMeasurer, layoutSemanticDocument } from '../semantic-layout.ts';
+import { linesOf } from '../semantic-records.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const W14 = 'http://schemas.microsoft.com/office/word/2010/wordml';
+const namespaces = `xmlns:w="${W}" xmlns:w14="${W14}"`;
+const outline = (color = '123abc', width = '3556', extra = '') =>
+  `<w14:textOutline w14:w="${width}" w14:cap="flat" w14:cmpd="sng">` +
+  `<w14:solidFill><w14:srgbClr w14:val="${color}"/></w14:solidFill>${extra}</w14:textOutline>`;
+function part(xml: string, name = '/word/document.xml') {
+  const read = readOoxmlPart(xml, { name, contentType: 'app/xml' });
+  if (!read.ok) throw new Error(read.reason);
+  return read.part;
+}
+const props = (xml: string) =>
+  propertiesOfRunContainer(part(`<w:rPr ${namespaces}>${xml}</w:rPr>`).root);
+
+describe('solid Word 2010 text outlines', () => {
+  test('projects EMU width and an opaque RGB outline, without making text bold', () => {
+    const resolved = resolveRunStyle(
+      props(outline('123abc', '3556', '<w14:prstDash w14:val="solid"/><w14:miter w14:lim="1"/>'))
+    );
+    expect(resolved.textOutline).toEqual({ widthPt: 0.28, color: '123ABC' });
+    expect(resolved.bold).toBe(false);
+    expect(resolved.color).toBeNull();
+    expect(Object.isFrozen(resolved.textOutline)).toBe(true);
+  });
+  test('a direct noFill, empty, or zero-width outline clears an inherited outline', () => {
+    for (const reset of [
+      '<w14:textOutline><w14:noFill/></w14:textOutline>',
+      '<w14:textOutline/>',
+      outline('000000', '0'),
+    ]) {
+      expect(resolveRunStyle([...props(outline()), ...props(reset)]).textOutline).toBeUndefined();
+    }
+  });
+  test('does not conflate outline and normal run colour', () => {
+    const resolved = resolveRunStyle(props('<w:color w:val="CC0000"/>' + outline('00AA00')));
+    expect(resolved.color).toBe('CC0000');
+    expect(resolved.textOutline?.color).toBe('00AA00');
+  });
+  test('refuses unsupported or hostile variants without retaining an inherited outline', () => {
+    const unsupported = [
+      outline('red'),
+      outline('url(x)'),
+      outline('000000', '-1'),
+      outline('000000', '20116801'),
+      outline().replace('w14:cmpd="sng"', 'w14:cmpd="dbl"'),
+      outline().replace('w14:cap="flat"', 'w14:algn="in"'),
+      outline('000000', '12700', '<w14:prstDash w14:val="dash"/>'),
+      outline().replace(
+        '/></w14:solidFill>',
+        '><w14:alpha w14:val="50000"/></w14:srgbClr></w14:solidFill>'
+      ),
+      outline().replace('srgbClr', 'schemeClr'),
+      outline('000000', '12700', '<w14:gradFill/>'),
+      outline('000000', '12700', '<w14:miter w14:lim="oops"/>'),
+    ];
+    for (const xml of unsupported)
+      expect(resolveRunStyle([...props(outline()), ...props(xml)]).textOutline).toBeUndefined();
+  });
+  test('checks namespaces but does not require a specific prefix', () => {
+    const renamed = outline().replaceAll('w14:', 'x:');
+    const root = part(`<w:rPr xmlns:w="${W}" xmlns:x="${W14}">${renamed}</w:rPr>`).root;
+    expect(resolveRunStyle(propertiesOfRunContainer(root)).textOutline?.widthPt).toBe(0.28);
+    const foreign = part(`<w:rPr xmlns:w="${W}" xmlns:w14="urn:foreign">${outline()}</w:rPr>`).root;
+    expect(propertiesOfRunContainer(foreign)).toEqual([]);
+    expect(
+      resolveRunStyle(
+        props(outline().replace('<w14:srgbClr', '<w14:srgbClr xmlns:w14="urn:foreign"'))
+      ).textOutline
+    ).toBeUndefined();
+  });
+  test('style equality includes colour and width, but compares values not object identity', () => {
+    const a = resolveRunStyle(props(outline()));
+    expect(runStylesEqual(a, resolveRunStyle(props(outline())))).toBe(true);
+    expect(runStylesEqual(a, resolveRunStyle(props(outline('000000'))))).toBe(false);
+    expect(runStylesEqual(a, resolveRunStyle(props(outline('123abc', '12700'))))).toBe(false);
+    expect(runStylesEqual(a, resolveRunStyle([]))).toBe(false);
+  });
+  test('character-style inheritance and its fingerprint retain nested outline colours', () => {
+    const table = (color: string) =>
+      buildStyleCascadeTable(
+        part(
+          `<w:styles ${namespaces}><w:style w:type="character" w:styleId="Outline"><w:rPr>${outline(color)}</w:rPr></w:style></w:styles>`,
+          '/word/styles.xml'
+        ).root
+      );
+    expect(table('000000').cacheToken).not.toBe(table('000001').cacheToken);
+    const doc = part(
+      `<w:document ${namespaces}><w:body><w:p><w:r><w:rPr><w:rStyle w:val="Outline"/></w:rPr><w:t>Header</w:t></w:r></w:p></w:body></w:document>`
+    );
+    const result = layoutSemanticDocument(doc, 1, {
+      measurer: createFixedMeasurer(6, 14),
+      styleCascade: table('000000'),
+    });
+    expect(linesOf(result)[0]!.spans[0]!.style.textOutline?.color).toBe('000000');
+  });
+  test('outline ink never changes wrapping, boxes, model ranges, or saved source XML', () => {
+    const layout = (effect: string) => {
+      const doc = part(
+        `<w:document ${namespaces}><w:body><w:p><w:r><w:rPr><w:sz w:val="22"/>${effect}</w:rPr><w:t>AB CD EF</w:t></w:r></w:p></w:body></w:document>`
+      );
+      const before = serializeOoxmlPart(doc);
+      const result = layoutSemanticDocument(doc, 1, {
+        measurer: createFixedMeasurer(6, 14),
+        geometry: { width: 30, height: 100, margin: { left: 0, right: 0, top: 0, bottom: 0 } },
+      });
+      expect(serializeOoxmlPart(doc)).toBe(before);
+      return linesOf(result).map((line) => ({
+        box: line.box,
+        range: line.range,
+        spans: line.spans.map((span) => ({ text: span.text, box: span.box, range: span.range })),
+      }));
+    };
+    expect(layout(outline())).toEqual(layout(''));
+  });
+});

--- a/packages/core/src/layout/field-run-text.ts
+++ b/packages/core/src/layout/field-run-text.ts
@@ -6,6 +6,7 @@
 // by construction.
 
 import { hardBreakText, type OoxmlNode, type OoxmlProperty } from '@docx-editor.dev/core/store';
+import { runTextOutlineProperty } from './run-text-outline.ts';
 
 /** Optional per-run merge of inherited + direct `rPr` (character styles, defaults). */
 export type RunPropertyCascader = (
@@ -33,6 +34,11 @@ export function propertiesOfRunContainer(container: OoxmlNode | undefined): Ooxm
   const props: OoxmlProperty[] = [];
   for (const child of container.children) {
     if (child.kind === 'textValue') continue;
+    if (child.localName === 'textOutline') {
+      const outline = runTextOutlineProperty(child);
+      if (outline) props.push(outline);
+      continue;
+    }
     const attributes: Record<string, string> = {};
     for (const entry of child.attributes) attributes[entry.localName] = entry.value;
     const hasAttributes = Object.keys(attributes).length > 0;

--- a/packages/core/src/layout/run-style.ts
+++ b/packages/core/src/layout/run-style.ts
@@ -13,6 +13,7 @@
 import type { OoxmlProperty } from '@docx-editor.dev/core/store';
 import { themeFontFamilyOf } from '../store/package/theme-font-scheme.ts';
 import { resolveOoxmlShadingFill } from './ooxml-shading.ts';
+import { resolveTextOutline } from './run-text-outline.ts';
 // One reading of `CT_OnOff` for the whole lane. The style cascade combines toggle levels with
 // it and this resolver reads the combined result with it, so the two cannot drift apart.
 import { styleToggleIsOn as toggle } from './style-toggles.ts';
@@ -51,6 +52,8 @@ export interface ResolvedRunStyle {
   /** RRGGBB, or null for the inherited/automatic colour. */
   readonly color: string | null;
   readonly bold: boolean;
+  /** Opaque solid `w14:textOutline`, in points; paint only, never a font-weight change. */
+  readonly textOutline?: { readonly widthPt: number; readonly color: string };
   readonly italic: boolean;
   readonly underline: ResolvedUnderline | null;
   readonly strike: boolean;
@@ -213,6 +216,9 @@ export function resolveRunStyle(
       case 'b':
         style.bold = toggle(property);
         break;
+      case 'textOutline':
+        style.textOutline = resolveTextOutline(property);
+        break;
       case 'i':
         style.italic = toggle(property);
         break;
@@ -345,6 +351,8 @@ export function runStylesEqual(a: ResolvedRunStyle, b: ResolvedRunStyle): boolea
     a.fontFamilyEastAsia === b.fontFamilyEastAsia &&
     a.fontSizePt === b.fontSizePt &&
     a.color === b.color &&
+    a.textOutline?.widthPt === b.textOutline?.widthPt &&
+    a.textOutline?.color === b.textOutline?.color &&
     a.bold === b.bold &&
     a.italic === b.italic &&
     a.strike === b.strike &&

--- a/packages/core/src/layout/run-text-outline.ts
+++ b/packages/core/src/layout/run-text-outline.ts
@@ -1,0 +1,98 @@
+import type { OoxmlElement, OoxmlProperty } from '@docx-editor.dev/core/store';
+
+const W14 = 'http://schemas.microsoft.com/office/word/2010/wordml';
+const HEX = /^[0-9a-f]{6}$/i;
+
+/** Read-only projection of the opaque, solid, single, centred outline subset. */
+export function runTextOutlineProperty(node: OoxmlElement): OoxmlProperty | null {
+  if (node.namespaceUri !== W14 || node.localName !== 'textOutline') return null;
+  const off: OoxmlProperty = { localName: 'textOutline' };
+  const attrs: Record<string, string> = {};
+  for (const attr of node.attributes) {
+    if (attr.namespaceUri !== W14 || !['w', 'cap', 'cmpd', 'algn'].includes(attr.localName)) {
+      return off;
+    }
+    attrs[attr.localName] = attr.value;
+  }
+  if (
+    (attrs.cmpd !== undefined && attrs.cmpd !== 'sng') ||
+    (attrs.algn !== undefined && attrs.algn !== 'ctr') ||
+    (attrs.cap !== undefined && !['flat', 'rnd', 'sq'].includes(attrs.cap)) ||
+    !/^\d{1,8}$/.test(attrs.w ?? '') ||
+    Number(attrs.w) > 20116800
+  )
+    return off;
+  let color: string | undefined;
+  let fill = false;
+  let dash = false;
+  let join = false;
+  if (node.children.length > 7) return off;
+  for (const child of node.children) {
+    if (child.kind === 'textValue') {
+      if (child.value.trim()) return off;
+      continue;
+    }
+    if (child.namespaceUri !== W14) return off;
+    if (child.localName === 'solidFill' && !fill && child.attributes.length === 0) {
+      fill = true;
+      if (
+        child.children.length > 3 ||
+        child.children.some((entry) => entry.kind === 'textValue' && entry.value.trim())
+      )
+        return off;
+      const colors = child.children.filter((entry) => entry.kind !== 'textValue');
+      if (colors.length !== 1) return off;
+      const rgb = colors[0]!;
+      if (rgb.namespaceUri !== W14 || rgb.localName !== 'srgbClr' || rgb.children.length !== 0)
+        return off;
+      if (rgb.attributes.length !== 1) return off;
+      const value = rgb.attributes[0]!;
+      if (value.namespaceUri !== W14 || value.localName !== 'val' || !HEX.test(value.value))
+        return off;
+      color = value.value.toUpperCase();
+    } else if (child.localName === 'prstDash' && !dash) {
+      dash = true;
+      const value = child.attributes[0];
+      if (
+        child.children.length ||
+        child.attributes.length !== 1 ||
+        value?.namespaceUri !== W14 ||
+        value.localName !== 'val' ||
+        value.value !== 'solid'
+      )
+        return off;
+    } else if (['round', 'bevel', 'miter'].includes(child.localName) && !join) {
+      // CSS text stroke uses the browser's glyph-join rasterization. Keep the canonical
+      // authored join untouched; this projection does not claim custom join parity.
+      join = true;
+      if (child.children.length) return off;
+      if (child.localName === 'miter') {
+        if (child.attributes.length > 1) return off;
+        const limit = child.attributes[0];
+        if (
+          limit &&
+          (limit.namespaceUri !== W14 ||
+            limit.localName !== 'lim' ||
+            !/^\d{1,8}$/.test(limit.value))
+        )
+          return off;
+      } else if (child.attributes.length) return off;
+    } else return off;
+  }
+  return color && Number(attrs.w) > 0
+    ? { localName: 'textOutline', attributes: { w: attrs.w!, outlineColor: color } }
+    : off;
+}
+
+/** Resolve only the validated projection; no XML markup enters the output lane. */
+export function resolveTextOutline(
+  property: OoxmlProperty
+): { readonly widthPt: number; readonly color: string } | undefined {
+  const raw = property.attributes?.w;
+  const color = property.attributes?.outlineColor;
+  if (!raw || !/^\d{1,8}$/.test(raw) || !color || !HEX.test(color)) return undefined;
+  const width = Number(raw);
+  return width > 0 && width <= 20116800
+    ? Object.freeze({ widthPt: width / 12700, color: color.toUpperCase() })
+    : undefined;
+}

--- a/packages/core/src/output/__tests__/text-outline.test.ts
+++ b/packages/core/src/output/__tests__/text-outline.test.ts
@@ -1,0 +1,60 @@
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, serializeOoxmlPart } from '@docx-editor.dev/core/store';
+import { createFixedMeasurer, layoutSemanticDocument } from '../../layout/semantic-layout.ts';
+import { DEFAULT_RUN_STYLE } from '../../layout/run-style.ts';
+import { paintSemanticLayout } from '../semantic-paint.ts';
+import { applyTextOutline } from '../semantic-paint-text-outline.ts';
+
+describe('text outline paint', () => {
+  test('paints a glyph stroke at zoom scale, retaining one selectable text node and fill', () => {
+    const read = readOoxmlPart(
+      '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"><w:body><w:p><w:r><w:rPr><w:color w:val="CC0000"/><w14:textOutline w14:w="12700"><w14:solidFill><w14:srgbClr w14:val="00AA00"/></w14:solidFill></w14:textOutline></w:rPr><w:t>Sample</w:t></w:r></w:p></w:body></w:document>',
+      { name: '/word/document.xml', contentType: 'app/xml' }
+    );
+    if (!read.ok) throw new Error(read.reason);
+    const before = serializeOoxmlPart(read.part);
+    const layout = layoutSemanticDocument(read.part, 1, { measurer: createFixedMeasurer(6, 14) });
+    const container = document.createElement('div');
+    paintSemanticLayout(container, layout, { scale: 2 });
+    const span = container.querySelector<HTMLElement>('.layout-run-text')!;
+    expect(span.style.getPropertyValue('-webkit-text-stroke-width')).toBe('2px');
+    expect(span.style.getPropertyValue('-webkit-text-stroke-color')).toBe('#00AA00');
+    expect(span.style.color).toBe('#CC0000');
+    expect(span.style.fontWeight).toBe('');
+    expect(span.childNodes).toHaveLength(1);
+    expect(span.firstChild?.nodeType).toBe(3);
+    expect(span.textContent).toBe('Sample');
+    expect(span.dataset.start).toBe('0');
+    expect(span.dataset.end).toBe('6');
+    expect(serializeOoxmlPart(read.part)).toBe(before);
+  });
+  test('the paint sink independently refuses invalid values', () => {
+    for (const outline of [
+      { widthPt: NaN, color: '000000' },
+      { widthPt: Infinity, color: '000000' },
+      { widthPt: -1, color: '000000' },
+      { widthPt: 1585, color: '000000' },
+      { widthPt: 1, color: 'url(https://bad.invalid)' },
+    ]) {
+      const css = document.createElement('span').style;
+      applyTextOutline(css, { ...DEFAULT_RUN_STYLE, textOutline: outline }, 1);
+      expect(css.cssText).toBe('');
+    }
+    for (const scale of [0, -1, Infinity, NaN]) {
+      const css = document.createElement('span').style;
+      applyTextOutline(
+        css,
+        { ...DEFAULT_RUN_STYLE, textOutline: { widthPt: 1, color: '000000' } },
+        scale
+      );
+      expect(css.cssText).toBe('');
+    }
+  });
+  test('ordinary run styles do not acquire a stroke', () => {
+    const css = document.createElement('span').style;
+    applyTextOutline(css, DEFAULT_RUN_STYLE, 1);
+    expect(css.cssText).toBe('');
+  });
+});

--- a/packages/core/src/output/semantic-paint-text-outline.ts
+++ b/packages/core/src/output/semantic-paint-text-outline.ts
@@ -1,0 +1,24 @@
+import type { ResolvedRunStyle } from '../layout/run-style.ts';
+
+/** CSS glyph stroke keeps the existing text node, advance, selection and fill colour. */
+export function applyTextOutline(
+  css: CSSStyleDeclaration,
+  style: ResolvedRunStyle,
+  scale: number
+): void {
+  const outline = style.textOutline;
+  if (
+    !outline ||
+    !Number.isFinite(scale) ||
+    scale <= 0 ||
+    !Number.isFinite(outline.widthPt) ||
+    outline.widthPt <= 0 ||
+    outline.widthPt > 1584 ||
+    !/^[0-9a-f]{6}$/i.test(outline.color)
+  )
+    return;
+  const width = outline.widthPt * scale;
+  if (!Number.isFinite(width)) return;
+  css.setProperty('-webkit-text-stroke-width', `${width}px`);
+  css.setProperty('-webkit-text-stroke-color', `#${outline.color}`);
+}

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -1,6 +1,4 @@
-// Paint semantic layout records to DOM (task 7.5).
-//
-// A NON-AUTHORITATIVE CONSUMER. It positions every element from the numbers layout already
+// Non-authoritative semantic DOM paint: position elements from the numbers layout already
 // published and never measures anything back: no `getBoundingClientRect`, no `offsetWidth`,
 // no `getComputedStyle`, no canvas text metrics. If this file could measure, the DOM would
 // become a second source of geometry and the two would drift — which is exactly the
@@ -71,6 +69,7 @@ import {
 } from './semantic-paint-drawings.ts';
 import { mountEquationGeometry } from './semantic-paint-equation.ts';
 import { prepareTextPaintHost } from './semantic-paint-line-end-whitespace.ts';
+import { applyTextOutline } from './semantic-paint-text-outline.ts';
 
 /**
  * When a field's result is drawn on its grey block, following Word's own View option.
@@ -670,6 +669,7 @@ function applyTabAdvanceUnderline(
 function applyRunFaceStyle(element: HTMLElement, style: ResolvedRunStyle, ctx: PaintContext): void {
   const css = element.style;
   const scale = ctx.scale;
+  applyTextOutline(css, style, scale);
   // Super/subscript draw at three quarters — the same reduction the measurer applies, so
   // the painted glyphs match the advance layout reserved. Painting them full size while
   // measuring them small made every line containing one slightly too wide.

--- a/packages/docx-to-markdown/src/markdown-semantic-policy.ts
+++ b/packages/docx-to-markdown/src/markdown-semantic-policy.ts
@@ -92,6 +92,7 @@ const MARKDOWN_SEMANTIC_POLICY_RATCHETS = Object.freeze({
     horizontalScalePercent: 'layout-only',
     kerningMinPt: 'layout-only',
     hidden: 'layout-only',
+    textOutline: 'layout-only',
   } satisfies Record<keyof ResolvedRunStyle, MarkdownFieldPolicy>,
   link: {
     id: 'layout-only',


### PR DESCRIPTION
## Summary

Some Word/WPS documents use a thin `w14:textOutline` to strengthen heading strokes rather than `w:b`. The nested outline colour was discarded by the flat run-property collector, so these runs rendered as ordinary thin text.

- Project explicitly sized, opaque RGB, solid/single/centred text outlines through direct formatting and the existing style cascade.
- Paint the authored stroke width and colour without substituting a bold font, changing text advances, or adding duplicate text nodes.
- Include outline values in style equality and the style-cascade fingerprint. Explicit no-fill/zero-width and unsupported overrides do not retain a stale inherited outline.
- Keep the original XML untouched; add the optional resolved-style field to the API report.

## Scope

This is a bounded text-outline implementation, not general WordArt support. Theme/gradient/alpha fills, dashed/compound/inset outlines are not implemented. Glyph joins use the browser's native CSS text-stroke rasterization, not a custom renderer for Word's join and miter-limit semantics. Unhandled source markup is preserved.

The Word 2010 definition describes width in DrawingML line-width units and default single/centred/solid outlines: [Microsoft TextOutlineEffect documentation](https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.office2010.word.textoutlineeffect?view=openxml-3.0.1).

## Validation

- 11 new regression tests: nested projection, namespaces, inherited overrides, unsupported/hostile inputs, equality/fingerprint, layout/model/XML invariance, zoomed paint and independent paint-sink validation.
- Core tests: 2,558 store + 2,407 layout + 172 binding + 214 output = **5,351 passed**.
- Core and DOM-free layout TypeScript checks, scoped ESLint/Prettier and line-cap checks, core ESM/CJS/DTS builds, and all 15 core API entry checks passed. API checks retain the existing 1,905 warnings and have zero errors.
- Chromium 152 native semantic-paint smoke test: the 0.28pt outline at 1.5x adds visible ink (2,556 versus 2,180 dark pixels), with unchanged DOM boxes, font weight, selectable text and canonical XML; zero page errors/external requests.

Browser smoke coverage uses a synthetic fixture and a fixed measurer. It is not full monorepo/browser E2E coverage or a claim of complete Word/WPS visual parity. No private documents, fonts, photos or reports are included.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791200337&installation_model_id=422592&pr_number=741&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F741&signature=a5594adcc236be1942c59703fc1678b45b3848437a0249beb6e02548f31032ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->