### PR TITLE
docs: simplify 2.15.0 and 2.15.1 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ npm install @docx-editor.dev/vue @docx-editor.dev/core     # Vue
 
 See the [React](#react) or [Vue](#vue) quick start below.
 
-Node users need `^20.16.0 || >=22.3.0`. Browser applications can use the
-packages through their normal build tool.
+For Node.js, use `^20.16.0 || >=22.3.0`. Browser applications can use the
+packages with their build tool.
 
 <p align="center">
   <a href="https://docx-editor.dev/editor">
@@ -34,20 +34,20 @@ packages through their normal build tool.
 
 ## Packages
 
-| Package                                                                                    | Description                                                                                                                                                                                | Docs                                                      |
-| ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
-| [`@docx-editor.dev/react`](https://www.npmjs.com/package/@docx-editor.dev/react)           | <img src="https://cdn.simpleicons.org/react/61DAFB" width="20" align="middle" /> &nbsp; React adapter. Root component, provider primitives, shared hooks, and compound chrome.             | [Docs](https://www.docx-editor.dev/docs/2.x/react)        |
-| [`@docx-editor.dev/vue`](https://www.npmjs.com/package/@docx-editor.dev/vue)               | <img src="https://cdn.simpleicons.org/vuedotjs/4FC08D" width="20" align="middle" /> &nbsp; Vue 3 adapter. Root component, composition primitives, shared composables, and compound chrome. | [Docs](https://www.docx-editor.dev/docs/2.x/vue)          |
-| [`@docx-editor.dev/core`](https://www.npmjs.com/package/@docx-editor.dev/core)             | Framework-agnostic engine: OOXML read/write, canonical document tree, layout, paint. Depend on this if you fork an adapter.                                                                | [Docs](https://www.docx-editor.dev/docs/2.x/core)         |
-| [`@docx-editor.dev/i18n`](https://www.npmjs.com/package/@docx-editor.dev/i18n)             | Shared locale strings and types consumed by the adapter.                                                                                                                                   | [Docs](https://www.docx-editor.dev/docs/2.x/i18n)         |
-| [`@docx-editor.dev/fonts`](https://www.npmjs.com/package/@docx-editor.dev/fonts)           | Open-licensed substitutes for common Word fonts, with local and on-demand resolvers.                                                                                                       | [Docs](https://www.docx-editor.dev/docs/2.x/guides/fonts) |
-| `@docx-editor.dev/docx-to-markdown`                                                        | Private workspace package for server-first DOCX to Markdown conversion using the shared semantic layout engine, packaged fonts, and HarfBuzz.                                              | Internal preview                                          |
-| [`@docx-editor.dev/pro`](https://www.npmjs.com/package/@docx-editor.dev/pro)               | Tracked changes, comments, real-time collaboration, and custom nodes.                                                                                                                      | [Docs](https://www.docx-editor.dev/docs/2.x/pro)          |
-| [`@docx-editor.dev/editor-api`](https://www.npmjs.com/package/@docx-editor.dev/editor-api) | Office.js-compatible editing API: a batching object model that edits a document from a server, or an editor already open in a page.                                                        | [Docs](https://www.docx-editor.dev/docs/2.x/editor-api)   |
+| Package                                                                                    | Description                                                 | Docs                                                      |
+| ------------------------------------------------------------------------------------------ | ----------------------------------------------------------- | --------------------------------------------------------- |
+| [`@docx-editor.dev/react`](https://www.npmjs.com/package/@docx-editor.dev/react)           | React editor components and hooks.                          | [Docs](https://www.docx-editor.dev/docs/2.x/react)        |
+| [`@docx-editor.dev/vue`](https://www.npmjs.com/package/@docx-editor.dev/vue)               | Vue 3 editor components and composables.                    | [Docs](https://www.docx-editor.dev/docs/2.x/vue)          |
+| [`@docx-editor.dev/core`](https://www.npmjs.com/package/@docx-editor.dev/core)             | DOCX parsing, editing, and rendering.                       | [Docs](https://www.docx-editor.dev/docs/2.x/core)         |
+| [`@docx-editor.dev/i18n`](https://www.npmjs.com/package/@docx-editor.dev/i18n)             | Translations and locale types.                              | [Docs](https://www.docx-editor.dev/docs/2.x/i18n)         |
+| [`@docx-editor.dev/fonts`](https://www.npmjs.com/package/@docx-editor.dev/fonts)           | Open-licensed substitutes for Word fonts.                   | [Docs](https://www.docx-editor.dev/docs/2.x/guides/fonts) |
+| `@docx-editor.dev/docx-to-markdown`                                                        | Convert DOCX to Markdown.                                   | Private preview                                           |
+| [`@docx-editor.dev/pro`](https://www.npmjs.com/package/@docx-editor.dev/pro)               | Tracked changes, comments, collaboration, and custom nodes. | [Docs](https://www.docx-editor.dev/docs/2.x/pro)          |
+| [`@docx-editor.dev/editor-api`](https://www.npmjs.com/package/@docx-editor.dev/editor-api) | Office.js-compatible API for browser and server editing.    | [Docs](https://www.docx-editor.dev/docs/2.x/editor-api)   |
 
 `@docx-editor.dev/editor-api` and `@docx-editor.dev/pro` are licensed under the EigenPal Pro License ([editor-api](packages/editor-api/LICENSE.md), [pro](packages/pro/LICENSE.md)), and you can compare and buy license and support levels on the [pricing page](https://www.docx-editor.dev/pricing).
 
-> **Forking the adapter?** Keep your fork thin. Depend on `@docx-editor.dev/core` directly so parser, serializer, and rendering fixes land in your build automatically, without backporting each upstream change by hand.
+If you fork an adapter, depend on `@docx-editor.dev/core` to receive engine fixes.
 
 ## React
 
@@ -126,13 +126,13 @@ See [Fonts and measurement](https://www.docx-editor.dev/docs/2.x/guides/fonts).
 
 ```bash
 bun install
-bun run dev        # localhost:5173
-bun run dev:markdown # DOCX → paginated Markdown demo on localhost:5177
+bun run dev          # localhost:5173
+bun run dev:markdown # Markdown demo: localhost:5177
 bun run build
 bun run typecheck
 ```
 
-A live preview of `main` is auto-deployed at **[latest.docx-editor.dev](https://latest.docx-editor.dev/)** — useful for trying out changes before they ship to npm.
+Try unreleased changes in the [preview of `main`](https://latest.docx-editor.dev/).
 
 Examples: [Vite](examples/vite) | [DOCX to Markdown](examples/docx-to-markdown) | [Next.js](examples/nextjs) | [Remix](examples/remix) | [Astro](examples/astro) | [Vue](examples/vue) | [Collaboration](examples/collaboration)
 

--- a/docs/site/content/react/composition.mdx
+++ b/docs/site/content/react/composition.mdx
@@ -18,7 +18,7 @@ Your controls can use the same command and state APIs.
 | `DocxEditor.Root`        | Every composed editor            | Owns and provides the editor instance                            |
 | `DocxEditor.Viewport`    | Every composed editor            | Supplies the scroll container and page-layout classes            |
 | `DocxEditor.Content`     | Every composed editor            | Mounts the painted document surface                              |
-| Remount `key`            | When you change modules          | Registers the new construction-only module set                   |
+| Remount `key`            | When you change modules          | Loads the new modules                                            |
 | Positioned workspace row | When you use the navigation pane | Anchors the navigation pane                                      |
 | Pro review module        | When you use Pro review chrome   | Enables comments, tracked changes, and custom-node review chrome |
 
@@ -65,21 +65,21 @@ Changes to `author`, `locale`, `mode`, `translate`, `zoom`, `zoomMode`, or the l
 apply without a remount.
 These changes preserve edits, caret position, and undo history.
 
-| Prop                    | Type                                                             | Description                                                                                                       |
-| ----------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `document`              | `DocumentSource`                                                 | Loads DOCX bytes, `'blank'`, or a `DocumentHandle`. An identity change remounts the editor.                       |
-| `fonts`                 | `FontConfiguration \| FontConfigurationFragment \| FontResolver` | Supplies font bytes or a resolver. An identity change remounts the editor.                                        |
-| `author`                | `string`                                                         | Sets the author for later comments, replies, and tracked changes. Changes apply without a remount.                |
-| `locale`                | `string`                                                         | Engine locale for engine-generated content, such as the table of contents title. Changes apply without a remount. |
-| `mode`                  | `'edit' \| 'view' \| 'suggesting'`                               | Sets the live host mode. When omitted, `w:trackRevisions` can select suggesting mode.                             |
-| `modules`               | `readonly EditorModule[]`                                        | Registers modules during construction. Remount with a different `key` to change them.                             |
-| `zoom` / `zoomMode`     | `number` / `ZoomMode \| 'auto'`                                  | Sets the display scale and its source. `'auto'` fits the page width.                                              |
-| `onReady`               | `(editor: Editor) => void`                                       | Runs once per instance after `Content` attaches.                                                                  |
-| `onChange`              | `(change: DocumentChange) => void`                               | Reports revision and identity changes after mutations.                                                            |
-| `onFontError`           | `(error: EditorFontError) => void`                               | Reports typed font-resolution failures.                                                                           |
-| `translate`             | `(key, params?) => string`                                       | Resolves live document-surface labels. It defaults to the active catalog.                                         |
-| `tableInteractionLabel` | `(key) => string`                                                | Resolves labels for table insertion controls.                                                                     |
-| `imageDecodePort`       | `ImageDecodePort`                                                | Overrides raster decoding for tests or custom hosts.                                                              |
+| Prop                    | Type                                                             | Description                                                                                        |
+| ----------------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `document`              | `DocumentSource`                                                 | Loads DOCX bytes, `'blank'`, or a `DocumentHandle`. An identity change remounts the editor.        |
+| `fonts`                 | `FontConfiguration \| FontConfigurationFragment \| FontResolver` | Supplies font bytes or a resolver. An identity change remounts the editor.                         |
+| `author`                | `string`                                                         | Sets the author for later comments, replies, and tracked changes. Changes apply without a remount. |
+| `locale`                | `string`                                                         | Locale for generated content, such as the table of contents title. Updates without a remount.      |
+| `mode`                  | `'edit' \| 'view' \| 'suggesting'`                               | Sets the editing mode. When omitted, `w:trackRevisions` can select suggesting mode.                |
+| `modules`               | `readonly EditorModule[]`                                        | Registers modules during construction. Remount with a different `key` to change them.              |
+| `zoom` / `zoomMode`     | `number` / `ZoomMode \| 'auto'`                                  | Sets the display scale and its source. `'auto'` fits the page width.                               |
+| `onReady`               | `(editor: Editor) => void`                                       | Runs once per instance after `Content` attaches.                                                   |
+| `onChange`              | `(change: DocumentChange) => void`                               | Reports revision and identity changes after mutations.                                             |
+| `onFontError`           | `(error: EditorFontError) => void`                               | Reports typed font-resolution failures.                                                            |
+| `translate`             | `(key, params?) => string`                                       | Resolves live document-surface labels. It defaults to the active catalog.                          |
+| `tableInteractionLabel` | `(key) => string`                                                | Resolves labels for table insertion controls.                                                      |
+| `imageDecodePort`       | `ImageDecodePort`                                                | Overrides raster decoding for tests or custom hosts.                                               |
 
 For exact signatures, see the [React API reference](/docs/2.x/api/react).
 

--- a/docs/site/content/react/props.mdx
+++ b/docs/site/content/react/props.mdx
@@ -14,15 +14,15 @@ For all signatures, see the [React API reference](/docs/2.x/api/react).
 Use `document` for the document source.
 Use `fonts` to supply font metrics for measurement.
 
-| Prop       | Type                                                             | Description                                                                                                       |
-| ---------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `document` | `DocumentSource`                                                 | DOCX bytes, `'blank'`, or an existing `DocumentHandle`.                                                           |
-| `fonts`    | `FontConfiguration \| FontConfigurationFragment \| FontResolver` | Font bytes or a resolver for text shaping and pagination.                                                         |
-| `author`   | `string`                                                         | Author for later comments, replies, and tracked changes. Changes apply without a remount.                         |
-| `locale`   | `string`                                                         | Engine locale for engine-generated content, such as the table of contents title. Changes apply without a remount. |
-| `mode`     | `'edit' \| 'view' \| 'suggesting'`                               | Host editing mode. Changes apply without a remount.                                                               |
-| `zoom`     | `number`                                                         | Fixed display scale. Changes apply without a remount.                                                             |
-| `zoomMode` | `ZoomMode \| 'auto'`                                             | Scale source. The default `'auto'` fits the page width.                                                           |
+| Prop       | Type                                                             | Description                                                                                   |
+| ---------- | ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `document` | `DocumentSource`                                                 | DOCX bytes, `'blank'`, or an existing `DocumentHandle`.                                       |
+| `fonts`    | `FontConfiguration \| FontConfigurationFragment \| FontResolver` | Font bytes or a resolver for text shaping and pagination.                                     |
+| `author`   | `string`                                                         | Author for later comments, replies, and tracked changes. Changes apply without a remount.     |
+| `locale`   | `string`                                                         | Locale for generated content, such as the table of contents title. Updates without a remount. |
+| `mode`     | `'edit' \| 'view' \| 'suggesting'`                               | Editing mode. Changes apply without a remount.                                                |
+| `zoom`     | `number`                                                         | Fixed display scale. Changes apply without a remount.                                         |
+| `zoomMode` | `ZoomMode \| 'auto'`                                             | Scale source. The default `'auto'` fits the page width.                                       |
 
 The editor colors tracked changes by author.
 Changing `author` preserves the editor instance and all existing revisions.

--- a/docs/site/content/vue/composition.mdx
+++ b/docs/site/content/vue/composition.mdx
@@ -15,7 +15,7 @@ need a different interface.
 | `DocxEditorRoot`         | Every composed editor            | Owns and provides the editor instance                            |
 | `DocxEditorViewport`     | Every composed editor            | Supplies the scroll container and page-layout classes            |
 | `DocxEditorContent`      | Every composed editor            | Mounts the painted document surface                              |
-| Remount `:key`           | When you change modules          | Registers the new construction-only module set                   |
+| Remount `:key`           | When you change modules          | Loads the new modules                                            |
 | Positioned workspace row | When you use the navigation pane | Anchors the navigation pane                                      |
 | Pro review module        | When you use Pro review chrome   | Enables comments, tracked changes, and custom-node review chrome |
 
@@ -59,8 +59,7 @@ Changes to `author`, `locale`, `mode`, `translate`, `zoom`, `zoomMode`, and the 
 apply without a rebuild. Existing revisions keep their authors.
 The root ignores a later `modules` array change until you remount it with a different `:key`.
 
-The engine uses `locale` for engine-generated content, such as the table of contents title.
-Changes apply without a remount.
+The engine uses `locale` for generated content, such as the table of contents title.
 
 For full prop types, see the
 [Vue API reference](/docs/2.x/api/vue).

--- a/docs/site/content/vue/props.mdx
+++ b/docs/site/content/vue/props.mdx
@@ -12,14 +12,14 @@ use. See the [Vue API reference](/docs/2.x/api/vue) for generated signatures.
 
 Use `document` for the document source.
 
-| Prop       | Type                               | Description                                                                                                       |
-| ---------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `document` | `DocumentSource`                   | DOCX bytes, `'blank'`, or a `DocumentHandle`.                                                                     |
-| `author`   | `string`                           | Author for later comments, replies, and tracked changes.                                                          |
-| `locale`   | `string`                           | Engine locale for engine-generated content, such as the table of contents title. Changes apply without a remount. |
-| `mode`     | `'edit' \| 'view' \| 'suggesting'` | Live host mode. The packaged `<DocxEditor>` defaults to `'edit'`.                                                 |
-| `zoom`     | `number`                           | Numeric display scale.                                                                                            |
-| `zoomMode` | `ZoomMode \| 'auto'`               | Zoom source. `'auto'` fits the page width.                                                                        |
+| Prop       | Type                               | Description                                                                                   |
+| ---------- | ---------------------------------- | --------------------------------------------------------------------------------------------- |
+| `document` | `DocumentSource`                   | DOCX bytes, `'blank'`, or a `DocumentHandle`.                                                 |
+| `author`   | `string`                           | Author for later comments, replies, and tracked changes.                                      |
+| `locale`   | `string`                           | Locale for generated content, such as the table of contents title. Updates without a remount. |
+| `mode`     | `'edit' \| 'view' \| 'suggesting'` | Editing mode. The packaged `<DocxEditor>` defaults to `'edit'`.                               |
+| `zoom`     | `number`                           | Numeric display scale.                                                                        |
+| `zoomMode` | `ZoomMode \| 'auto'`               | Zoom source. `'auto'` fits the page width.                                                    |
 
 `DocumentSource` accepts `Uint8Array`, `ArrayBuffer`, `'blank'`, or an existing
 `DocumentHandle`. Resolve URLs and paths with

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,7 +17,7 @@ bun run dev                 # React and Vue
 bun run dev:react           # Vite and React
 bun run dev:vue             # Vite and Vue
 bun run dev:happypath       # Packaged React component
-bun run dev:markdown        # Live DOCX editor + page-aware Markdown export
+bun run dev:markdown        # DOCX editor and Markdown preview
 bun run dev:igloo           # Customized React interface
 bun run dev:custom-nodes    # Custom content controls
 bun run dev:nextjs          # Next.js
@@ -55,8 +55,8 @@ Build and serve the combined deployment preview:
 bun run preview
 ```
 
-Open `/react/`, `/vue/`, `/igloo/`, or `/docx-to-markdown/` on the printed local URL. The local
-static server does not apply the hostname rewrites from `vercel.json`, so use these explicit paths.
+Open `/react/`, `/vue/`, `/igloo/`, or `/docx-to-markdown/` at the local URL.
+The preview does not apply hostname rewrites from `vercel.json`.
 
 Fill a DOCX template without a browser:
 
@@ -73,8 +73,7 @@ Stop one server before you start the other.
   under the EigenPal Pro License and a custom citation node.
 - `vue/` shows the Vue 3 adapter and mirrors the React example.
 - `happy-path/` shows the packaged `<DocxEditor>` component with minimal host code.
-- `docx-to-markdown/` shows live, page-aware Markdown beside an editable DOCX, including GFM
-  tables and separate header/footer output.
+- `docx-to-markdown/` shows Markdown beside an editable DOCX, with tables, headers, and footers.
 - `igloo/` shows extensive interface customization. See
   [Customize the editor](../docs/CUSTOMIZING.md).
 - `custom-nodes/` defines and edits a custom citation content control.

--- a/examples/collaboration/CHANGELOG.md
+++ b/examples/collaboration/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.0.7
 
-### Patch Changes
+### Patch changes
 
 - @docx-editor.dev/core@2.15.1
   - @docx-editor.dev/editor-api@2.15.1
@@ -11,7 +11,7 @@
 
 ## 0.0.6
 
-### Patch Changes
+### Patch changes
 
 - Updated dependencies [5284df5]
 - Updated dependencies [e9baf4d]

--- a/examples/docx-to-markdown/README.md
+++ b/examples/docx-to-markdown/README.md
@@ -1,31 +1,29 @@
 # DOCX to Markdown demo
 
-A standalone browser demo for the private `@docx-editor.dev/docx-to-markdown` package. It keeps the
-editable, Word-style paginated document on the left and renders the exporter's real `pages[]` result
-on the right.
+Edit a DOCX and preview its Markdown page by page. This demo uses the private
+`@docx-editor.dev/docx-to-markdown` workspace package.
+
+## Run the demo
+
+From the repository root, run:
 
 ```bash
 bun dev:markdown
 ```
 
-Open <http://localhost:5177>. Upload or drag in a `.docx`, edit it, and pause briefly to refresh the
-Markdown. Preview mode renders GitHub-flavored Markdown, including tables and task lists; Source mode
-shows the exact Markdown for each page's body, header, and footer. Comments are presented from the
-separate review sidecar: Preview pairs each thread with its selected Markdown range, while Source
-shows the same information as plain text without modifying the exported document Markdown.
+Open [the local demo](http://localhost:5177). Upload or drag in a `.docx`, then edit it.
+The Markdown refreshes after you pause typing.
 
-The preview uses `react-markdown`, `remark-gfm`, `rehype-raw`, and `rehype-sanitize`. It does not
-implement a Markdown parser. Because GFM cannot represent a table inside another table, the exporter
-uses narrowly scoped inline HTML for nested tables; the demo's sanitizer admits only those known
-span classes and ARIA roles.
+- **Preview** renders GitHub-flavored Markdown (GFM), including tables and task lists.
+- **Source** shows each page's Markdown, header, and footer.
+- Both views show comments separately from the exported Markdown.
 
-Pictures still participate in Core layout so page boundaries reflect their geometry, but this v1
-Markdown projection deliberately omits image content. A portable asset contract will be designed
-before image syntax becomes part of the package API.
+## Fonts and output
 
-The demo uses the same font ordering as production export: packaged metric-compatible faces first,
-then the opt-in Google Fonts resolver for families declared by the current document. Both the editor
-and exporter receive the same on-demand origins. Proprietary families absent from the DOCX, packaged
-set, and pinned Google catalog remain reported as unresolved rather than receiving an invented
-metric substitute. Raw file-derived HTML is never trusted; generated inline HTML is parsed and
-sanitized before rendering.
+The editor and exporter use the same fonts: packaged substitutes first, then Google Fonts.
+The Google Fonts resolver makes network requests. Fonts unavailable in the document, packaged
+set, or pinned Google catalog are reported as unresolved.
+
+Images affect page layout but are omitted from Markdown. Nested tables use inline HTML.
+The preview renders and sanitizes output with `react-markdown`, `remark-gfm`, `rehype-raw`,
+and `rehype-sanitize`.

--- a/examples/parity/README.md
+++ b/examples/parity/README.md
@@ -1,11 +1,11 @@
 # Combined demo deployment
 
-This artifact serves the React, Vue, Igloo, and DOCX-to-Markdown examples from one Vercel
-deployment. Each app owns the full viewport without an iframe or shared wrapper.
+This site serves the React, Vue, Igloo, and DOCX-to-Markdown examples from one Vercel
+deployment. Each app fills the viewport.
 
-## Run source development
+## Run locally
 
-From the repository root, run both source-based development servers:
+From the repository root, start the React and Vue development servers:
 
 ```bash
 bun install
@@ -23,15 +23,14 @@ Build and preview the assembled site from the repository root:
 bun run preview
 ```
 
-Open one of these explicit local paths:
+Open one of these local URLs:
 
 - `http://localhost:4173/react/`
 - `http://localhost:4173/vue/`
 - `http://localhost:4173/igloo/`
 - `http://localhost:4173/docx-to-markdown/`
 
-The local static preview does not apply `vercel.json`, so its root and custom-host behavior are not
-representative of the deployed site.
+The local preview does not apply the root or hostname rewrites in `vercel.json`.
 
 The build performs these steps:
 
@@ -40,10 +39,9 @@ The build performs these steps:
 3. It assigns `/react/`, `/vue/`, `/igloo/`, and `/docx-to-markdown/` as their base paths.
 4. It assembles all four builds in `examples/parity/dist/`.
 
-On Vercel, `/` rewrites to the React app. Host-conditioned rewrites serve
+On Vercel, `/` rewrites to the React app. Hostname rewrites serve
 `igloo.docx-editor.dev` from `/igloo/` and `docx-to-markdown.docx-editor.dev` from
-`/docx-to-markdown/` without changing the browser URL. Both custom domains must be attached to the
-same Vercel project before the old standalone Igloo project is removed.
+`/docx-to-markdown/` without changing the browser URL. Before removing the old Igloo project, attach both custom domains to the same Vercel project.
 
 ## Adapter switcher
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,37 +2,33 @@
 
 ## 2.15.1
 
-### Patch Changes
+### Patch changes
 
 - @docx-editor.dev/i18n@2.15.1
 
 ## 2.15.0
 
-### Minor Changes
+### Minor changes
 
-- 5284df5: Add the DOM-free `@docx-editor.dev/core/export` session with immutable export-ready semantic
-  layouts and shared shaping and resource settlement. Exporters consume the same layout
-  coordinator and semantic records as the browser engine, including page-scoped, exporter-neutral
-  comment and tracked-change provenance that future Markdown, PDF, and other exporters can bind to
-  their own output coordinates. Document-aware font-backed sessions also retain immutable resolution
-  evidence so every exporter can report the exact direct, substituted, incomplete, and failed font
-  origins behind pagination.
-- 0d81033: Add session-owned font resources, exact shaped text, embedded document fonts, document metadata,
-  internal destinations, and review occurrence geometry to semantic export sessions.
-- 8e6133f: Apply live author, mode, translation, and locale changes without rebuilding the editor. Keep Vue root and packaged editor props reactive after mount. A locale catalog change no longer rebuilds the editor. Fixes #695 and #561.
+- 5284df5: Add `@docx-editor.dev/core/export` for document layout without a DOM. Export sessions
+  share the browser editor's layout engine and return immutable pages, comments, tracked changes,
+  and font-resolution reports.
+- 0d81033: Add font resources, shaped text, embedded fonts, metadata, internal link targets, and
+  comment and tracked-change positions to export sessions.
+- 8e6133f: Apply author, mode, translation, and locale changes without rebuilding the editor, including Vue root and packaged components. Fixes #695 and #561.
 
-### Patch Changes
+### Patch changes
 
-- e9baf4d: Search headers, footers, footnotes, endnotes, table cells, and saved field results. Fixes #703, fixes #694
-- 087bb78: Position page- and margin-anchored floating tables at `tblpY` without advancing body flow. Preserve `btLr` cell text, built-up bar fractions, and inline pictures in later columns. Keep automatic line spacing from scaling built-up equations and changing pagination. Fixes #662.
-- a3819aa: Reflow long unbroken words continuously across tracked-insertion run boundaries while typing in
-  Suggesting mode, without splitting Unicode graphemes. Fixes #716.
-- a53f75c: Hyperlinks in headers, footers, and anchored text boxes now resolve through their owning OOXML part and paint as link anchors. You can edit or remove header and footer links with Ctrl+K while editing their story; secondary-story anchors remain inert. Fixes #643.
-- 36c1f04: Keep table-hosted text-box list markers current while reducing repeated layout work for their host paragraphs. Fixes #639.
-- 678fe91: Group every tracked field control into the review card beside it, so a struck or inserted field is one decision instead of one card per control. Fixes #718
-- cfe3fe1: Treat empty on-demand font resolver fragments like an undefined result instead of reporting a missing-font configuration.
+- e9baf4d: Search headers, footers, footnotes, endnotes, table cells, and saved field results. Fixes #703 and #694.
+- 087bb78: Fix floating table positions, vertical cell text, stacked fractions, and inline pictures
+  in later columns. Preserve equation size and pagination with automatic line spacing. Fixes #662.
+- a3819aa: Wrap long words across tracked insertions in suggesting mode without splitting Unicode graphemes. Fixes #716.
+- a53f75c: Render hyperlinks in headers, footers, and anchored text boxes. While editing a header or footer, use Control+K to edit or remove its links. Links in these regions do not navigate. Fixes #643.
+- 36c1f04: Update list markers in text boxes inside tables and reduce repeated paragraph layout work. Fixes #639.
+- 678fe91: Group tracked field controls into one review card for each insertion or deletion. Fixes #718.
+- cfe3fe1: Allow on-demand font resolvers to return empty results without a configuration error.
 - 0e1360d: Keep underlined trailing spaces and underscore tab leaders as single rules that reach the line margin.
-- 2a8e57e: Show tracked field controls with their adjacent replacement instead of separate Deleted cards.
+- 2a8e57e: Show tracked field controls with their adjacent replacement instead of separate **Deleted** cards.
 - @docx-editor.dev/i18n@2.15.0
 
 ## 2.14.1

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -50,7 +50,7 @@ layout pass, and the paint step directly.
 | `./store`                     | The canonical tree and its transactional store.                                              |
 | `./layout`                    | The DOM-free layout pass.                                                                    |
 | `./output`                    | Serialization.                                                                               |
-| `./export`                    | Reusable, DOM-free semantic layout sessions for Markdown, PDF, and future exporters.         |
+| `./export`                    | Document layout sessions for exporters. No DOM required.                                     |
 | `./automation`                | The object model behind `@docx-editor.dev/editor-api`.                                       |
 | `./collaboration`             | Provider-neutral collaboration session contracts.                                            |
 | `./collaboration/replication` | Replication helpers for collaboration providers.                                             |
@@ -70,17 +70,14 @@ Nodes are typed where layout needs them and generic everywhere else, preserving 
 verbatim. Content the engine does not model is carried rather than dropped, so a document full
 of unknown extensions still opens, edits, and saves.
 
-Export sessions use the editor's reader-safe revision view by default: `all-markup` keeps both
-halves of pending tracked changes visible. Pass `displayMode: 'proposed'` or
-`displayMode: 'original'` explicitly when the exporter should present a resolved view instead.
+Export sessions default to `all-markup`, which shows inserted and deleted text.
+Use `displayMode: 'proposed'` for the accepted view or `displayMode: 'original'` for the rejected view.
 
-### Building a physical-page exporter
+### Build a paginated exporter
 
-Use the document-aware font composition root for Markdown, PDF, or any exporter whose page breaks
-matter. `openDocumentForExport(bytes)` without a measurer intentionally uses deterministic
-fixed-width approximation. `openFontBackedDocumentForExport` discovers the document's actual run,
-style, header, footer, note, field, symbol, and equation families, then binds the resolved shaping
-snapshot to the layout session.
+For exports that need accurate page breaks, use `openFontBackedDocumentForExport`. It resolves
+the fonts used throughout the document before layout. Without a measurer,
+`openDocumentForExport(bytes)` uses a fixed-width approximation.
 
 ```ts
 import { readFile } from 'node:fs/promises';
@@ -105,11 +102,8 @@ try {
 }
 ```
 
-Keep font retrieval, substitution, cancellation, diagnostics, and memory ownership in this Core
-lane. Format adapters should consume the resulting semantic pages; Markdown binds Core source
-artifacts to string offsets, while PDF can bind the same artifacts to page rectangles. For a live
-`HeadlessDocumentView`, pass the revision-stable measurer already used by its editor rather than
-starting asynchronous document-specific font resolution against mutable state.
+Let Core manage fonts, resources, and layout. Build your output from the returned pages.
+For a live `HeadlessDocumentView`, pass the editor's revision-stable measurer.
 
 ## Fidelity
 

--- a/packages/docx-to-markdown/README.md
+++ b/packages/docx-to-markdown/README.md
@@ -1,18 +1,16 @@
 # `@docx-editor.dev/docx-to-markdown`
 
-> Private workspace package. Publishing is intentionally deferred to the final release step.
+> Private workspace package. Not available on npm.
 
-Server-first DOCX-to-Markdown conversion powered by the same semantic layout engine as the
-browser editor and future exporters. It requires no DOM, browser, editor instance, or CLI.
+Convert DOCX to Markdown with page boundaries, headers, footers, and review metadata.
+No browser or DOM required.
 
 ## Quick start
 
-To try the private package from this workspace, run `bun dev:markdown`. The standalone demo opens
-the real paginated editor beside a live page-by-page GFM preview, supports upload and drag/drop,
-and re-exports the current DOCX after edits.
+Run `bun dev:markdown` from the repository root to try the editor and Markdown preview.
+Within this workspace, use `workspace:*` as the dependency version.
 
-The one-shot API accepts DOCX bytes, opens and lays out the document, translates it, and disposes
-its internal session.
+Use `exportMarkdown` to convert DOCX bytes. It manages layout and session cleanup:
 
 ```ts
 import { readFile } from 'node:fs/promises';
@@ -35,14 +33,9 @@ for (const page of pages) {
 }
 ```
 
-The package is private in this change and cannot be installed from the public registry yet.
-Inside this monorepo, depend on it with `workspace:*`.
-
-The final release step must replace this private banner and workspace demo quick start with public
-installation and usage instructions, remove the package from Changesets `ignore`, choose the public
-version, align the `@docx-editor.dev/core` and `@docx-editor.dev/fonts` version floors with that
-release, and only then remove `private: true`. Repository tests intentionally reject a partial
-release state.
+For public release, replace this private banner and workspace demo quick start with public
+installation and usage instructions. Remove the package from Changesets `ignore`, choose its
+version, align the Core and fonts dependency versions, then remove `private: true`.
 
 ## Public interface
 
@@ -64,11 +57,9 @@ exportMarkdownFrom(
 exportMarkdownLayout(layout: ExportSemanticLayout): MarkdownExportResult;
 ```
 
-`exportMarkdown` is the usual entry point. It disposes its producer session after layout and
-translates the detached immutable snapshot, keeping the one-shot memory lifecycle bounded.
-`openDocumentForExport` and `exportMarkdownFrom` are for workflows that need to reuse one settled
-layout, inspect semantic records, or share the same layout with another exporter.
-`exportMarkdownLayout` translates a snapshot after its session has been disposed.
+Use `exportMarkdown` for a single export. To reuse or inspect a layout, use
+`openDocumentForExport` and `exportMarkdownFrom`. To convert a layout after disposing its session,
+use `exportMarkdownLayout`.
 
 ### Result shape
 
@@ -134,29 +125,16 @@ interface MarkdownReviewBinding {
 }
 ```
 
-`fontResolution` is returned data, not a console side effect. It lists requested families, every
-resolved face and whether it was direct or substituted, per-family `complete`/`partial`/`none`
-coverage, and nonfatal `originFailures`. A reusable `opened.session.fontResolution` retains the
-same report and `exportMarkdownFrom(opened.session)` copies it into its result. It is non-null for
-document-aware byte sessions opened by Markdown or Core. It is `null` when no session owns font
-evidence: detached layouts, caller-supplied measurers, ordinary Core sessions, and live views using
-shared shaping. Fatal
-document-open and resource/layout failures remain typed refusals or thrown
-`DocumentOpenError`/`ExportResourceError`; they are not disguised as font warnings.
+`fontResolution` lists requested families, resolved and substituted faces, coverage
+(`complete`, `partial`, or `none`), and nonfatal `originFailures`. Document-aware byte sessions
+return this report. Reusable sessions also expose it as `session.fontResolution`.
+It is `null` for detached layouts, custom measurers, ordinary Core sessions, and live views
+using shared shaping. Fatal failures throw `DocumentOpenError` or `ExportResourceError`.
 
-`pages` is the primary interface. Page boundaries come from the same layout engine that renders
-the editor; they are not inferred from `w:lastRenderedPageBreak` or approximated after Markdown
-conversion. This is the appropriate shape for page citations such as “page 12”, legal/compliance
-review, retrieval chunks tied to one rendered result, and page-aware agent workflows.
+`pages` contains the page output from the editor's layout engine. Page numbers and IDs apply
+only to this export. Different fonts or Microsoft Word versions can produce different page breaks.
 
-`pagination.source` confirms that pages came from the layout engine. `pagination.scope` means the
-page numbers describe this returned export. `layoutRevision` identifies the Core document state,
-and `displayMode` repeats the option used to show tracked changes as markup, proposed content, or
-original content.
-
-Page IDs and numbers are local to this returned export; do not use them as permanent document
-identifiers. They reflect the same Core layout the editor uses, but are not a certification that a
-particular Microsoft Word build with a different font installation will produce identical breaks.
+`pagination` records the layout source, export scope, Core revision, and tracked-change display mode.
 
 For citations that must survive storage or document updates, retain your own document version or
 content hash alongside the page number. For example:
@@ -171,22 +149,17 @@ const citation = {
 };
 ```
 
-`result.markdown` is a convenience projection for consumers that only need one conventional
-Markdown document. It joins split records and excludes repeated page furniture, so it deliberately
-cannot preserve page provenance.
+`result.markdown` contains the whole document. It joins content split across pages and excludes
+repeated headers and footers. Use `pages` when you need page citations.
 
 ### Comments and tracked changes
 
-Ordinary Markdown stays clean: comments and revision metadata are not injected as HTML comments,
-CriticMarkup, or visible footnotes. Normalized structured review metadata is returned beside it.
+Comments and revision metadata are returned separately from Markdown.
+Review IDs are opaque and valid only within one export. For stored citations, include your own
+document version or content hash.
 
-> **Important:** Review IDs are opaque and stable only within one export result. Never store or
-> compare them across exports. Pair any persisted citation with your own document version or
-> content hash.
-
-`page.comments` and `page.trackedChanges` are membership views. Each entry is the complete
-document-wide artifact, not a page-trimmed copy, so its `occurrences` can include other pages. To
-avoid double counting and select page-local provenance, always filter the occurrences:
+`page.comments` and `page.trackedChanges` contain complete artifacts with occurrences on that page.
+Their `occurrences` can include other pages. Filter them to avoid double counting:
 
 ```ts
 const localComments = page.comments.flatMap((artifact) =>
@@ -196,9 +169,8 @@ const localComments = page.comments.flatMap((artifact) =>
 );
 ```
 
-Page membership covers artifacts physically occurring in the body, header, footer, footnotes,
-endnotes, or note separator. `result.reviewArtifacts` is the authoritative document-wide list and
-also retains orphaned comments or structural changes with no linear page occurrence.
+Page artifacts can occur in the body, headers, footers, footnotes, endnotes, or note separators.
+`result.reviewArtifacts` contains all artifacts, including those without a page occurrence.
 
 `result.reviewBindings` connects each occurrence to offsets in `result.markdown`,
 `page.markdown`, `page.headerMarkdown`, or `page.footerMarkdown`. Offsets use JavaScript UTF-16
@@ -217,14 +189,11 @@ for (const binding of result.reviewBindings) {
 }
 ```
 
-Use `coverage === 'complete'` with only `precision === 'exact'` ranges for source-aligned edits.
-Citation or presentation workflows can accept partial or `containing-construct` bindings while
-preserving the declared fidelity. Text boxes and structural changes that have no honest linear
-Markdown range remain available as artifacts and carry an explicit `unmappedReason`.
+For source-aligned edits, require `coverage === 'complete'` and `precision === 'exact'`.
+For citations or display, you can use partial or `containing-construct` bindings if you retain
+that precision information. Unmapped artifacts include an `unmappedReason`.
 
-Artifact IDs, occurrence indexes, page IDs, and binding offsets are local to this immutable export
-result. IDs are opaque, even when their string values look familiar. Do not join them across
-exports; store your own document version or content hash when a workflow needs durable identity.
+Artifact IDs, occurrence indexes, page IDs, and offsets are valid only within this export.
 
 Tracked changes also participate in layout through `displayMode`: `all-markup` (default) keeps
 inserted and deleted text visible, `proposed` shows the accepted view, and `original` shows the
@@ -240,20 +209,19 @@ rejected view. There is no reviewer/author filtering in this API.
 | `signal`                | Aborts resource waits and later layout work.                                                  |
 | `resourceTimeoutMs`     | Deadline applied separately to initial font provisioning and each layout resource wait.       |
 | `reuseAcrossRevisions`  | Retains state for live/caller-measured sessions; document-aware byte sessions reject `true`.  |
-| `fonts`                 | Caller configuration/resolver, first-wins; requires immutable DOCX-byte input.                |
-| `fallbackFonts`         | Opt-in origins after bundled substitutes; requires bytes; use for `googleFonts()`.            |
+| `fonts`                 | Font configuration or resolver. Earlier entries win. Requires immutable DOCX bytes.           |
+| `fallbackFonts`         | Fallback after bundled fonts. Requires DOCX bytes. Accepts `googleFonts()`.                   |
 | `fontPolicy`            | `best-effort` (default), or `strict` to require all four static faces and no origin failures. |
-| `onFontResolution`      | Receives requested, direct/substituted, unresolved, and failed-origin evidence.               |
-| `measurer`              | Host-owned text measurer; when present it takes precedence over all font origins.             |
+| `onFontResolution`      | Receives the font-resolution report.                                                          |
+| `measurer`              | Custom text measurer. Overrides font resolution.                                              |
 | `producer`              | Stable identity for a host-owned measurer and its cache entries.                              |
-| `imageDecodePort`       | Host image metadata decoder. Omit for the bounded Node decoder.                               |
+| `imageDecodePort`       | Custom image metadata decoder. Defaults to the Node.js decoder.                               |
 | `convertPreservedImage` | Converts preserved EMF, WMF, or TIFF bytes to a supported raster format.                      |
 
 ### Tracked changes
 
-The default keeps all pending changes visible in Markdown. A whole-document resolved view must be
-requested explicitly. The artifact list remains available as provenance; this option controls the
-whole-document revision projection.
+To show the document with changes accepted, set `displayMode` to `proposed`.
+Review artifacts remain available:
 
 ```ts
 const proposed = await exportMarkdown(bytes, {
@@ -261,7 +229,7 @@ const proposed = await exportMarkdown(bytes, {
 });
 ```
 
-## Reusing an export session
+## Reuse an export session
 
 ```ts
 import { readFile } from 'node:fs/promises';
@@ -291,37 +259,33 @@ try {
 }
 ```
 
-Always dispose a reusable session. `dispose()` is idempotent and releases document caches and
-pending resource work. A live `HeadlessDocumentView` can retain incremental state across document
-revisions; immutable byte sources default to one-shot cache ownership.
+Always call `dispose()` on reusable sessions to release caches and pending resource work.
+Repeated calls are safe. Live views can retain state across revisions; byte sources use
+one-shot caching by default.
 
-If only one projection is needed, prefer `exportMarkdown(bytes)`. A reusable session deliberately
-retains source, resource, and alternate-display-mode state. To inspect or share a layout without
-retaining that producer state, dispose the session, then pass the already-published layout to
-`exportMarkdownLayout`. Published layouts are immutable snapshots and remain valid after disposal.
+For a single export, use `exportMarkdown(bytes)`. To keep a layout without retaining session
+resources, obtain it before disposal, then pass it to `exportMarkdownLayout`. Layouts remain
+valid after disposal.
 
 ## Images
 
-Image geometry participates in layout and therefore in page boundaries, but v1 deliberately omits
-image content from Markdown. The package does not expose an image URL callback or emit temporary
-browser URLs. This keeps the initial contract portable while a durable asset-manifest design is
-developed. When omission would fuse word-like text on either side of an inline drawing, the
-translator inserts one neutral space; punctuation is left untouched. Core image facilities remain
-exporter-neutral and available to future exporters.
+Images affect page boundaries but are omitted from Markdown. There is no image URL callback.
+If omitting an inline image would join words, the exporter inserts a space.
 
 ## Errors and cancellation
 
-The one-shot `exportMarkdown` API throws `DocumentOpenError` for malformed or unsupported DOCX
-input. Use `openDocumentForExport` when control flow should inspect its typed `{ ok: false,
-reason, detail }` result instead. Layout or resource processing can throw `ExportResourceError`
-with `code` equal to `aborted`, `timedOut`, `nonConvergent`, `disposed`, `layoutInvariant`, or
-`layoutFailed` in either workflow. `layoutInvariant` means recognized authored geometry could not
-be represented within the engine's bounded page model. `layoutFailed` identifies another engine
-or host-integration failure, such as an unavailable custom measurer. Both retain the original
-diagnostic as the standard `cause` without making consumers import a layout implementation type.
-Aborting the caller signal is terminal for a reusable session and immediately runs its idempotent
-resource teardown, including pending image work and document-specific font leases. Calling
-`dispose()` afterward remains safe.
+For malformed or unsupported DOCX input, `exportMarkdown` throws `DocumentOpenError`.
+`openDocumentForExport` returns `{ ok: false, reason, detail }` instead.
+
+Both workflows can throw `ExportResourceError` with one of these codes:
+
+- `aborted`, `timedOut`, `nonConvergent`, or `disposed`.
+- `layoutInvariant`: document geometry exceeds the engine's page model.
+- `layoutFailed`: another layout or host integration failure.
+
+The layout errors retain the original diagnostic as `cause`.
+Aborting a reusable session releases its resources and prevents reuse. Calling `dispose()`
+afterward is safe.
 
 ```ts
 import {
@@ -349,49 +313,29 @@ try {
 }
 ```
 
-## Layout and Markdown policy
+## Layout and fonts
 
-### Export fidelity contract
+Core resolves fonts, images, document geometry, and `displayMode` before pagination.
+Markdown uses that immutable layout. There is no separate page-width override.
+`signal` and `resourceTimeoutMs` cover resource processing.
 
-Pagination is created in Core before Markdown translation. The export lane must therefore settle
-every input that can change geometry before it asks for a layout snapshot:
+Fonts resolve in this order:
 
-- DOCX page geometry, section breaks, margins, columns, styles, theme mappings, run font family,
-  run font size, weight, italic state, character spacing, scaling, and line spacing come from the
-  immutable document snapshot. There is intentionally no Markdown-only page-width override.
-- Font origins are resolved in `fonts` → bundled substitutes → `fallbackFonts` order. Core measures
-  every run at its resolved OOXML size. It shapes a run with admitted bytes when its face resolves
-  and uses the deterministic fixed measurer for that run otherwise; Markdown never measures text
-  or invents page breaks after the fact.
-- Images and preserved-format conversion settle through the same bounded Core session before the
-  semantic layout is published. `signal` and `resourceTimeoutMs` cover that work.
-- `displayMode` is applied by Core before pagination, so inserted/deleted content and page fields
-  are measured in the same mode reported by `pagination.displayMode`.
-- The resulting layout is immutable. Markdown and future translators must consume that one
-  snapshot rather than reopening the DOCX or re-resolving fonts independently.
+1. Your `fonts` configuration or resolvers; earlier entries take priority.
+2. Bundled substitutes from `@docx-editor.dev/fonts`.
+3. Optional `fallbackFonts`.
 
-For citation-sensitive production exports, supply the same licensed font files used by the author
-through `fonts`, use `fontPolicy: 'strict'`, persist `onFontResolution` with the job record, and pin
-the exporter/Core/font-catalog versions. Only complete strict coverage establishes that every
-requested static face used font-backed shaping. In `best-effort`, any family reported as `partial`
-or `none` can use Core's deterministic approximate measurer for unresolved runs; if no source is
-admitted, the whole layout uses it rather than losing the document. That fallback is bounded and
-reproducible, but it is not a high-fidelity pagination claim.
+The Node.js defaults use HarfBuzz and packaged substitutes: Carlito for Calibri, Caladea for
+Cambria, Liberation Serif for Times New Roman, Liberation Sans for Arial, and Liberation Mono
+for Courier New. These fonts require no network requests.
 
-The Node defaults use the packaged, validated metric-compatible faces from
-`@docx-editor.dev/fonts` with shared HarfBuzz shaping: Calibri → Carlito, Cambria → Caladea, Times
-New Roman → Liberation Serif, Arial → Liberation Sans, and Courier New → Liberation Mono. These
-open faces are selected for matching layout metrics and require no runtime Google Fonts request.
+For accurate pagination, supply the author's licensed fonts, use `fontPolicy: 'strict'`,
+save the font-resolution report, and pin the exporter, Core, and font catalog versions.
+The default `best-effort` policy uses approximate measurements for unresolved fonts.
 
-For higher fidelity, pass licensed or application-owned faces through `fonts`. The value can be a
-Core font configuration, a marked on-demand resolver, or an ordered list; earlier entries win.
-The exporter parses the DOCX first, asks resolvers only for the bounded family list used by the
-body, styles, headers, footers, and notes, then lays out once with the settled HarfBuzz measurer.
-Bundled Word-compatible substitutes fill any gaps after caller fonts.
-
-Google Fonts is an explicit last resort because it performs network requests and can disclose the
-font families a document uses to the CDN. Opt in with `fallbackFonts`; the resolver uses a closed,
-commit-pinned catalog and content hashes rather than constructing URLs from DOCX text:
+To enable Google Fonts as a fallback, pass `googleFonts()` through `fallbackFonts`.
+It uses a pinned catalog and verified content hashes. Requests disclose requested font families
+to the CDN:
 
 ```ts
 import { readFile } from 'node:fs/promises';
@@ -434,51 +378,44 @@ const result = await exportMarkdown(bytes, {
 });
 ```
 
-Omit `fallbackFonts` for a network-free export. Supply only `fallbackFonts: googleFonts()` when
-there are no application-owned faces. If a host already owns a complete measurement stack, pass
-`measurer` with a stable `producer`; that explicit measurer takes precedence over font origins.
-Custom `fonts` and `fallbackFonts` are accepted only with immutable DOCX bytes. A live
-`HeadlessDocumentView` may change between resolution and layout, so export it with the host's
-revision-stable `measurer`; when `measurer` is present, neither font-origin option is invoked.
+Omit `fallbackFonts` to use only your fonts and bundled substitutes. For network-free exports,
+your own resolvers must also use local data.
 
-For audit-sensitive jobs, route `googleFonts({ onFailure })` failures into job diagnostics and
-supply licensed/application faces in `fonts` for every required family. `fontPolicy: 'strict'`
-refuses the export if an origin failed or any requested family lacks regular, bold, italic, or
-bold-italic coverage; `onFontResolution` records the direct and substituted faces that produced
-the page breaks. Documents whose candidate catalog exceeds the safe 64-family resolver boundary
-also fail with a typed `layoutFailed` error instead of silently dropping a face. Google fallback is
-opt-in, uses a bounded process cache, and a timeout or abort never leaves a failed request cached.
+Custom `fonts` and `fallbackFonts` require immutable DOCX bytes. For a live `HeadlessDocumentView`,
+use a host-owned, revision-stable `measurer` with a stable `producer`. A custom measurer takes
+precedence and bypasses both font options.
 
-Font admission is deliberately bounded against hostile or unexpectedly large inputs. The public
-`HARD_MAX_FONT_BYTES`, `HARD_MAX_FONT_SOURCES`, and `HARD_MAX_AGGREGATE_FONT_BYTES` constants are
-re-exported by this package; currently they cap one face at 64 MiB, one composition at 256 sources
-and 128 MiB, and all active document-specific export leases in a process at 128 MiB. A malformed or
-individually over-limit origin is reported and skipped before later origins are consulted. A
-process-wide lease refusal is a typed `layoutFailed` error: it does not start another network
-fallback or silently substitute approximate pagination. Serverless and worker hosts should return
-only the document-requested faces from resolvers, cap concurrent font-heavy exports, dispose every
-reusable session promptly, and use the exported constants rather than duplicating numeric limits.
+`fontPolicy: 'strict'` rejects origin failures or missing regular, bold, italic, or bold-italic
+faces. Use `onFontResolution` to record resolved and substituted faces, and
+`googleFonts({ onFailure })` to log fallback failures. More than 64 candidate families causes
+`layoutFailed`. Failed or aborted Google Fonts requests are not cached.
 
-Document-embedded fonts are admitted after explicit origins, using the same mapper as the browser editor. A DOCX that depends on `w:embedRegular`, `w:embedBold`, `w:embedItalic`, or
-`w:embedBoldItalic` therefore paginates with those faces when they pass the shared byte budgets.
-Logical full-document Markdown remains independent of page breaks.
+### Font limits
 
-Markdown is a semantic degradation:
+The package exports these limits:
 
-- Physical Word-layout pages are first-class; flattened `markdown` is secondary.
+- `HARD_MAX_FONT_BYTES`: 64 MiB per face.
+- `HARD_MAX_FONT_SOURCES`: 256 sources per composition.
+- `HARD_MAX_AGGREGATE_FONT_BYTES`: 128 MiB per composition and across active document font leases.
+
+Invalid or oversized origins are reported and skipped. Exceeding the process-wide lease budget
+causes `layoutFailed`. Return only requested faces from resolvers, limit concurrent exports,
+and dispose reusable sessions promptly. Use the exported constants in your code.
+
+Document-embedded fonts are admitted after explicit origins, using the same mapper as the browser editor.
+Regular, bold, italic, and bold-italic embedded faces must pass the shared font limits.
+
+## Markdown limitations
+
+- Use `pages` for page output and `markdown` for the whole document.
 - Page headers and footers are returned separately per page.
 - Merged table cells are flattened.
 - GFM has no nested-table construct. Nested tables alone use plain inline `<table>`, `<tr>`,
   `<td>`, and `<th>` HTML on one line, so strict sanitizers (including GitHub's) keep the
   structure and inline Markdown inside each cell remains parseable.
-- Image content is omitted in v1, while image geometry still participates in page layout.
+- Images affect layout but are omitted from Markdown.
 - Anchored text-box text is omitted because it has no unambiguous linear position; comments and
   tracked changes inside it remain available as page artifacts with exact text-box provenance.
 - Office Math uses the core semantic equation fallback.
-- A note continued without its reference is emitted as a labelled continuation block in page
+- A note continued without its reference is emitted as a labeled continuation block in page
   Markdown.
-
-Browser and headless export use the same core layout coordinator. Core projection and layout
-improvements therefore flow into Markdown automatically. Compile-time policy ratchets require a
-new semantic record field or kind to be represented or explicitly classified as layout-only or
-omitted; focused output tests remain the behavioral authority.

--- a/packages/editor-api/CHANGELOG.md
+++ b/packages/editor-api/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 2.15.0
 
-### Patch Changes
+### Patch changes
 
 - Updated dependencies [5284df5]
 - Updated dependencies [e9baf4d]

--- a/packages/fonts/CHANGELOG.md
+++ b/packages/fonts/CHANGELOG.md
@@ -2,41 +2,22 @@
 
 ## 2.15.1
 
-### Patch Changes
+### Patch changes
 
-- 1acd366: Stop `FONT_ASSET_ROOT` from throwing at module scope under webpack and Turbopack, which
-  took down the whole client bundle of any app that imported this package.
-
-  Those bundlers replace `new URL('../assets/<face>', import.meta.url)` with a bare
-  relative path string for the asset they emitted. Deriving the asset root from one entry
-  with a single-argument `new URL()` therefore threw `URL constructor:
-/_next/static/media/Caladea-Bold.<hash>.ttf is not a valid URL` while the module was
-  still evaluating, where nothing can catch it.
-
-  In a bundled build the root now reports a non-`file:` URL, which is what consumers
-  already gate on before using it as a `createPackagedFileFetch` trusted root. That holds
-  even when the page itself was opened from disk, as in an Electron renderer or a static
-  export: the bundler moved the faces, so no local directory holds them, and a bundle
-  serving assets from the path root would otherwise have resolved to the filesystem root,
-  which `createPackagedFileFetch` rejects by throwing.
-
-  Two ways a packaged face could silently fail to register are also fixed. The `FontFace`
-  URL source read `.href` off the bundler's string, which is `undefined`, emitting the
-  literal `url(undefined)`. And the source was unquoted, so an install path containing
-  characters an unquoted CSS `url()` token forbids, parentheses among them, produced a
-  token the browser could not parse.
+- 1acd366: Fix import crashes in webpack and Turbopack builds. Bundled `FONT_ASSET_ROOT` now
+  returns a non-`file:` URL, including in Electron and pages opened from disk. Fix font loading
+  when bundlers emit relative paths or install paths contain parentheses.
 
 ## 2.15.0
 
-### Minor Changes
+### Minor changes
 
-- 0d81033: Export `FONT_ASSET_ROOT` so hosts can confine packaged-font reads to the fonts package without guessing its install path.
+- 0d81033: Export `FONT_ASSET_ROOT` to restrict font reads to the package directory.
 
-### Patch Changes
+### Patch changes
 
-- 5284df5: Preserve one literal asset URL per packaged font face in the ESM browser build so Next.js with
-  Turbopack, Vite, and webpack resolve every requested filename instead of collapsing dynamic URLs
-  to one font. Keep the CommonJS build resolving the same packaged files in Node.
+- 5284df5: Fix packaged font URLs in Turbopack, Vite, and webpack builds. The CommonJS build
+  continues to use local font files in Node.js.
 
 ## 2.14.1
 

--- a/packages/nuxt/CHANGELOG.md
+++ b/packages/nuxt/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## 2.15.1
 
-### Patch Changes
+### Patch changes
 
 - @docx-editor.dev/vue@2.15.1
 
 ## 2.15.0
 
-### Patch Changes
+### Patch changes
 
 - @docx-editor.dev/vue@2.15.0
 

--- a/packages/pro/CHANGELOG.md
+++ b/packages/pro/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 2.15.0
 
-### Patch Changes
+### Patch changes
 
 - 7dc8b22: Preserve concurrent text edits when another collaborator formats the same run. Fixes #590.
 - Updated dependencies [5284df5]

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## 2.15.1
 
-### Patch Changes
+### Patch changes
 
 - @docx-editor.dev/i18n@2.15.1
 
 ## 2.15.0
 
-### Patch Changes
+### Patch changes
 
 - Updated dependencies [5284df5]
 - Updated dependencies [e9baf4d]

--- a/packages/vue/CHANGELOG.md
+++ b/packages/vue/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## 2.15.1
 
-### Patch Changes
+### Patch changes
 
 - @docx-editor.dev/i18n@2.15.1
 
 ## 2.15.0
 
-### Patch Changes
+### Patch changes
 
 - Updated dependencies [5284df5]
 - Updated dependencies [e9baf4d]


### PR DESCRIPTION
Simplify documentation for releases 2.15.0 and 2.15.1 using Google's developer documentation style guide. Shorten README package descriptions—for example, the Markdown package now says “Convert DOCX to Markdown”—and reduce the Markdown usage guide by about one-third while retaining API requirements and limitations.

Use sentence-case release headings and concise descriptions in the changelogs, export guides, examples, and React/Vue prop references. Older release entries and generated API snapshots remain unchanged.

Validation: full workspace typecheck, adapter parity and license checks, four documentation checks, changed-document formatting, and all six Markdown package-contract tests pass. Reviewed the diff for lost requirements and references to renamed headings.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/747"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791242625&installation_model_id=422592&pr_number=747&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F747&signature=fc4938753f10975cade6c91bcb92a9cf4f13b94231e7a760414686c97f7c7b9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->