### PR TITLE
fix: avoid extra pages after terminal text-anchored tables

### DIFF
--- a/.changeset/tidy-text-table-anchors.md
+++ b/.changeset/tidy-text-table-anchors.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Avoid an extra blank page after simple text-anchored tables with a terminal empty paragraph that fits the same page.

--- a/docs/site/content/word-fidelity.mdx
+++ b/docs/site/content/word-fidelity.mdx
@@ -53,6 +53,11 @@ The matrix reports three separate support axes.
 
 <FeatureMatrix category="tables" />
 
+A text-anchored table can share a terminal empty paragraph without shrinking that paragraph.
+This applies to simple tables that fit with the anchor inside one content box.
+Explicit page breaks, paragraph spacing, complex tables, and anchors with text retain their existing layout.
+Text wrapping beside floating tables is not supported.
+
 ### Images and drawings
 
 <FeatureMatrix category="images" />

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -443,7 +443,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'An anchored table uses tblpXSpec or tblpX across the text, margin, or page box. It uses tblpY or tblpYSpec against the selected vertical anchor. Page-anchored and margin-anchored tables do not advance body flow. Text does not wrap beside them yet.',
+      'An anchored table uses tblpXSpec or tblpX across the text, margin, or page box. It uses tblpY or tblpYSpec against the selected vertical anchor. Page-anchored and margin-anchored tables do not advance body flow. Simple text-anchored tables can share a terminal empty paragraph without adding a blank page when the complete group fits the same content box. Other text-anchored tables remain in flow. Text does not wrap beside them yet.',
   },
   {
     id: 'tables.text-direction',

--- a/packages/core/src/layout/__tests__/terminal-table-anchor.test.ts
+++ b/packages/core/src/layout/__tests__/terminal-table-anchor.test.ts
@@ -1,0 +1,316 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  readOoxmlPart,
+  serializeOoxmlPart,
+  type OoxmlElement,
+  type OoxmlPart,
+} from '../../store/index.ts';
+import {
+  createFixedMeasurer,
+  createLayoutSession,
+  layoutSemanticDocument,
+} from '../semantic-layout.ts';
+import { caretAt } from '../semantic-interaction.ts';
+import { pagesToMaterialize } from '../viewport.ts';
+import { isOutOfFlowTableFragment } from '../table-float-position.ts';
+import type {
+  ParagraphFragmentRecord,
+  SemanticLayout,
+  TableFragmentRecord,
+} from '../semantic-records.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const p = (height: number, text = '', props = '') =>
+  `<w:p><w:pPr><w:widowControl w:val="0"/><w:spacing w:line="${Math.round(height * 20)}" w:lineRule="exact"/><w:rPr><w:sz w:val="36"/></w:rPr>${props}</w:pPr>${text ? `<w:r><w:t>${text}</w:t></w:r>` : ''}</w:p>`;
+const table = (offset = 230, extra = '', height = 624) =>
+  `<w:tbl><w:tblPr><w:tblpPr w:vertAnchor="text" w:horzAnchor="margin" w:tblpXSpec="center" w:tblpY="${offset}" ${extra}/><w:tblW w:type="dxa" w:w="5528"/><w:tblLayout w:type="fixed"/><w:tblCellMar><w:top w:type="dxa" w:w="0"/><w:bottom w:type="dxa" w:w="0"/></w:tblCellMar></w:tblPr><w:tblGrid><w:gridCol w:w="5528"/></w:tblGrid>${[1, 2].map((row) => `<w:tr><w:trPr><w:trHeight w:val="${height}" w:hRule="exact"/></w:trPr><w:tc>${p(31.2, `Row ${row}`)}</w:tc></w:tr>`).join('')}</w:tbl>`;
+const section = (type = '') =>
+  `<w:sectPr>${type ? `<w:type w:val="${type}"/>` : ''}<w:pgSz w:w="11906" w:h="16838"/><w:pgMar w:top="1440" w:bottom="1440" w:left="1440" w:right="1466"/></w:sectPr>`;
+function part(body: string): OoxmlPart {
+  const parsed = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
+    name: '/word/document.xml',
+    contentType: 'application/xml',
+  });
+  if (!parsed.ok) throw new Error(parsed.reason);
+  return parsed.part;
+}
+const fixture = (tables = table(), anchor = p(31.2), lead = 595.2) =>
+  part(p(lead, 'Lead') + tables + anchor + section());
+const measurer = createFixedMeasurer(6, 18);
+const render = (source: OoxmlPart, options = {}) =>
+  layoutSemanticDocument(source, 0, { measurer, ...options });
+const tablesOf = (layout: SemanticLayout) =>
+  layout.pages
+    .flatMap((page) => page.fragments)
+    .filter((fragment): fragment is TableFragmentRecord => fragment.kind === 'table');
+const paragraphsOf = (layout: SemanticLayout) =>
+  layout.pages
+    .flatMap((page) => page.fragments)
+    .filter((fragment): fragment is ParagraphFragmentRecord => fragment.kind === 'paragraph');
+function bodyOf(source: OoxmlPart): OoxmlElement {
+  return source.root.children.find(
+    (node): node is OoxmlElement => node.kind !== 'textValue' && node.localName === 'body'
+  )!;
+}
+function replaceAnchor(source: OoxmlPart, replacement: OoxmlElement): OoxmlPart {
+  const body = bodyOf(source);
+  const anchor = body.children.at(-2)!;
+  const nextBody = {
+    ...body,
+    children: body.children.map((node) => (node === anchor ? replacement : node)),
+  };
+  return {
+    ...source,
+    root: {
+      ...source.root,
+      children: source.root.children.map((node) => (node === body ? nextBody : node)),
+    },
+  };
+}
+
+function withBodyChildren(source: OoxmlPart, children: OoxmlElement['children']): OoxmlPart {
+  const body = bodyOf(source);
+  return {
+    ...source,
+    root: {
+      ...source.root,
+      children: source.root.children.map((node) => (node === body ? { ...body, children } : node)),
+    },
+  };
+}
+
+describe('terminal empty text-table anchors', () => {
+  test('keeps the full-sized empty anchor on the table page without changing source XML', () => {
+    const source = fixture();
+    const before = serializeOoxmlPart(source);
+    const layout = render(source);
+    expect(layout.pages).toHaveLength(1);
+    const [floating] = tablesOf(layout);
+    const anchor = paragraphsOf(layout).at(-1)!;
+    expect(floating!.box.y).toBeCloseTo(606.7, 3);
+    expect(floating!.box.height).toBeCloseTo(62.4, 3);
+    expect(isOutOfFlowTableFragment(floating!)).toBe(true);
+    expect(anchor.box.y).toBeCloseTo(595.2, 3);
+    expect(anchor.box.height).toBeCloseTo(31.2, 3);
+    expect(anchor.range.start).toBe(0);
+    expect(anchor.range.end).toBe(0);
+    expect(anchor.lines[0]!.spans).toHaveLength(0);
+    expect(serializeOoxmlPart(source)).toBe(before);
+    const caret = caretAt(layout, { paragraphId: anchor.paragraphId, offset: 0 });
+    expect(caret).not.toBeNull();
+    expect(caret!.height).toBeGreaterThan(0);
+    expect(pagesToMaterialize({ layout, viewport: { top: 0, height: 841.9 } }).size).toBe(1);
+  });
+
+  test('keeps filled and nonterminal anchors on the original safe flow path', () => {
+    for (const anchor of [p(31.2, 'TAIL'), p(31.2) + p(31.2, 'TAIL')]) {
+      const layout = render(fixture(table(), anchor));
+      expect(layout.pages).toHaveLength(2);
+      expect(tablesOf(layout).some(isOutOfFlowTableFragment)).toBe(false);
+      const tail = paragraphsOf(layout).at(-1)!;
+      expect(layout.pages[1]!.fragments).toContain(tail);
+    }
+  });
+
+  test('retains explicit inline positioning and genuine inline overflow', () => {
+    const inline = table().replace(/<w:tblpPr[^>]+\/>/, '');
+    for (const source of [fixture(inline), fixture(table(230, 'w:tblpYSpec="inline"'))]) {
+      const layout = render(source);
+      expect(layout.pages).toHaveLength(1);
+      expect(tablesOf(layout).some(isOutOfFlowTableFragment)).toBe(false);
+      expect(paragraphsOf(layout).at(-1)!.box.y).toBeCloseTo(657.6, 3);
+    }
+    expect(render(fixture(inline, p(31.2), 606.7)).pages).toHaveLength(2);
+  });
+
+  test('declines explicit page breaks, hidden marks, revisions, and painted empty paragraphs', () => {
+    for (const properties of [
+      '<w:pageBreakBefore/>',
+      '<w:pBdr><w:bottom w:val="single" w:sz="4"/></w:pBdr>',
+      '<w:shd w:fill="FFFF00"/>',
+      '<w:rPr><w:vanish/></w:rPr>',
+    ]) {
+      expect(
+        tablesOf(render(fixture(table(), p(31.2, '', properties)))).some(isOutOfFlowTableFragment)
+      ).toBe(false);
+    }
+    const deleted = p(31.2).replace(
+      '</w:p>',
+      '<w:del w:id="1" w:author="A"><w:r><w:delText>hidden</w:delText></w:r></w:del></w:p>'
+    );
+    expect(
+      tablesOf(render(fixture(table(), deleted), { displayMode: 'proposed' })).some(
+        isOutOfFlowTableFragment
+      )
+    ).toBe(false);
+  });
+
+  test('positions all tables from the same anchor without charging preceding float heights', () => {
+    const layout = render(fixture(table(230) + table(1700), p(31.2), 400));
+    expect(layout.pages).toHaveLength(1);
+    expect(tablesOf(layout).map((fragment) => fragment.box.y)).toEqual([411.5, 485]);
+    expect(tablesOf(layout).every(isOutOfFlowTableFragment)).toBe(true);
+    expect(paragraphsOf(layout).at(-1)!.box.y).toBe(400);
+    expect(tablesOf(layout)[0]!.box.y + tablesOf(layout)[0]!.box.height).toBeLessThan(
+      tablesOf(layout)[1]!.box.y
+    );
+  });
+
+  test('declines intersecting table boxes and explicit no-overlap positioning', () => {
+    const noOverlap = table().replace('<w:tblPr>', '<w:tblPr><w:tblOverlap w:val="never"/>');
+    for (const tables of [table() + table(), noOverlap + noOverlap]) {
+      const layout = render(fixture(tables, p(31.2), 400));
+      const [first, second] = tablesOf(layout);
+      expect(tablesOf(layout).some(isOutOfFlowTableFragment)).toBe(false);
+      expect(first!.box.y + first!.box.height).toBeLessThanOrEqual(second!.box.y);
+    }
+  });
+
+  test('does not enter the lane while a sheet-positioned table awaits publication', () => {
+    const sheetTable = table(230).replace('w:vertAnchor="text"', 'w:vertAnchor="page"');
+    const source = part(
+      sheetTable + p(400, 'Lead') + table(230) + table(1700) + p(31.2) + section()
+    );
+    const layout = render(source);
+    const textIds = bodyOf(source)
+      .children.slice(2, 4)
+      .map((node) => node.id);
+    const textTables = tablesOf(layout).filter((fragment) => textIds.includes(fragment.tableId));
+    expect(textTables).toHaveLength(2);
+    expect(textTables.some(isOutOfFlowTableFragment)).toBe(false);
+    expect(textTables[0]!.box.y + textTables[0]!.box.height).toBeLessThanOrEqual(
+      textTables[1]!.box.y
+    );
+  });
+
+  test('declines invalid positions, horizontal overflow, and paragraph spacing', () => {
+    const anchors = [
+      fixture(table().replace(/<w:tblpPr[^>]+\/>/, '<w:tblpPr/>')),
+      fixture(table().replace(/<w:tblpPr[^>]+\/>/, '<w:tblpPr w:horzAnchor="margin"/>')),
+      fixture(table().replace('w:vertAnchor="text"', 'w:vertAnchor="unknown"')),
+      fixture(table().replace('w:tblpY="230"', 'w:tblpY="1.5"')),
+      fixture(table(230, 'w:tblpYSpec="unknown"')),
+      fixture(table(230, 'w:topFromText="120"')),
+      fixture(table(230, 'w:bottomFromText="720"')),
+      fixture(table().replace('w:tblpXSpec="center"', 'w:tblpX="9000"')),
+      fixture(table(), p(31.2).replace('w:lineRule="exact"', 'w:lineRule="exact" w:before="120"')),
+      part(
+        p(595.2, 'Lead').replace('w:lineRule="exact"', 'w:lineRule="exact" w:after="120"') +
+          table() +
+          p(31.2) +
+          section()
+      ),
+    ];
+    for (const source of anchors)
+      expect(tablesOf(render(source)).some(isOutOfFlowTableFragment)).toBe(false);
+  });
+
+  test('declines the whole group if any table or anchor exceeds the available band', () => {
+    for (const source of [
+      fixture(table(1300)),
+      fixture(table(230) + table(1300)),
+      fixture(table(), p(130)),
+      fixture(table(-100)),
+    ]) {
+      const layout = render(source);
+      expect(tablesOf(layout).some(isOutOfFlowTableFragment)).toBe(false);
+      for (const page of layout.pages)
+        for (const fragment of page.fragments) {
+          expect(fragment.box.y + fragment.box.height).toBeLessThanOrEqual(
+            page.contentBox.height + 0.001
+          );
+        }
+    }
+  });
+
+  test('does not bypass the existing refusal for an oversized exact row', () => {
+    expect(() => render(fixture(table(230, '', 16000)))).toThrow();
+  });
+
+  test('invalidates the group on empty-to-text edits and restores it on undo', () => {
+    const empty = fixture();
+    const filledAnchor = bodyOf(fixture(table(), p(31.2, 'TAIL'))).children.at(-2) as OoxmlElement;
+    const filled = replaceAnchor(empty, filledAnchor);
+    expect(bodyOf(filled).children[1]).toBe(bodyOf(empty).children[1]);
+    const session = createLayoutSession();
+    for (const [revision, source] of [empty, filled, empty].entries()) {
+      const warm = layoutSemanticDocument(source, revision, { measurer, session });
+      const cold = layoutSemanticDocument(source, revision, { measurer });
+      expect(warm.pages).toEqual(cold.pages);
+      expect(warm.pages).toHaveLength(source === empty ? 1 : 2);
+    }
+  });
+
+  test('invalidates all member keys for append, group edits, deletion, and undo', () => {
+    const initial = fixture(table(230) + table(1700), p(31.2), 400);
+    const originalChildren = bodyOf(initial).children;
+    const changedTable = bodyOf(fixture(table(230) + table(2100), p(31.2), 400)).children[2]!;
+    const changed = withBodyChildren(
+      initial,
+      originalChildren.map((node, index) => (index === 2 ? changedTable : node))
+    );
+    const appendedTail = bodyOf(
+      fixture(table(230) + table(1700), p(31.2) + p(31.2, 'APPENDED'), 400)
+    ).children.at(-2)!;
+    const appended = withBodyChildren(initial, [
+      ...originalChildren.slice(0, -1),
+      appendedTail,
+      originalChildren.at(-1)!,
+    ]);
+    const removed = withBodyChildren(
+      initial,
+      originalChildren.filter((_, index) => index !== 2)
+    );
+    const session = createLayoutSession();
+    for (const [revision, source] of [
+      initial,
+      appended,
+      initial,
+      changed,
+      initial,
+      removed,
+      initial,
+    ].entries()) {
+      expect(bodyOf(source).children[1]).toBe(originalChildren[1]);
+      const warm = layoutSemanticDocument(source, revision, { measurer, session });
+      const cold = layoutSemanticDocument(source, revision, { measurer });
+      expect(warm.pages).toEqual(cold.pages);
+      expect(tablesOf(warm).some(isOutOfFlowTableFragment)).toBe(source !== appended);
+    }
+  });
+
+  test('declines complex table groups and does not skip their content', () => {
+    const merged = table().replace('<w:tc>', '<w:tc><w:tcPr><w:vMerge w:val="restart"/></w:tcPr>');
+    const layout = render(fixture(table() + merged, p(31.2), 400));
+    expect(tablesOf(layout).some(isOutOfFlowTableFragment)).toBe(false);
+    expect(tablesOf(layout)).toHaveLength(2);
+  });
+
+  test('reserves the float bottom when a continuous section follows the empty section mark', () => {
+    const source = part(
+      p(400, 'Lead') +
+        table() +
+        p(31.2, '', section()) +
+        p(31.2, 'FOLLOWING') +
+        section('continuous')
+    );
+    const layout = render(source);
+    expect(layout.pages).toHaveLength(1);
+    const floating = tablesOf(layout)[0]!;
+    expect(isOutOfFlowTableFragment(floating)).toBe(true);
+    const following = paragraphsOf(layout).at(-1)!;
+    expect(following.box.y).toBeGreaterThanOrEqual(floating.box.y + floating.box.height);
+  });
+
+  test('leaves vertical text-distance handling on the original continuous-section path', () => {
+    const source = part(
+      p(400, 'Lead') +
+        table(230, 'w:bottomFromText="720"') +
+        p(31.2, '', section()) +
+        p(31.2, 'FOLLOWING') +
+        section('continuous')
+    );
+    const layout = render(source);
+    expect(tablesOf(layout).some(isOutOfFlowTableFragment)).toBe(false);
+  });
+});

--- a/packages/core/src/layout/section-prepass-guards.ts
+++ b/packages/core/src/layout/section-prepass-guards.ts
@@ -48,4 +48,5 @@ export const SECTION_PREPASS_GUARDS = {
   keepsNext: 'derived-covered',
   markerTexts: 'derived-covered',
   flowKeys: 'derived-covered',
+  terminalTextTables: 'derived-covered',
 } as const satisfies Record<keyof SectionPrepass, SectionPrepassGuard>;

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -91,6 +91,7 @@ import {
   type TableFlowDeps,
 } from './semantic-table-layout.ts';
 import { paginateTableInFlow, type TableFlowCursor } from './table-flow-pagination.ts';
+import * as terminalTables from './terminal-table-anchor.ts';
 import { mergeBoundariesOf, remapMergedLines } from './merged-paragraph-ranges.ts';
 import { paragraphMergeGroupOf, storyBlocks } from './story-roots.ts';
 import type { InlineDrawingLayoutContext } from './drawing-layout.ts';
@@ -549,6 +550,7 @@ export interface SectionPrepass {
    */
   readonly refToken: string;
   readonly flowKeys: string[];
+  readonly terminalTextTables: terminalTables.TerminalTextTableGroup | undefined;
 }
 
 /**
@@ -1333,6 +1335,22 @@ function layoutBlocksPass(
   function buildSectionPrepass(): SectionPrepass {
     const prepared = bodies.map((block) => prepareBlock(block, contentWidth));
     const keys = prepared.map((entry) => entry.key);
+    const terminalTextTables = terminalTables.terminalTextTableGroup(
+      prepared,
+      contentWidth,
+      styleCascade,
+      displayMode,
+      authorFilter
+    );
+    // The anchor can change without changing any table. Resume before the whole
+    // group when typing into it, undoing, or changing another table in the group.
+    const terminalFlowKeys = terminalTextTables
+      ? keys.map((key, index) =>
+          index >= terminalTextTables.start && index <= terminalTextTables.anchorIndex
+            ? framedTokenJoin([key, terminalTextTables.token])
+            : key
+        )
+      : keys;
     const keepsNext = prepared.map((entry) => entry.kind === 'paragraph' && entry.keeps.keepNext);
     const markerTexts = prepared.map((entry) =>
       entry.kind === 'paragraph' ? listItems?.get(entry.paragraph.id)?.markerText : undefined
@@ -1361,7 +1379,7 @@ function layoutBlocksPass(
     // FLOW keys — what incremental resume compares. The composition, its fold order and
     // the argument for that order live with the folds in `pagination-keeps.ts`, where the
     // order is testable.
-    const flow = composeFlowKeys(keys, {
+    const flow = composeFlowKeys(terminalFlowKeys, {
       contextualSpacingAt: (index) => contextualSpacings[index]!,
       styleIdAt: (index) => styleIds[index] ?? null,
       borderGroupKeyAt: (index) => borderGroupKeys[index]!,
@@ -1393,12 +1411,14 @@ function layoutBlocksPass(
       tocToken,
       refToken: refFields?.valuesToken ?? '',
       flowKeys: flow,
+      terminalTextTables,
     };
   }
   if (session && drawingEpoch !== null && projectionEpoch !== null && !prepassValid) {
     session.prepass = prepass;
   }
-  const { prepared, keys, paragraphDocumentOrder, keepsNext, flowKeys } = prepass;
+  const { prepared, keys, paragraphDocumentOrder, keepsNext, flowKeys, terminalTextTables } =
+    prepass;
   /** Retain the whole document's live keys — block keys plus recorded table-cell keys. */
   const publishRetainedKeys = (): void => {
     // `false` is the orchestrator saying this pass skips the sweep; a standalone pass asks
@@ -1516,6 +1536,8 @@ function layoutBlocksPass(
   const anchorPageDeferCounts = new Map<string, number>();
   const pendingFloatIds = new Set<string>();
   const floatSignals: tableFloat.PositionedTableAnchorSignal[] = [];
+  const terminalTextTableIds = new Set<string>();
+  let terminalTextTableBottom = 0;
   // A continuous section resumes the previous section's column rather than opening a
   // sheet, so its first block starts at that column's used height and its first paragraph
   // is NOT at a page top — page-top space-before suppression must not apply to it, and the
@@ -2151,6 +2173,51 @@ function layoutBlocksPass(
     placed += 1;
 
     if (entry.kind === 'table') {
+      if (terminalTextTableIds.has(entry.table.id)) continue;
+      if (
+        terminalTextTables?.start === index &&
+        columns.count === 1 &&
+        pendingFloatIds.size === 0 &&
+        !pageFragments.some(tableFloat.isOutOfFlowTableFragment) &&
+        !options.drawingExclusionZonesByPage?.get(pages.length)?.length
+      ) {
+        const anchor = prepared[terminalTextTables.anchorIndex]!;
+        if (
+          anchor.kind === 'paragraph' &&
+          anchor.spacing.before === 0 &&
+          anchor.spacing.after === 0 &&
+          previousSpaceAfter === 0
+        ) {
+          const anchorLines = breakBlock(anchor, terminalTextTables.anchorIndex);
+          if (anchorLines.length === 1 && anchorLines[0]!.spans.length === 0) {
+            collectingCellBreakKeys = [];
+            try {
+              const placed = terminalTables.placeTerminalTextTables(terminalTextTables, {
+                cursorY,
+                anchorHeight: anchor.spacing.before + anchor.spacing.after + anchorLines[0]!.height,
+                contentWidth,
+                contentHeight: contentHeight(),
+                frames: anchorFrames(),
+                deps: tableDeps,
+                styleCascade,
+                displayMode,
+                authorFilter,
+              });
+              if (placed) {
+                for (const fragment of placed.fragments) pageFragments.push(fragment);
+                for (const table of terminalTextTables.tables) {
+                  terminalTextTableIds.add(table.id);
+                  registerTableCellBreakKeys(table, collectingCellBreakKeys);
+                }
+                terminalTextTableBottom = placed.bottom;
+                continue;
+              }
+            } finally {
+              collectingCellBreakKeys = null;
+            }
+          }
+        }
+      }
       if (positionedTableIds.has(entry.table.id)) {
         pendingFloatIds.add(entry.table.id);
         continue;
@@ -2837,7 +2904,8 @@ function layoutBlocksPass(
 
   // Captured BEFORE the terminal flush, which zeroes the cursor. A converged pass stopped
   // early and never walked the tail, so its end state is the one the previous pass stored.
-  const endCursorY = converged && session ? session.endCursorY : cursorY;
+  const endCursorY =
+    converged && session ? session.endCursorY : Math.max(cursorY, terminalTextTableBottom);
   const endSpaceAfter = converged && session ? session.endSpaceAfter : previousSpaceAfter;
   // The terminal flush closes the page the flow was still filling. When it does NOT run,
   // the last page was already closed by a page break and the cursor sits at the top of a

--- a/packages/core/src/layout/terminal-table-anchor.ts
+++ b/packages/core/src/layout/terminal-table-anchor.ts
@@ -1,0 +1,296 @@
+// A text-relative table anchors to the next regular paragraph (17.4.57).
+// Only a terminal, empty anchor is handled here. Other text still needs wrapping.
+import type { OoxmlElement, OoxmlProperty } from '@docx-editor.dev/core/store';
+import { framedTokenJoin } from './layout-cache.ts';
+import { readTableStructure, tableFloatOriginX, type TableAnchorFrames } from './semantic-table.ts';
+import {
+  createTableBorderOwnershipBudget,
+  createTableVMergeResolveBudget,
+  layoutTableFragment,
+  type TableFlowDeps,
+} from './semantic-table-layout.ts';
+import { stripAnchorSinksForProbe } from './table-probe-deps.ts';
+import type { StyleCascadeTable } from './style-cascade.ts';
+import type { RevisionAuthorFilter, RevisionDisplayMode } from './revision-projection.ts';
+import type { TableFragmentRecord } from './semantic-records.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const MAX_TERMINAL_TABLES = 32;
+const MAX_TABLE_NODES = 10000;
+type Block =
+  | { readonly kind: 'table'; readonly table: OoxmlElement; readonly key: string }
+  | {
+      readonly kind: 'paragraph';
+      readonly paragraph: OoxmlElement;
+      readonly props: readonly OoxmlProperty[];
+      readonly listItem?: unknown;
+      readonly shading?: string;
+      readonly key: string;
+    };
+
+export interface TerminalTextTableGroup {
+  readonly start: number;
+  readonly anchorIndex: number;
+  readonly tables: readonly OoxmlElement[];
+  readonly token: string;
+}
+
+/** Raw content cannot disappear merely because the current revision view hides it. */
+function emptyAnchor(block: Block): boolean {
+  if (block.kind !== 'paragraph' || block.listItem || block.shading) return false;
+  if (block.paragraph.children.some((node) => node.kind !== 'paragraphProperties')) return false;
+  if (
+    block.props.some((prop) =>
+      ['framePr', 'numPr', 'pBdr', 'shd', 'pageBreakBefore'].includes(prop.localName)
+    )
+  )
+    return false;
+  const pending = [block.paragraph];
+  let visits = 0;
+  while (pending.length) {
+    const node = pending.pop()!;
+    if (++visits > MAX_TABLE_NODES || node.namespaceUri !== W) return false;
+    if (
+      [
+        'ins',
+        'del',
+        'moveFrom',
+        'moveTo',
+        'pPrChange',
+        'rPrChange',
+        'vanish',
+        'webHidden',
+      ].includes(node.localName)
+    )
+      return false;
+    if (visits + pending.length + node.children.length > MAX_TABLE_NODES) return false;
+    for (const child of node.children) {
+      if (child.kind === 'textValue') return false;
+      pending.push(child);
+    }
+  }
+  return true;
+}
+
+/** Keep the admission probe and the final placement on the same simple-row path. */
+function simpleTable(table: OoxmlElement): boolean {
+  const pending = [table];
+  let visits = 0;
+  while (pending.length) {
+    const node = pending.pop()!;
+    if (++visits > MAX_TABLE_NODES || node.namespaceUri !== W) return false;
+    if (node !== table && node.kind === 'table') return false;
+    if (
+      [
+        'vMerge',
+        'hMerge',
+        'tblHeader',
+        'drawing',
+        'pict',
+        'object',
+        'fldChar',
+        'fldSimple',
+        'instrText',
+        'footnoteReference',
+        'endnoteReference',
+        'ins',
+        'del',
+        'moveFrom',
+        'moveTo',
+        'sdt',
+        'altChunk',
+        'framePr',
+      ].includes(node.localName)
+    )
+      return false;
+    if (
+      node.localName === 'tblOverlap' &&
+      !node.attributes.some(
+        (attr) => attr.namespaceUri === W && attr.localName === 'val' && attr.value === 'overlap'
+      )
+    )
+      return false;
+    if (visits + pending.length + node.children.length > MAX_TABLE_NODES) return false;
+    for (const child of node.children) if (child.kind !== 'textValue') pending.push(child);
+  }
+  return true;
+}
+
+/** Do not opt in through an invalid value that the general reader defaults or clamps. */
+function supportedPosition(table: OoxmlElement): boolean {
+  let properties: OoxmlElement | undefined;
+  for (const node of table.children) {
+    if (node.kind !== 'tableProperties') continue;
+    if (properties) return false;
+    properties = node;
+  }
+  if (!properties) return false;
+  const positions = properties.children.filter(
+    (node) => node.kind !== 'textValue' && node.localName === 'tblpPr'
+  );
+  if (positions.length !== 1) return false;
+  const position = positions[0]!;
+  if (position.kind === 'textValue' || position.namespaceUri !== W || position.children.length)
+    return false;
+  const names = new Set<string>();
+  for (const attr of position.attributes) {
+    if (attr.namespaceUri !== W || names.has(attr.localName)) return false;
+    names.add(attr.localName);
+    if (attr.localName === 'vertAnchor') {
+      if (attr.value !== 'text') return false;
+    } else if (attr.localName === 'horzAnchor') {
+      if (!['text', 'margin', 'page'].includes(attr.value)) return false;
+    } else if (attr.localName === 'tblpXSpec') {
+      if (!['left', 'center', 'right', 'inside', 'outside'].includes(attr.value)) return false;
+    } else if (attr.localName === 'tblpX' || attr.localName === 'tblpY') {
+      if (!/^-?\d+$/.test(attr.value) || Math.abs(Number(attr.value)) > 31680) return false;
+    } else if (
+      ['leftFromText', 'rightFromText', 'topFromText', 'bottomFromText'].includes(attr.localName)
+    ) {
+      if (!/^\d+$/.test(attr.value) || Number(attr.value) > 31680) return false;
+      if (
+        (attr.localName === 'topFromText' || attr.localName === 'bottomFromText') &&
+        Number(attr.value) !== 0
+      )
+        return false;
+    } else return false;
+  }
+  return names.has('vertAnchor');
+}
+
+export function terminalTextTableGroup(
+  blocks: readonly Block[],
+  contentWidth: number,
+  styleCascade: StyleCascadeTable | undefined,
+  displayMode: RevisionDisplayMode,
+  authorFilter: RevisionAuthorFilter | undefined
+): TerminalTextTableGroup | undefined {
+  const anchorIndex = blocks.length - 1;
+  const anchor = blocks[anchorIndex];
+  if (!anchor || !emptyAnchor(anchor)) return undefined;
+  let start = anchorIndex;
+  const tables: OoxmlElement[] = [];
+  const tokens = [anchor.key];
+  for (let index = anchorIndex - 1; index >= 0; index -= 1) {
+    const block = blocks[index]!;
+    if (block.kind !== 'table') break;
+    if (!simpleTable(block.table) || !supportedPosition(block.table)) return undefined;
+    const structure = readTableStructure(
+      block.table,
+      contentWidth,
+      0,
+      styleCascade,
+      displayMode,
+      authorFilter
+    );
+    const float = structure?.float;
+    if (!float || float.vertAnchor !== 'text' || float.ySpec) return undefined;
+    if (tables.length >= MAX_TERMINAL_TABLES) return undefined;
+    tables.push(block.table);
+    tokens.push(block.key);
+    start = index;
+  }
+  if (!tables.length) return undefined;
+  return { start, anchorIndex, tables: tables.reverse(), token: framedTokenJoin(tokens) };
+}
+
+export interface TerminalTablePlacement {
+  readonly fragments: readonly TableFragmentRecord[];
+  readonly bottom: number;
+}
+
+/** Decline the whole group unless its table/anchor union fits this content rectangle. */
+export function placeTerminalTextTables(
+  group: TerminalTextTableGroup,
+  input: {
+    readonly cursorY: number;
+    readonly anchorHeight: number;
+    readonly contentWidth: number;
+    readonly contentHeight: number;
+    readonly frames: TableAnchorFrames;
+    readonly deps: TableFlowDeps;
+    readonly styleCascade: StyleCascadeTable | undefined;
+    readonly displayMode: RevisionDisplayMode;
+    readonly authorFilter: RevisionAuthorFilter | undefined;
+  }
+): TerminalTablePlacement | undefined {
+  const { cursorY, anchorHeight, contentWidth, contentHeight } = input;
+  if (
+    !Number.isFinite(anchorHeight) ||
+    anchorHeight <= 0 ||
+    cursorY + anchorHeight > contentHeight + 0.001
+  )
+    return undefined;
+  const structures = group.tables.map((table) =>
+    readTableStructure(
+      table,
+      contentWidth,
+      0,
+      input.styleCascade,
+      input.displayMode,
+      input.authorFilter
+    )
+  );
+  const placements: { left: number; top: number; right: number; bottom: number }[] = [];
+  let bottom = cursorY + anchorHeight;
+  let probeLine = 0;
+  const probeDeps: TableFlowDeps = {
+    ...stripAnchorSinksForProbe(input.deps),
+    borderOwnershipBudget: createTableBorderOwnershipBudget(),
+    vMergeResolveBudget: createTableVMergeResolveBudget(),
+    nextLineId: () => `terminal-table-probe-${probeLine++}`,
+  };
+  for (let index = 0; index < structures.length; index += 1) {
+    const structure = structures[index];
+    if (!structure?.float || !structure.rows.length) return undefined;
+    const width = structure.columnWidthsPt.reduce((sum, value) => sum + value, 0);
+    const left = tableFloatOriginX(structure.float, width, input.frames);
+    const top = cursorY + structure.float.yPt;
+    if (
+      ![left, top, width].every(Number.isFinite) ||
+      width <= 0 ||
+      left < 0 ||
+      left + width > contentWidth + 0.001 ||
+      top < cursorY ||
+      top > contentHeight
+    )
+      return undefined;
+    const probe = layoutTableFragment(
+      structure,
+      left,
+      top,
+      0,
+      group.tables[index]!.id,
+      0,
+      probeDeps
+    );
+    if (!Number.isFinite(probe.bottom) || probe.bottom > contentHeight + 0.001) return undefined;
+    // Collision handling is outside this lane. Never introduce overlapping table text.
+    if (
+      placements.some(
+        (placed) =>
+          left < placed.right &&
+          left + width > placed.left &&
+          top < placed.bottom &&
+          probe.bottom > placed.top
+      )
+    )
+      return undefined;
+    bottom = Math.max(bottom, probe.bottom);
+    placements.push({ left, top, right: left + width, bottom: probe.bottom });
+  }
+  const fragments = structures.map((structure, index) => {
+    const { left, top } = placements[index]!;
+    const placed = layoutTableFragment(
+      structure!,
+      left,
+      top,
+      0,
+      group.tables[index]!.id,
+      0,
+      input.deps
+    );
+    return { ...placed.fragment, outOfFlow: true as const };
+  });
+  return { fragments, bottom };
+}


### PR DESCRIPTION
## Summary

Fix an extra page caused by charging a text-anchored table's offset and height to body flow before its terminal empty anchor paragraph.

This is a bounded layout fix, not suppression of trailing paragraphs. The original paragraph, its full line height, source range, and caret remain intact. No document XML is rewritten.

## Changes

- Detect a terminal group of simple tables with an explicit `vertAnchor="text"` and an ordinary empty anchor.
- Position the group from the same anchor baseline only when the complete table/anchor union fits the current single-column content rectangle.
- Keep the anchor in body flow and reserve the table bottom when a continuous section follows.
- Include every member and the anchor in incremental flow dependencies, so typing, appending, deleting, and undoing cannot reuse stale placement.
- Keep speculative layout separate from live drawing/note sinks and line identifiers.

The new path declines filled or nonterminal anchors, explicit page breaks, spacing, hidden/revised content, complex tables, invalid positioning, nonzero vertical text distances, intersecting table boxes, and mixed floating-table regions. Those cases keep their previous layout. General text wrapping around floating tables is not implemented here.

## Reproduction and tests

The synthetic fixture has a 697.9pt content height, a 595.2pt preceding block, a 62.4pt table positioned 11.5pt below the text anchor, and a 31.2pt empty paragraph. Previously the paragraph was pushed to a second page. It now stays at 595.2pt with its full 31.2pt height; the table stays at 606.7pt. The source XML is unchanged, and a caret is still available in the anchor.

Added 15 focused tests for placement, genuine overflow, fallback cases, multiple tables, incremental edits/undo, continuous sections, and mixed floating regions. The existing floating-table and prepass tests also pass.

Validation on the final source tree:

- Store: 2,558; layout: 2,415; binding: 172; output: 211; targeted paginated-table host tests: 8. **5,364 tests passed**.
- Core and DOM-free layout/store type checks; scoped ESLint/Prettier; line caps; `git diff --check`.
- Core ESM/CJS/DTS build and API snapshot/check.
- Feature matrix, fidelity guide, and changeset updated. All fixtures are synthetic; no private reports or media are included.

The full monorepo/browser E2E suite and broad document visual certification were not run for this independent branch. Other floating-table limitations remain marked partial.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/743"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791219404&installation_model_id=422592&pr_number=743&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F743&signature=8a5388de8b1d7adbaa733be18f117b98ee8239cc09f5f9e887059550348d867e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->