### PR TITLE
fix: honor CJK typography across run boundaries

### DIFF
--- a/.changeset/cjk-typography-followups.md
+++ b/.changeset/cjk-typography-followups.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': minor
+---
+
+Fix East Asian wrapping across formatting changes, preserve full-width number groups, and apply CJK justification and document typography settings.

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -139,7 +139,7 @@ export function buildNumberingIndex(root: OoxmlElement | null | undefined): Numb
 export function buildPageRefIndex(allRefs: readonly PageRefHit[]): PageRefIndex;
 
 // @public
-export function buildStyleCascadeTable(stylesRoot: OoxmlElement | null, themeFonts?: ThemeFonts): StyleCascadeTable;
+export function buildStyleCascadeTable(stylesRoot: OoxmlElement | null, themeFonts?: ThemeFonts, settingsRoot?: OoxmlElement | null): StyleCascadeTable;
 
 // @public
 export type CacheLookup<V> = {
@@ -335,6 +335,14 @@ export function cellSelectionText(layout: SemanticLayout, selection: CellSelecti
 
 // @public
 export type CellVerticalAlign = 'top' | 'center' | 'bottom';
+
+// @public
+export interface CjkTypographySettings {
+    readonly after: Readonly<Record<string, string>>;
+    readonly before: Readonly<Record<string, string>>;
+    readonly compression: 'doNotCompress' | 'compressPunctuation' | 'compressPunctuationAndJapaneseKana';
+    readonly strict: boolean;
+}
 
 // @public
 export function clampListValue(value: number): number;
@@ -3910,6 +3918,8 @@ export interface StyleCascadeTable {
     // (undocumented)
     readonly styles: ReadonlyMap<string, StyleDefinition>;
     readonly themeFonts: ThemeFonts;
+    // (undocumented)
+    readonly typography?: CjkTypographySettings;
 }
 
 // @public (undocumented)

--- a/docs/site/content/word-fidelity.mdx
+++ b/docs/site/content/word-fidelity.mdx
@@ -99,6 +99,16 @@ as DOM text, not a canvas bitmap.
 Usable font bytes are required for Word-accurate text measurement. See
 [Fonts and measurement](/docs/2.x/guides/fonts).
 
+East Asian layout keeps punctuation, graphemes, and full-width number groups
+together across formatting changes. Justified lines distribute inter-character
+spacing through the same geometry used for paint and caret placement.
+
+Existing document settings control kinsoku, Japanese strict rules, custom
+language-specific break restrictions, Korean character wrapping, punctuation
+overflow, and punctuation or kana compression. Compression uses deterministic
+advance reductions. Font-specific optical compression is not modeled.
+The feature matrix lists the support limits for East Asian typography.
+
 For pipeline details, see [Architecture](/docs/2.x/core/architecture). Test your
 documents in the [live demo](https://docx-editor.dev/editor).
 

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -215,6 +215,19 @@ export const wordFeatures: WordFeature[] = [
     rendering: 'full',
     roundTrip: 'full',
     tier: 'community',
+    notes:
+      'Justified East Asian lines distribute inter-character spacing. The last line stays left-aligned. Tabs and float passages retain their reserved positions.',
+  },
+  {
+    id: 'paragraphs.east-asian-typography',
+    name: 'East Asian typography',
+    category: 'paragraphs',
+    editing: 'preserved',
+    rendering: 'partial',
+    roundTrip: 'full',
+    tier: 'community',
+    notes:
+      'Protects graphemes, punctuation, and full-width number groups across run boundaries. Reads kinsoku, wordWrap, overflowPunct, strictFirstAndLastChars, language-specific custom line-break sets, and characterSpacingControl. Korean character wrapping follows wordWrap. Compression uses deterministic punctuation and kana advance reductions; font-specific optical compression and vertical Japanese composition are not modeled. Typography settings have no dedicated UI.',
   },
   {
     id: 'paragraphs.spacing',

--- a/packages/core/src/layout/__tests__/cjk-followups.test.ts
+++ b/packages/core/src/layout/__tests__/cjk-followups.test.ts
@@ -6,6 +6,7 @@ import { cjkTypographyFromSettings, resolveCjkTypography } from '../cjk-typograp
 import { buildStyleCascadeTable, resolveParagraphLayoutInputs } from '../style-cascade.ts';
 import { anchorLineStartsByModelOffset } from '../anchor-line-probe.ts';
 import { cjkParagraphBreaks } from '../cjk-paragraph-breaks.ts';
+import { compressCjkPieces } from '../cjk-spacing.ts';
 import { DEFAULT_RUN_STYLE } from '../run-style.ts';
 import type { FieldAwarePiece } from '../field-projection.ts';
 
@@ -92,6 +93,21 @@ describe('CJK follow-up: protected groups across every run seam', () => {
 });
 
 describe('CJK follow-up: mixed text and figure groups', () => {
+  test('non-breaking glue survives every run seam and paragraph wrapping policy', () => {
+    for (const glue of ['\u00a0', '\u202f', '\u2060', '\ufeff']) {
+      const text = `甲乙A${glue}B丙`;
+      for (const pPr of ['', '<w:kinsoku w:val="0"/>', '<w:wordWrap w:val="0"/>']) {
+        const expected = textLines([text], 24, pPr);
+        expect(expected.some((line) => line.includes(`A${glue}B`))).toBe(true);
+        for (let split = 1; split < text.length; split++) {
+          expect(textLines([text.slice(0, split), text.slice(split)], 24, pPr)).toEqual(expected);
+        }
+        // Even an undersized measure cannot split either side of explicit glue.
+        expect(textLines([`天${glue}地`], 7, pPr)).toEqual([`天${glue}地`]);
+      }
+    }
+    expect(textLines(['甲乙A B丙'], 24)).not.toEqual(textLines(['甲乙A\u00a0B丙'], 24));
+  });
   test('full-width decimal and alphabetic groups move together', () => {
     expect(textLines(['天地０.５日'], 24)).toEqual(['天地', '０.５日']);
     expect(textLines(['天地０．５日'], 24)).toEqual(['天地', '０．５日']);
@@ -201,6 +217,52 @@ describe('CJK follow-up: document and paragraph policy', () => {
         '<w:characterSpacingControl w:val="compressPunctuationAndJapaneseKana"/>'
       )[0]!.width
     ).toBe(10.5);
+  });
+  test('compression preserves grapheme geometry across every formatting seam', () => {
+    const settings = '<w:characterSpacingControl w:val="compressPunctuationAndJapaneseKana"/>';
+    for (const text of ['か\u3099天地', 'カ\u309a天地', '「か\u3099」天地。']) {
+      for (const width of [7, 17, 24, 60]) {
+        const expected = layout([text], width, '', '', settings);
+        for (let split = 1; split < text.length; split++) {
+          const actual = layout([text.slice(0, split), text.slice(split)], width, '', '', settings);
+          expect(actual.map((line) => line.spans.map((span) => span.text).join(''))).toEqual(
+            expected.map((line) => line.spans.map((span) => span.text).join(''))
+          );
+          expect(actual.map((line) => line.width)).toEqual(expected.map((line) => line.width));
+          const spans = actual.flatMap((line) => line.spans);
+          expect(spans.map((span) => span.text).join('')).toBe(text);
+          let end = 0;
+          for (const span of spans) {
+            expect(span.range.start).toBe(end);
+            end = span.range.end;
+          }
+          expect(end).toBe(text.length);
+        }
+      }
+    }
+    expect(textLines(['か\u3099天地'], 17, '', '', settings)).toEqual(['か\u3099天', '地']);
+  });
+  test('compression leaves projected atoms and source properties unchanged', () => {
+    const style = Object.freeze({ ...DEFAULT_RUN_STYLE, fontSizePt: 11 });
+    const pieces: FieldAwarePiece[] = [
+      { text: 'か', start: 0, end: 1, style, props: [] },
+      { text: '', start: 1, end: 1, style, props: [], projected: true },
+      { text: '\u3099', start: 1, end: 2, style, props: [] },
+      { text: '。', start: 2, end: 3, style, props: [], projected: true },
+    ];
+    pieces.forEach(Object.freeze);
+    const settings = cjkTypographyFromSettings(
+      root(
+        `<w:settings xmlns:w="${W}"><w:characterSpacingControl w:val="compressPunctuationAndJapaneseKana"/></w:settings>`
+      )
+    );
+    const result = compressCjkPieces(pieces, resolveCjkTypography([], settings), measurer);
+    expect(result[0]!.style.characterSpacingPt).toBe(-0.75);
+    expect(result[1]).toBe(pieces[1]!);
+    expect(result[2]).toBe(pieces[2]!);
+    expect(result[3]).toBe(pieces[3]!);
+    expect(style.characterSpacingPt).toBe(0);
+    expect(result[0]!.props).toBe(pieces[0]!.props);
   });
 });
 

--- a/packages/core/src/layout/__tests__/cjk-followups.test.ts
+++ b/packages/core/src/layout/__tests__/cjk-followups.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, type OoxmlElement } from '@docx-editor.dev/core/store';
+import { alignSpans, breakParagraph } from '../paragraph-flow.ts';
+import { createFixedMeasurer } from '../fixed-measurer.ts';
+import { cjkTypographyFromSettings, resolveCjkTypography } from '../cjk-typography.ts';
+import { buildStyleCascadeTable, resolveParagraphLayoutInputs } from '../style-cascade.ts';
+import { anchorLineStartsByModelOffset } from '../anchor-line-probe.ts';
+import { cjkParagraphBreaks } from '../cjk-paragraph-breaks.ts';
+import { DEFAULT_RUN_STYLE } from '../run-style.ts';
+import type { FieldAwarePiece } from '../field-projection.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const measurer = createFixedMeasurer(6, 14);
+const escape = (text: string) =>
+  text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
+function root(xml: string): OoxmlElement {
+  const read = readOoxmlPart(xml, { name: '/word/document.xml', contentType: 'app/xml' });
+  if (!read.ok) throw new Error(read.reason);
+  return read.part.root;
+}
+function paragraph(parts: readonly string[], pPr = '', rPr = ''): OoxmlElement {
+  return root(
+    `<w:p xmlns:w="${W}"><w:pPr><w:overflowPunct w:val="0"/>${pPr}</w:pPr>${parts.map((text) => `<w:r><w:rPr><w:sz w:val="22"/>${rPr}</w:rPr><w:t xml:space="preserve">${escape(text)}</w:t></w:r>`).join('')}</w:p>`
+  );
+}
+function layout(parts: readonly string[], width: number, pPr = '', rPr = '', settings = '') {
+  const p = paragraph(parts, pPr, rPr);
+  const settingsRoot = root(`<w:settings xmlns:w="${W}">${settings}</w:settings>`);
+  const props = resolveParagraphLayoutInputs(p, width, undefined).props;
+  return breakParagraph(
+    p,
+    'p',
+    0,
+    width,
+    measurer,
+    undefined,
+    null,
+    [],
+    undefined,
+    undefined,
+    undefined,
+    { typography: resolveCjkTypography(props, cjkTypographyFromSettings(settingsRoot)) }
+  );
+}
+const textLines = (...args: Parameters<typeof layout>) =>
+  layout(...args).map((line) => line.spans.map((span) => span.text).join(''));
+
+describe('CJK follow-up: protected groups across every run seam', () => {
+  test.each([
+    [['月。', '。盈'], 7, ['月。。', '盈']],
+    [['月、', '」盈'], 7, ['月、」', '盈']],
+    [['（以', '）来'], 7, ['（以）', '来']],
+    [['「方」', '）盈'], 13, ['「方」）', '盈']],
+  ] as const)('%j at %dpt', (parts, width, expected) => {
+    expect(textLines(parts, width)).toEqual([...expected]);
+  });
+
+  test('formatting seams cannot change line breaks or lose source offsets', () => {
+    for (const text of [
+      '甲方（以下简称「买方」）应当按照本合同第３条、第４条之约定，支付０．５％。',
+      '甲か\u3099\u309a月𠀋乙',
+      '甲👩‍👩‍👧‍👦乙',
+      '甲ＡＢＣ乙１２，３４５．６７％丙',
+    ]) {
+      for (const width of [7, 13, 25, 36, 60]) {
+        const expected = textLines([text], width);
+        for (let split = 1; split < text.length; split++) {
+          // XML cannot represent an isolated surrogate; split at code-point boundaries.
+          if (/[\udc00-\udfff]/u.test(text[split]!)) continue;
+          const lines = layout([text.slice(0, split), text.slice(split)], width);
+          expect(lines.map((line) => line.spans.map((span) => span.text).join(''))).toEqual(
+            expected
+          );
+          expect(
+            lines
+              .flatMap((line) => line.spans)
+              .map((span) => span.text)
+              .join('')
+          ).toBe(text);
+          let end = 0;
+          for (const line of lines)
+            for (const span of line.spans) {
+              expect(span.range.start).toBe(end);
+              expect(span.range.end - span.range.start).toBe(span.text.length);
+              end = span.range.end;
+            }
+          expect(end).toBe(text.length);
+        }
+      }
+    }
+  });
+});
+
+describe('CJK follow-up: mixed text and figure groups', () => {
+  test('full-width decimal and alphabetic groups move together', () => {
+    expect(textLines(['天地０.５日'], 24)).toEqual(['天地', '０.５日']);
+    expect(textLines(['天地０．５日'], 24)).toEqual(['天地', '０．５日']);
+    expect(textLines(['天地ＡＢＣ日'], 24)).toEqual(['天地', 'ＡＢＣ日']);
+  });
+  test('Latin words remain whole while boundaries beside CJK become available', () => {
+    expect(textLines(['甲ABCD乙'], 25)).toEqual(['甲', 'ABCD', '乙']);
+    expect(textLines(['aa bb ℃cccc'], 60)).toEqual(['aa bb ', '℃cccc']);
+  });
+  test('ASCII punctuation beside CJK stays with its carrier', () => {
+    expect(textLines(['天地,月'], 13)).toEqual(['天', '地,', '月']);
+    expect(textLines(['天(', '地)月'], 13)).toEqual(['天', '(地)', '月']);
+  });
+  test('Korean word wrapping is selectable without dividing a syllable', () => {
+    expect(textLines(['가나 다라마'], 25)).toEqual(['가나 ', '다라마']);
+    expect(textLines(['가나 다라마'], 25, '<w:wordWrap w:val="0"/>')).toEqual(['가나 다', '라마']);
+    expect(textLines(['ᄀ', 'ᅡᆨ나'], 7, '<w:wordWrap w:val="0"/>')).toEqual(['각', '나']);
+  });
+});
+
+describe('CJK follow-up: document and paragraph policy', () => {
+  test('kinsoku can be disabled without disabling grapheme safety', () => {
+    expect(textLines(['天。地'], 7, '<w:kinsoku w:val="0"/>')).toEqual(['天', '。', '地']);
+    expect(textLines(['か', '\u3099月'], 7, '<w:kinsoku w:val="0"/>')).toEqual(['か\u3099', '月']);
+  });
+  test('Japanese normal and strict kinsoku use different small-kana rules', () => {
+    const lang = '<w:lang w:eastAsia="ja-JP"/>';
+    expect(textLines(['あゃい'], 7, '', lang)).toEqual(['あ', 'ゃ', 'い']);
+    expect(textLines(['あゃい'], 7, '', lang, '<w:strictFirstAndLastChars/>')).toEqual([
+      'あゃ',
+      'い',
+    ]);
+  });
+  test('custom settings replace the specified direction for the specified language', () => {
+    const custom = '<w:noLineBreaksBefore w:lang="ja-JP" w:val="甲"/>';
+    expect(textLines(['天地甲人'], 13, '', '<w:lang w:eastAsia="ja-JP"/>', custom)).toEqual([
+      '天',
+      '地甲',
+      '人',
+    ]);
+    expect(textLines(['天地甲人'], 13, '', '<w:lang w:eastAsia="zh-CN"/>', custom)).toEqual([
+      '天地',
+      '甲人',
+    ]);
+    expect(
+      textLines(
+        ['天地甲人'],
+        13,
+        '',
+        '<w:lang w:eastAsia="ja-JP"/>',
+        '<w:noLineBreaksAfter w:lang="ja-JP" w:val="地"/>'
+      )
+    ).toEqual(['天', '地甲', '人']);
+  });
+  test('style inheritance and settings participate in the cascade fingerprint', () => {
+    const styles = root(
+      `<w:styles xmlns:w="${W}"><w:style w:type="paragraph" w:styleId="Base" w:default="1"><w:pPr><w:kinsoku w:val="0"/></w:pPr></w:style></w:styles>`
+    );
+    const before = buildStyleCascadeTable(styles);
+    const after = buildStyleCascadeTable(
+      styles,
+      undefined,
+      root(`<w:settings xmlns:w="${W}"><w:strictFirstAndLastChars/></w:settings>`)
+    );
+    expect(after.cacheToken).not.toBe(before.cacheToken);
+    const inherited = resolveParagraphLayoutInputs(paragraph(['天。']), 13, before);
+    expect(resolveCjkTypography(inherited.props, before.typography).kinsoku).toBe(false);
+    const overridden = resolveParagraphLayoutInputs(
+      paragraph(['天。'], '<w:kinsoku/>'),
+      13,
+      before
+    );
+    expect(resolveCjkTypography(overridden.props, before.typography).kinsoku).toBe(true);
+  });
+  test('punctuation overflow follows the paragraph switch and allows only one character', () => {
+    expect(textLines(['天地。人'], 12, '<w:overflowPunct/>')).toEqual(['天地。', '人']);
+    expect(textLines(['天地。人'], 12, '<w:overflowPunct w:val="0"/>')).toEqual([
+      '天',
+      '地。',
+      '人',
+    ]);
+    expect(textLines(['天地。。人'], 12, '<w:overflowPunct/>')).toEqual(['天', '地。。', '人']);
+  });
+  test('compression changes advances, keeps text and model ranges, and respects dont-compress', () => {
+    const ordinary = layout(['天。地。'], 18);
+    const compressed = layout(
+      ['天。地。'],
+      18,
+      '',
+      '',
+      '<w:characterSpacingControl w:val="compressPunctuation"/>'
+    );
+    expect(ordinary.length).toBe(2);
+    expect(compressed.length).toBe(1);
+    expect(compressed[0]!.width).toBe(18);
+    expect(compressed[0]!.spans.map((span) => span.text).join('')).toBe('天。地。');
+    expect(compressed[0]!.end).toBe(4);
+    expect(
+      textLines(['天。地。'], 18, '', '', '<w:characterSpacingControl w:val="doNotCompress"/>')
+    ).toEqual(['天。', '地。']);
+    expect(
+      layout(
+        ['アイ'],
+        12,
+        '',
+        '',
+        '<w:characterSpacingControl w:val="compressPunctuationAndJapaneseKana"/>'
+      )[0]!.width
+    ).toBe(10.5);
+  });
+});
+
+describe('CJK follow-up: geometry', () => {
+  test('justification fills a shortened line with measured inter-character gaps', () => {
+    const line = layout(['天地玄黄'], 60)[0]!;
+    const aligned = alignSpans(line.spans, measurer, 0, 30, 'both', false);
+    expect(aligned.map((span) => span.box.x)).toEqual([0, 8, 16, 24]);
+    expect(aligned.at(-1)!.box.x + aligned.at(-1)!.box.width).toBe(30);
+    expect(aligned.map((span) => span.range.start)).toEqual([0, 1, 2, 3]);
+    expect(alignSpans(line.spans, measurer, 0, 30, 'both', true)).toBe(line.spans);
+  });
+  test('anchor probe uses the same protected seams as placement', () => {
+    const pieces: FieldAwarePiece[] = [
+      {
+        text: '天地月',
+        start: 0,
+        end: 3,
+        props: [],
+        style: { ...DEFAULT_RUN_STYLE, fontSizePt: 11 },
+      },
+      {
+        text: '、盈',
+        start: 3,
+        end: 5,
+        props: [],
+        style: { ...DEFAULT_RUN_STYLE, fontSizePt: 11 },
+      },
+    ];
+    const typography = resolveCjkTypography([
+      { localName: 'overflowPunct', attributes: { val: '0' } },
+    ]);
+    const starts = anchorLineStartsByModelOffset({
+      pieces,
+      measurer,
+      available: 18,
+      firstLineOffset: 0,
+      anchorStarts: [0, 2, 3],
+      equationLayoutOf: () => null,
+      typography,
+      cjkBreaks: cjkParagraphBreaks(pieces, typography),
+    });
+    expect(starts.get(3)).toBe(2);
+    expect(starts.get(0)).toBe(0);
+    expect(starts.get(2)).toBe(2);
+  });
+});

--- a/packages/core/src/layout/__tests__/cjk-line-breaking.test.ts
+++ b/packages/core/src/layout/__tests__/cjk-line-breaking.test.ts
@@ -18,6 +18,8 @@ const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const measurer = createFixedMeasurer(6, 14);
 
 function paragraph(body: string): OoxmlNode {
+  // These tests exercise kinsoku carry, independently of default hanging punctuation.
+  body = body.replace('<w:p>', '<w:p><w:pPr><w:overflowPunct w:val="0"/></w:pPr>');
   const result = readOoxmlPart(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`, {
     name: '/word/document.xml',
     contentType: 'app/xml',

--- a/packages/core/src/layout/anchor-line-probe.ts
+++ b/packages/core/src/layout/anchor-line-probe.ts
@@ -14,6 +14,9 @@
 import { PAGE_BREAK_CHAR } from '@docx-editor.dev/core/store';
 import type { FieldAwarePiece } from './field-projection.ts';
 import { lineOpenDecisionAt, wordBoundaries } from './cjk-line-break.ts';
+import type { CjkParagraphBreaks } from './cjk-paragraph-breaks.ts';
+import { canHangCjkPunctuation } from './cjk-spacing.ts';
+import type { CjkParagraphTypography } from './cjk-typography.ts';
 import { measureInlineDrawing } from './drawing-layout.ts';
 import { styleForFontSlot } from './script-itemization.ts';
 import type { EquationSpanRecord } from './equation-layout.ts';
@@ -21,6 +24,8 @@ import type { TextMeasurer } from './semantic-records.ts';
 
 /** Model offset of the first character of the line each anchor start falls on. */
 export function anchorLineStartsByModelOffset(input: {
+  readonly cjkBreaks?: CjkParagraphBreaks | null;
+  readonly typography?: CjkParagraphTypography;
   readonly pieces: readonly FieldAwarePiece[];
   readonly measurer: TextMeasurer;
   readonly available: number;
@@ -31,7 +36,8 @@ export function anchorLineStartsByModelOffset(input: {
   const { pieces, measurer, available, firstLineOffset, anchorStarts, equationLayoutOf } = input;
   const out = new Map<number, number>();
   if (anchorStarts.length === 0) return out;
-  let probeLineStart = 0;
+  let probeLineStart = pieces[0]?.start ?? 0;
+  const lineStarts = [probeLineStart];
   let probeWidth = 0;
   let probeLineIndex = 0;
   // Mirrors the placement loop's word state — the same open decision (`lineOpenDecisionAt`)
@@ -46,6 +52,7 @@ export function anchorLineStartsByModelOffset(input: {
   const probeLineAvail = (): number => Math.max(1, available - probeLineOffset());
   const closeProbeLine = (nextStart: number): void => {
     probeLineStart = nextStart;
+    lineStarts.push(nextStart);
     probeWidth = 0;
     probeLineIndex += 1;
   };
@@ -54,7 +61,6 @@ export function anchorLineStartsByModelOffset(input: {
     if (equation) {
       const width = equation.geometry.box.width;
       if (probeWidth > 0 && probeWidth + width > probeLineAvail()) closeProbeLine(piece.start);
-      if (anchorStarts.includes(piece.start)) out.set(piece.start, probeLineStart);
       probeWidth += width;
       probeLastEmitted = '';
       probeWordStartWidth = -1;
@@ -63,7 +69,6 @@ export function anchorLineStartsByModelOffset(input: {
     if (piece.inlineDrawing) {
       const width = measureInlineDrawing(piece.inlineDrawing.projection).totalWidth;
       if (probeWidth > 0 && probeWidth + width > probeLineAvail()) closeProbeLine(piece.start);
-      if (anchorStarts.includes(piece.start)) out.set(piece.start, probeLineStart);
       probeWidth += width;
       probeLastEmitted = '';
       probeWordStartWidth = -1;
@@ -78,19 +83,25 @@ export function anchorLineStartsByModelOffset(input: {
       Boolean(piece.positionalTab) ||
       piece.end - piece.start !== piece.text.length;
     let consumed = 0;
-    for (const boundary of wordBoundaries(piece.text, !probePieceLayoutOwned)) {
+    for (const boundary of input.cjkBreaks?.boundaries(piece) ??
+      wordBoundaries(piece.text, !probePieceLayoutOwned)) {
       const candidate = piece.text.slice(consumed, boundary);
       if (candidate.length === 0) continue;
       const style = styleForFontSlot(piece.style, piece.fontSlot);
       const width = measurer.measure(candidate, style);
       const modelStart = piece.start + consumed;
-      const probeDecision = lineOpenDecisionAt(probeLastEmitted, candidate, consumed > 0);
+      const probeDecision =
+        input.cjkBreaks?.decision(piece, consumed) ??
+        lineOpenDecisionAt(probeLastEmitted, candidate, consumed > 0);
       const opens = probeDecision === 'opens';
       if (opens) {
         probeWordStart = modelStart;
         probeWordStartWidth = probeWidth;
       }
-      if (probeWidth > 0 && probeWidth + width > probeLineAvail()) {
+      const hangs =
+        input.typography?.overflowPunctuation &&
+        canHangCjkPunctuation(candidate, piece, probeLineAvail() - probeWidth, width, measurer);
+      if (!hangs && probeWidth > 0 && probeWidth + width > probeLineAvail()) {
         if (probeDecision === 'forbidden' && probeWordStartWidth <= 0) {
           // Placement pushes the group out past the measure rather than opening a line
           // before it, so this probe line does not end here either.
@@ -105,15 +116,23 @@ export function anchorLineStartsByModelOffset(input: {
         }
         probeWordStartWidth = 0;
       }
-      if (anchorStarts.includes(modelStart)) out.set(modelStart, probeLineStart);
-      if (anchorStarts.includes(piece.start)) out.set(piece.start, probeLineStart);
       probeWidth += width;
       probeLastEmitted = candidate;
       consumed = boundary;
     }
   }
   for (const anchorStart of anchorStarts) {
-    if (!out.has(anchorStart)) out.set(anchorStart, probeLineStart);
+    // Resolve after mid-word carries have finalized line starts. Eager assignment
+    // retained a stale line for carried anchors and overwrote a piece-start anchor
+    // with the final line of every multi-line piece.
+    let low = 0;
+    let high = lineStarts.length - 1;
+    while (low < high) {
+      const mid = (low + high + 1) >> 1;
+      if (lineStarts[mid]! <= anchorStart) low = mid;
+      else high = mid - 1;
+    }
+    out.set(anchorStart, lineStarts[low]!);
   }
   return out;
 }

--- a/packages/core/src/layout/cjk-justify.ts
+++ b/packages/core/src/layout/cjk-justify.ts
@@ -1,0 +1,108 @@
+// Inter-character justification uses real span geometry. Paint and exporters already
+// consume the gaps between spans; no browser-only text-justify rule may move the caret.
+import { segmentGraphemes } from './grapheme.ts';
+import { cjkParagraphBreaks, hasCjkText, isCjk } from './cjk-paragraph-breaks.ts';
+import { DEFAULT_CJK_TYPOGRAPHY } from './cjk-typography.ts';
+import { cjkCutAllowedBetween, lastCodePointOf } from './cjk-line-break.ts';
+import { measureDisplayText } from './run-style.ts';
+import { styleForFontSlot } from './script-itemization.ts';
+import type { StyleSpanRecord, TextMeasurer } from './semantic-records.ts';
+
+export function justifyCjkSpans(
+  spans: readonly StyleSpanRecord[],
+  measurer: TextMeasurer,
+  slack: number
+): readonly StyleSpanRecord[] | null {
+  if (!spans.some((span) => hasCjkText(span.text))) return null;
+  // Tabs and float passages reserve exact positions, which justification must not cross.
+  if (spans.some((span) => span.text.includes('\t') || span.wrapAdvanceBefore)) return spans;
+  const split: StyleSpanRecord[] = [];
+  for (const span of spans) {
+    if (
+      span.projected ||
+      span.equation ||
+      span.range.end - span.range.start !== span.text.length ||
+      !hasCjkText(span.text)
+    ) {
+      split.push(span);
+      continue;
+    }
+    const clusters = segmentGraphemes(span.text);
+    const parts: { from: number; to: number }[] = [];
+    let from = 0;
+    for (let index = 1; index < clusters.length; index++) {
+      if (
+        isCjk(lastCodePointOf(clusters[index - 1]!.text)!) ||
+        isCjk(clusters[index]!.text.codePointAt(0)!)
+      ) {
+        parts.push({ from, to: clusters[index]!.utf16From });
+        from = clusters[index]!.utf16From;
+      }
+    }
+    parts.push({ from, to: span.text.length });
+    if (parts.length === 1) {
+      split.push(span);
+      continue;
+    }
+    const style = styleForFontSlot(span.style, span.fontSlot);
+    const widths = parts.map((part) =>
+      measureDisplayText(span.text.slice(part.from, part.to), style, measurer)
+    );
+    const total = widths.reduce((sum, value) => sum + value, 0);
+    let x = span.box.x;
+    for (let index = 0; index < parts.length; index++) {
+      const part = parts[index]!;
+      const width = total > 0 ? (widths[index]! * span.box.width) / total : 0;
+      const { caretEdges: _edges, ...rest } = span;
+      split.push({
+        ...rest,
+        text: span.text.slice(part.from, part.to),
+        range: {
+          ...span.range,
+          start: span.range.start + part.from,
+          end: span.range.start + part.to,
+        },
+        box: { ...span.box, x, width },
+      });
+      x += width;
+    }
+  }
+  const gaps = new Set<number>();
+  const pieces = split.map((span) => ({
+    text: span.text,
+    props: span.props,
+    style: span.style,
+    start: span.range.start,
+    end: span.range.end,
+    projected: !!(span.projected || span.equation),
+  }));
+  const breaks = cjkParagraphBreaks(pieces, DEFAULT_CJK_TYPOGRAPHY);
+  for (let index = 1; index < split.length; index++) {
+    const previous = split[index - 1]!;
+    const current = split[index]!;
+    const before = lastCodePointOf(previous.text);
+    const after = current.text.codePointAt(0);
+    if (
+      before === undefined ||
+      after === undefined ||
+      current.lineEndWhitespace ||
+      current.text === '\n'
+    )
+      continue;
+    if (
+      previous.text.endsWith(' ') ||
+      ((isCjk(before) || isCjk(after)) &&
+        breaks?.decision(pieces[index]!, 0) === 'opens' &&
+        cjkCutAllowedBetween(before, after) &&
+        !/[\u00a0\u202f\u2060\ufeff]/u.test(previous.text.slice(-1) + current.text[0]))
+    )
+      gaps.add(index);
+  }
+  if (gaps.size === 0) return spans;
+  const step = slack / gaps.size;
+  let shift = 0;
+  return split.map((span, index) => {
+    if (gaps.has(index)) shift += step;
+    return shift === 0 ? span : { ...span, box: { ...span.box, x: span.box.x + shift } };
+  });
+}

--- a/packages/core/src/layout/cjk-line-break.ts
+++ b/packages/core/src/layout/cjk-line-break.ts
@@ -8,28 +8,14 @@
 // opportunity on BOTH sides instead, subject to the kinsoku prohibitions: a line must not
 // START with a closing character (。，、」…) and must not END with an opening one (「（…).
 //
-// Scope is deliberately the ideographic classes only — Han, Kana (half-width forms
-// included), CJK symbols and punctuation, compatibility ideographs, and the full-width
-// forms. A break between an ideograph and Latin/digit text (UAX #14 allows one) is NOT
-// introduced, so every existing Latin break decision stays byte-identical and "1." stays
-// glued to the 甲 that follows it. Named cuts, so the follow-ups stay discoverable:
-//
-// - Full-width digits and letters sit inside the ideographic ranges, so a figure group
-//   such as ０．５ can split across lines where Word keeps it together.
-// - The kinsoku sets carry the ideographic-class subset only. Word's East Asian tables
-//   also veto ASCII and Latin-1 punctuation (!%,.:;?°′″℃) at a line start, but only in
-//   East Asian context — honouring that needs script itemization these boundaries do not
-//   see, and vetoing unconditionally changes pure-Latin wrapping.
-// - Justification still stretches only trailing spaces. A justified CJK paragraph
-//   (`w:jc` set to `both`, the Normal-style default in Chinese and Japanese templates)
-//   paints ragged-right on kinsoku-shortened lines where Word distributes
-//   inter-character slack.
-// - A protected group that starts its line and does not fit is PUSHED OUT past the measure,
-//   Word's 追い出し. Word can also compress inter-character space to pull the offender back
-//   in (追い込み); that needs justification slack this layer does not distribute.
-// - Hangul, JIS kinsoku levels and other tailorings are out of scope.
+// These helpers retain the inexpensive Latin fallback and conservative ideographic
+// character tables. Production East Asian flow uses cjk-paragraph-breaks.ts: one
+// paragraph-wide analysis protects graphemes and numeric groups across every run seam,
+// handles mixed-script boundaries, and consumes the OOXML language/settings policy.
+// cjk-spacing.ts owns compression and hanging punctuation; cjk-justify.ts distributes
+// line slack as published geometry. Layout-owned field results remain atomic.
 
-import { segmentGraphemes } from './grapheme.ts';
+import { graphemeBoundaryEpoch, segmentGraphemes } from './grapheme.ts';
 
 /**
  * Whether the code point takes ideographic line breaking — a break opportunity on both
@@ -38,7 +24,7 @@ import { segmentGraphemes } from './grapheme.ts';
  * Ranges: CJK radicals/Kangxi through symbols-and-punctuation and Kana (U+2E80–U+312F),
  * strokes/Katakana-ext through the unified block (U+31C0–U+9FFF), compatibility ideographs
  * (U+F900–U+FAFF), vertical/compat forms (U+FE30–U+FE4F), full-width forms and half-width
- * Katakana (U+FF01–U+FF9F), and the supplementary ideographic planes (U+20000–U+3134F).
+ * Katakana (U+FF01–U+FF9F), and supplementary ideographs (U+20000–U+323AF).
  */
 export function isIdeographicForLineBreak(codePoint: number): boolean {
   return (
@@ -47,7 +33,7 @@ export function isIdeographicForLineBreak(codePoint: number): boolean {
     (codePoint >= 0xf900 && codePoint <= 0xfaff) ||
     (codePoint >= 0xfe30 && codePoint <= 0xfe4f) ||
     (codePoint >= 0xff01 && codePoint <= 0xff9f) ||
-    (codePoint >= 0x20000 && codePoint <= 0x3134f)
+    (codePoint >= 0x20000 && codePoint <= 0x323af)
   );
 }
 
@@ -240,7 +226,13 @@ export function cjkChopCutAllowedAt(text: string, index: number): boolean {
  * Latin placement never pays for it.
  */
 const clusterBreakCache = new Map<number, boolean>();
+let clusterBreakEpoch = -1;
 function clusterBreaksBetween(before: number, after: number): boolean {
+  const epoch = graphemeBoundaryEpoch();
+  if (clusterBreakEpoch !== epoch || clusterBreakCache.size >= 2048) {
+    clusterBreakCache.clear();
+    clusterBreakEpoch = epoch;
+  }
   const key = before * 0x110000 + after;
   const cached = clusterBreakCache.get(key);
   if (cached !== undefined) return cached;

--- a/packages/core/src/layout/cjk-paragraph-breaks.ts
+++ b/packages/core/src/layout/cjk-paragraph-breaks.ts
@@ -1,0 +1,218 @@
+// Paragraph-wide boundary analysis. A formatting, revision, or font-slot seam is
+// not a Unicode boundary: segment the visible text once, then map cuts to pieces.
+import type { FieldAwarePiece } from './field-projection.ts';
+import { segmentGraphemes } from './grapheme.ts';
+import {
+  CJK_NO_BREAK_AFTER,
+  CJK_NO_BREAK_BEFORE,
+  isIdeographicForLineBreak,
+  lastCodePointOf,
+  wordBoundaries,
+  type LineOpenDecision,
+} from './cjk-line-break.ts';
+import {
+  eastAsianLanguage,
+  kinsokuCharacters,
+  type CjkParagraphTypography,
+} from './cjk-typography.ts';
+
+export function isHangul(cp: number): boolean {
+  return (
+    (cp >= 0x1100 && cp <= 0x11ff) ||
+    (cp >= 0x3130 && cp <= 0x318f) ||
+    (cp >= 0xa960 && cp <= 0xa97f) ||
+    (cp >= 0xac00 && cp <= 0xd7ff)
+  );
+}
+export const isCjk = (cp: number): boolean => isIdeographicForLineBreak(cp) || isHangul(cp);
+export const hasCjkText = (text: string): boolean =>
+  /[\u1100-\u11ff\u2e80-\u318f\u31c0-\u9fff\ua960-\ua97f\uac00-\ud7ff\uf900-\ufaff\ufe30-\ufe4f\uff01-\uff9f\u{20000}-\u{323af}]/u.test(
+    text
+  );
+const isFullwidthAlphanumeric = (cp: number): boolean =>
+  (cp >= 0xff10 && cp <= 0xff19) ||
+  (cp >= 0xff21 && cp <= 0xff3a) ||
+  (cp >= 0xff41 && cp <= 0xff5a);
+const isText = (piece: FieldAwarePiece): boolean =>
+  !piece.projected &&
+  !piece.positionalTab &&
+  !piece.inlineDrawing &&
+  !piece.equation &&
+  piece.end - piece.start === piece.text.length;
+
+export interface CjkParagraphBreaks {
+  boundaries(piece: FieldAwarePiece): readonly number[];
+  decision(piece: FieldAwarePiece, offset: number): LineOpenDecision;
+  cutAllowed(piece: FieldAwarePiece, candidateStart: number, index: number): boolean;
+}
+
+export function cjkParagraphBreaks(
+  pieces: readonly FieldAwarePiece[],
+  policy: CjkParagraphTypography
+): CjkParagraphBreaks | null {
+  if (
+    !policy.characterWrap &&
+    !pieces.some(
+      (piece) =>
+        /[\u1100-\u11ff\u2e80-\ud7ff\uf900-\uffef\u{20000}-\u{323af}]/u.test(piece.text) ||
+        eastAsianLanguage(piece.props)
+    )
+  )
+    return null;
+  const starts = new Map<FieldAwarePiece, number>();
+  const strings: string[] = [];
+  let total = 0;
+  for (const piece of pieces) {
+    starts.set(piece, total);
+    // Layout-owned atoms form barriers. Their display characters have no one-to-one
+    // model mapping and must not become inter-character placement candidates.
+    const text = isText(piece) ? piece.text : '\ufffc'.repeat(Math.min(piece.text.length, 1));
+    strings.push(text);
+    total += text.length;
+  }
+  const text = strings.join('');
+  const clusters = segmentGraphemes(text);
+  const decisions = new Map<number, LineOpenDecision>([
+    [0, 'opens'],
+    [text.length, 'opens'],
+  ]);
+  const latinCuts = new Set(wordBoundaries(text, false));
+  // Numeric expressions and full-width alphabetic words are units, even when
+  // runs split a decimal separator or currency sign from its digits.
+  const numeric = new Set<number>();
+  const figures =
+    /[＄￥￡￦＋－$£¥+\-]?[0-9０-９]+(?:[．，：／.,:/][0-9０-９]+)*(?:[％%‰])?|[Ａ-Ｚａ-ｚ]+/gu;
+  for (const match of text.matchAll(figures)) {
+    if (!/[０-９Ａ-Ｚａ-ｚ]/u.test(match[0])) continue;
+    for (let index = match.index + 1; index < match.index + match[0].length; index++)
+      numeric.add(index);
+  }
+  let pieceIndex = 0;
+  let leftPieceIndex = 0;
+  const hasKorean = clusters.some((cluster) => isHangul(cluster.text.codePointAt(0)!));
+  const detectedLanguage = hasKorean
+    ? 'ko-kr'
+    : /[\u3040-\u30ff\uff66-\uff9f]/u.test(text)
+      ? 'ja-jp'
+      : 'zh-cn';
+  // Carry script context through punctuation, but never across a Latin word or space.
+  const eastAsianContext: boolean[] = [];
+  let context = false;
+  for (const cluster of clusters) {
+    if (!/^[\p{P}\p{S}\p{M}]+$/u.test(cluster.text)) context = isCjk(cluster.text.codePointAt(0)!);
+    eastAsianContext.push(context || isCjk(cluster.text.codePointAt(0)!));
+  }
+  const languages = pieces.map((piece) => eastAsianLanguage(piece.props));
+  const tables = new Map<string, ReturnType<typeof kinsokuCharacters>>();
+  const tableFor = (language: string) => {
+    let table = tables.get(language);
+    if (!table) {
+      table = kinsokuCharacters(language, policy.settings);
+      tables.set(language, table);
+    }
+    return table;
+  };
+  for (let index = 1; index < clusters.length; index++) {
+    const left = clusters[index - 1]!;
+    const right = clusters[index]!;
+    const at = right.utf16From;
+    while (pieceIndex + 1 < pieces.length && starts.get(pieces[pieceIndex + 1]!)! <= at)
+      pieceIndex++;
+    while (
+      leftPieceIndex + 1 < pieces.length &&
+      starts.get(pieces[leftPieceIndex + 1]!)! <= left.utf16From
+    )
+      leftPieceIndex++;
+    const before = lastCodePointOf(left.text)!;
+    const beforeBase = left.text.codePointAt(0)!;
+    const after = right.text.codePointAt(0)!;
+    if (/[\t\n\f\ufffc]/u.test(left.text + right.text)) {
+      decisions.set(at, 'opens');
+      continue;
+    }
+    let forbidden = false;
+    if (policy.kinsoku) {
+      const language =
+        languages[pieceIndex] ??
+        (policy.settings &&
+        (isCjk(after) || (eastAsianContext[index - 1] && /^[\p{P}\p{S}]+$/u.test(right.text)))
+          ? detectedLanguage
+          : undefined);
+      const previousLanguage =
+        languages[leftPieceIndex] ??
+        (policy.settings &&
+        (isCjk(beforeBase) || (isCjk(after) && /^[\p{P}\p{S}]+$/u.test(left.text)))
+          ? detectedLanguage
+          : undefined);
+      if (language || previousLanguage) {
+        forbidden =
+          (language
+            ? tableFor(language).before.includes(String.fromCodePoint(after))
+            : CJK_NO_BREAK_BEFORE.has(after)) ||
+          (previousLanguage
+            ? tableFor(previousLanguage).after.includes(String.fromCodePoint(before))
+            : CJK_NO_BREAK_AFTER.has(before));
+      } else {
+        forbidden = CJK_NO_BREAK_BEFORE.has(after) || CJK_NO_BREAK_AFTER.has(before);
+        // ASCII/scientific punctuation participates only beside East Asian text.
+        // A Latin paragraph containing ℃ retains its ordinary word boundaries.
+        if (eastAsianContext[index - 1] || isCjk(after)) {
+          const inferred = isHangul(before) || isHangul(after) ? 'ko-kr' : 'ja-jp';
+          const table = tableFor(inferred);
+          forbidden ||=
+            (eastAsianContext[index - 1]! && table.before.includes(String.fromCodePoint(after))) ||
+            (isCjk(after) && table.after.includes(String.fromCodePoint(before)));
+        }
+      }
+    }
+    if (forbidden) {
+      decisions.set(at, 'forbidden');
+      continue;
+    }
+    // Figure/letter groups move as words. Like an oversized Latin word, an
+    // extremely long group can still use emergency chopping at safe boundaries.
+    if (numeric.has(at)) {
+      decisions.set(at, 'continues');
+      continue;
+    }
+    const eastAsian =
+      (isCjk(beforeBase) && !isFullwidthAlphanumeric(beforeBase)) ||
+      (isCjk(after) && !isFullwidthAlphanumeric(after)) ||
+      (eastAsianContext[index - 1]! && /^[\p{P}\p{S}]+$/u.test(left.text));
+    const wrapCharacters =
+      policy.characterWrap && (!hasKorean || (isHangul(beforeBase) && isHangul(after)));
+    const koreanWord = isHangul(beforeBase) && isHangul(after) && !wrapCharacters;
+    const opens =
+      latinCuts.has(at) ||
+      /\s$/u.test(left.text) ||
+      /^\s/u.test(right.text) ||
+      (eastAsian && !koreanWord) ||
+      wrapCharacters;
+    decisions.set(at, opens ? 'opens' : 'continues');
+  }
+  const boundaries = new Map<FieldAwarePiece, readonly number[]>();
+  for (const piece of pieces) {
+    const start = starts.get(piece)!;
+    if (!isText(piece)) {
+      boundaries.set(piece, wordBoundaries(piece.text, false));
+      continue;
+    }
+    const cuts: number[] = [];
+    // Walk each piece once; decisions are O(1), including cluster-interior vetoes.
+    for (let offset = 1; offset < piece.text.length; offset++) {
+      const decision = decisions.get(start + offset);
+      if (decision === 'opens' || (numeric.has(start + offset) && decision === 'continues'))
+        cuts.push(offset);
+    }
+    cuts.push(piece.text.length);
+    boundaries.set(piece, cuts);
+  }
+  return {
+    boundaries: (piece) => boundaries.get(piece)!,
+    decision: (piece, offset) =>
+      !isText(piece) ? 'opens' : (decisions.get(starts.get(piece)! + offset) ?? 'forbidden'),
+    cutAllowed: (piece, candidateStart, index) =>
+      decisions.get(starts.get(piece)! + candidateStart + index) !== 'forbidden' &&
+      decisions.has(starts.get(piece)! + candidateStart + index),
+  };
+}

--- a/packages/core/src/layout/cjk-paragraph-breaks.ts
+++ b/packages/core/src/layout/cjk-paragraph-breaks.ts
@@ -130,6 +130,12 @@ export function cjkParagraphBreaks(
       decisions.set(at, 'opens');
       continue;
     }
+    // Glue is independent of language and kinsoku. Neither character wrapping
+    // nor emergency chopping may separate a non-breaking character's neighbours.
+    if (/[\u00a0\u202f\u2060\ufeff]/u.test(left.text + right.text)) {
+      decisions.set(at, 'forbidden');
+      continue;
+    }
     let forbidden = false;
     if (policy.kinsoku) {
       const language =

--- a/packages/core/src/layout/cjk-spacing.ts
+++ b/packages/core/src/layout/cjk-spacing.ts
@@ -1,0 +1,99 @@
+// Opt-in OOXML punctuation/kana compression and hanging punctuation. All advances
+// are measured here and travel in layout records to browser paint and exporters.
+import type { FieldAwarePiece } from './field-projection.ts';
+import { segmentGraphemes } from './grapheme.ts';
+import { measureDisplayText, type ResolvedRunStyle } from './run-style.ts';
+import { styleForFontSlot } from './script-itemization.ts';
+import type { TextMeasurer } from './semantic-records.ts';
+import { eastAsianLanguage, type CjkParagraphTypography } from './cjk-typography.ts';
+
+const FULLWIDTH_PUNCTUATION =
+  /^[、。〈〉《》「」『』【】〔〕〖〗〘〙〚〛！（），．：；？［］｛｝]$/u;
+const KANA = /^[\u3041-\u3096\u30a1-\u30fa][\u3099\u309a]?$/u;
+
+export function compressCjkPieces(
+  pieces: readonly FieldAwarePiece[],
+  policy: CjkParagraphTypography,
+  measurer: TextMeasurer
+): readonly FieldAwarePiece[] {
+  const compression = policy.settings?.compression;
+  if (!compression || compression === 'doNotCompress') return pieces;
+  const result: FieldAwarePiece[] = [];
+  const derived = new WeakMap<ResolvedRunStyle, Map<number, ResolvedRunStyle>>();
+  for (const piece of pieces) {
+    if (
+      piece.projected ||
+      piece.measureText !== undefined ||
+      piece.positionalTab ||
+      piece.equation ||
+      piece.inlineDrawing ||
+      piece.end - piece.start !== piece.text.length
+    ) {
+      result.push(piece);
+      continue;
+    }
+    const style = styleForFontSlot(piece.style, piece.fontSlot);
+    let from = 0;
+    for (const cluster of segmentGraphemes(piece.text)) {
+      const fraction = FULLWIDTH_PUNCTUATION.test(cluster.text)
+        ? 0.5
+        : compression === 'compressPunctuationAndJapaneseKana' && KANA.test(cluster.text)
+          ? 0.125
+          : 0;
+      if (!fraction) continue;
+      if (cluster.utf16From > from)
+        result.push({
+          ...piece,
+          text: piece.text.slice(from, cluster.utf16From),
+          start: piece.start + from,
+          end: piece.start + cluster.utf16From,
+        });
+      // Compress whitespace, never horizontally scale the glyph. The same letter
+      // spacing reaches measurement, paint, caret edges, and export.
+      const advance = measureDisplayText(cluster.text, style, measurer);
+      const spacing =
+        piece.style.characterSpacingPt - Math.max(0, advance * fraction) / cluster.text.length;
+      let bySpacing = derived.get(piece.style);
+      if (!bySpacing) {
+        bySpacing = new Map();
+        derived.set(piece.style, bySpacing);
+      }
+      let compressed = bySpacing.get(spacing);
+      if (!compressed) {
+        compressed = { ...piece.style, characterSpacingPt: spacing };
+        bySpacing.set(spacing, compressed);
+      }
+      result.push({
+        ...piece,
+        text: cluster.text,
+        start: piece.start + cluster.utf16From,
+        end: piece.start + cluster.utf16To,
+        style: compressed,
+      });
+      from = cluster.utf16To;
+    }
+    if (from === 0) result.push(piece);
+    else if (from < piece.text.length)
+      result.push({ ...piece, text: piece.text.slice(from), start: piece.start + from });
+  }
+  return result;
+}
+
+export function canHangCjkPunctuation(
+  text: string,
+  piece: FieldAwarePiece,
+  remaining: number,
+  width: number,
+  measurer: TextMeasurer
+): boolean {
+  if (piece.projected || piece.measureText !== undefined) return false;
+  // Hanging is enabled by default. Ordinary Latin words/spaces must not allocate
+  // a grapheme array on every placement candidate just to discover no punctuation.
+  const tail = text[text.length - 1];
+  if (!tail || !/^[\p{Pe}\p{Pf}\p{Po}]$/u.test(tail)) return false;
+  if (!FULLWIDTH_PUNCTUATION.test(tail) && !eastAsianLanguage(piece.props)) return false;
+  const last = segmentGraphemes(text).at(-1)?.text;
+  if (!last || !/^[\p{Pe}\p{Pf}\p{Po}]$/u.test(last)) return false;
+  const advance = measureDisplayText(last, styleForFontSlot(piece.style, piece.fontSlot), measurer);
+  return width - advance <= remaining + 0.001 && remaining >= -0.001;
+}

--- a/packages/core/src/layout/cjk-spacing.ts
+++ b/packages/core/src/layout/cjk-spacing.ts
@@ -11,6 +11,75 @@ const FULLWIDTH_PUNCTUATION =
   /^[、。〈〉《》「」『』【】〔〕〖〗〘〙〚〛！（），．：；？［］｛｝]$/u;
 const KANA = /^[\u3041-\u3096\u30a1-\u30fa][\u3099\u309a]?$/u;
 
+const compressible = (piece: FieldAwarePiece): boolean =>
+  !piece.projected &&
+  piece.measureText === undefined &&
+  !piece.positionalTab &&
+  !piece.equation &&
+  !piece.inlineDrawing &&
+  piece.end - piece.start === piece.text.length;
+
+interface CompressionSlice {
+  readonly from: number;
+  readonly to: number;
+  readonly reduction: number;
+}
+
+function compressionSlices(
+  pieces: readonly FieldAwarePiece[],
+  includeKana: boolean,
+  measurer: TextMeasurer
+): ReadonlyMap<FieldAwarePiece, readonly CompressionSlice[]> {
+  const starts: number[] = [];
+  let length = 0;
+  const text = pieces
+    .map((piece) => {
+      starts.push(length);
+      const visible = compressible(piece) ? piece.text : '\ufffc';
+      length += visible.length;
+      return visible;
+    })
+    .join('');
+  const slices = new Map<FieldAwarePiece, CompressionSlice[]>();
+  let pieceIndex = 0;
+  for (const cluster of segmentGraphemes(text)) {
+    const fraction = FULLWIDTH_PUNCTUATION.test(cluster.text)
+      ? 0.5
+      : includeKana && KANA.test(cluster.text)
+        ? 0.125
+        : 0;
+    if (!fraction) continue;
+    while (pieceIndex + 1 < pieces.length && starts[pieceIndex + 1]! <= cluster.utf16From)
+      pieceIndex++;
+    const base = pieces[pieceIndex]!;
+    // Measure the complete cluster with its base character's font. Apply the
+    // same per-unit reduction to every fragment, including split combining marks.
+    const advance = measureDisplayText(
+      cluster.text,
+      styleForFontSlot(base.style, base.fontSlot),
+      measurer
+    );
+    const reduction = Math.max(0, advance * fraction) / cluster.text.length;
+    for (
+      let index = pieceIndex;
+      index < pieces.length && starts[index]! < cluster.utf16To;
+      index++
+    ) {
+      const piece = pieces[index]!;
+      const from = Math.max(0, cluster.utf16From - starts[index]!);
+      const to = Math.min(piece.text.length, cluster.utf16To - starts[index]!);
+      if (from === to) continue;
+      let list = slices.get(piece);
+      if (!list) {
+        list = [];
+        slices.set(piece, list);
+      }
+      list.push({ from, to, reduction });
+    }
+  }
+  return slices;
+}
+
 export function compressCjkPieces(
   pieces: readonly FieldAwarePiece[],
   policy: CjkParagraphTypography,
@@ -20,39 +89,29 @@ export function compressCjkPieces(
   if (!compression || compression === 'doNotCompress') return pieces;
   const result: FieldAwarePiece[] = [];
   const derived = new WeakMap<ResolvedRunStyle, Map<number, ResolvedRunStyle>>();
+  const slices = compressionSlices(
+    pieces,
+    compression === 'compressPunctuationAndJapaneseKana',
+    measurer
+  );
   for (const piece of pieces) {
-    if (
-      piece.projected ||
-      piece.measureText !== undefined ||
-      piece.positionalTab ||
-      piece.equation ||
-      piece.inlineDrawing ||
-      piece.end - piece.start !== piece.text.length
-    ) {
+    const compressedSlices = slices.get(piece);
+    if (!compressedSlices) {
       result.push(piece);
       continue;
     }
-    const style = styleForFontSlot(piece.style, piece.fontSlot);
     let from = 0;
-    for (const cluster of segmentGraphemes(piece.text)) {
-      const fraction = FULLWIDTH_PUNCTUATION.test(cluster.text)
-        ? 0.5
-        : compression === 'compressPunctuationAndJapaneseKana' && KANA.test(cluster.text)
-          ? 0.125
-          : 0;
-      if (!fraction) continue;
-      if (cluster.utf16From > from)
+    for (const slice of compressedSlices) {
+      if (slice.from > from)
         result.push({
           ...piece,
-          text: piece.text.slice(from, cluster.utf16From),
+          text: piece.text.slice(from, slice.from),
           start: piece.start + from,
-          end: piece.start + cluster.utf16From,
+          end: piece.start + slice.from,
         });
       // Compress whitespace, never horizontally scale the glyph. The same letter
       // spacing reaches measurement, paint, caret edges, and export.
-      const advance = measureDisplayText(cluster.text, style, measurer);
-      const spacing =
-        piece.style.characterSpacingPt - Math.max(0, advance * fraction) / cluster.text.length;
+      const spacing = piece.style.characterSpacingPt - slice.reduction;
       let bySpacing = derived.get(piece.style);
       if (!bySpacing) {
         bySpacing = new Map();
@@ -65,12 +124,12 @@ export function compressCjkPieces(
       }
       result.push({
         ...piece,
-        text: cluster.text,
-        start: piece.start + cluster.utf16From,
-        end: piece.start + cluster.utf16To,
+        text: piece.text.slice(slice.from, slice.to),
+        start: piece.start + slice.from,
+        end: piece.start + slice.to,
         style: compressed,
       });
-      from = cluster.utf16To;
+      from = slice.to;
     }
     if (from === 0) result.push(piece);
     else if (from < piece.text.length)

--- a/packages/core/src/layout/cjk-typography.ts
+++ b/packages/core/src/layout/cjk-typography.ts
@@ -1,0 +1,142 @@
+// OOXML East Asian typography policy. Settings travel with the style cascade so its
+// producer fingerprint invalidates all stories when document typography changes.
+// References: ECMA-376 §17.3.1.16, §17.3.1.21, §17.15.1.18, §17.15.1.58–59, §17.15.1.82.
+import type { OoxmlElement, OoxmlProperty } from '@docx-editor.dev/core/store';
+
+/** Document-wide East Asian line-break and whitespace policy. @public */
+export interface CjkTypographySettings {
+  /** Apply the strict Japanese small-kana and prolonged-sound-mark restrictions. */
+  readonly strict: boolean;
+  /** Whitespace compression selected by `w:characterSpacingControl`. */
+  readonly compression:
+    | 'doNotCompress'
+    | 'compressPunctuation'
+    | 'compressPunctuationAndJapaneseKana';
+  /** Custom no-line-start characters, keyed by normalized language tag. */
+  readonly before: Readonly<Record<string, string>>;
+  /** Custom no-line-end characters, keyed by normalized language tag. */
+  readonly after: Readonly<Record<string, string>>;
+}
+
+export interface CjkParagraphTypography {
+  readonly settings?: CjkTypographySettings;
+  readonly kinsoku: boolean;
+  readonly overflowPunctuation: boolean;
+  readonly characterWrap: boolean;
+}
+
+export const DEFAULT_CJK_TYPOGRAPHY: CjkParagraphTypography = Object.freeze({
+  kinsoku: true,
+  overflowPunctuation: true,
+  characterWrap: false,
+});
+
+const on = (value: string | undefined): boolean => !['0', 'false', 'off'].includes(value ?? '');
+export function cjkTypographyFromSettings(root: OoxmlElement | null): CjkTypographySettings {
+  let strict = false;
+  let compression: CjkTypographySettings['compression'] = 'doNotCompress';
+  const before: Record<string, string> = Object.create(null);
+  const after: Record<string, string> = Object.create(null);
+  for (const child of root?.children ?? []) {
+    if (!('localName' in child)) continue;
+    if (child.namespaceUri !== 'http://schemas.openxmlformats.org/wordprocessingml/2006/main')
+      continue;
+    const value = child.attributes.find(
+      (attribute) => attribute.localName === 'val' && attribute.namespaceUri === child.namespaceUri
+    )?.value;
+    if (child.localName === 'strictFirstAndLastChars') strict = on(value);
+    if (
+      child.localName === 'characterSpacingControl' &&
+      (value === 'doNotCompress' ||
+        value === 'compressPunctuation' ||
+        value === 'compressPunctuationAndJapaneseKana')
+    )
+      compression = value;
+    if (child.localName !== 'noLineBreaksBefore' && child.localName !== 'noLineBreaksAfter')
+      continue;
+    const language = child.attributes
+      .find(
+        (attribute) =>
+          attribute.localName === 'lang' && attribute.namespaceUri === child.namespaceUri
+      )
+      ?.value.toLowerCase();
+    // Bound file-derived policy storage independently of XML parser limits.
+    if (!language || !/^[a-z]{2,3}(?:-[a-z0-9]{2,8}){0,3}$/.test(language)) continue;
+    const target = child.localName === 'noLineBreaksBefore' ? before : after;
+    if (Object.keys(target).length < 64 || Object.hasOwn(target, language))
+      target[language] = (value ?? '').slice(0, 4096);
+  }
+  return Object.freeze({
+    strict,
+    compression,
+    before: Object.freeze(before),
+    after: Object.freeze(after),
+  });
+}
+
+export function resolveCjkTypography(
+  props: readonly OoxmlProperty[],
+  settings?: CjkTypographySettings
+): CjkParagraphTypography {
+  let { kinsoku, overflowPunctuation, characterWrap } = DEFAULT_CJK_TYPOGRAPHY;
+  for (const prop of props) {
+    if (prop.localName === 'kinsoku') kinsoku = on(prop.attributes?.val);
+    if (prop.localName === 'overflowPunct') overflowPunctuation = on(prop.attributes?.val);
+    if (prop.localName === 'wordWrap') characterWrap = !on(prop.attributes?.val);
+  }
+  return { settings, kinsoku, overflowPunctuation, characterWrap };
+}
+
+export function eastAsianLanguage(props: readonly OoxmlProperty[]): string | undefined {
+  let language: string | undefined;
+  for (const prop of props) {
+    if (prop.localName !== 'lang') continue;
+    const value = prop.attributes?.eastAsia ?? prop.attributes?.val;
+    if (value && /^(ja|zh|ko)(-|$)/i.test(value)) language = value.toLowerCase();
+  }
+  return language;
+}
+
+// Language-specific default tables from §17.3.1.16. Custom sets replace one direction.
+const JA_BEFORE = '!%),.:;?]}¢°’”‰′″℃、。々〉》」』】〕゛゜ゝゞ・ヽヾ！％），．：；？］｝｡｣､･ﾞﾟ￠';
+const JA_AFTER = '$([\\{£¥‘“〈《「『【〔＄（［｛｢￡￥';
+const ZH_BEFORE =
+  '!%),.:;>?]}¢¨°·ˇˉ―‖’”…‰′″›℃∶、。〃〉》」』】〕〗〞︶︺︾﹀﹄﹚﹜﹞！＂％＇），．：；？］｀｜｝～￠';
+const ZH_AFTER = '$([{£¥·‘“〈《「『【〔〖〝﹙﹛﹝＄（．［｛￡￥';
+const ZH_TRAD_BEFORE =
+  '! ),.:;?]}¢·–—’”•‥…‧′╴、。〉》」』】〕〞︰︱︳︴︶︸︺︼︾﹀﹂﹄﹏﹐﹑﹒﹔﹕﹖﹗﹚﹜﹞！），．：；？］｜｝､'.replace(
+    ' ',
+    ''
+  );
+const ZH_TRAD_AFTER = '([{£¥‘“‵〈《「『【〔〝︵︷︹︻︽︿﹁﹃﹙﹛﹝（｛';
+const KO_BEFORE = '!%),.:;?]}¢°’”′″℃〉》」』】〕！％），．：；？］｝￠';
+const KO_AFTER = '$([\\{£¥‘“〈《「『【〔＄（［｛￡￥￦';
+export const STRICT_KANA = 'ぁぃぅぇぉっゃゅょゎァィゥェォッャュョヮヵヶーｧｨｩｪｫｬｭｮｯｰ';
+
+export function kinsokuCharacters(
+  language: string,
+  settings?: CjkTypographySettings
+): { before: string; after: string } {
+  const family = language.split('-')[0];
+  const traditional = /^zh-(tw|hk|mo|hant)(-|$)/.test(language);
+  let before =
+    family === 'zh'
+      ? traditional
+        ? ZH_TRAD_BEFORE
+        : ZH_BEFORE
+      : family === 'ko'
+        ? KO_BEFORE
+        : JA_BEFORE;
+  let after =
+    family === 'zh'
+      ? traditional
+        ? ZH_TRAD_AFTER
+        : ZH_AFTER
+      : family === 'ko'
+        ? KO_AFTER
+        : JA_AFTER;
+  if (family === 'ja' && settings?.strict) before += STRICT_KANA;
+  before = settings?.before[language] ?? before;
+  after = settings?.after[language] ?? after;
+  return { before, after };
+}

--- a/packages/core/src/layout/document-style-deps.ts
+++ b/packages/core/src/layout/document-style-deps.ts
@@ -24,15 +24,18 @@ export function createDocumentStyleDependencies(
   let styleThemeMajorEastAsia: string | null | undefined;
   let styleThemeMinorEastAsia: string | null | undefined;
   let styles: StyleCascadeTable | undefined;
+  let typographyRoot: OoxmlElement | null | undefined;
   let settingsRoot: OoxmlElement | null | undefined;
   let defaultTabStopPt: number | undefined;
   return {
     styleCascade() {
       const current = view.stylesRoot();
       const theme = view.documentThemeFonts();
+      const currentSettings = view.settingsRoot();
       if (
         styles === undefined ||
         current !== stylesRoot ||
+        currentSettings !== typographyRoot ||
         theme.major !== styleThemeMajor ||
         theme.minor !== styleThemeMinor ||
         theme.majorEastAsia !== styleThemeMajorEastAsia ||
@@ -43,7 +46,8 @@ export function createDocumentStyleDependencies(
         styleThemeMinor = theme.minor;
         styleThemeMajorEastAsia = theme.majorEastAsia;
         styleThemeMinorEastAsia = theme.minorEastAsia;
-        styles = buildStyleCascadeTable(current, theme);
+        typographyRoot = currentSettings;
+        styles = buildStyleCascadeTable(current, theme, currentSettings);
       }
       return styles;
     },

--- a/packages/core/src/layout/index.ts
+++ b/packages/core/src/layout/index.ts
@@ -379,6 +379,7 @@ export {
   type ResolvedListItem,
 } from './list-resolve.ts';
 export { createFixedMeasurer } from './fixed-measurer.ts';
+export type { CjkTypographySettings } from './cjk-typography.ts';
 export {
   layoutEquation,
   type EquationFractionGeometry,

--- a/packages/core/src/layout/oversized-word-break.ts
+++ b/packages/core/src/layout/oversized-word-break.ts
@@ -24,8 +24,8 @@ export interface OversizedWordRemainder extends OversizedWordPrefix {
 /**
  * Move a grapheme-safe cut to one `cutAllowedAt` also accepts: shorter first, so the line
  * stays inside its measure; longer only when no shorter cut is left, pushing the offending
- * character out with its carrier. A text with no accepted cut at all (。。。) keeps the
- * measured one, so the chop always makes progress.
+ * character out with its carrier. If no cut is accepted, return the whole remainder;
+ * ordinary placement keeps it pending until the next piece's boundary is known.
  */
 function acceptedCut(
   text: string,
@@ -41,7 +41,7 @@ function acceptedCut(
   for (let candidate = fitTo + 1; candidate <= graphemes.length; candidate += 1) {
     if (cutAllowedAt(text, graphemes[candidate - 1]!.utf16To)) return candidate;
   }
-  return fitTo;
+  return graphemes.length;
 }
 
 export function chopOversizedWord(
@@ -112,6 +112,9 @@ export function chopOversizedWord(
     // by one UTF-16 code unit (which could split a surrogate pair or combining sequence).
     if (fitTo === graphemeFrom) fitTo += 1;
     fitTo = acceptedCut(text, graphemes, graphemeFrom, fitTo, options.cutAllowedAt);
+    // The final group may continue in the next run. Keep it on the pending line;
+    // only the caller can decide whether the next piece permits a line break.
+    if (fitTo === graphemes.length) break;
 
     const utf16To = graphemes[fitTo - 1]!.utf16To;
     const prefixText = text.slice(utf16From, utf16To);

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -34,6 +34,10 @@ import {
 } from './revision-projection.ts';
 import type { ParagraphLayoutCache } from './layout-cache.ts';
 import { cjkChopCutAllowedAt, lineOpenDecisionAt, wordBoundaries } from './cjk-line-break.ts';
+import { cjkParagraphBreaks } from './cjk-paragraph-breaks.ts';
+import { justifyCjkSpans } from './cjk-justify.ts';
+import { compressCjkPieces, canHangCjkPunctuation } from './cjk-spacing.ts';
+import { resolveCjkTypography, type CjkParagraphTypography } from './cjk-typography.ts';
 import {
   EMPTY_TAB_STOPS,
   nextTabDestination,
@@ -101,6 +105,7 @@ const OVERFLOW_TOLERANCE_PT = 0.001;
  * cache key — a paragraph re-broken at a different line spacing is a different break.
  */
 export interface ParagraphFlowOptions {
+  readonly typography?: CjkParagraphTypography;
   readonly lineSpacing?: ParagraphLineSpacing;
   /** First-line offset from the paragraph indent: `w:firstLine` right, `w:hanging` left. */
   readonly firstLineOffset?: number;
@@ -545,6 +550,8 @@ export function alignSpans(
   // The last line of a justified paragraph is set flush left, never stretched.
   if (alignment === 'both') {
     if (isLastLine) return spans;
+    const justified = justifyCjkSpans(spans, measurer, slack);
+    if (justified) return justified;
     // Only boundaries after an expandable space receive slack — the same slots paint stretches
     // with `word-spacing`. A uniform step across every span pair invented gaps before tabs and
     // run splits and drifted every later caret by N×step.
@@ -627,7 +634,7 @@ export function breakParagraph(
     flow?.revisionAuthorFilter
   );
   const startOffset = Math.max(0, flow?.startOffset ?? 0);
-  const pieces = allPieces.flatMap((piece): FieldAwarePiece[] => {
+  const visiblePieces = allPieces.flatMap((piece): FieldAwarePiece[] => {
     if (piece.end <= startOffset) return [];
     if (piece.start >= startOffset) return [piece];
     const trim = startOffset - piece.start;
@@ -639,7 +646,18 @@ export function breakParagraph(
       },
     ];
   });
+  const typography =
+    flow?.typography ??
+    resolveCjkTypography(
+      propertiesOf(
+        'children' in paragraph
+          ? paragraph.children.find((child) => child.kind === 'paragraphProperties')
+          : undefined
+      )
+    );
+  const pieces = compressCjkPieces(visiblePieces, typography, measurer);
   const placeableSuffixes = placeableContentSuffixes(pieces);
+  const cjkBreaks = cjkParagraphBreaks(pieces, typography);
   const layoutEquation = createEquationLayouter(measurer, flow?.equationCacheToken);
   const equationLayoutOf = (piece: FieldAwarePiece) =>
     piece.equation ? layoutEquation(piece.equation, piece.style) : null;
@@ -731,6 +749,8 @@ export function breakParagraph(
   ];
 
   const anchorLineStartByOffset = anchorLineStartsByModelOffset({
+    typography,
+    cjkBreaks,
     pieces,
     measurer,
     available,
@@ -1371,7 +1391,8 @@ export function breakParagraph(
       Boolean(piece.positionalTab) ||
       piece.end - piece.start !== piece.text.length;
     let consumed = 0;
-    for (const boundary of wordBoundaries(piece.text, !layoutOwned)) {
+    for (const boundary of cjkBreaks?.boundaries(piece) ??
+      wordBoundaries(piece.text, !layoutOwned)) {
       const candidate = piece.text.slice(consumed, boundary);
       if (candidate.length === 0) continue;
       const spanRange = layoutOwned
@@ -1465,7 +1486,9 @@ export function breakParagraph(
       let width = measurer.measure(displayText(measureSource, faceStyle), faceStyle);
       // A candidate may open a line only at a real break opportunity — the shared
       // decision in `lineOpenDecisionAt`, which the anchor-line probe above consumes too.
-      const openDecision = lineOpenDecisionAt(lastEmitted, candidate, consumed > 0);
+      const openDecision =
+        cjkBreaks?.decision(piece, consumed) ??
+        lineOpenDecisionAt(lastEmitted, candidate, consumed > 0);
       const opensWord = openDecision === 'opens';
       if (opensWord) {
         wordStartSpan = line.spans.length;
@@ -1479,7 +1502,11 @@ export function breakParagraph(
       if (lineEndWhitespace) {
         width = Math.min(width, Math.max(0, lineAvailable() - line.width));
       }
+      const hangs =
+        typography.overflowPunctuation &&
+        canHangCjkPunctuation(candidate, piece, lineAvailable() - line.width, width, measurer);
       if (
+        !hangs &&
         line.width + width > lineAvailable() + OVERFLOW_TOLERANCE_PT &&
         (line.spans.length > 0 || line.drawings.length > 0)
       ) {
@@ -1546,6 +1573,7 @@ export function breakParagraph(
       const canChopWord = !layoutOwned && piece.measureText === undefined;
       if (
         canChopWord &&
+        !hangs &&
         (line.spans.length === 0 ||
           (!opensWord && wordStartSpan === 0 && openDecision !== 'forbidden')) &&
         width > remainingLineWidth() + OVERFLOW_TOLERANCE_PT
@@ -1584,7 +1612,9 @@ export function breakParagraph(
           overflowTolerancePt: OVERFLOW_TOLERANCE_PT,
           // The measured fit knows nothing about kinsoku: at a one-character measure
           // 天。地。人。 chopped every other line onto a leading 。.
-          cutAllowedAt: cjkChopCutAllowedAt,
+          cutAllowedAt: cjkBreaks
+            ? (_text, index) => cjkBreaks.cutAllowed(piece, consumed, index)
+            : cjkChopCutAllowedAt,
         });
         remaining = chopped.text;
         remainingStart = chopped.modelStart;
@@ -1595,8 +1625,8 @@ export function breakParagraph(
           wordStartEnd = line.end;
         }
       }
-      // A kinsoku push-out can consume the whole candidate (天。 at a one-character measure):
-      // the chop emitted it as one overflowing line and left nothing for this placement.
+      // The chop leaves its final protected group pending, including oversized groups
+      // whose next run may start with another closing character or combining mark.
       if (remaining.length > 0) {
         line.spans.push({
           range: layoutOwned

--- a/packages/core/src/layout/semantic-hit-test.ts
+++ b/packages/core/src/layout/semantic-hit-test.ts
@@ -23,6 +23,8 @@
 
 import { PAGE_BREAK_CHAR } from '../store/package/hard-break.ts';
 import { graphemeBoundaryEpoch, segmentGraphemes } from './grapheme.ts';
+import { isCjk } from './cjk-paragraph-breaks.ts';
+import { lastCodePointOf } from './cjk-line-break.ts';
 import { lineSegments, type LineSegment } from './line-segments.ts';
 import { baselineShiftPtOf, measureDisplayText } from './run-style.ts';
 import { styleForFontSlot } from './script-itemization.ts';
@@ -1080,9 +1082,10 @@ export function caretBoxOnLine(
       // gap. That gap is what paint draws as `word-spacing`; sitting on the upstream end
       // lands inside the stretched space. With no gap (unjustified, or a mere run split
       // after a space), keep upstream affinity so typing continues the preceding run.
-      if (next && next.range.start === offset && span.text.endsWith(' ')) {
-        const gap = next.box.x - (span.box.x + span.box.width);
-        if (gap > 0.25) {
+      if (next && next.range.start === offset) {
+        const cjk = isCjk(lastCodePointOf(span.text) ?? 0) || isCjk(next.text.codePointAt(0) ?? 0);
+        const gap = next.box.x - (span.box.x + span.box.width) - (next.wrapAdvanceBefore ?? 0);
+        if ((span.text.endsWith(' ') && gap > 0.25) || (cjk && gap > 0.001)) {
           chosen = next;
           break;
         }

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -34,6 +34,7 @@ import {
   withDrawingContext,
   type ParagraphLayoutCache,
 } from './layout-cache.ts';
+import { resolveCjkTypography } from './cjk-typography.ts';
 import {
   alignSpans,
   alignDrawings,
@@ -1881,6 +1882,7 @@ function layoutBlocksPass(
         : undefined,
       {
         lineSpacing: entry.lineSpacing,
+        typography: resolveCjkTypography(entry.props, styleCascade?.typography),
         equationCacheToken: producer,
         firstLineOffset: startOffset === 0 ? firstLineOffsetOf(entry) : 0,
         startOffset,

--- a/packages/core/src/layout/semantic-table-layout.ts
+++ b/packages/core/src/layout/semantic-table-layout.ts
@@ -44,6 +44,7 @@ import {
   type ParagraphLayoutCache,
 } from './layout-cache.ts';
 import { alignDrawings, alignSpans, breakParagraph, type PendingLine } from './paragraph-flow.ts';
+import { resolveCjkTypography } from './cjk-typography.ts';
 import { mergeBoundariesOf, remapMergedLines } from './merged-paragraph-ranges.ts';
 import { isEmptyCellTerminator, paragraphMergeGroupOf } from './story-roots.ts';
 import {
@@ -561,6 +562,7 @@ function placeCellParagraph(
       : undefined,
     {
       lineSpacing,
+      typography: resolveCjkTypography(props, deps.styleCascade?.typography),
       equationCacheToken: deps.producer,
       firstLineOffset,
       // A cell's own content box is the column a positional tab measures against.

--- a/packages/core/src/layout/style-cascade.ts
+++ b/packages/core/src/layout/style-cascade.ts
@@ -21,6 +21,7 @@ import {
   type OoxmlProperty,
 } from '@docx-editor.dev/core/store';
 import { stableHash } from '../store/comparators/canonical.ts';
+import { cjkTypographyFromSettings, type CjkTypographySettings } from './cjk-typography.ts';
 import {
   indentTwips,
   paragraphAlignment,
@@ -75,6 +76,7 @@ export const MAX_STYLE_DEFINITIONS = 4096;
  * styles part are never reused under another.
  */
 export interface StyleCascadeTable {
+  readonly typography?: CjkTypographySettings;
   /**
    * Bounded fingerprint folded into layout cache producers so a different styles part cannot
    * reuse breaks measured under another cascade. Computed once per table (FNV-1a hex).
@@ -389,14 +391,17 @@ export function tableCellStyleFormatting(
  */
 export function buildStyleCascadeTable(
   stylesRoot: OoxmlElement | null,
-  themeFonts: ThemeFonts = NO_THEME_FONTS
+  themeFonts: ThemeFonts = NO_THEME_FONTS,
+  settingsRoot: OoxmlElement | null = null
 ): StyleCascadeTable {
+  const typography = cjkTypographyFromSettings(settingsRoot);
   const styles = new Map<string, StyleDefinition>();
   if (!stylesRoot) {
     return {
       // Still keyed on the theme: a document with no styles part can carry a theme, and
       // its runs resolve `+Body` through it.
-      cacheToken: stableHash({ empty: true, theme: themeFonts }),
+      cacheToken: stableHash({ empty: true, theme: themeFonts, typography }),
+      typography,
       docDefaultsRun: [],
       docDefaultsParagraph: [],
       docDefaultsParagraphNode: undefined,
@@ -436,6 +441,7 @@ export function buildStyleCascadeTable(
 
   // Canonical material hashed once — never embed the full styles dump in paragraph keys.
   const cacheToken = stableHash({
+    typography,
     dR: propertiesFingerprint(defaults.run),
     dP: propertiesFingerprint(defaults.paragraph),
     defP: defaultParagraphStyleId,
@@ -462,6 +468,7 @@ export function buildStyleCascadeTable(
 
   return {
     cacheToken,
+    typography,
     docDefaultsRun: defaults.run,
     docDefaultsParagraph: defaults.paragraph,
     docDefaultsParagraphNode: defaults.paragraphNode,

--- a/packages/core/src/output/__tests__/cjk-typography-paint.test.ts
+++ b/packages/core/src/output/__tests__/cjk-typography-paint.test.ts
@@ -1,0 +1,123 @@
+import { expect, test } from 'bun:test';
+import { readOoxmlPart } from '@docx-editor.dev/core/store';
+import {
+  buildStyleCascadeTable,
+  createFixedMeasurer,
+  createLayoutSession,
+  layoutSemanticDocument,
+} from '@docx-editor.dev/core/layout';
+import { caretAt } from '../../layout/semantic-interaction.ts';
+import { layoutHeaderFooterStory } from '../../layout/hf-layout.ts';
+import { paintSemanticLayout } from '../semantic-paint.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const measurer = createFixedMeasurer(6, 14);
+function part(xml: string, name = '/word/document.xml') {
+  const read = readOoxmlPart(xml, { name, contentType: 'app/xml' });
+  if (!read.ok) throw new Error(read.reason);
+  return read.part;
+}
+function documentPart(text: string, pPr = '<w:jc w:val="both"/>') {
+  return part(
+    `<w:document xmlns:w="${W}"><w:body><w:p><w:pPr><w:overflowPunct w:val="0"/>${pPr}</w:pPr><w:r><w:rPr><w:sz w:val="22"/></w:rPr><w:t>${text}</w:t></w:r></w:p></w:body></w:document>`
+  );
+}
+const geometry = { width: 50, height: 500, margin: { top: 10, bottom: 10, left: 10, right: 10 } };
+
+test('CJK justification paints every gap and maps each caret to the same geometry', () => {
+  const layout = layoutSemanticDocument(documentPart('天地玄黄月、日'), 0, { measurer, geometry });
+  const first = layout.pages[0]!.fragments[0]!.lines[0]!;
+  expect(first.spans.map((span) => span.text)).toEqual(['天', '地', '玄', '黄']);
+  const container = document.createElement('div');
+  paintSemanticLayout(container, layout, { scale: 1 });
+  const painted = container.querySelectorAll<HTMLElement>('.docx-line:first-child [data-start]');
+  expect(painted.length).toBe(4);
+  expect([...painted].map((span) => span.style.marginLeft)).toEqual(['', '2px', '2px', '2px']);
+  for (const span of first.spans) {
+    const caret = caretAt(
+      layout,
+      { paragraphId: span.range.paragraphId, offset: span.range.start },
+      measurer
+    );
+    expect(caret).not.toBeNull();
+    expect(caret!.x).toBeCloseTo(span.box.x, 5);
+  }
+  const last = layout.pages[0]!.fragments[0]!.lines.at(-1)!;
+  expect(last.spans.map((span) => span.text).join('')).toBe('月、日');
+});
+
+test('CJK compression uses the same spacing in layout and DOM paint', () => {
+  const settings = part(
+    `<w:settings xmlns:w="${W}"><w:characterSpacingControl w:val="compressPunctuation"/></w:settings>`,
+    '/word/settings.xml'
+  );
+  const styleCascade = buildStyleCascadeTable(null, undefined, settings.root);
+  const layout = layoutSemanticDocument(documentPart('天。地。', ''), 0, {
+    measurer,
+    geometry,
+    styleCascade,
+  });
+  const line = layout.pages[0]!.fragments[0]!.lines[0]!;
+  const container = document.createElement('div');
+  paintSemanticLayout(container, layout, { scale: 1 });
+  const punctuation = [...container.querySelectorAll<HTMLElement>('[data-start]')].filter(
+    (element) => element.textContent === '。'
+  );
+  expect(punctuation).toHaveLength(2);
+  expect(punctuation.map((element) => element.style.letterSpacing)).toEqual(['-3px', '-3px']);
+  expect(line.spans.at(-1)!.box.x + line.spans.at(-1)!.box.width - line.spans[0]!.box.x).toBe(18);
+});
+
+test('typography settings invalidate cached layout without a text edit', () => {
+  const document = documentPart('天地玄黄。人', '');
+  const session = createLayoutSession();
+  const settings = part(
+    `<w:settings xmlns:w="${W}"><w:characterSpacingControl w:val="compressPunctuation"/></w:settings>`
+  );
+  const initial = layoutSemanticDocument(document, 0, {
+    measurer,
+    geometry,
+    session,
+    styleCascade: buildStyleCascadeTable(null),
+  });
+  const updated = layoutSemanticDocument(document, 0, {
+    measurer,
+    geometry,
+    session,
+    styleCascade: buildStyleCascadeTable(null, undefined, settings.root),
+  });
+  const clean = layoutSemanticDocument(document, 0, {
+    measurer,
+    geometry,
+    styleCascade: buildStyleCascadeTable(null, undefined, settings.root),
+  });
+  expect(updated.pages).toEqual(clean.pages);
+  expect(JSON.stringify(updated.pages)).not.toBe(JSON.stringify(initial.pages));
+});
+
+test('headers and table cells consume the same document typography settings', () => {
+  const settings = part(
+    `<w:settings xmlns:w="${W}"><w:characterSpacingControl w:val="compressPunctuation"/></w:settings>`
+  );
+  const styleCascade = buildStyleCascadeTable(null, undefined, settings.root);
+  const p =
+    '<w:p><w:pPr><w:overflowPunct w:val="0"/></w:pPr><w:r><w:rPr><w:sz w:val="22"/></w:rPr><w:t>天。地。</w:t></w:r></w:p>';
+  const header = part(`<w:hdr xmlns:w="${W}">${p}</w:hdr>`, '/word/header1.xml');
+  const story = layoutHeaderFooterStory(header, 18, measurer, 'cjk-test', undefined, styleCascade);
+  const headerParagraph = story.fragments[0]!;
+  expect(headerParagraph.kind).toBe('paragraph');
+  if (headerParagraph.kind !== 'paragraph') throw new Error('expected header paragraph');
+  expect(headerParagraph.lines).toHaveLength(1);
+  expect(headerParagraph.lines[0]!.spans.map((span) => span.text).join('')).toBe('天。地。');
+  const table = part(
+    `<w:document xmlns:w="${W}"><w:body><w:tbl><w:tblPr><w:tblW w:w="360" w:type="dxa"/><w:tblLayout w:type="fixed"/><w:tblCellMar><w:left w:w="0" w:type="dxa"/><w:right w:w="0" w:type="dxa"/></w:tblCellMar></w:tblPr><w:tblGrid><w:gridCol w:w="360"/></w:tblGrid><w:tr><w:tc>${p}</w:tc></w:tr></w:tbl></w:body></w:document>`
+  );
+  const layout = layoutSemanticDocument(table, 0, { measurer, geometry, styleCascade });
+  const tableFragment = layout.pages[0]!.fragments[0]!;
+  expect(tableFragment.kind).toBe('table');
+  if (tableFragment.kind !== 'table') throw new Error('expected table');
+  const cell = tableFragment.rows[0]!.cells[0]!.blocks[0]!;
+  if (cell.kind !== 'paragraph') throw new Error('expected cell paragraph');
+  expect(cell.lines).toHaveLength(1);
+  expect(cell.lines[0]!.spans.map((span) => span.text).join('')).toBe('天。地。');
+});

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -1567,7 +1567,7 @@ function interSpanGapBefore(
   if (drawingOccupiesGap) return 0;
   const gap =
     current.box.x - (previous.box.x + previous.box.width) - (current.wrapAdvanceBefore ?? 0);
-  return gap > 0.25 ? gap : 0;
+  return gap > 0.001 ? gap : 0;
 }
 
 /**


### PR DESCRIPTION
Follow up on #540 with run-independent CJK wrapping, full-width number grouping, mixed-script punctuation rules, and Korean character wrapping. Apply document kinsoku, hanging punctuation, and compression settings across document stories. Keep justification, paint, and caret geometry consistent.

Self-review covers run seams, grapheme safety, emergency wrapping, settings caches, anchor placement, and paint/caret alignment. Regression tests include headers and table cells.

The second self-review fixes non-breaking spaces and joiners in mixed CJK text. Compression now measures complete graphemes across run boundaries. Regression tests cover paragraph policies, narrow measures, combining marks, projected atoms, and source immutability.

Validation: 11,521 tests pass across 910 files. Package builds, package typechecks, formatting, lint, API checks, parity, translation validation, and strict OpenSpec validation pass. Lint retains 75 existing warnings. The separate root typecheck reports 165 translation-key and Vite type errors, also present on the review baseline.

Compression uses deterministic advance reductions, not font-specific optical compression. Vertical Japanese composition remains outside this change. No visual comparison against Microsoft Word was performed.
