### PR TITLE
fix: keep symbol faces out of the font substitution notice

### DIFF
--- a/.changeset/quiet-symbol-font-notice.md
+++ b/.changeset/quiet-symbol-font-notice.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': minor
+---
+
+Keep symbol faces, such as the MS Gothic face a Word checkbox names, out of the font substitution notice, and report them to the font resolver so an app can supply them. Fixes #729, fixes #730

--- a/docs/api/docx-editor-core/binding.api.md
+++ b/docs/api/docx-editor-core/binding.api.md
@@ -201,6 +201,7 @@ export interface TreeDocxSessionView extends HeadlessDocumentView {
     // (undocumented)
     subscribe(onChange: (change: TreeModelChange) => void): () => void;
     sweepCustomNodePayloads(namespaces: readonly string[]): CustomNodeSweepOutcome;
+    symbolFontFamilies(): readonly string[];
     trackingSettings(): DocumentTrackingSettings;
     undo(): SelectionMark | null;
 }

--- a/docs/api/docx-editor-core/editor.api.md
+++ b/docs/api/docx-editor-core/editor.api.md
@@ -2421,6 +2421,7 @@ export interface TreeDocxSessionView extends HeadlessDocumentView {
     // (undocumented)
     subscribe(onChange: (change: TreeModelChange) => void): () => void;
     sweepCustomNodePayloads(namespaces: readonly string[]): CustomNodeSweepOutcome;
+    symbolFontFamilies(): readonly string[];
     trackingSettings(): DocumentTrackingSettings;
     undo(): SelectionMark | null;
 }

--- a/docs/site/content/guides/fonts.mdx
+++ b/docs/site/content/guides/fonts.mdx
@@ -62,6 +62,11 @@ compatible face. It excludes metric-compatible substitutions.
 The notice also excludes font declarations that rendered text does not use. The
 font picker can still list those declared families.
 
+The notice excludes symbol faces too, such as the MS Gothic face a Word checkbox
+names in `w:sym`. A symbol run paints one character, and the editor resolves it
+to its Unicode equivalent wherever one exists, so any face can draw it. The font
+picker doesn't offer symbol faces either.
+
 ## Load Word-compatible defaults
 
 The optional `@docx-editor.dev/fonts` package provides open-licensed substitutes.
@@ -432,6 +437,12 @@ const brandFonts = defineFontResolver(async ({ families, defaultFamily, resolved
 
 The request carries `families`, the names that document declares, and `defaultFamily`,
 the face a run naming no font resolves to. Both count as declared.
+
+`families` ends with the symbol faces the document names in `w:sym`, after the
+declared ones. Supply those to paint a symbol in the authored face: the editor
+maps a private-use character to its Unicode equivalent where one exists, and
+keeps the original character otherwise. A face you supply for a symbol stays out
+of the font picker.
 
 `resolvedFaces` lists the faces earlier origins in the same composition can already
 paint. It reports faces rather than families, and only faces backed by bytes, so

--- a/docs/site/content/guides/fonts.mdx
+++ b/docs/site/content/guides/fonts.mdx
@@ -65,7 +65,8 @@ font picker can still list those declared families.
 The notice excludes symbol faces too, such as the MS Gothic face a Word checkbox
 names in `w:sym`. A symbol run paints one character, and the editor resolves it
 to its Unicode equivalent wherever one exists, so any face can draw it. The font
-picker doesn't offer symbol faces either.
+picker doesn't list a symbol face either, unless your font configuration supplies
+it: the picker offers the families the editor can honor.
 
 ## Load Word-compatible defaults
 
@@ -441,8 +442,8 @@ the face a run naming no font resolves to. Both count as declared.
 `families` ends with the symbol faces the document names in `w:sym`, after the
 declared ones. Supply those to paint a symbol in the authored face: the editor
 maps a private-use character to its Unicode equivalent where one exists, and
-keeps the original character otherwise. A face you supply for a symbol stays out
-of the font picker.
+keeps the original character otherwise. A face you supply this way becomes
+offerable in the font picker, like any other family you supply.
 
 `resolvedFaces` lists the faces earlier origins in the same composition can already
 paint. It reports faces rather than families, and only faces backed by bytes, so

--- a/docs/site/content/guides/fonts.mdx
+++ b/docs/site/content/guides/fonts.mdx
@@ -64,9 +64,12 @@ font picker can still list those declared families.
 
 The notice excludes symbol faces too, such as the MS Gothic face a Word checkbox
 names in `w:sym`. A symbol run paints one character, and the editor resolves it
-to its Unicode equivalent wherever one exists, so any face can draw it. The font
-picker doesn't list a symbol face either, unless your font configuration supplies
-it: the picker offers the families the editor can honor.
+to its Unicode equivalent wherever one exists, so any face can draw it.
+
+The font picker is a separate list. It offers the families your configuration
+supplies and the families the document declares in `w:rFonts`, so a symbol face
+appears there when the file declares it as a run font, which Word's checkbox
+markup does.
 
 ## Load Word-compatible defaults
 

--- a/packages/core/src/binding/__tests__/document-rendered-fonts.test.ts
+++ b/packages/core/src/binding/__tests__/document-rendered-fonts.test.ts
@@ -166,6 +166,9 @@ describe('collectRenderedFontFamilies', () => {
       })
     );
     expect(verticalWriting.renderedFontFamilies()).toEqual([]);
+    // The `@` is a writing mode, not a family, so the resolver is asked for the family —
+    // otherwise the notice is silent about a face nothing can supply.
+    expect(verticalWriting.symbolFontFamilies()).toEqual(['MS Gothic']);
 
     // A `font` in a foreign namespace is one layout ignores, so the run keeps its own face
     // and this answer must keep reporting it.

--- a/packages/core/src/binding/__tests__/document-rendered-fonts.test.ts
+++ b/packages/core/src/binding/__tests__/document-rendered-fonts.test.ts
@@ -155,6 +155,29 @@ describe('collectRenderedFontFamilies', () => {
     );
     expect(runFaced.renderedFontFamilies()).toEqual(['Garamond']);
 
+    // Layout applies any `@w:font` within its length bound, including a name no CSS sink
+    // would take — Word's vertical-writing `@` prefix is the everyday one. The override is
+    // real, so the run's own face still paints nothing.
+    const verticalWriting = open(
+      docx({
+        body:
+          '<w:p><w:r><w:rPr><w:rFonts w:ascii="MS Gothic"/></w:rPr>' +
+          '<w:sym w:font="@MS Gothic" w:char="2612"/></w:r></w:p>',
+      })
+    );
+    expect(verticalWriting.renderedFontFamilies()).toEqual([]);
+
+    // A `font` in a foreign namespace is one layout ignores, so the run keeps its own face
+    // and this answer must keep reporting it.
+    const foreignNamespace = open(
+      docx({
+        body:
+          '<w:p><w:r><w:rPr><w:rFonts w:ascii="Garamond"/></w:rPr>' +
+          '<w:sym xmlns:x="urn:x" x:font="Wingdings" w:char="2612"/></w:r></w:p>',
+      })
+    );
+    expect(foreignNamespace.renderedFontFamilies()).toEqual(['Garamond']);
+
     // A face named BOTH by a symbol and by rendered text stays reported.
     const alsoText = open(
       docx({

--- a/packages/core/src/binding/__tests__/document-rendered-fonts.test.ts
+++ b/packages/core/src/binding/__tests__/document-rendered-fonts.test.ts
@@ -166,9 +166,9 @@ describe('collectRenderedFontFamilies', () => {
       })
     );
     expect(verticalWriting.renderedFontFamilies()).toEqual([]);
-    // The `@` is a writing mode, not a family, so the resolver is asked for the family —
-    // otherwise the notice is silent about a face nothing can supply.
-    expect(verticalWriting.symbolFontFamilies()).toEqual(['MS Gothic']);
+    // And no resolver is asked for `@MS Gothic`: the measurer and the paint sink both
+    // reject that name, so bytes supplied under it could never reach the glyph.
+    expect(verticalWriting.symbolFontFamilies()).toEqual([]);
 
     // A `font` in a foreign namespace is one layout ignores, so the run keeps its own face
     // and this answer must keep reporting it.

--- a/packages/core/src/binding/__tests__/document-rendered-fonts.test.ts
+++ b/packages/core/src/binding/__tests__/document-rendered-fonts.test.ts
@@ -116,6 +116,83 @@ describe('collectRenderedFontFamilies', () => {
     expect(cjk.renderedFontFamilies()).toEqual(['DengXian', 'Garamond']);
   });
 
+  test('a w:sym face is not a rendered text face', () => {
+    // Word writes `w:sym w:font="MS Gothic"` for a checkbox and `Wingdings` for a bullet.
+    // A symbol face paints one glyph, moves no text metrics, and is not a family the picker
+    // offers or the editor asks a resolver for — so the substitution notice, which reports
+    // faces an app could have supplied, must not name it. The run's own face still counts:
+    // it is what the surrounding text renders in.
+    const session = open(
+      docx({
+        body:
+          '<w:p><w:r><w:rPr><w:rFonts w:ascii="Garamond"/></w:rPr>' +
+          '<w:sym w:font="MS Gothic" w:char="2612"/><w:t>checked</w:t></w:r></w:p>',
+      })
+    );
+    expect(session.renderedFontFamilies()).toEqual(['Garamond']);
+
+    // Word's own checkbox shape, which `applySetContentControlValue` also mints when the
+    // user ticks a box: the symbol face is repeated on the RUN. Nothing paints in it —
+    // `symbolRunStyle` overrides `rFonts` with `w:sym/@w:font` — so it must not come back
+    // into the answer through the run.
+    const wordCheckbox = open(
+      docx({
+        body:
+          '<w:p><w:r><w:rPr><w:rFonts w:ascii="MS Gothic" w:eastAsia="MS Gothic" ' +
+          'w:hAnsi="MS Gothic"/></w:rPr><w:sym w:font="MS Gothic" w:char="2612"/></w:r>' +
+          '<w:r><w:rPr><w:rFonts w:ascii="Garamond"/></w:rPr><w:t>Task done</w:t></w:r></w:p>',
+      })
+    );
+    expect(wordCheckbox.renderedFontFamilies()).toEqual(['Garamond']);
+
+    // A `w:sym` naming no face of its own DOES paint in the run's face, so that one counts.
+    const runFaced = open(
+      docx({
+        body:
+          '<w:p><w:r><w:rPr><w:rFonts w:ascii="Garamond"/></w:rPr>' +
+          '<w:sym w:char="2612"/></w:r></w:p>',
+      })
+    );
+    expect(runFaced.renderedFontFamilies()).toEqual(['Garamond']);
+
+    // A face named BOTH by a symbol and by rendered text stays reported.
+    const alsoText = open(
+      docx({
+        body:
+          '<w:p><w:r><w:rPr><w:rFonts w:ascii="MS Gothic"/></w:rPr>' +
+          '<w:sym w:font="MS Gothic" w:char="2612"/><w:t>checked</w:t></w:r></w:p>',
+      })
+    );
+    expect(alsoText.renderedFontFamilies()).toEqual(['MS Gothic']);
+  });
+
+  test('a w:sym face is its own answer: not the picker, not the notice, but the resolver', () => {
+    const session = open(
+      docx({
+        body:
+          '<w:p><w:r><w:rPr><w:rFonts w:ascii="Garamond"/></w:rPr>' +
+          '<w:sym w:font="Wingdings" w:char="F0A8"/><w:t>bullet</w:t></w:r></w:p>',
+      })
+    );
+    // Applying Wingdings to a selection would set text in a dingbat face, so the picker
+    // never offers it — but a resolver has to hear about it, or nothing can supply the face
+    // an unmapped private-use glyph needs.
+    expect(session.documentFonts()).toEqual(['Garamond']);
+    expect(session.renderedFontFamilies()).toEqual(['Garamond']);
+    expect(session.symbolFontFamilies()).toEqual(['Wingdings']);
+  });
+
+  test('symbol faces fold case-insensitively, keeping the first spelling a reader sees', () => {
+    const session = open(
+      docx({
+        body:
+          '<w:p><w:r><w:sym w:font="Wingdings" w:char="F0A8"/><w:t>one</w:t></w:r></w:p>' +
+          '<w:p><w:r><w:sym w:font="WINGDINGS" w:char="F0A7"/><w:t>two</w:t></w:r></w:p>',
+      })
+    );
+    expect(session.symbolFontFamilies()).toEqual(['Wingdings']);
+  });
+
   test('a run without text contributes nothing; an empty document answers []', () => {
     const empty = open(docx({ body: '<w:p/>' }));
     expect(empty.renderedFontFamilies()).toEqual([]);

--- a/packages/core/src/binding/document-catalog.ts
+++ b/packages/core/src/binding/document-catalog.ts
@@ -160,6 +160,90 @@ function subtreeFontsOf(
 }
 
 /**
+ * Every valid family a `w:sym/@w:font` names, deduplicated and sorted like
+ * {@link collectDocumentFonts}, and validated at the same boundary for the same reason.
+ *
+ * Kept apart from the font catalog because the two answer different questions. A symbol
+ * face is not a family a PICKER should offer: applying it to a selection would set the
+ * text of a run in a face carrying dingbats. It IS a family a font resolver must hear
+ * about — `layout/symbol-run.ts` keeps an unmapped private-use code point in the authored
+ * face, which paints as a tofu box in any other, and an app that owns those bytes can only
+ * supply them if it is told the document wants them.
+ */
+export function collectSymbolFontFamilies(roots: readonly OoxmlElement[]): readonly string[] {
+  const byFold = new Map<string, string>();
+  for (const root of roots) {
+    // The root element is never a `w:sym`; its children carry the memo, exactly as in
+    // `collectDocumentFonts`.
+    for (const child of root.children) {
+      if (!isElement(child)) continue;
+      for (const [fold, family] of subtreeSymbolFontsOf(child)) {
+        if (!byFold.has(fold)) byFold.set(fold, family);
+      }
+    }
+  }
+  const fonts = [...byFold.values()];
+  fonts.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  return fonts;
+}
+
+/**
+ * Per-subtree memo, for the reason {@link collectDocumentFonts} has one: this is a public
+ * session answer, and a derivation that re-walks every story per revision becomes a
+ * per-keystroke cost the moment any chrome reads it in a selector. No theme in the key —
+ * `w:sym/@w:font` is a literal family name, never a theme slot.
+ */
+const subtreeSymbolFontsMemos = new WeakMap<OoxmlElement, ReadonlyMap<string, string>>();
+
+/**
+ * Shared by every subtree that names no symbol face, which in a real document is nearly all
+ * of them: a per-block empty `Map` retained for the life of the tree is pure overhead.
+ */
+const NO_SYMBOL_FONTS: ReadonlyMap<string, string> = new Map();
+
+function subtreeSymbolFontsOf(subtree: OoxmlElement, depth = 0): ReadonlyMap<string, string> {
+  const cached = subtreeSymbolFontsMemos.get(subtree);
+  if (cached) return cached;
+  const remember = (byFold: Map<string, string>): ReadonlyMap<string, string> => {
+    const answer = byFold.size === 0 ? NO_SYMBOL_FONTS : byFold;
+    subtreeSymbolFontsMemos.set(subtree, answer);
+    return answer;
+  };
+  const byFold = new Map<string, string>();
+  // The compose branch never inspects the node itself, so a `w:sym` wide enough to take it
+  // would lose its own face — the same self-check `subtreeFontsOf` makes for `w:rFonts`.
+  // `w:sym` is a generic node, so a hand-built package can give it children.
+  if (
+    subtree.children.length >= COMPOSE_CHILD_THRESHOLD &&
+    depth < MAX_COMPOSE_DEPTH &&
+    subtree.localName !== 'sym'
+  ) {
+    for (const child of subtree.children) {
+      if (!isElement(child)) continue;
+      for (const [fold, family] of subtreeSymbolFontsOf(child, depth + 1)) {
+        if (!byFold.has(fold)) byFold.set(fold, family);
+      }
+    }
+    return remember(byFold);
+  }
+  // Iterative and depth-safe like its sibling, and children push in reverse for the same
+  // reason: first-seen casing has to mean the first occurrence a reader would see.
+  const stack: OoxmlNode[] = [subtree];
+  while (stack.length > 0) {
+    const node = stack.pop()!;
+    if (!isElement(node)) continue;
+    if (node.localName === 'sym' && node.namespaceUri === WML_NAMESPACE_URI) {
+      const family = attributeValue(node, 'font');
+      if (family && FONT_NAME.test(family) && !byFold.has(family.toLowerCase())) {
+        byFold.set(family.toLowerCase(), family);
+      }
+    }
+    for (let i = node.children.length - 1; i >= 0; i -= 1) stack.push(node.children[i]!);
+  }
+  return remember(byFold);
+}
+
+/**
  * Whether any of `roots` actually puts CHARACTERS on a page.
  *
  * `collectDocumentFonts` answers what the document DECLARES, which is what a font picker

--- a/packages/core/src/binding/document-catalog.ts
+++ b/packages/core/src/binding/document-catalog.ts
@@ -241,8 +241,9 @@ function subtreeSymbolFontsOf(subtree: OoxmlElement, depth = 0): ReadonlyMap<str
           attribute.localName === 'font' &&
           (attribute.namespaceUri === WML_NAMESPACE_URI || attribute.namespaceUri === '')
       )?.value;
-      // `symbolFontFamily` applies the same bound `FONT_NAME` does here, plus Word's
-      // vertical-writing `@` prefix — one rule, shared with the export lane's own walk.
+      // One rule for every caller that asks a resolver for a symbol face, shared with the
+      // export lane's own walk: a name no measurer or paint sink would take is a face
+      // nothing could supply, so it is not asked for.
       const family = symbolFontFamily(authored);
       if (family !== null && !byFold.has(family.toLowerCase())) {
         byFold.set(family.toLowerCase(), family);

--- a/packages/core/src/binding/document-catalog.ts
+++ b/packages/core/src/binding/document-catalog.ts
@@ -235,11 +235,17 @@ function subtreeSymbolFontsOf(subtree: OoxmlElement, depth = 0): ReadonlyMap<str
     if (node.localName === 'sym' && node.namespaceUri === WML_NAMESPACE_URI) {
       // The WML namespace or none, matching how `layout/symbol-run.ts` reads it: a face
       // layout will not use is a face no resolver should be asked for.
-      const family = node.attributes.find(
+      const authored = node.attributes.find(
         (attribute) =>
           attribute.localName === 'font' &&
           (attribute.namespaceUri === WML_NAMESPACE_URI || attribute.namespaceUri === '')
       )?.value;
+      // Word writes the vertical form of a family as the same name behind an `@`
+      // (`@MS Gothic`). The bytes are the family's, so ask for the family: the prefix is a
+      // writing mode, and `FONT_NAME` — which every name leaving this module passes, because
+      // a CSS sink receives it — would otherwise reject the name and leave the face
+      // unsuppliable for a glyph that needs it.
+      const family = authored?.startsWith('@') ? authored.slice(1) : authored;
       if (family && FONT_NAME.test(family) && !byFold.has(family.toLowerCase())) {
         byFold.set(family.toLowerCase(), family);
       }

--- a/packages/core/src/binding/document-catalog.ts
+++ b/packages/core/src/binding/document-catalog.ts
@@ -163,12 +163,12 @@ function subtreeFontsOf(
  * Every valid family a `w:sym/@w:font` names, deduplicated and sorted like
  * {@link collectDocumentFonts}, and validated at the same boundary for the same reason.
  *
- * Kept apart from the font catalog because the two answer different questions. A symbol
- * face is not a family a PICKER should offer: applying it to a selection would set the
- * text of a run in a face carrying dingbats. It IS a family a font resolver must hear
- * about — `layout/symbol-run.ts` keeps an unmapped private-use code point in the authored
- * face, which paints as a tofu box in any other, and an app that owns those bytes can only
- * supply them if it is told the document wants them.
+ * Kept apart from the font catalog because the two answer different questions.
+ * `collectDocumentFonts` answers what the document DECLARES — `w:rFonts` — and a `w:sym`
+ * face is not a declaration; it is the face ONE glyph is drawn from. A font resolver still
+ * has to hear about it: `layout/symbol-run.ts` keeps an unmapped private-use code point in
+ * the authored face, which paints as a tofu box in any other, and an app that owns those
+ * bytes can only supply them if it is told the document wants them.
  */
 export function collectSymbolFontFamilies(roots: readonly OoxmlElement[]): readonly string[] {
   const byFold = new Map<string, string>();
@@ -233,7 +233,13 @@ function subtreeSymbolFontsOf(subtree: OoxmlElement, depth = 0): ReadonlyMap<str
     const node = stack.pop()!;
     if (!isElement(node)) continue;
     if (node.localName === 'sym' && node.namespaceUri === WML_NAMESPACE_URI) {
-      const family = attributeValue(node, 'font');
+      // The WML namespace or none, matching how `layout/symbol-run.ts` reads it: a face
+      // layout will not use is a face no resolver should be asked for.
+      const family = node.attributes.find(
+        (attribute) =>
+          attribute.localName === 'font' &&
+          (attribute.namespaceUri === WML_NAMESPACE_URI || attribute.namespaceUri === '')
+      )?.value;
       if (family && FONT_NAME.test(family) && !byFold.has(family.toLowerCase())) {
         byFold.set(family.toLowerCase(), family);
       }

--- a/packages/core/src/binding/document-catalog.ts
+++ b/packages/core/src/binding/document-catalog.ts
@@ -10,6 +10,7 @@
 import type { OoxmlElement, OoxmlNode } from '../store/package/ooxml-tree.ts';
 import { WML_NAMESPACE_URI } from '../store/package/ooxml-shared.ts';
 import { themeFontFamilyOf, type ThemeSchemeFaces } from '../store/package/theme-font-scheme.ts';
+import { symbolFontFamily } from '../store/package/run-defaults.ts';
 
 /**
  * The same shape `semantic-paint.ts` enforces at the CSS sink (its `FONT_NAME`):
@@ -240,13 +241,10 @@ function subtreeSymbolFontsOf(subtree: OoxmlElement, depth = 0): ReadonlyMap<str
           attribute.localName === 'font' &&
           (attribute.namespaceUri === WML_NAMESPACE_URI || attribute.namespaceUri === '')
       )?.value;
-      // Word writes the vertical form of a family as the same name behind an `@`
-      // (`@MS Gothic`). The bytes are the family's, so ask for the family: the prefix is a
-      // writing mode, and `FONT_NAME` — which every name leaving this module passes, because
-      // a CSS sink receives it — would otherwise reject the name and leave the face
-      // unsuppliable for a glyph that needs it.
-      const family = authored?.startsWith('@') ? authored.slice(1) : authored;
-      if (family && FONT_NAME.test(family) && !byFold.has(family.toLowerCase())) {
+      // `symbolFontFamily` applies the same bound `FONT_NAME` does here, plus Word's
+      // vertical-writing `@` prefix — one rule, shared with the export lane's own walk.
+      const family = symbolFontFamily(authored);
+      if (family !== null && !byFold.has(family.toLowerCase())) {
         byFold.set(family.toLowerCase(), family);
       }
     }

--- a/packages/core/src/binding/tree-session-contract.ts
+++ b/packages/core/src/binding/tree-session-contract.ts
@@ -193,6 +193,15 @@ export interface TreeDocxSessionView extends HeadlessDocumentView {
    */
   renderedFontFamilies(): readonly string[];
   /**
+   * Font families named by a `w:sym/@w:font`, over the same roots
+   * {@link TreeDocxSessionView.documentFonts} reads. Memoized per package revision.
+   *
+   * Separate from both other answers on purpose: a symbol face is not one a picker should
+   * offer and not one the substitution notice should report, but a font resolver has to
+   * hear about it, or an app cannot supply the face a private-use glyph needs.
+   */
+  symbolFontFamilies(): readonly string[];
+  /**
    * Whether the document puts any literal character on a page, over the same roots
    * {@link TreeDocxSessionView.documentFonts} reads. Memoized per package revision.
    *

--- a/packages/core/src/binding/tree-session-contract.ts
+++ b/packages/core/src/binding/tree-session-contract.ts
@@ -196,9 +196,10 @@ export interface TreeDocxSessionView extends HeadlessDocumentView {
    * Font families named by a `w:sym/@w:font`, over the same roots
    * {@link TreeDocxSessionView.documentFonts} reads. Memoized per package revision.
    *
-   * Separate from both other answers on purpose: a symbol face is not one a picker should
-   * offer and not one the substitution notice should report, but a font resolver has to
-   * hear about it, or an app cannot supply the face a private-use glyph needs.
+   * Separate from both other answers on purpose. It is not a DECLARATION, so it does not
+   * join `documentFonts`, and it is not a face TEXT renders in, so the substitution notice
+   * must not report it — but a font resolver has to hear about it, or an app cannot supply
+   * the face a private-use glyph needs.
    */
   symbolFontFamilies(): readonly string[];
   /**

--- a/packages/core/src/binding/tree-session.ts
+++ b/packages/core/src/binding/tree-session.ts
@@ -72,6 +72,7 @@ import { headerFooterPartsFromResolution } from '../store/package/hf-references.
 import {
   collectDocumentFonts,
   collectDocumentStyles,
+  collectSymbolFontFamilies,
   documentRendersText,
   type DocumentStyleEntry,
 } from './document-catalog.ts';
@@ -494,6 +495,8 @@ export function openTreeSession(
     readonly styles: OoxmlElement | null;
     readonly families: readonly string[];
   } | null = null;
+  let symbolFontsCache: { readonly revision: number; readonly fonts: readonly string[] } | null =
+    null;
   let rendersTextCache: { readonly revision: number; readonly rendersText: boolean } | null = null;
   let stylesCache: readonly DocumentStyleEntry[] | null = null;
   let themeColorsCache: readonly DocumentThemeColorEntry[] | null = null;
@@ -824,6 +827,18 @@ export function openTreeSession(
           ),
         };
         return fontsCache.fonts;
+      },
+
+      symbolFontFamilies() {
+        // Same revision key as `documentFonts`: a `w:sym` can be pasted in or deleted.
+        if (symbolFontsCache && symbolFontsCache.revision === packageStore.packageRevision) {
+          return symbolFontsCache.fonts;
+        }
+        symbolFontsCache = {
+          revision: packageStore.packageRevision,
+          fonts: collectSymbolFontFamilies(catalogRoots()),
+        };
+        return symbolFontsCache.fonts;
       },
 
       renderedFontFamilies() {

--- a/packages/core/src/contracts/editor.ts
+++ b/packages/core/src/contracts/editor.ts
@@ -1652,15 +1652,15 @@ export interface EditorSnapshot {
    */
   readonly lastRejection?: string | null;
   /**
-   * Document font families that are NOT AVAILABLE: declared by the document, but with no
-   * byte source admitted for them, no configured redirect to an admitted face, nothing
-   * embedded in the file, and nothing the platform could resolve. Chrome shows a
-   * compatibility notice from this the way Word does.
+   * Document font families that are NOT AVAILABLE: declared by the document, but with no byte
+   * source admitted, no redirect to an admitted face, nothing embedded, and nothing the platform
+   * could resolve. Chrome shows a compatibility notice from this the way Word does.
    *
-   * A family the app deliberately answers with a metric-compatible stand-in — Word's
-   * Times New Roman with Liberation Serif, say — is AVAILABLE and stays out of the list.
-   * The glyph outlines differ; the advance widths do not, so wrap and pagination land
-   * where Word puts them and there is nothing for a fidelity notice to report.
+   * A family the app answers with a metric-compatible stand-in — Word's Times New Roman
+   * with Liberation Serif — is AVAILABLE and stays out: the outlines differ, the advance
+   * widths do not, so wrap and pagination land where Word puts them. The face a `w:sym`
+   * names (MS Gothic for a checkbox, Wingdings for a bullet) stays out too, because it
+   * paints one code point rather than text, and has no metric twin an app could supply.
    *
    * Optional and additive like `canUndo`: absent means the implementation has not derived
    * it; empty means every family resolved (or no document is loaded).

--- a/packages/core/src/editor/__tests__/font-availability.test.ts
+++ b/packages/core/src/editor/__tests__/font-availability.test.ts
@@ -122,6 +122,14 @@ describe('fontResolverFamilies', () => {
     expect(families[0]).toBe('Garamond');
   });
 
+  test('a symbol face the cut would drop is still asked for, declared or not', () => {
+    // Word writes the symbol face on the run as well, so a checkbox face is usually
+    // declared too — and `documentFonts()` sorts by code point, which puts Wingdings past
+    // the cut in any long list.
+    const declared = [...Array.from({ length: 70 }, (_, index) => `Face ${index}`), 'Wingdings'];
+    expect(fontResolverFamilies(declared, ['Wingdings'], 64)).toContain('Wingdings');
+  });
+
   test('room left over after the reservation still goes to the remaining symbol faces', () => {
     const symbols = Array.from({ length: 10 }, (_, index) => `Symbol ${index}`);
     expect(fontResolverFamilies(['Garamond'], symbols, 64)).toHaveLength(11);

--- a/packages/core/src/editor/__tests__/font-availability.test.ts
+++ b/packages/core/src/editor/__tests__/font-availability.test.ts
@@ -113,8 +113,17 @@ describe('fontResolverFamilies', () => {
     expect(families[0]).toBe('Face 0');
   });
 
-  test('the bound is never exceeded, however many symbol faces a file names', () => {
+  test('the bound is never exceeded, and symbol faces never take it whole', () => {
+    // The reservation is a floor on what steps aside, so a tight bound still leads with the
+    // face the text renders in.
     const symbols = Array.from({ length: 20 }, (_, index) => `Symbol ${index}`);
-    expect(fontResolverFamilies(['Garamond'], symbols, 4)).toHaveLength(4);
+    const families = fontResolverFamilies(['Garamond'], symbols, 4);
+    expect(families).toHaveLength(4);
+    expect(families[0]).toBe('Garamond');
+  });
+
+  test('room left over after the reservation still goes to the remaining symbol faces', () => {
+    const symbols = Array.from({ length: 10 }, (_, index) => `Symbol ${index}`);
+    expect(fontResolverFamilies(['Garamond'], symbols, 64)).toHaveLength(11);
   });
 });

--- a/packages/core/src/editor/__tests__/font-availability.test.ts
+++ b/packages/core/src/editor/__tests__/font-availability.test.ts
@@ -1,7 +1,11 @@
 // The font compatibility notice's detection: which document families render substituted.
 
 import { describe, expect, test } from 'bun:test';
-import { createLocalFontProbe, detectFontSubstitutions } from '../font-availability.ts';
+import {
+  createLocalFontProbe,
+  detectFontSubstitutions,
+  fontResolverFamilies,
+} from '../font-availability.ts';
 
 /** A canvas-like context where only `widths`-listed families change the measurement. */
 function fakeContext(resolvedFamilies: readonly string[]) {
@@ -89,5 +93,28 @@ describe('detectFontSubstitutions', () => {
         (family) => family === 'Carlito'
       )
     ).toEqual([]);
+  });
+});
+
+describe('fontResolverFamilies', () => {
+  test('declared families come first, symbol faces after, with no duplicate', () => {
+    expect(fontResolverFamilies(['Garamond', 'MS Gothic'], ['Wingdings', 'ms gothic'], 64)).toEqual(
+      ['Garamond', 'MS Gothic', 'Wingdings']
+    );
+  });
+
+  test('a document that fills the bound with declared families still asks for its symbols', () => {
+    // Without the reservation a template naming `cap` faces crowds every symbol face out,
+    // so an app could never supply the face a private-use glyph needs.
+    const declared = Array.from({ length: 64 }, (_, index) => `Face ${index}`);
+    const families = fontResolverFamilies(declared, ['Wingdings'], 64);
+    expect(families).toHaveLength(64);
+    expect(families.at(-1)).toBe('Wingdings');
+    expect(families[0]).toBe('Face 0');
+  });
+
+  test('the bound is never exceeded, however many symbol faces a file names', () => {
+    const symbols = Array.from({ length: 20 }, (_, index) => `Symbol ${index}`);
+    expect(fontResolverFamilies(['Garamond'], symbols, 4)).toHaveLength(4);
   });
 });

--- a/packages/core/src/editor/__tests__/font-availability.test.ts
+++ b/packages/core/src/editor/__tests__/font-availability.test.ts
@@ -130,6 +130,13 @@ describe('fontResolverFamilies', () => {
     expect(fontResolverFamilies(declared, ['Wingdings'], 64)).toContain('Wingdings');
   });
 
+  test('a symbol face the bound already carries costs the declared list nothing', () => {
+    const declared = ['MS Gothic', ...Array.from({ length: 63 }, (_, index) => `Face ${index}`)];
+    const families = fontResolverFamilies(declared, ['MS Gothic'], 64);
+    expect(families).toHaveLength(64);
+    expect(families.at(-1)).toBe('Face 62');
+  });
+
   test('room left over after the reservation still goes to the remaining symbol faces', () => {
     const symbols = Array.from({ length: 10 }, (_, index) => `Symbol ${index}`);
     expect(fontResolverFamilies(['Garamond'], symbols, 64)).toHaveLength(11);

--- a/packages/core/src/editor/__tests__/font-availability.test.ts
+++ b/packages/core/src/editor/__tests__/font-availability.test.ts
@@ -137,6 +137,16 @@ describe('fontResolverFamilies', () => {
     expect(families.at(-1)).toBe('Face 62');
   });
 
+  test('reserving for one symbol face never evicts another into its slot', () => {
+    // The head cut can push a symbol face that WAS inside the bound out of it, and that
+    // face must not then spend the slot reserved for the one that never fitted.
+    const declared = [...Array.from({ length: 63 }, (_, index) => `Face ${index}`), 'MS Gothic'];
+    const families = fontResolverFamilies(declared, ['MS Gothic', 'Wingdings'], 64);
+    expect(families).toContain('MS Gothic');
+    expect(families).toContain('Wingdings');
+    expect(families).toHaveLength(64);
+  });
+
   test('room left over after the reservation still goes to the remaining symbol faces', () => {
     const symbols = Array.from({ length: 10 }, (_, index) => `Symbol ${index}`);
     expect(fontResolverFamilies(['Garamond'], symbols, 64)).toHaveLength(11);

--- a/packages/core/src/editor/__tests__/font-catalog.test.ts
+++ b/packages/core/src/editor/__tests__/font-catalog.test.ts
@@ -76,28 +76,13 @@ describe('availableFontFamilies', () => {
     expect(catalog).toEqual(['Calibri', 'Georgia']);
   });
 
-  test('a symbol-only face is not offered, even once a resolver supplies it', () => {
-    // The editor asks the resolver for the face a `w:sym` names, so an app CAN answer it —
-    // and a face that arrives that way must not become a text choice.
-    const catalog = availableFontFamilies(
-      { sources: [source('Wingdings')] },
-      ['Georgia'],
-      ['Wingdings']
-    );
-    expect(catalog).toEqual(['Calibri', 'Georgia']);
-  });
-
-  test('the default face is offered even when the document names it only in a symbol', () => {
-    // The catalog's whole reason to exist is that a picker is never a dead control.
-    expect(availableFontFamilies(undefined, [], ['Calibri'])).toEqual(['Calibri']);
-  });
-
-  test('a face the document also declares stays offered, symbol use or not', () => {
-    const catalog = availableFontFamilies(
-      { sources: [source('MS Gothic')] },
-      ['MS Gothic'],
-      ['MS Gothic']
-    );
-    expect(catalog).toEqual(['Calibri', 'MS Gothic']);
+  test('a face supplied for a symbol is offerable, like every other honoured family', () => {
+    // The editor asks the resolver for the face a `w:sym` names. Once an app answers, the
+    // editor can honour that family for text too, which is the only question this catalog
+    // asks — Word lists installed symbol fonts in its own picker for the same reason. A
+    // symbol face nothing supplied never reaches here: `collectDocumentFonts` reads
+    // `w:rFonts` declarations, and a `w:sym` face is not one.
+    const catalog = availableFontFamilies({ sources: [source('Wingdings')] }, ['Georgia']);
+    expect(catalog).toEqual(['Calibri', 'Georgia', 'Wingdings']);
   });
 });

--- a/packages/core/src/editor/__tests__/font-catalog.test.ts
+++ b/packages/core/src/editor/__tests__/font-catalog.test.ts
@@ -87,6 +87,11 @@ describe('availableFontFamilies', () => {
     expect(catalog).toEqual(['Calibri', 'Georgia']);
   });
 
+  test('the default face is offered even when the document names it only in a symbol', () => {
+    // The catalog's whole reason to exist is that a picker is never a dead control.
+    expect(availableFontFamilies(undefined, [], ['Calibri'])).toEqual(['Calibri']);
+  });
+
   test('a face the document also declares stays offered, symbol use or not', () => {
     const catalog = availableFontFamilies(
       { sources: [source('MS Gothic')] },

--- a/packages/core/src/editor/__tests__/font-catalog.test.ts
+++ b/packages/core/src/editor/__tests__/font-catalog.test.ts
@@ -75,4 +75,24 @@ describe('availableFontFamilies', () => {
     const catalog = availableFontFamilies(undefined, ['Georgia', 'x'.repeat(65), 'bad;name']);
     expect(catalog).toEqual(['Calibri', 'Georgia']);
   });
+
+  test('a symbol-only face is not offered, even once a resolver supplies it', () => {
+    // The editor asks the resolver for the face a `w:sym` names, so an app CAN answer it —
+    // and a face that arrives that way must not become a text choice.
+    const catalog = availableFontFamilies(
+      { sources: [source('Wingdings')] },
+      ['Georgia'],
+      ['Wingdings']
+    );
+    expect(catalog).toEqual(['Calibri', 'Georgia']);
+  });
+
+  test('a face the document also declares stays offered, symbol use or not', () => {
+    const catalog = availableFontFamilies(
+      { sources: [source('MS Gothic')] },
+      ['MS Gothic'],
+      ['MS Gothic']
+    );
+    expect(catalog).toEqual(['Calibri', 'MS Gothic']);
+  });
 });

--- a/packages/core/src/editor/__tests__/on-demand-fonts.test.ts
+++ b/packages/core/src/editor/__tests__/on-demand-fonts.test.ts
@@ -74,6 +74,42 @@ describe('on-demand font resolution', () => {
     editor.destroy();
   });
 
+  test('the resolver also hears the face a w:sym names, after the declared families', async () => {
+    // `layout/symbol-run.ts` keeps an unmapped private-use code point in the authored face,
+    // which paints as a tofu box in any other. An app can only supply Wingdings if it is
+    // told the file wants it — and the font picker still must not offer it as a text face.
+    const seen: FontResolutionRequest[] = [];
+    const editor = createDocxEditor({
+      container: document.createElement('div'),
+      document: docx(
+        '<w:p><w:r><w:rPr><w:rFonts w:ascii="Garamond" w:hAnsi="Garamond"/></w:rPr>' +
+          '<w:sym w:font="Wingdings" w:char="F0A8"/><w:t>bullet</w:t></w:r></w:p>'
+      ),
+      fonts: (request) => {
+        seen.push(request);
+        // Answer it, the way an app that owns Wingdings would: the face is then loaded,
+        // and must still not turn into a text choice in the picker.
+        return {
+          sources: [
+            {
+              request: { family: 'Wingdings', weight: 400, style: 'normal' as const },
+              id: 'on-demand-wingdings',
+              bytes: regularBytes,
+              hash: sha256FontBytes(regularBytes),
+              faceIndex: 0,
+            },
+          ],
+        };
+      },
+    });
+    await fontsSettled(editor);
+    expect(seen[0]!.families).toEqual(['Garamond', 'Wingdings']);
+    expect(editor.snapshot().fontSubstitutions).not.toContain('Wingdings');
+    expect(editor.getAvailableFonts()).not.toContain('Wingdings');
+    expect(editor.getDocumentFonts()).toEqual(['Garamond']);
+    editor.destroy();
+  });
+
   test('resolving to nothing is a normal answer: fixed measurer, no error', async () => {
     const errors: EditorFontError[] = [];
     const editor = createDocxEditor({

--- a/packages/core/src/editor/__tests__/on-demand-fonts.test.ts
+++ b/packages/core/src/editor/__tests__/on-demand-fonts.test.ts
@@ -77,7 +77,8 @@ describe('on-demand font resolution', () => {
   test('the resolver also hears the face a w:sym names, after the declared families', async () => {
     // `layout/symbol-run.ts` keeps an unmapped private-use code point in the authored face,
     // which paints as a tofu box in any other. An app can only supply Wingdings if it is
-    // told the file wants it — and the font picker still must not offer it as a text face.
+    // told the file wants it. The document still DECLARES only Garamond: a symbol face is
+    // not an `w:rFonts` declaration, and the notice reports neither.
     const seen: FontResolutionRequest[] = [];
     const editor = createDocxEditor({
       container: document.createElement('div'),
@@ -87,8 +88,7 @@ describe('on-demand font resolution', () => {
       ),
       fonts: (request) => {
         seen.push(request);
-        // Answer it, the way an app that owns Wingdings would: the face is then loaded,
-        // and must still not turn into a text choice in the picker.
+        // Answer it, the way an app that owns Wingdings would.
         return {
           sources: [
             {
@@ -105,7 +105,6 @@ describe('on-demand font resolution', () => {
     await fontsSettled(editor);
     expect(seen[0]!.families).toEqual(['Garamond', 'Wingdings']);
     expect(editor.snapshot().fontSubstitutions).not.toContain('Wingdings');
-    expect(editor.getAvailableFonts()).not.toContain('Wingdings');
     expect(editor.getDocumentFonts()).toEqual(['Garamond']);
     editor.destroy();
   });

--- a/packages/core/src/editor/__tests__/symbol-font-bound-parity.test.ts
+++ b/packages/core/src/editor/__tests__/symbol-font-bound-parity.test.ts
@@ -1,0 +1,15 @@
+// The two lanes that decide whether a `w:sym` replaces the run's face must agree.
+//
+// `layout/symbol-run.ts` applies `@w:font` up to its own bound; `store/package/rendered-fonts.ts`
+// answers "did that happen?" for the substitution notice, and cannot import layout to ask.
+// It keeps the bound by value, the way that file keeps every other cross-lane constant, so
+// this is the gate: a name in the gap between two bounds would be an override to one lane
+// and not the other, and the run's real face would silently leave or re-enter the notice.
+
+import { expect, test } from 'bun:test';
+import { MAX_SYMBOL_FONT_LENGTH as LAYOUT_BOUND } from '../../layout/symbol-run.ts';
+import { MAX_SYMBOL_FONT_LENGTH as STORE_BOUND } from '../../store/package/rendered-fonts.ts';
+
+test('the store lane keeps layout own symbol-font bound', () => {
+  expect(STORE_BOUND).toBe(LAYOUT_BOUND);
+});

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -2008,15 +2008,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
     // The picker's list: the configured catalog is offerable with no document at all,
     // and the document's declared families join it once one is mounted.
     getAvailableFonts: () =>
-      availableFontFamilies(
-        fontConfiguration(),
-        surface?.session.documentFonts() ?? [],
-        // Only for the on-demand form: those sources answer the request this editor made,
-        // which now includes symbol faces, and a face supplied for a `w:sym` is not a text
-        // choice. A STATIC catalog is the app's own deliberate offer — if it lists MS
-        // Gothic, the picker offers MS Gothic, whatever the open document uses it for.
-        typeof config.fonts === 'function' ? (surface?.session.symbolFontFamilies() ?? []) : []
-      ),
+      availableFontFamilies(fontConfiguration(), surface?.session.documentFonts() ?? []),
     getDocumentThemeColors: () => surface?.session.documentThemeColors() ?? [],
     getOutline: () => surface?.session.documentOutline() ?? [],
     getComments: () => [],

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -191,6 +191,7 @@ import {
   coveredFontFamiliesOf,
   createLocalFontProbe,
   detectFontSubstitutions,
+  fontResolverFamilies,
 } from './font-availability.ts';
 import { tryCreateBrowserCanvasContext } from './browser-canvas-context.ts';
 import {
@@ -751,7 +752,11 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
         typeof configured === 'function'
           ? normalizeFontResolverResult(
               await configured({
-                families: mounted.session.documentFonts().slice(0, MAX_RESOLVER_FAMILIES),
+                families: fontResolverFamilies(
+                  mounted.session.documentFonts(),
+                  mounted.session.symbolFontFamilies(),
+                  MAX_RESOLVER_FAMILIES
+                ),
                 defaultFamily: configuredDefaultFontFamily(fontConfiguration()),
               })
             )
@@ -2003,7 +2008,15 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
     // The picker's list: the configured catalog is offerable with no document at all,
     // and the document's declared families join it once one is mounted.
     getAvailableFonts: () =>
-      availableFontFamilies(fontConfiguration(), surface?.session.documentFonts() ?? []),
+      availableFontFamilies(
+        fontConfiguration(),
+        surface?.session.documentFonts() ?? [],
+        // Only for the on-demand form: those sources answer the request this editor made,
+        // which now includes symbol faces, and a face supplied for a `w:sym` is not a text
+        // choice. A STATIC catalog is the app's own deliberate offer — if it lists MS
+        // Gothic, the picker offers MS Gothic, whatever the open document uses it for.
+        typeof config.fonts === 'function' ? (surface?.session.symbolFontFamilies() ?? []) : []
+      ),
     getDocumentThemeColors: () => surface?.session.documentThemeColors() ?? [],
     getOutline: () => surface?.session.documentOutline() ?? [],
     getComments: () => [],

--- a/packages/core/src/editor/font-availability.ts
+++ b/packages/core/src/editor/font-availability.ts
@@ -103,19 +103,28 @@ export function fontResolverFamilies(
     seen.add(fold);
     wanted.push(family);
   }
+  const keptFolds = (size: number): ReadonlySet<string> =>
+    new Set(declared.slice(0, Math.max(size, 0)).map((family) => family.toLowerCase()));
   // Only the symbol faces the declared list would not carry anyway need reserving. Word
   // writes a symbol face on the run too, so a checkbox face is usually declared as well —
   // and `documentFonts()` sorts by code point, which puts Symbol, Webdings and Wingdings
   // near the end of a long list. One that lands inside the bound costs nothing; one that
   // lands past it is the case the reservation exists for.
-  const withinBound = new Set(declared.slice(0, cap).map((family) => family.toLowerCase()));
-  const unreachable = wanted.filter((family) => !withinBound.has(family.toLowerCase()));
-  // A FLOOR, not a ceiling: it only decides how much of the declared list steps aside, and
-  // never more than half the bound, so a small `cap` cannot invert the priority. Whatever
-  // room is left over still goes to the remaining symbol faces.
-  const reserved = Math.min(unreachable.length, RESERVED_SYMBOL_FAMILIES, Math.floor(cap / 2));
+  //
+  // Run to a fixed point, because reserving a slot shortens the declared head, which can
+  // evict a symbol face that WAS inside the bound and so need one more. Each pass either
+  // raises the count or is the last, and `RESERVED_SYMBOL_FAMILIES` bounds it. The floor is
+  // never more than half the bound, so a small `cap` cannot invert the priority.
+  let reserved = 0;
+  for (let pass = 0; pass <= RESERVED_SYMBOL_FAMILIES; pass += 1) {
+    const kept = keptFolds(cap - reserved);
+    const unreachable = wanted.filter((family) => !kept.has(family.toLowerCase())).length;
+    const next = Math.min(unreachable, RESERVED_SYMBOL_FAMILIES, Math.floor(cap / 2));
+    if (next === reserved) break;
+    reserved = next;
+  }
   const head = declared.slice(0, Math.max(cap - reserved, 0));
-  const kept = new Set(head.map((family) => family.toLowerCase()));
+  const kept = keptFolds(cap - reserved);
   const tail = wanted.filter((family) => !kept.has(family.toLowerCase()));
   return [...head, ...tail].slice(0, cap);
 }

--- a/packages/core/src/editor/font-availability.ts
+++ b/packages/core/src/editor/font-availability.ts
@@ -102,7 +102,10 @@ export function fontResolverFamilies(
     seen.add(family.toLowerCase());
     wanted.push(family);
   }
-  const reserved = Math.min(wanted.length, RESERVED_SYMBOL_FAMILIES);
+  // A FLOOR, not a ceiling: it only decides how much of the declared list steps aside, and
+  // never more than half the bound, so a small `cap` cannot invert the priority. Whatever
+  // room is left over still goes to the remaining symbol faces.
+  const reserved = Math.min(wanted.length, RESERVED_SYMBOL_FAMILIES, Math.floor(cap / 2));
   return [...declared.slice(0, Math.max(cap - reserved, 0)), ...wanted].slice(0, cap);
 }
 

--- a/packages/core/src/editor/font-availability.ts
+++ b/packages/core/src/editor/font-availability.ts
@@ -95,18 +95,27 @@ export function fontResolverFamilies(
   symbols: readonly string[],
   cap: number
 ): readonly string[] {
-  const seen = new Set(declared.map((family) => family.toLowerCase()));
+  const seen = new Set<string>();
   const wanted: string[] = [];
   for (const family of symbols) {
-    if (seen.has(family.toLowerCase())) continue;
-    seen.add(family.toLowerCase());
+    const fold = family.toLowerCase();
+    if (seen.has(fold)) continue;
+    seen.add(fold);
     wanted.push(family);
   }
   // A FLOOR, not a ceiling: it only decides how much of the declared list steps aside, and
   // never more than half the bound, so a small `cap` cannot invert the priority. Whatever
   // room is left over still goes to the remaining symbol faces.
   const reserved = Math.min(wanted.length, RESERVED_SYMBOL_FAMILIES, Math.floor(cap / 2));
-  return [...declared.slice(0, Math.max(cap - reserved, 0)), ...wanted].slice(0, cap);
+  const head = declared.slice(0, Math.max(cap - reserved, 0));
+  // Deduplicate against the families that SURVIVED the cut, not the whole declared list.
+  // Word writes a symbol face on the run too, so a checkbox face is usually declared as
+  // well — and `documentFonts()` sorts by code point, which puts Symbol, Webdings and
+  // Wingdings near the end of a long list. Folding them against a name the cut already
+  // dropped would spend the reservation on nothing.
+  const kept = new Set(head.map((family) => family.toLowerCase()));
+  const tail = wanted.filter((family) => !kept.has(family.toLowerCase()));
+  return [...head, ...tail].slice(0, cap);
 }
 
 /**

--- a/packages/core/src/editor/font-availability.ts
+++ b/packages/core/src/editor/font-availability.ts
@@ -103,16 +103,18 @@ export function fontResolverFamilies(
     seen.add(fold);
     wanted.push(family);
   }
+  // Only the symbol faces the declared list would not carry anyway need reserving. Word
+  // writes a symbol face on the run too, so a checkbox face is usually declared as well —
+  // and `documentFonts()` sorts by code point, which puts Symbol, Webdings and Wingdings
+  // near the end of a long list. One that lands inside the bound costs nothing; one that
+  // lands past it is the case the reservation exists for.
+  const withinBound = new Set(declared.slice(0, cap).map((family) => family.toLowerCase()));
+  const unreachable = wanted.filter((family) => !withinBound.has(family.toLowerCase()));
   // A FLOOR, not a ceiling: it only decides how much of the declared list steps aside, and
   // never more than half the bound, so a small `cap` cannot invert the priority. Whatever
   // room is left over still goes to the remaining symbol faces.
-  const reserved = Math.min(wanted.length, RESERVED_SYMBOL_FAMILIES, Math.floor(cap / 2));
+  const reserved = Math.min(unreachable.length, RESERVED_SYMBOL_FAMILIES, Math.floor(cap / 2));
   const head = declared.slice(0, Math.max(cap - reserved, 0));
-  // Deduplicate against the families that SURVIVED the cut, not the whole declared list.
-  // Word writes a symbol face on the run too, so a checkbox face is usually declared as
-  // well — and `documentFonts()` sorts by code point, which puts Symbol, Webdings and
-  // Wingdings near the end of a long list. Folding them against a name the cut already
-  // dropped would spend the reservation on nothing.
   const kept = new Set(head.map((family) => family.toLowerCase()));
   const tail = wanted.filter((family) => !kept.has(family.toLowerCase()));
   return [...head, ...tail].slice(0, cap);

--- a/packages/core/src/editor/font-availability.ts
+++ b/packages/core/src/editor/font-availability.ts
@@ -74,6 +74,39 @@ export function createLocalFontProbe(
 }
 
 /**
+ * Symbol faces a document may claim from the resolver bound, whatever else it declares.
+ *
+ * Appending symbol faces after the declared list alone would let a template naming `cap`
+ * families crowd every one of them out, so an app could never supply the face a private-use
+ * glyph needs. Small on purpose: a file uses one or two symbol fonts, and the reservation
+ * comes out of the declared families' share.
+ */
+const RESERVED_SYMBOL_FAMILIES = 4;
+
+/**
+ * The families one font-resolver call may ask for, in priority order and capped.
+ *
+ * Declared families first, symbol faces after them. Both are genuinely wanted — a symbol
+ * face is the only thing that can paint an unmapped private-use glyph — but a face carrying
+ * one dingbat must not spend the bound ahead of the face a page of text renders in.
+ */
+export function fontResolverFamilies(
+  declared: readonly string[],
+  symbols: readonly string[],
+  cap: number
+): readonly string[] {
+  const seen = new Set(declared.map((family) => family.toLowerCase()));
+  const wanted: string[] = [];
+  for (const family of symbols) {
+    if (seen.has(family.toLowerCase())) continue;
+    seen.add(family.toLowerCase());
+    wanted.push(family);
+  }
+  const reserved = Math.min(wanted.length, RESERVED_SYMBOL_FAMILIES);
+  return [...declared.slice(0, Math.max(cap - reserved, 0)), ...wanted].slice(0, cap);
+}
+
+/**
  * The document families that will render in a face with DIFFERENT metrics: not covered by
  * an embedded or app-supplied face, not resolvable by the platform, and with no
  * metric-compatible twin in the surface fallback stack either. Order follows `families`

--- a/packages/core/src/editor/font-catalog.ts
+++ b/packages/core/src/editor/font-catalog.ts
@@ -28,6 +28,9 @@ export { configuredDefaultFontFamily, type FontCatalogConfiguration };
  */
 const FONT_NAME = /^[\p{L}\p{N}\p{M} \-.+_]{1,64}$/u;
 
+/** Empty hold-back set, for the entries no filter may remove. */
+const NOTHING_HELD_BACK: ReadonlySet<string> = new Set();
+
 /**
  * Every family a font picker can offer: the configured catalog (default face,
  * substitution Word-names, host-registered source families) merged with the document's
@@ -49,14 +52,17 @@ export function availableFontFamilies(
   const symbolOnly = new Set(
     symbolFonts.map((family) => family.toLowerCase()).filter((fold) => !declared.has(fold))
   );
-  const add = (family: string | undefined): void => {
+  const offer = (family: string | undefined, heldBack: ReadonlySet<string>): void => {
     if (family === undefined || !FONT_NAME.test(family)) return;
     const fold = family.toLowerCase();
-    if (symbolOnly.has(fold) || byFold.has(fold)) return;
+    if (heldBack.has(fold) || byFold.has(fold)) return;
     byFold.set(fold, family);
   };
+  const add = (family: string | undefined): void => offer(family, symbolOnly);
 
-  add(configuredDefaultFontFamily(configuration));
+  // The default face is the catalog's floor — this module exists so a picker is never a
+  // dead control — so it is offered even when the document happens to name it in a `w:sym`.
+  offer(configuredDefaultFontFamily(configuration), NOTHING_HELD_BACK);
   const substitutions = configuration?.substitutions ?? [];
   const standIns = new Set(substitutions.map((entry) => entry.to.family.toLowerCase()));
   for (const entry of substitutions) add(entry.from.family);

--- a/packages/core/src/editor/font-catalog.ts
+++ b/packages/core/src/editor/font-catalog.ts
@@ -11,6 +11,11 @@
 // Substitution TARGETS are deliberately excluded: `Carlito` exists to render "Calibri",
 // and listing both would offer the same metrics twice under two names — the stand-in is
 // an implementation face, not a choice.
+//
+// Symbol faces are excluded for the same kind of reason. The editor asks a resolver for the
+// face a `w:sym` names, so an app can supply the Wingdings a private-use glyph needs — and a
+// face that arrives that way must not become a text choice, or the picker offers to set a
+// paragraph in dingbats.
 
 import { configuredDefaultFontFamily, type FontCatalogConfiguration } from './font-composition.ts';
 
@@ -33,13 +38,22 @@ const FONT_NAME = /^[\p{L}\p{N}\p{M} \-.+_]{1,64}$/u;
  */
 export function availableFontFamilies(
   configuration: FontCatalogConfiguration | undefined,
-  documentFonts: readonly string[]
+  documentFonts: readonly string[],
+  /** Faces the document uses only through a `w:sym`; never offered as a text choice. */
+  symbolFonts: readonly string[] = []
 ): readonly string[] {
   const byFold = new Map<string, string>();
+  // A family the document ALSO declares through `w:rFonts` is a text face that happens to
+  // draw a symbol too, so only the symbol-only names are held back.
+  const declared = new Set(documentFonts.map((family) => family.toLowerCase()));
+  const symbolOnly = new Set(
+    symbolFonts.map((family) => family.toLowerCase()).filter((fold) => !declared.has(fold))
+  );
   const add = (family: string | undefined): void => {
     if (family === undefined || !FONT_NAME.test(family)) return;
     const fold = family.toLowerCase();
-    if (!byFold.has(fold)) byFold.set(fold, family);
+    if (symbolOnly.has(fold) || byFold.has(fold)) return;
+    byFold.set(fold, family);
   };
 
   add(configuredDefaultFontFamily(configuration));

--- a/packages/core/src/editor/font-catalog.ts
+++ b/packages/core/src/editor/font-catalog.ts
@@ -12,10 +12,12 @@
 // and listing both would offer the same metrics twice under two names — the stand-in is
 // an implementation face, not a choice.
 //
-// Symbol faces are excluded for the same kind of reason. The editor asks a resolver for the
-// face a `w:sym` names, so an app can supply the Wingdings a private-use glyph needs — and a
-// face that arrives that way must not become a text choice, or the picker offers to set a
-// paragraph in dingbats.
+// Symbol faces are NOT excluded, deliberately. The editor asks a resolver for the face a
+// `w:sym` names, so an app can supply the Wingdings a private-use glyph needs — and once it
+// has, the editor can honour that family for text as well, which is the only question this
+// catalog answers. Word lists installed symbol fonts in its own picker for the same reason.
+// What keeps a symbol face out of a picker in practice is that nothing supplied it:
+// `collectDocumentFonts` reads `w:rFonts` declarations, and a `w:sym` face is not one.
 
 import { configuredDefaultFontFamily, type FontCatalogConfiguration } from './font-composition.ts';
 
@@ -28,9 +30,6 @@ export { configuredDefaultFontFamily, type FontCatalogConfiguration };
  */
 const FONT_NAME = /^[\p{L}\p{N}\p{M} \-.+_]{1,64}$/u;
 
-/** Empty hold-back set, for the entries no filter may remove. */
-const NOTHING_HELD_BACK: ReadonlySet<string> = new Set();
-
 /**
  * Every family a font picker can offer: the configured catalog (default face,
  * substitution Word-names, host-registered source families) merged with the document's
@@ -41,28 +40,16 @@ const NOTHING_HELD_BACK: ReadonlySet<string> = new Set();
  */
 export function availableFontFamilies(
   configuration: FontCatalogConfiguration | undefined,
-  documentFonts: readonly string[],
-  /** Faces the document uses only through a `w:sym`; never offered as a text choice. */
-  symbolFonts: readonly string[] = []
+  documentFonts: readonly string[]
 ): readonly string[] {
   const byFold = new Map<string, string>();
-  // A family the document ALSO declares through `w:rFonts` is a text face that happens to
-  // draw a symbol too, so only the symbol-only names are held back.
-  const declared = new Set(documentFonts.map((family) => family.toLowerCase()));
-  const symbolOnly = new Set(
-    symbolFonts.map((family) => family.toLowerCase()).filter((fold) => !declared.has(fold))
-  );
-  const offer = (family: string | undefined, heldBack: ReadonlySet<string>): void => {
+  const add = (family: string | undefined): void => {
     if (family === undefined || !FONT_NAME.test(family)) return;
     const fold = family.toLowerCase();
-    if (heldBack.has(fold) || byFold.has(fold)) return;
-    byFold.set(fold, family);
+    if (!byFold.has(fold)) byFold.set(fold, family);
   };
-  const add = (family: string | undefined): void => offer(family, symbolOnly);
 
-  // The default face is the catalog's floor — this module exists so a picker is never a
-  // dead control — so it is offered even when the document happens to name it in a `w:sym`.
-  offer(configuredDefaultFontFamily(configuration), NOTHING_HELD_BACK);
+  add(configuredDefaultFontFamily(configuration));
   const substitutions = configuration?.substitutions ?? [];
   const standIns = new Set(substitutions.map((entry) => entry.to.family.toLowerCase()));
   for (const entry of substitutions) add(entry.from.family);

--- a/packages/core/src/editor/font-catalog.ts
+++ b/packages/core/src/editor/font-catalog.ts
@@ -14,10 +14,12 @@
 //
 // Symbol faces are NOT excluded, deliberately. The editor asks a resolver for the face a
 // `w:sym` names, so an app can supply the Wingdings a private-use glyph needs — and once it
-// has, the editor can honour that family for text as well, which is the only question this
-// catalog answers. Word lists installed symbol fonts in its own picker for the same reason.
-// What keeps a symbol face out of a picker in practice is that nothing supplied it:
-// `collectDocumentFonts` reads `w:rFonts` declarations, and a `w:sym` face is not one.
+// has, the editor can honour that family for text as well, which is the only question the
+// CONFIGURED half of this catalog answers. Word lists installed symbol fonts in its own
+// picker for the same reason. A symbol face also reaches the DOCUMENT half whenever the
+// file declares it in a `w:rFonts`, which Word's checkbox markup does (and which
+// `applySetContentControlValue` mints when a user ticks one), supplied or not: the document
+// half is a catalog of what the file names, and has always offered names nothing can paint.
 
 import { configuredDefaultFontFamily, type FontCatalogConfiguration } from './font-composition.ts';
 

--- a/packages/core/src/export/__tests__/document-export-shaping.test.ts
+++ b/packages/core/src/export/__tests__/document-export-shaping.test.ts
@@ -214,9 +214,10 @@ test('the public export opener requests run, style, story, symbol, and equation 
   const opened = await openFontBackedDocumentForExport(fontCatalogDocx(), { fonts: resolver });
   expect(opened.ok).toBe(true);
   if (!opened.ok) return;
+  // 'Symbol Face' comes from a `w:sym/@w:font`, so it ranks with the other synthesized
+  // glyph faces — the SYMBOL fields below it — rather than with the faces text renders in.
   expect(request?.families).toEqual([
     'Body Face',
-    'Symbol Face',
     'CJK Face',
     'Box Text',
     'Field Face',
@@ -225,6 +226,7 @@ test('the public export opener requests run, style, story, symbol, and equation 
     'Soft Cache Marker',
     'Soft Cache Face',
     'Checkbox Marker',
+    'Symbol Face',
     'Cambria Math',
     'Box Marker Face',
     'Marker Face',

--- a/packages/core/src/export/document-export-shaping.ts
+++ b/packages/core/src/export/document-export-shaping.ts
@@ -775,8 +775,8 @@ function layoutSynthesizedFontFamilies(roots: readonly OoxmlElement[]): readonly
         // The WML namespace or none, the way `layout/symbol-run.ts` reads it. A
         // foreign-namespaced `font` is a face layout never applies, and the request is
         // capped — so admitting one could evict a face the document really renders in.
-        // `symbolFontFamily` also resolves Word's vertical-writing `@` prefix, the same
-        // rule the editor's own symbol-face collection applies.
+        // `symbolFontFamily` is the same rule the editor's own symbol-face collection
+        // applies, so both ask for exactly the faces a sink could paint with.
         add(symbolFontFamily(wmlAttributeValue(node, 'font')));
       }
       if (node.namespaceUri === WML_NAMESPACE_URI && node.localName === 'fldSimple') {

--- a/packages/core/src/export/document-export-shaping.ts
+++ b/packages/core/src/export/document-export-shaping.ts
@@ -1,7 +1,7 @@
 // Document-aware font resolution shared by every headless exporter.
 
 import { collectRenderedFontFamilyCandidates } from '../store/package/rendered-fonts.ts';
-import { validFontFamily } from '../store/package/run-defaults.ts';
+import { symbolFontFamily, validFontFamily } from '../store/package/run-defaults.ts';
 import {
   MAX_RESOLVER_FAMILIES,
   WORD_DEFAULT_FONT,
@@ -775,7 +775,9 @@ function layoutSynthesizedFontFamilies(roots: readonly OoxmlElement[]): readonly
         // The WML namespace or none, the way `layout/symbol-run.ts` reads it. A
         // foreign-namespaced `font` is a face layout never applies, and the request is
         // capped — so admitting one could evict a face the document really renders in.
-        add(wmlAttributeValue(node, 'font') ?? null);
+        // `symbolFontFamily` also resolves Word's vertical-writing `@` prefix, the same
+        // rule the editor's own symbol-face collection applies.
+        add(symbolFontFamily(wmlAttributeValue(node, 'font')));
       }
       if (node.namespaceUri === WML_NAMESPACE_URI && node.localName === 'fldSimple') {
         const instruction = attributeValue(node, 'instr');

--- a/packages/core/src/export/document-export-shaping.ts
+++ b/packages/core/src/export/document-export-shaping.ts
@@ -182,6 +182,19 @@ function attributeValue(node: OoxmlElement, localName: string): string | undefin
 }
 
 /**
+ * The same read `layout/symbol-run.ts` makes: the WML namespace, or none — unprefixed
+ * attributes on WML elements are common in authored packages. Use it wherever the answer
+ * decides what LAYOUT will do, so a foreign-namespaced attribute cannot say otherwise.
+ */
+function wmlAttributeValue(node: OoxmlElement, localName: string): string | undefined {
+  return node.attributes.find(
+    (attribute) =>
+      attribute.localName === localName &&
+      (attribute.namespaceUri === WML_NAMESPACE_URI || attribute.namespaceUri === '')
+  )?.value;
+}
+
+/**
  * Open immutable DOCX bytes with document-aware, session-owned font shaping.
  *
  * This is the composition root exporters should use. It parses before requesting fonts, applies
@@ -759,7 +772,10 @@ function layoutSynthesizedFontFamilies(roots: readonly OoxmlElement[]): readonly
       const node = stack.pop()!;
       if (node.namespaceUri === OMML_NAMESPACE_URI) add(EQUATION_FONT_FAMILY);
       if (node.namespaceUri === WML_NAMESPACE_URI && node.localName === 'sym') {
-        add(attributeValue(node, 'font') ?? null);
+        // The WML namespace or none, the way `layout/symbol-run.ts` reads it. A
+        // foreign-namespaced `font` is a face layout never applies, and the request is
+        // capped — so admitting one could evict a face the document really renders in.
+        add(wmlAttributeValue(node, 'font') ?? null);
       }
       if (node.namespaceUri === WML_NAMESPACE_URI && node.localName === 'fldSimple') {
         const instruction = attributeValue(node, 'instr');

--- a/packages/core/src/export/document-export-shaping.ts
+++ b/packages/core/src/export/document-export-shaping.ts
@@ -736,7 +736,15 @@ function revisionWrapperVisibility(node: OoxmlElement): number {
   return ALL_REVISION_VIEWS;
 }
 
-/** Faces selected by layout semantics rather than a glyph-bearing run's `w:rFonts`. */
+/**
+ * Faces selected by layout semantics rather than a glyph-bearing run's `w:rFonts`.
+ *
+ * `w:sym/@w:font` belongs here rather than in the store's rendered-family derivation: a
+ * symbol run paints one synthesized glyph, exactly like the `{ SYMBOL 183 \\f "Wingdings" }`
+ * field two lines below it, and an unmapped private-use code point paints as a tofu box in
+ * any face but the authored one — so an exporter that can load it should ask for it. The
+ * editor's substitution notice deliberately does not; see `store/package/rendered-fonts.ts`.
+ */
 function layoutSynthesizedFontFamilies(roots: readonly OoxmlElement[]): readonly string[] {
   const byFold = new Map<string, string>();
   const add = (candidate: string | null): void => {
@@ -750,6 +758,9 @@ function layoutSynthesizedFontFamilies(roots: readonly OoxmlElement[]): readonly
     while (stack.length > 0) {
       const node = stack.pop()!;
       if (node.namespaceUri === OMML_NAMESPACE_URI) add(EQUATION_FONT_FAMILY);
+      if (node.namespaceUri === WML_NAMESPACE_URI && node.localName === 'sym') {
+        add(attributeValue(node, 'font') ?? null);
+      }
       if (node.namespaceUri === WML_NAMESPACE_URI && node.localName === 'fldSimple') {
         const instruction = attributeValue(node, 'instr');
         add(parseSymbolInstruction(instruction ?? '')?.font ?? null);

--- a/packages/core/src/store/package/rendered-fonts.ts
+++ b/packages/core/src/store/package/rendered-fonts.ts
@@ -28,12 +28,7 @@
 import type { OoxmlElement, OoxmlNode } from './ooxml-tree.ts';
 import { WML_NAMESPACE_URI } from './ooxml-shared.ts';
 import type { DocumentThemeFonts } from './theme-font-scheme.ts';
-import {
-  eastAsiaFamilyFromRFonts,
-  familyFromRFonts,
-  validFontFamily,
-  validStyleId,
-} from './run-defaults.ts';
+import { eastAsiaFamilyFromRFonts, familyFromRFonts, validStyleId } from './run-defaults.ts';
 
 /** `basedOn` walk cap, matching `run-defaults`. */
 const CHAIN_CAP = 16;
@@ -162,21 +157,31 @@ const GLYPH_MARKS: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * The face a `w:sym` overrides the run with, or null when it names none and the glyph
- * paints in the run's own face.
- *
- * Read exactly as `layout/symbol-run.ts` reads it — the WML namespace or none, since
- * unprefixed attributes on WML elements are common in authored packages. A looser match
- * would drop a run this module must report: layout would keep the run's `rFonts` while
- * this answer decided a symbol face had replaced it.
+ * `layout/symbol-run.ts`'s `MAX_SYMBOL_FONT_LENGTH`, kept by value: the store lane does not
+ * import layout, and this question is about what layout will DO, not what a name may be.
  */
-function symbolFontOf(sym: OoxmlElement): string | null {
+const MAX_SYMBOL_FONT_LENGTH = 128;
+
+/**
+ * Whether a `w:sym` replaces the run's face with one of its own.
+ *
+ * Answered by layout's rule, not this module's name validation. `symbolRunStyle` overrides
+ * `rFonts` whenever `@w:font` is present and within its length bound — a vertical-writing
+ * `@MS Gothic`, a name too long for a CSS sink, any of them. Asking `validFontFamily` here
+ * instead would answer "no override" for a name layout does apply, and the run's own face
+ * would enter this answer for a glyph that never paints in it.
+ *
+ * The attribute is read the way `symbol-run.ts` reads it — the WML namespace or none, since
+ * unprefixed attributes on WML elements are common in authored packages — so a
+ * foreign-namespaced `font`, which layout ignores, does not count as an override either.
+ */
+function symbolOverridesRunFace(sym: OoxmlElement): boolean {
   for (const attribute of sym.attributes) {
     if (attribute.localName !== 'font') continue;
     if (attribute.namespaceUri !== WML_NAMESPACE_URI && attribute.namespaceUri !== '') continue;
-    return validFontFamily(attribute.value);
+    return attribute.value.length > 0 && attribute.value.length <= MAX_SYMBOL_FONT_LENGTH;
   }
-  return null;
+  return false;
 }
 
 /**
@@ -190,7 +195,7 @@ function runRendersGlyphs(run: OoxmlElement, projectedGlyphIds?: ReadonlySet<str
     if (!isElement(child) || child.namespaceUri !== WML_NAMESPACE_URI) continue;
     if (GLYPH_MARKS.has(child.localName)) return true;
     if (child.localName === 'sym') {
-      if (symbolFontOf(child) === null) return true;
+      if (!symbolOverridesRunFace(child)) return true;
       continue;
     }
     if (child.localName !== 't' && child.localName !== 'delText') continue;

--- a/packages/core/src/store/package/rendered-fonts.ts
+++ b/packages/core/src/store/package/rendered-fonts.ts
@@ -22,8 +22,10 @@
 //   evaluating `w:tblLook` — a first-row face usually does render.
 // - Only paragraphs, runs and tables that contain a GLYPH-BEARING run count — literal
 //   `w:t`/`w:delText` text or a mark element the run's face paints (`w:footnoteRef`,
-//   `w:sym`, `w:tab`, …). An empty paragraph's mark metrics do move layout, but the
-//   notice's contract is "text renders in the wrong face".
+//   `w:tab`, …). An empty paragraph's mark metrics do move layout, but the notice's
+//   contract is "text renders in the wrong face". A `w:sym` naming a face of its own is
+//   the one mark that does NOT count, because layout paints it in that face instead of the
+//   run's — see `GLYPH_MARKS` below.
 
 import type { OoxmlElement, OoxmlNode } from './ooxml-tree.ts';
 import { WML_NAMESPACE_URI } from './ooxml-shared.ts';

--- a/packages/core/src/store/package/rendered-fonts.ts
+++ b/packages/core/src/store/package/rendered-fonts.ts
@@ -162,6 +162,24 @@ const GLYPH_MARKS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * The face a `w:sym` overrides the run with, or null when it names none and the glyph
+ * paints in the run's own face.
+ *
+ * Read exactly as `layout/symbol-run.ts` reads it — the WML namespace or none, since
+ * unprefixed attributes on WML elements are common in authored packages. A looser match
+ * would drop a run this module must report: layout would keep the run's `rFonts` while
+ * this answer decided a symbol face had replaced it.
+ */
+function symbolFontOf(sym: OoxmlElement): string | null {
+  for (const attribute of sym.attributes) {
+    if (attribute.localName !== 'font') continue;
+    if (attribute.namespaceUri !== WML_NAMESPACE_URI && attribute.namespaceUri !== '') continue;
+    return validFontFamily(attribute.value);
+  }
+  return null;
+}
+
+/**
  * Whether a `w:r` puts a glyph on the page IN ITS OWN FACE: a non-empty `w:t`, a
  * `w:delText` (tracked deletions render in markup view — over-reporting in final view,
  * never hiding), a glyph mark element, or a `w:sym` that names no face of its own.
@@ -172,7 +190,7 @@ function runRendersGlyphs(run: OoxmlElement, projectedGlyphIds?: ReadonlySet<str
     if (!isElement(child) || child.namespaceUri !== WML_NAMESPACE_URI) continue;
     if (GLYPH_MARKS.has(child.localName)) return true;
     if (child.localName === 'sym') {
-      if (validFontFamily(attributeValue(child, 'font')) === null) return true;
+      if (symbolFontOf(child) === null) return true;
       continue;
     }
     if (child.localName !== 't' && child.localName !== 'delText') continue;

--- a/packages/core/src/store/package/rendered-fonts.ts
+++ b/packages/core/src/store/package/rendered-fonts.ts
@@ -139,9 +139,14 @@ function addFamily(families: Map<string, string>, family: string | null): void {
  * symbol face in this answer through the back door. It is ONE glyph whose code point
  * `layout/symbol-encoding.ts` resolves to a real Unicode character wherever it can, so the
  * fallback stack draws the character the author meant, and a notice naming the face would
- * report a fidelity loss the reader cannot see. The faces a resolver should try for a
- * symbol are collected separately (`collectSymbolFontFamilies`, and the export lane's own
- * walk).
+ * report a fidelity loss the reader cannot see.
+ *
+ * A code point that table cannot map does paint as a tofu box without the authored face —
+ * but the answer to that is supplying the face, not a notice. This module's contract is
+ * text rendering in the wrong face, and the notice can only name families a font
+ * configuration could cover. So the faces a resolver should TRY for a symbol are collected
+ * separately (`collectSymbolFontFamilies`, and the export lane's own walk), and the editor
+ * asks for them.
  *
  * A `w:sym` with no usable `@w:font` is the other case: nothing overrides the run, so the
  * glyph really does paint in the run's face, and the run counts like any other.

--- a/packages/core/src/store/package/rendered-fonts.ts
+++ b/packages/core/src/store/package/rendered-fonts.ts
@@ -161,8 +161,12 @@ const GLYPH_MARKS: ReadonlySet<string> = new Set([
 /**
  * `layout/symbol-run.ts`'s `MAX_SYMBOL_FONT_LENGTH`, kept by value: the store lane does not
  * import layout, and this question is about what layout will DO, not what a name may be.
+ *
+ * Exported so a test can pin the two together. A silent drift would make a name in the gap
+ * an override to one lane and not the other, and the run's real face would then be wrongly
+ * kept in this answer or wrongly dropped from it, with nothing failing.
  */
-const MAX_SYMBOL_FONT_LENGTH = 128;
+export const MAX_SYMBOL_FONT_LENGTH = 128;
 
 /**
  * Whether a `w:sym` replaces the run's face with one of its own.

--- a/packages/core/src/store/package/rendered-fonts.ts
+++ b/packages/core/src/store/package/rendered-fonts.ts
@@ -129,13 +129,24 @@ function addFamily(families: Map<string, string>, family: string | null): void {
 
 /**
  * Run children that paint a glyph in the RUN's face without carrying text: note reference
- * marks, symbol runs (their `w:font` face is a pre-existing `collectDocumentFonts` gap,
- * but the run's own `w:rFonts`/`w:rStyle` still resolve the surrounding face), tabs
- * (leader dots measure in the run face) and hyphens. `w:br` paints nothing;
+ * marks, tabs (leader dots measure in the run face) and hyphens. `w:br` paints nothing;
  * `w:instrText` is never painted — the field RESULT runs are.
+ *
+ * `w:sym` is NOT one of them when it names a face of its own. `layout/symbol-run.ts`
+ * overrides the run's `rFonts` with `w:sym/@w:font`, so the run's own face draws nothing
+ * there — and Word writes that face on the run as well (a checkbox content control is
+ * `w:rFonts ascii="MS Gothic"` beside `w:sym w:font="MS Gothic"`), which would put a
+ * symbol face in this answer through the back door. It is ONE glyph whose code point
+ * `layout/symbol-encoding.ts` resolves to a real Unicode character wherever it can, so the
+ * fallback stack draws the character the author meant, and a notice naming the face would
+ * report a fidelity loss the reader cannot see. The faces a resolver should try for a
+ * symbol are collected separately (`collectSymbolFontFamilies`, and the export lane's own
+ * walk).
+ *
+ * A `w:sym` with no usable `@w:font` is the other case: nothing overrides the run, so the
+ * glyph really does paint in the run's face, and the run counts like any other.
  */
 const GLYPH_MARKS: ReadonlySet<string> = new Set([
-  'sym',
   'tab',
   'noBreakHyphen',
   'softHyphen',
@@ -146,15 +157,19 @@ const GLYPH_MARKS: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Whether a `w:r` puts a glyph on the page: a non-empty `w:t`, a `w:delText` (tracked
- * deletions render in markup view — over-reporting in final view, never hiding), or a
- * glyph mark element.
+ * Whether a `w:r` puts a glyph on the page IN ITS OWN FACE: a non-empty `w:t`, a
+ * `w:delText` (tracked deletions render in markup view — over-reporting in final view,
+ * never hiding), a glyph mark element, or a `w:sym` that names no face of its own.
  */
 function runRendersGlyphs(run: OoxmlElement, projectedGlyphIds?: ReadonlySet<string>): boolean {
   if (projectedGlyphIds?.has(run.id)) return true;
   for (const child of run.children as readonly OoxmlNode[]) {
     if (!isElement(child) || child.namespaceUri !== WML_NAMESPACE_URI) continue;
     if (GLYPH_MARKS.has(child.localName)) return true;
+    if (child.localName === 'sym') {
+      if (validFontFamily(attributeValue(child, 'font')) === null) return true;
+      continue;
+    }
     if (child.localName !== 't' && child.localName !== 'delText') continue;
     for (const grand of child.children as readonly OoxmlNode[]) {
       if (!isElement(grand) && grand.value.length > 0) return true;
@@ -230,12 +245,6 @@ function applyRun(
     addFamily(summary.families, familyFromRFonts(rFonts, themeFonts));
     if (runHasEastAsianText(run)) {
       addFamily(summary.families, eastAsiaFamilyFromRFonts(rFonts, themeFonts));
-    }
-  }
-  for (const child of run.children as readonly OoxmlNode[]) {
-    if (!isElement(child) || child.namespaceUri !== WML_NAMESPACE_URI) continue;
-    if (child.localName === 'sym') {
-      addFamily(summary.families, validFontFamily(attributeValue(child, 'font')));
     }
   }
   const rStyle = rPr ? childElement(rPr, 'rStyle') : undefined;

--- a/packages/core/src/store/package/run-defaults.ts
+++ b/packages/core/src/store/package/run-defaults.ts
@@ -101,6 +101,20 @@ export function validFontFamily(raw: string | undefined): string | null {
   return raw !== undefined && FONT_NAME.test(raw) ? raw : null;
 }
 
+/**
+ * The family a symbol-bearing attribute (`w:sym/@w:font`, a SYMBOL field's `\f`) names, for
+ * anyone that has to ASK for the face rather than decide what layout does with it.
+ *
+ * Word writes the vertical form of a family as the same name behind an `@` — `@MS Gothic`.
+ * The bytes are the family's, so the prefix comes off before validation: it is a writing
+ * mode, and `FONT_NAME` would otherwise reject the name and leave the face unsuppliable for
+ * a glyph that needs it.
+ */
+export function symbolFontFamily(raw: string | undefined): string | null {
+  if (raw === undefined) return null;
+  return validFontFamily(raw.startsWith('@') ? raw.slice(1) : raw);
+}
+
 /** What one `w:rPr` container contributes: validated family and size, or nulls. */
 function rPrDefaults(
   rPr: OoxmlElement | undefined,

--- a/packages/core/src/store/package/run-defaults.ts
+++ b/packages/core/src/store/package/run-defaults.ts
@@ -103,16 +103,16 @@ export function validFontFamily(raw: string | undefined): string | null {
 
 /**
  * The family a symbol-bearing attribute (`w:sym/@w:font`, a SYMBOL field's `\f`) names, for
- * anyone that has to ASK for the face rather than decide what layout does with it.
+ * anyone that has to ASK a font resolver for the face.
  *
- * Word writes the vertical form of a family as the same name behind an `@` — `@MS Gothic`.
- * The bytes are the family's, so the prefix comes off before validation: it is a writing
- * mode, and `FONT_NAME` would otherwise reject the name and leave the face unsuppliable for
- * a glyph that needs it.
+ * The same bound as {@link validFontFamily}, deliberately, including for Word's
+ * vertical-writing prefix (`@MS Gothic`). Layout will apply that name to the run, but the
+ * measurer and the paint sink both re-validate against this shape and fall back when it
+ * fails — so bytes supplied under the stripped family would never reach the glyph, and
+ * asking for them would spend a slot of a capped request on nothing.
  */
 export function symbolFontFamily(raw: string | undefined): string | null {
-  if (raw === undefined) return null;
-  return validFontFamily(raw.startsWith('@') ? raw.slice(1) : raw);
+  return validFontFamily(raw);
 }
 
 /** What one `w:rPr` container contributes: validated family and size, or nulls. */


### PR DESCRIPTION
Opening the sample document showed "Some fonts in this document aren't available, so substitutes are shown: MS Gothic" on every load. The document renders no text in MS Gothic. It names the face 12 times, always as the checkbox glyph of a content control: `<w:sym w:char="2612" w:font="MS Gothic"/>`.

The rendered-family derivation started collecting `w:sym/@w:font` when the headless exporters needed those faces, and the notice reads the same answer. Nothing could clear the warning: `documentFonts()` never offered the face to a font resolver, no catalogued family is metric-compatible with it, and the platform doesn't have it.

## What changes

- The notice reports only faces that rendered text resolves to. A `w:sym` that names a face of its own overrides the run, so that run contributes nothing; a `w:sym` that names none still paints in the run's face and counts. Word repeats the symbol face on the run itself, and the checkbox widget mints the same shape when a user ticks one, so this is what keeps the notice quiet after the first click.
- Whether the symbol overrides the run's face follows layout's own rule, so Word's vertical-writing `@MS Gothic` counts as the override it is. A test pins the bound the store lane copies to the one layout applies.
- The editor asks the resolver for symbol faces, after the declared families and with a small reserved share of the request bound. The reservation is spent only on a face the bound would otherwise miss, and settles when reserving evicts another. An app that owns Wingdings can now supply it, which is what an unmapped private-use glyph needs to paint in the authored face.
- A resolver is asked only for names a measurer and a paint sink would accept. `@MS Gothic` is not one of them: layout hands that name to the run verbatim and both sinks reject it, so supplied bytes could never reach the glyph.
- Headless export still requests symbol faces, ranked with the other synthesized glyph faces, such as `{ SYMBOL 183 \f "Wingdings" }`. Every lane reads `w:sym/@w:font` in the namespace layout reads it.

The font picker is unchanged. It offers the families your configuration supplies and the families the document declares in `w:rFonts`, so a symbol face appears there when the file declares it as a run font, which Word's checkbox markup does.

`TreeDocxSessionView` gains `symbolFontFamilies()`.

Follow-ups filed while reviewing this change: #749, #750, #751, #752, #753, #754.

Fixes #729, fixes #730

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017q81nj53otG87rUaF1aFAn