### PR TITLE
fix: measure shared borders before repeating table headers

### DIFF
--- a/.changeset/repeated-header-border-metrics.md
+++ b/.changeset/repeated-header-border-metrics.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Fix shared-border spacing between repeated table headers and complete text rows without changing authored borders.

--- a/docs/site/content/word-fidelity.mdx
+++ b/docs/site/content/word-fidelity.mdx
@@ -59,6 +59,10 @@ Bookmarks, proofing markers, formatting-only runs, and paragraph spacing are sup
 Explicit page breaks, complex tables, and anchors with text retain their existing layout.
 Text wrapping beside floating tables is not supported.
 
+When you compare a multipage table, check the space between each repeated header
+and its first body row. The table pagination note lists the shared-border
+measurement limits. Keep the original document when you report a spacing issue.
+
 ### Images and drawings
 
 <FeatureMatrix category="images" />

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -423,7 +423,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'Rows split mid-content with correct cut borders. Vertically merged cells repaint on continuation pages, like Word.',
+      'Rows split mid-content with correct cut borders. Vertically merged cells repaint on continuation pages, like Word. Repeated headers and bounded complete text rows reserve their shared horizontal border before pagination. This boundary adjustment excludes spaced cells, vertical merges, split rows, positioned tables, drawings, nested tables, and vertical text.',
   },
   {
     id: 'tables.nested',

--- a/packages/core/src/layout/__tests__/repeated-header-border-metrics.test.ts
+++ b/packages/core/src/layout/__tests__/repeated-header-border-metrics.test.ts
@@ -1,0 +1,535 @@
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, serializeOoxmlPart } from '../../store/package/ooxml-tree.ts';
+import { createParagraphLayoutCache } from '../layout-cache.ts';
+import type { PendingLine } from '../paragraph-flow.ts';
+import {
+  createFixedMeasurer,
+  createLayoutSession,
+  layoutSemanticDocument,
+} from '../semantic-layout.ts';
+import type { TableCellFragmentRecord, TableFragmentRecord } from '../semantic-records.ts';
+import { readTableStructure } from '../semantic-table.ts';
+import { measureRowHeight, type TableFlowDeps } from '../semantic-table-layout.ts';
+import { prepareRepeatedHeaderBorderPlan } from '../repeated-header-border-metrics.ts';
+import { applyTreeOp } from '../../store/store/tree-ops.ts';
+
+type Edge = number | 'nil' | 'omit';
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const edge = (side: string, value: Edge): string =>
+  value === 'omit'
+    ? ''
+    : `<w:${side} w:val="${value === 'nil' ? 'nil' : 'single'}"${typeof value === 'number' ? ` w:sz="${value * 8}"` : ''}/>`;
+const paragraph = (text: string): string =>
+  `<w:p><w:pPr><w:spacing w:before="0" w:after="0" w:line="240" w:lineRule="exact"/></w:pPr><w:r><w:t>${text}</w:t></w:r></w:p>`;
+function cell(
+  text: string,
+  top: Edge = 0.5,
+  bottom: Edge = 0.5,
+  extra = '',
+  content = paragraph(text)
+): string {
+  return `<w:tc><w:tcPr><w:tcW w:w="1600" w:type="dxa"/><w:tcBorders>${edge('top', top)}${edge('bottom', bottom)}</w:tcBorders>${extra}</w:tcPr>${content}</w:tc>`;
+}
+function row(cells: string, properties = '<w:cantSplit/>'): string {
+  return `<w:tr><w:trPr>${properties}</w:trPr>${cells}</w:tr>`;
+}
+function fixture(
+  options: {
+    header?: string;
+    body?: string;
+    headerBottom?: Edge;
+    bodyTop?: Edge;
+    spacing?: number;
+    columns?: number;
+    tableProperties?: string;
+    bodyProperties?: string;
+  } = {}
+) {
+  const columns = options.columns ?? 1;
+  const header = options.header ?? row(cell('H', 0.5, options.headerBottom ?? 2), '<w:tblHeader/>');
+  const body =
+    options.body ??
+    Array.from({ length: 18 }, (_, index) =>
+      row(cell(`B${index}`, options.bodyTop ?? 0.5), options.bodyProperties)
+    ).join('');
+  const xml = `<w:document xmlns:w="${W}"><w:body><w:tbl><w:tblPr>
+    <w:tblLayout w:type="fixed"/><w:tblW w:w="${1600 * columns}" w:type="dxa"/>
+    <w:tblCellSpacing w:w="${20 * (options.spacing ?? 0)}" w:type="dxa"/>
+    <w:tblCellMar>${['top', 'bottom', 'left', 'right'].map((side) => `<w:${side} w:w="0" w:type="dxa"/>`).join('')}</w:tblCellMar>
+    ${options.tableProperties ?? ''}</w:tblPr><w:tblGrid>${Array.from({ length: columns }, () => '<w:gridCol w:w="1600"/>').join('')}</w:tblGrid>
+    ${header}${body}</w:tbl></w:body></w:document>`;
+  const parsed = readOoxmlPart(xml, { name: '/word/document.xml', contentType: 'app/xml' });
+  if (!parsed.ok) throw new Error(parsed.reason);
+  return parsed.part;
+}
+const geometry = { width: 200, height: 100, margin: { top: 10, right: 10, bottom: 10, left: 10 } };
+const measurer = createFixedMeasurer(5, 12);
+function layout(part: ReturnType<typeof fixture>, height = 100) {
+  return layoutSemanticDocument(part, 0, { geometry: { ...geometry, height }, measurer });
+}
+function fragments(result: ReturnType<typeof layout>): TableFragmentRecord[] {
+  return result.pages.flatMap((page) =>
+    page.fragments.filter((item): item is TableFragmentRecord => item.kind === 'table')
+  );
+}
+function repeated(result: ReturnType<typeof layout>): TableFragmentRecord[] {
+  return fragments(result).filter((fragment) => fragment.rows[0]?.isHeaderRepeat);
+}
+function band(cell: TableCellFragmentRecord) {
+  const paragraphs = cell.blocks.filter((block) => block.kind === 'paragraph');
+  const top = Math.min(...paragraphs.map((block) => block.box.y));
+  const bottom = Math.max(...paragraphs.map((block) => block.box.y + block.box.height));
+  return { top: top - cell.box.y, bottom: cell.box.y + cell.box.height - bottom };
+}
+function structureOf(part: ReturnType<typeof fixture>) {
+  const body = part.root.children.find(
+    (node) => node.kind !== 'textValue' && node.localName === 'body'
+  );
+  if (!body || body.kind === 'textValue') throw new Error('missing body');
+  const table = body.children.find((node) => node.kind === 'table');
+  if (!table) throw new Error('missing table');
+  const structure = readTableStructure(table, 180, 0);
+  if (!structure) throw new Error('missing structure');
+  return { table, structure };
+}
+function candidate(
+  part: ReturnType<typeof fixture>,
+  deps: TableFlowDeps = {
+    measurer,
+    producer: 'test',
+    nextLineId: () => 'live',
+  },
+  bottom = 80
+) {
+  const { structure } = structureOf(part);
+  const headers = structure.rows.filter((item) => item.isHeader);
+  const body = structure.rows[headers.length]!;
+  const headerHeight = headers.reduce(
+    (sum, item) => sum + measureRowHeight(item, structure.columnWidthsPt, 0, 0, deps),
+    0
+  );
+  const bodyHeight = measureRowHeight(body, structure.columnWidthsPt, 0, 0, deps);
+  return prepareRepeatedHeaderBorderPlan(
+    structure,
+    headers,
+    body,
+    0,
+    0,
+    bottom,
+    headerHeight,
+    bodyHeight,
+    deps
+  );
+}
+
+describe('repeated-header shared horizontal border measurement', () => {
+  test('both cells use the winning header edge before row sizing', () => {
+    const part = fixture();
+    const before = serializeOoxmlPart(part);
+    const result = layout(part);
+    expect(repeated(result).length).toBeGreaterThan(0);
+    for (const fragment of repeated(result)) {
+      const header = fragment.rows[0]!;
+      const body = fragment.rows[1]!;
+      expect(band(header.cells[0]!).bottom).toBeCloseTo(2, 6);
+      expect(band(body.cells[0]!).top).toBeCloseTo(2, 6);
+      expect(body.box.height).toBeCloseTo(14.5, 6);
+    }
+    expect(
+      fragments(result).flatMap((fragment) =>
+        fragment.rows.filter((item) => !item.isHeaderRepeat && !item.isHeaderRow)
+      )
+    ).toHaveLength(18);
+    expect(serializeOoxmlPart(part)).toBe(before);
+  });
+
+  test('a winning body edge also grows the preceding repeated header', () => {
+    const result = layout(fixture({ headerBottom: 0.5, bodyTop: 2 }));
+    for (const fragment of repeated(result)) {
+      expect(band(fragment.rows[0]!.cells[0]!).bottom).toBeCloseTo(2, 6);
+      expect(fragment.rows[0]!.box.height).toBeCloseTo(14.5, 6);
+      expect(band(fragment.rows[1]!.cells[0]!).top).toBeCloseTo(2, 6);
+    }
+  });
+
+  for (const rule of ['auto', 'atLeast', 'exact']) {
+    for (const align of ['top', 'center', 'bottom']) {
+      test(`${rule} rows preserve resolved insets through final ${align} alignment`, () => {
+        const height = rule === 'auto' ? '' : `<w:trHeight w:val="500" w:hRule="${rule}"/>`;
+        const body = Array.from({ length: 12 }, (_, index) =>
+          row(
+            cell(`B${index}`, 0.5, 0.5, `<w:vAlign w:val="${align}"/>`),
+            `<w:cantSplit/>${height}`
+          )
+        ).join('');
+        for (const fragment of repeated(layout(fixture({ body })))) {
+          const target = fragment.rows[1]!.cells[0]!;
+          const spare = rule === 'auto' ? 0 : 25 - 12 - 2 - 0.5;
+          const offset = align === 'center' ? spare / 2 : align === 'bottom' ? spare : 0;
+          expect(target.box.height).toBeCloseTo(rule === 'auto' ? 14.5 : 25, 6);
+          expect(band(target).top).toBeCloseTo(2 + offset, 6);
+          expect(band(target).bottom).toBeCloseTo(0.5 + spare - offset, 6);
+        }
+      });
+    }
+  }
+
+  test('positive cell spacing keeps independent authored insets', () => {
+    for (const fragment of repeated(layout(fixture({ spacing: 2 })))) {
+      expect(band(fragment.rows[0]!.cells[0]!).bottom).toBeCloseTo(2, 6);
+      expect(band(fragment.rows[1]!.cells[0]!).top).toBeCloseTo(0.5, 6);
+    }
+  });
+
+  test('one spanning body cell uses the maximum of its own shared intervals', () => {
+    const header = row(cell('H0', 0.5, 2) + cell('H1', 0.5, 0.5), '<w:tblHeader/>');
+    const body = Array.from({ length: 18 }, (_, index) =>
+      row(cell(`B${index}`, 0.5, 0.5, '<w:gridSpan w:val="2"/>'))
+    ).join('');
+    for (const fragment of repeated(layout(fixture({ header, body, columns: 2 })))) {
+      expect(band(fragment.rows[1]!.cells[0]!).top).toBeCloseTo(2, 6);
+    }
+  });
+
+  test('the shared winner follows table fallback and explicit nil provenance', () => {
+    for (const [headerBottom, bodyTop, expected] of [
+      ['omit', 'omit', 2],
+      ['nil', 'omit', 0],
+      ['nil', 1, 1],
+    ] as const) {
+      const result = layout(
+        fixture({
+          headerBottom,
+          bodyTop,
+          tableProperties: '<w:tblBorders><w:insideH w:val="single" w:sz="16"/></w:tblBorders>',
+        })
+      );
+      for (const fragment of repeated(result)) {
+        expect(band(fragment.rows[0]!.cells[0]!).bottom).toBeCloseTo(expected, 6);
+        expect(band(fragment.rows[1]!.cells[0]!).top).toBeCloseTo(expected, 6);
+      }
+    }
+  });
+
+  test('successive repeated occurrences and warm caches follow their pending row', () => {
+    const cache = createParagraphLayoutCache<readonly PendingLine[]>();
+    const session = createLayoutSession();
+    for (const [version, top] of [0.5, 3, 0.5].entries()) {
+      const part = fixture({
+        headerBottom: 1,
+        body: Array.from({ length: 18 }, (_, index) =>
+          row(cell(`B${index}`, index % 2 === 0 ? top : 2))
+        ).join(''),
+      });
+      const warm = layoutSemanticDocument(part, version, { geometry, measurer, cache, session });
+      const cold = layoutSemanticDocument(part, version, { geometry, measurer });
+      expect(JSON.parse(JSON.stringify(warm))).toEqual(JSON.parse(JSON.stringify(cold)));
+      for (const fragment of repeated(warm)) {
+        const target = fragment.rows[1]!.cells[0]!;
+        const text = target.blocks
+          .flatMap((block) => (block.kind === 'paragraph' ? block.lines : []))
+          .flatMap((line) => line.spans)
+          .map((span) => span.text)
+          .join('');
+        const expected = Math.max(1, Number(text.slice(1)) % 2 === 0 ? top : 2);
+        expect(band(target).top).toBeCloseTo(expected, 6);
+        expect(band(fragment.rows[0]!.cells[0]!).bottom).toBeCloseTo(expected, 6);
+      }
+    }
+  });
+
+  for (const [headerBottom, bodyTop] of [
+    [2, 0.5],
+    [0.5, 2],
+  ]) {
+    test(`joint preflight omits a repeat when ${headerBottom}/${bodyTop} leaves no complete body room`, () => {
+      const result = layout(fixture({ headerBottom, bodyTop }), 48);
+      expect(fragments(result).length).toBeGreaterThan(1);
+      expect(repeated(result)).toHaveLength(0);
+      for (const fragment of fragments(result).slice(1)) {
+        expect(band(fragment.rows[0]!.cells[0]!).top).toBeCloseTo(bodyTop!, 6);
+      }
+      expect(fragments(result).flatMap((fragment) => fragment.rows)).toHaveLength(19);
+    });
+  }
+
+  test('multiple headers keep the final boundary separate from earlier header rows', () => {
+    const header =
+      row(cell('H0', 0.5, 0.5), '<w:tblHeader/>') + row(cell('H1', 0.5, 2), '<w:tblHeader/>');
+    for (const fragment of repeated(layout(fixture({ header })))) {
+      expect(fragment.rows[1]!.isHeaderRepeat).toBe(true);
+      expect(fragment.rows[0]!.box.height).toBeCloseTo(13, 6);
+      expect(band(fragment.rows[1]!.cells[0]!).bottom).toBeCloseTo(2, 6);
+      expect(band(fragment.rows[2]!.cells[0]!).top).toBeCloseTo(2, 6);
+    }
+  });
+
+  test('an unrelated thick column does not enlarge its thin neighbours', () => {
+    const header = row(
+      cell('H0', 0.5, 1) + cell('H1', 0.5, 1) + cell('H2', 0.5, 6),
+      '<w:tblHeader/>'
+    );
+    const body = Array.from({ length: 18 }, (_, index) =>
+      row(cell(`B${index}`, 0.5, 0.5, '<w:gridSpan w:val="2"/>') + cell('side', 0.5))
+    ).join('');
+    for (const fragment of repeated(layout(fixture({ header, body, columns: 3 })))) {
+      expect(band(fragment.rows[1]!.cells[0]!).top).toBeCloseTo(1, 6);
+      expect(band(fragment.rows[1]!.cells[1]!).top).toBeCloseTo(6, 6);
+    }
+  });
+
+  for (const align of ['center', 'bottom']) {
+    test(`the repeated header keeps its ${align} alignment after a body edge wins`, () => {
+      const header = row(
+        cell('H', 0.5, 0.5, `<w:vAlign w:val="${align}"/>`),
+        '<w:tblHeader/><w:trHeight w:val="500" w:hRule="exact"/>'
+      );
+      for (const fragment of repeated(layout(fixture({ header, bodyTop: 2 })))) {
+        const target = fragment.rows[0]!.cells[0]!;
+        expect(target.box.height).toBe(25);
+        expect(band(target).bottom).toBeCloseTo(
+          align === 'center' ? 2 + (25 - 12 - 2 - 0.5) / 2 : 2,
+          6
+        );
+      }
+    });
+  }
+
+  test('actual cell-border edits retain body nodes and produce cold-equivalent warm geometry', () => {
+    const original = fixture();
+    const { table, structure } = structureOf(original);
+    const headerId = structure.rows[0]!.cells[0]!.id;
+    const bodyBlock = structure.rows[1]!.cells[0]!.blocks[0];
+    const cache = createParagraphLayoutCache<readonly PendingLine[]>();
+    const session = createLayoutSession();
+    layoutSemanticDocument(original, 0, { geometry, measurer, cache, session });
+    const edited = applyTreeOp(original, {
+      op: 'setTableCellBorders',
+      tableId: table.id,
+      cellIds: [headerId],
+      scope: 'bottom',
+      spec: { style: 'single', size: 32, color: { kind: 'hex', value: '000000' } },
+    });
+    expect(edited.ok).toBe(true);
+    if (!edited.ok) throw new Error(edited.reason);
+    expect(structureOf(edited.part).structure.rows[1]!.cells[0]!.blocks[0]).toBe(bodyBlock);
+    for (const [index, part] of [edited.part, original, edited.part].entries()) {
+      const version = index + 1;
+      const warm = layoutSemanticDocument(part, version, { geometry, measurer, cache, session });
+      const cold = layoutSemanticDocument(part, version, { geometry, measurer });
+      expect(JSON.parse(JSON.stringify(warm))).toEqual(JSON.parse(JSON.stringify(cold)));
+      for (const fragment of repeated(warm))
+        expect(band(fragment.rows[1]!.cells[0]!).top).toBeCloseTo(part === original ? 2 : 4, 6);
+    }
+  });
+
+  test('a preserved PAGE field has identical probe and committed metrics', () => {
+    const field =
+      '<w:p><w:pPr><w:spacing w:line="240" w:lineRule="exact"/></w:pPr><w:fldSimple w:instr="PAGE"><w:r><w:t>1</w:t></w:r></w:fldSimple></w:p>';
+    const part = fixture({ header: row(cell('H', 0.5, 2, '', field), '<w:tblHeader/>') });
+    const before = serializeOoxmlPart(part);
+    for (const fragment of repeated(layout(part)))
+      expect(band(fragment.rows[1]!.cells[0]!).top).toBeCloseTo(2, 6);
+    expect(serializeOoxmlPart(part)).toBe(before);
+    const reparsed = readOoxmlPart(before, { name: part.name, contentType: part.contentType });
+    expect(reparsed.ok).toBe(true);
+    if (reparsed.ok) expect(serializeOoxmlPart(reparsed.part)).toBe(before);
+  });
+
+  test('a rejected candidate cannot publish or spend live counters', () => {
+    let spent = 0;
+    const cache = createParagraphLayoutCache<readonly PendingLine[]>();
+    const cacheBefore = { ...cache.stats };
+    const budget = { intervalsRemaining: 100 };
+    const merges = { cellsRemaining: 100 };
+    const deps: TableFlowDeps = {
+      measurer,
+      cache,
+      producer: 'test',
+      nextLineId: () => {
+        spent++;
+        return 'live';
+      },
+      collectAnchoredDrawings: () => {
+        spent++;
+      },
+      onCellBreakKey: () => {
+        spent++;
+      },
+      borderOwnershipBudget: budget,
+      vMergeResolveBudget: merges,
+    };
+    const { structure } = structureOf(fixture());
+    expect(
+      prepareRepeatedHeaderBorderPlan(
+        structure,
+        [structure.rows[0]!],
+        structure.rows[1]!,
+        0,
+        0,
+        28,
+        14.5,
+        13,
+        deps
+      )
+    ).toBeNull();
+    expect(spent).toBe(0);
+    expect(budget.intervalsRemaining).toBe(100);
+    expect(merges.cellsRemaining).toBe(100);
+    expect(cache.stats).toEqual(cacheBefore);
+  });
+
+  test('unchanged and unsupported candidates retain the existing path', () => {
+    const plain = fixture();
+    expect(candidate(fixture({ headerBottom: 0.5 }))).toBeUndefined();
+    expect(candidate(fixture({ spacing: 2 }))).toBeUndefined();
+    expect(candidate(fixture({ header: '' }))).toBeUndefined();
+    expect(
+      candidate(fixture({ tableProperties: '<w:tblpPr w:vertAnchor="text"/>' }))
+    ).toBeUndefined();
+    expect(
+      candidate(
+        fixture({ body: row(cell('vertical', 0.5, 0.5, '<w:textDirection w:val="btLr"/>')) })
+      )
+    ).toBeUndefined();
+    expect(
+      candidate(
+        fixture({
+          body:
+            row(cell('merge', 0.5, 0.5, '<w:vMerge w:val="restart"/>')) +
+            row(cell('ghost', 0.5, 0.5, '<w:vMerge/>')),
+        })
+      )
+    ).toBeUndefined();
+    expect(
+      candidate(
+        fixture({ body: row(cell('nested', 0.5, 0.5, '', `<w:tbl>${row(cell('N'))}</w:tbl>`)) })
+      )
+    ).toBeUndefined();
+    expect(
+      candidate(fixture({ body: row(cell('unknown', 0.5, 0.5, '', '<w:p><w:unknown/></w:p>')) }))
+    ).toBeUndefined();
+    expect(
+      candidate(
+        fixture({
+          body: row(
+            cell(
+              'long',
+              0.5,
+              0.5,
+              '',
+              Array.from({ length: 20 }, (_, index) => paragraph(`L${index}`)).join('')
+            ),
+            ''
+          ),
+        })
+      )
+    ).toBeUndefined();
+    expect(
+      candidate(plain, {
+        measurer,
+        producer: 'test',
+        nextLineId: () => 'x',
+        borderOwnershipBudget: { intervalsRemaining: 0 },
+      })
+    ).toBeUndefined();
+    expect(candidate(plain, undefined, Number.NaN)).toBeUndefined();
+  });
+
+  test('short splittable auto rows use the complete-row candidate', () => {
+    const result = layout(fixture({ bodyProperties: '' }));
+    expect(repeated(result).length).toBeGreaterThan(0);
+    for (const fragment of repeated(result)) {
+      expect(band(fragment.rows[1]!.cells[0]!).top).toBeCloseTo(2, 6);
+      expect(fragment.rows[1]!.isContinuation).toBeUndefined();
+    }
+  });
+
+  test('a spanning header resolves each body neighbour independently', () => {
+    const header = row(cell('H', 0.5, 1, '<w:gridSpan w:val="2"/>'), '<w:tblHeader/>');
+    const body = Array.from({ length: 18 }, (_, index) =>
+      row(cell(`B${index}`, 0.5) + cell('side', 3))
+    ).join('');
+    const result = layout(fixture({ header, body, columns: 2 }));
+    expect(repeated(result).length).toBeGreaterThan(0);
+    for (const fragment of repeated(result)) {
+      expect(band(fragment.rows[0]!.cells[0]!).bottom).toBeCloseTo(3, 6);
+      expect(band(fragment.rows[1]!.cells[0]!).top).toBeCloseTo(1, 6);
+      expect(band(fragment.rows[1]!.cells[1]!).top).toBeCloseTo(3, 6);
+    }
+  });
+
+  test('omitting one repeat does not leak its insets or disable later repeats', () => {
+    const body =
+      row(cell('first')) +
+      row(cell('large'), '<w:trHeight w:val="1360" w:hRule="exact"/>') +
+      Array.from({ length: 10 }, (_, index) => row(cell(`B${index}`))).join('');
+    const result = layout(fixture({ body }));
+    const tables = fragments(result);
+    expect(tables[1]!.rows[0]!.isHeaderRepeat).toBe(false);
+    expect(band(tables[1]!.rows[0]!.cells[0]!).top).toBeCloseTo(0.5, 6);
+    expect(tables[2]!.rows[0]!.isHeaderRepeat).toBe(true);
+    expect(band(tables[2]!.rows[1]!.cells[0]!).top).toBeCloseTo(2, 6);
+  });
+
+  test('bounded candidate inspection rejects large, deep, sparse and foreign markup', () => {
+    const run = '<w:r><w:t>X</w:t></w:r>';
+    const oversized = `<w:p>${run.repeat(2800)}</w:p>`;
+    expect(
+      candidate(fixture({ body: row(cell('many', 0.5, 0.5, '', oversized)) }))
+    ).toBeUndefined();
+    const deep = `<w:p><w:pPr>${'<w:rPr>'.repeat(34)}${'</w:rPr>'.repeat(34)}</w:pPr>${run}</w:p>`;
+    expect(candidate(fixture({ body: row(cell('deep', 0.5, 0.5, '', deep)) }))).toBeUndefined();
+    expect(
+      candidate(
+        fixture({
+          header: row(cell('H0') + cell('H1'), '<w:tblHeader/>'),
+          body: row(cell('gap'), '<w:gridBefore w:val="1"/>'),
+          columns: 2,
+        })
+      )
+    ).toBeUndefined();
+    const foreign = '<w:p><x:t xmlns:x="urn:unsupported">X</x:t></w:p>';
+    expect(
+      candidate(fixture({ body: row(cell('foreign', 0.5, 0.5, '', foreign)) }))
+    ).toBeUndefined();
+    const explicitBreak = '<w:p><w:r><w:br w:type="page"/><w:t>X</w:t></w:r></w:p>';
+    expect(
+      candidate(fixture({ body: row(cell('break', 0.5, 0.5, '', explicitBreak)) }))
+    ).toBeUndefined();
+  });
+
+  test('first authored headers and tables without headers keep their existing insets', () => {
+    const original = fragments(layout(fixture()))[0]!;
+    expect(original.rows[0]!.isHeaderRepeat).toBe(false);
+    expect(band(original.rows[1]!.cells[0]!).top).toBeCloseTo(0.5, 6);
+    for (const fragment of fragments(layout(fixture({ header: '' })))) {
+      expect(band(fragment.rows[0]!.cells[0]!).top).toBeCloseTo(0.5, 6);
+    }
+  });
+
+  test('split body fragments keep their authored text and existing boundary path', () => {
+    const body = row(
+      cell(
+        'long',
+        0.5,
+        0.5,
+        '',
+        Array.from({ length: 20 }, (_, index) => paragraph(`L${index}`)).join('')
+      ),
+      ''
+    );
+    const result = layout(fixture({ body }));
+    expect(repeated(result).length).toBeGreaterThan(0);
+    for (const fragment of repeated(result))
+      expect(band(fragment.rows[1]!.cells[0]!).top).toBeCloseTo(0.5, 6);
+    const text = fragments(result)
+      .flatMap((fragment) => fragment.rows.filter((item) => !item.isHeaderRow))
+      .flatMap((item) => item.cells)
+      .flatMap((item) => item.blocks)
+      .flatMap((block) => (block.kind === 'paragraph' ? block.lines : []))
+      .flatMap((line) => line.spans)
+      .map((span) => span.text);
+    expect(text).toEqual(Array.from({ length: 20 }, (_, index) => `L${index}`));
+  });
+});

--- a/packages/core/src/layout/repeated-header-border-metrics.ts
+++ b/packages/core/src/layout/repeated-header-border-metrics.ts
@@ -1,0 +1,234 @@
+// A repeated header and its first complete body row share one measured boundary.
+// These insets belong to one page occurrence. The authored borders never change.
+
+import type { OoxmlNode } from '@docx-editor.dev/core/store';
+import { borderExtentPt, resolveTableCellBorderGrid } from './table-borders.ts';
+import { contentInsets, type CellContentInsets } from './table-cell-geometry.ts';
+import { stripAnchorSinksForProbe } from './table-probe-deps.ts';
+import { layoutRowFragment, type TableFlowDeps } from './semantic-table-layout.ts';
+import {
+  MAX_TABLE_COLUMNS,
+  type SemanticTableRow,
+  type SemanticTableStructure,
+} from './semantic-table.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const MAX_CANDIDATE_NODES = 8192;
+const MAX_CANDIDATE_DEPTH = 32;
+const MAX_HEADER_ROWS = 64;
+// Resolved structures are immutable. Do not scan a large table again on every page.
+const mergePresence = new WeakMap<SemanticTableStructure, boolean>();
+function hasMerge(structure: SemanticTableStructure): boolean {
+  const known = mergePresence.get(structure);
+  if (known !== undefined) return known;
+  const present = structure.rows.some((row) => row.cells.some((cell) => cell.vMergeContinue));
+  mergePresence.set(structure, present);
+  return present;
+}
+const CONTENT_ELEMENTS = new Set([
+  'p',
+  'r',
+  't',
+  'tab',
+  'br',
+  'cr',
+  'noBreakHyphen',
+  'softHyphen',
+  'hyperlink',
+  'fldSimple',
+  'fldChar',
+  'instrText',
+  'bookmarkStart',
+  'bookmarkEnd',
+  'proofErr',
+  'pPr',
+  'rPr',
+]);
+
+/** Text-only rows keep the candidate probe independent of drawing and note publication. */
+function simpleRows(rows: readonly SemanticTableRow[], columns: number): boolean {
+  let visited = 0;
+  for (const row of rows) {
+    let end = 0;
+    for (const cell of row.cells) {
+      if (cell.vMergeContinue || cell.textDirection !== 'horizontal' || cell.gridColumn !== end)
+        return false;
+      end += cell.gridSpan;
+      if (end > columns) return false;
+      for (const block of cell.blocks) {
+        if (block.kind !== 'paragraph') return false;
+        const stack: { node: OoxmlNode; depth: number; properties: boolean }[] = [
+          { node: block, depth: 0, properties: false },
+        ];
+        while (stack.length > 0) {
+          const { node, depth, properties } = stack.pop()!;
+          if (++visited > MAX_CANDIDATE_NODES || depth > MAX_CANDIDATE_DEPTH) return false;
+          if (node.kind === 'textValue') continue;
+          if (node.namespaceUri !== W || (!properties && !CONTENT_ELEMENTS.has(node.localName)))
+            return false;
+          if (
+            node.localName === 'br' &&
+            node.attributes.some(
+              (attribute) => attribute.localName === 'type' && attribute.value !== 'textWrapping'
+            )
+          )
+            return false;
+          // Drawing, nested story and merge markup are not paragraph/run formatting.
+          if (
+            ['drawing', 'pict', 'object', 'txbxContent', 'tbl', 'vMerge', 'framePr'].includes(
+              node.localName
+            )
+          )
+            return false;
+          if (visited + stack.length + node.children.length > MAX_CANDIDATE_NODES) return false;
+          const childProperties =
+            properties || node.localName === 'pPr' || node.localName === 'rPr';
+          for (const child of node.children)
+            stack.push({ node: child, depth: depth + 1, properties: childProperties });
+        }
+      }
+    }
+    if (end !== columns) return false;
+  }
+  return true;
+}
+
+export interface RepeatedHeaderBorderPlan {
+  readonly bodyRowId: string;
+  readonly headerHeight: number;
+  readonly bodyHeight: number;
+  readonly deps: TableFlowDeps;
+}
+
+/**
+ * Undefined retains the existing complex-row path. Null omits this repeat.
+ * A plan guarantees that the complete candidate fits before any live placement.
+ */
+export function prepareRepeatedHeaderBorderPlan(
+  structure: SemanticTableStructure,
+  headers: readonly SemanticTableRow[],
+  body: SemanticTableRow,
+  left: number,
+  top: number,
+  bottom: number,
+  baselineHeaderHeight: number,
+  baselineBodyHeight: number,
+  deps: TableFlowDeps
+): RepeatedHeaderBorderPlan | null | undefined {
+  if (
+    structure.cellSpacingPt > 0 ||
+    structure.float ||
+    headers.length === 0 ||
+    headers.length > MAX_HEADER_ROWS ||
+    structure.columnWidthsPt.length > MAX_TABLE_COLUMNS ||
+    ![left, top, bottom, baselineHeaderHeight, baselineBodyHeight].every(Number.isFinite) ||
+    hasMerge(structure) ||
+    (deps.pageExclusionZones?.().length ?? 0) > 0 ||
+    !simpleRows([...headers, body], structure.columnWidthsPt.length)
+  )
+    return undefined;
+  const boundaryCells = headers.reduce((sum, row) => sum + row.cells.length, body.cells.length);
+  if (deps.borderOwnershipBudget && deps.borderOwnershipBudget.intervalsRemaining < boundaryCells)
+    return undefined;
+  // This lane does not change existing split-row pagination. Only an atomic row, or
+  // a row that previously fit complete, takes the shared-boundary transaction.
+  if (
+    !body.cantSplit &&
+    body.height.rule !== 'exact' &&
+    baselineBodyHeight > bottom - top - baselineHeaderHeight + 0.001
+  )
+    return undefined;
+
+  const lastHeader = headers[headers.length - 1]!;
+  // The existing resolver owns fallback, explicit nil and style/color tie rules.
+  // This two-row view is safe only because merges and sparse ownership were excluded.
+  const resolved = resolveTableCellBorderGrid(
+    [lastHeader.cells, body.cells],
+    structure.tableBorders,
+    structure.columnWidthsPt.length
+  )[0]!;
+  const insets = new Map<string, CellContentInsets>();
+  const intervals: { start: number; end: number; extent: number }[] = [];
+  for (const [index, cell] of lastHeader.cells.entries()) {
+    let extent = 0;
+    for (const segment of resolved[index]!.edgeSegments ?? []) {
+      if (segment.side !== 'bottom') continue;
+      const width = borderExtentPt(segment.edge);
+      extent = Math.max(extent, width);
+      intervals.push({ start: segment.gridStart, end: segment.gridEnd, extent: width });
+    }
+    insets.set(cell.id, {
+      ...contentInsets(cell.margins, cell.borders),
+      bottom: cell.margins.bottom + extent,
+    });
+  }
+  let intervalIndex = 0;
+  for (const cell of body.cells) {
+    let extent = 0;
+    const end = cell.gridColumn + cell.gridSpan;
+    while (intervalIndex < intervals.length && intervals[intervalIndex]!.end <= cell.gridColumn)
+      intervalIndex++;
+    for (
+      let index = intervalIndex;
+      index < intervals.length && intervals[index]!.start < end;
+      index++
+    ) {
+      extent = Math.max(extent, intervals[index]!.extent);
+    }
+    insets.set(cell.id, {
+      ...contentInsets(cell.margins, cell.borders),
+      top: cell.margins.top + extent,
+    });
+  }
+  if (
+    [lastHeader, body].every((row) =>
+      row.cells.every((cell) => {
+        const before = contentInsets(cell.margins, cell.borders);
+        const after = insets.get(cell.id)!;
+        return before.top === after.top && before.bottom === after.bottom;
+      })
+    )
+  )
+    return undefined;
+  let line = 0;
+  const probeDeps: TableFlowDeps = {
+    ...stripAnchorSinksForProbe(deps),
+    cache: undefined,
+    borderOwnershipBudget: undefined,
+    vMergeResolveBudget: undefined,
+    onCellBreakKey: undefined,
+    cellContentInsets: insets,
+    nextLineId: () => `probe-header-border-${line++}`,
+  };
+  let cursor = top;
+  for (const row of headers) {
+    const placed = layoutRowFragment(
+      row,
+      structure.columnWidthsPt,
+      left,
+      cursor,
+      true,
+      0,
+      probeDeps
+    );
+    cursor = placed.bottom;
+    if (placed.remainder !== null || cursor > bottom + 0.001) return null;
+  }
+  const headerHeight = cursor - top;
+  const placed = layoutRowFragment(
+    body,
+    structure.columnWidthsPt,
+    left,
+    cursor,
+    false,
+    0,
+    probeDeps
+  );
+  if (placed.remainder !== null || placed.bottom > bottom + 0.001) return null;
+  return {
+    bodyRowId: body.id,
+    headerHeight,
+    bodyHeight: placed.bottom - cursor,
+    deps: { ...deps, cellContentInsets: insets },
+  };
+}

--- a/packages/core/src/layout/semantic-table-layout.ts
+++ b/packages/core/src/layout/semantic-table-layout.ts
@@ -105,7 +105,7 @@ import { annotateTableFragmentGeometry } from './semantic-table-interaction.ts';
 import { borderExtentPt, type TableBorderOwnershipBudget } from './table-borders.ts';
 import { type TableVMergeResolveBudget } from './table-vmerge.ts';
 import { acceptVMergeSpansAt, planTableVMergeHeights } from './table-vmerge-heights.ts';
-import { contentInsets } from './table-cell-geometry.ts';
+import { contentInsets, type CellContentInsets } from './table-cell-geometry.ts';
 import { blockInlineRight } from './table-cell-text-direction.ts';
 import { finalizeTableRows, shiftBlocks } from './table-fragment-finalize.ts';
 export { finalizeTableRows } from './table-fragment-finalize.ts';
@@ -209,6 +209,8 @@ export interface HostedStoryFlowDeps {
 
 export interface TableFlowDeps {
   readonly measurer: TextMeasurer;
+  /** Layout-only insets for one repeated-header/body occurrence. */
+  readonly cellContentInsets?: ReadonlyMap<string, CellContentInsets>;
   readonly cache?: ParagraphLayoutCache<readonly PendingLine[]> | undefined;
   readonly producer: string;
   /** Produces a stable id from the paragraph-local line identity. */
@@ -1316,7 +1318,8 @@ export function layoutRowFragmentBounded(
     const inset = Math.min(gap, Math.max((slotW - MIN_CELL_BOX_PT) / 2, 0));
     const cellX = slotX + inset;
     const cellW = Math.max(slotW - 2 * inset, MIN_CELL_BOX_PT);
-    const insets = contentInsets(cell.margins, cell.borders);
+    const insets =
+      deps.cellContentInsets?.get(cell.id) ?? contentInsets(cell.margins, cell.borders);
     const topInset = isContinuation ? borderExtentPt(cell.borders.top) : insets.top;
     // Always reserve bottom inset so the fragment never paints into the margin/border band.
     // A detached head answers to the page and to its own SPAN, and to nothing about this

--- a/packages/core/src/layout/table-flow-pagination.ts
+++ b/packages/core/src/layout/table-flow-pagination.ts
@@ -25,6 +25,11 @@ import {
   type TableFlowDeps,
 } from './semantic-table-layout.ts';
 import { probeRowFragmentProgress } from './table-row-progress-probe.ts';
+import {
+  prepareRepeatedHeaderBorderPlan,
+  type RepeatedHeaderBorderPlan,
+} from './repeated-header-border-metrics.ts';
+import type { CellContentInsets } from './table-cell-geometry.ts';
 import { admitVMergeSpansAt, type RowVMergeLayoutOptions } from './table-vmerge-heights.ts';
 import { annotateTableFragmentGeometry } from './semantic-table-interaction.ts';
 import {
@@ -191,6 +196,12 @@ export function paginateTableInFlow(
   const rowOrdinals = new Map<string, number>();
   // Authored rows backing the open fragment (includes header repeats) for finalize.
   let sourceRows: (typeof structure.rows)[number][] = [];
+  let occurrenceInsets = new Map<TableRowFragmentRecord, ReadonlyMap<string, CellContentInsets>>();
+  let repeatedPlan: RepeatedHeaderBorderPlan | undefined;
+  let prepareRepeat: (() => RepeatedHeaderBorderPlan | null | undefined) | undefined;
+  const rememberInsets = (record: TableRowFragmentRecord, deps: TableFlowDeps): void => {
+    if (deps.cellContentInsets) occurrenceInsets.set(record, deps.cellContentInsets);
+  };
   const closeTableFragment = (): void => {
     if (rows.length === 0) return;
     const finalized = finalizeTableRows(
@@ -201,7 +212,8 @@ export function paginateTableInFlow(
       tableDeps.vMergeResolveBudget,
       undefined,
       shiftAnchor,
-      tableDeps
+      tableDeps,
+      occurrenceInsets
     );
     const last = finalized[finalized.length - 1]!;
     const fragment = annotateTableFragmentGeometry(
@@ -248,6 +260,8 @@ export function paginateTableInFlow(
     fragmentIndex += 1;
     rows = [];
     sourceRows = [];
+    occurrenceInsets = new Map();
+    repeatedPlan = undefined;
   };
 
   /**
@@ -260,7 +274,9 @@ export function paginateTableInFlow(
   ): void => {
     if (headerRows.length === 0) return;
 
-    const groupHeight = headerGroupHeight;
+    const candidate = asRepeat ? prepareRepeat?.() : undefined;
+    if (candidate === null) return;
+    const groupHeight = candidate?.headerHeight ?? headerGroupHeight;
     // `breakForContinuation` already advanced to the target region before asking for a repeat.
     // If that region cannot carry the group, keep it for the pending body row instead of skipping
     // a usable nonzero-origin continuous-section column.
@@ -290,7 +306,10 @@ export function paginateTableInFlow(
     // A repeated header is furniture for the pending body row, not a reason to reject that row.
     // Probe at the exact post-header position before committing any repeated lines or drawings.
     // If the row cannot advance there, Word suppresses the repeat on this continuation page.
-    if (asRepeat && admitsBodyAfter && !admitsBodyAfter(flow.cursorY + groupHeight)) return;
+    if (asRepeat && !candidate && admitsBodyAfter && !admitsBodyAfter(flow.cursorY + groupHeight))
+      return;
+
+    const headerDeps = candidate?.deps ?? tableDeps;
 
     for (const headerRow of headerRows) {
       const placed = layoutRowFragment(
@@ -300,7 +319,7 @@ export function paginateTableInFlow(
         flow.cursorY,
         asRepeat,
         0,
-        tableDeps,
+        headerDeps,
         structure.cellSpacingPt
       );
       if (placed.bottom > placementBottom + 0.001) {
@@ -310,9 +329,11 @@ export function paginateTableInFlow(
         );
       }
       rows.push(placed.record);
+      rememberInsets(placed.record, headerDeps);
       sourceRows.push(headerRow);
       flow.cursorY = placed.bottom;
     }
+    repeatedPlan = candidate;
   };
 
   const breakForContinuation = (admitsBodyAfter?: (bodyTop: number) => boolean): void => {
@@ -337,9 +358,18 @@ export function paginateTableInFlow(
   const vMergePlan = vMergePlanFor(structure, () => tableLeft, 0, tableDeps, bodyRows);
   let vMerge: RowVMergeLayoutOptions | undefined;
   let naturalHeight = 0;
+  let baselineBodyHeight = 0;
   const admitSpans = (bodyRowIndex: number, probeRow?: SemanticTableRow): void => {
     vMerge = admitVMergeSpansAt(vMergePlan, bodyRowIndex, flow.cursorY, contentHeight());
-    naturalHeight = vMerge?.heightFloorPt ?? (probeRow ? rowHeightOf(probeRow) : naturalHeight);
+    // Keep the original admission history separate from one occurrence's override.
+    // A later merge offer can change its floor before the row is committed.
+    baselineBodyHeight =
+      vMerge?.heightFloorPt ?? (probeRow ? rowHeightOf(probeRow) : baselineBodyHeight);
+    naturalHeight =
+      vMerge?.heightFloorPt ??
+      (repeatedPlan?.bodyRowId === bodyRows[bodyRowIndex]?.id
+        ? repeatedPlan.bodyHeight
+        : baselineBodyHeight);
   };
 
   for (const [bodyRowIndex, row] of bodyRows.entries()) {
@@ -349,6 +379,22 @@ export function paginateTableInFlow(
     let isContinuation = false;
     let fragmentsForRow = 0;
     let movedToFreshPage = false;
+    const rowDeps = (): TableFlowDeps =>
+      repeatedPlan?.bodyRowId === row.id ? repeatedPlan.deps : tableDeps;
+    prepareRepeat = () =>
+      isContinuation
+        ? undefined
+        : prepareRepeatedHeaderBorderPlan(
+            structure,
+            headerRows,
+            row,
+            tableLeft,
+            flow.cursorY,
+            contentHeight(),
+            headerGroupHeight,
+            baselineBodyHeight,
+            tableDeps
+          );
 
     // A row an accepted span covers does not take the whole-row MOVE: alone among the
     // breaks below, that one is an optimization rather than a recovery, and it ends the
@@ -435,7 +481,7 @@ export function paginateTableInFlow(
           flow.cursorY,
           false,
           0,
-          tableDeps,
+          rowDeps(),
           structure.cellSpacingPt,
           vMerge,
           contentHeight()
@@ -451,6 +497,7 @@ export function paginateTableInFlow(
         // to re-place would leave a float positioned by a layout that never happened.
         const hasMore = placed.remainder !== null;
         rows.push(placed.record);
+        rememberInsets(placed.record, rowDeps());
         sourceRows.push(hasMore ? rowWithSplitBorders(row, isContinuation, true) : row);
         flow.cursorY = placed.bottom;
         if (!hasMore) break;
@@ -496,13 +543,14 @@ export function paginateTableInFlow(
             flow.cursorY,
             false,
             0,
-            tableDeps,
+            rowDeps(),
             structure.cellSpacingPt,
             vMerge,
             fullBand
           );
           if (placed.bottom <= fullBand + 0.001 && placed.remainder === null) {
             rows.push(placed.record);
+            rememberInsets(placed.record, rowDeps());
             sourceRows.push(row);
             flow.cursorY = placed.bottom;
             break;

--- a/packages/core/src/layout/table-fragment-finalize.ts
+++ b/packages/core/src/layout/table-fragment-finalize.ts
@@ -13,7 +13,7 @@ import {
   publishAnchoredDrawingsForParagraph,
   shiftInlineDrawingRecord,
 } from './drawing-layout.ts';
-import { contentInsets } from './table-cell-geometry.ts';
+import { contentInsets, type CellContentInsets } from './table-cell-geometry.ts';
 import {
   resolveTableCellBorderGrid,
   type BorderGridCell,
@@ -158,7 +158,8 @@ export function finalizeTableRows(
   vMergeBudget?: TableVMergeResolveBudget,
   vMergeWork?: TableVMergeResolveWork,
   onAnchorShift?: (paragraphId: string, dy: number) => void,
-  anchorDeps?: TableFlowDeps
+  anchorDeps?: TableFlowDeps,
+  occurrenceInsets?: ReadonlyMap<TableRowFragmentRecord, ReadonlyMap<string, CellContentInsets>>
 ): TableRowFragmentRecord[] {
   if (rows.length === 0) return [];
 
@@ -196,7 +197,9 @@ export function finalizeTableRows(
       const authored = authoredById.get(cell.id);
       let blocks = cell.blocks;
       if (authored && authored.vAlign !== 'top' && blocks.length > 0) {
-        const insets = contentInsets(authored.margins, authored.borders);
+        const insets =
+          occurrenceInsets?.get(row)?.get(cell.id) ??
+          contentInsets(authored.margins, authored.borders);
         // Content was placed relative to the first row; measure current content band.
         let contentTop = Number.POSITIVE_INFINITY;
         let contentBottom = Number.NEGATIVE_INFINITY;


### PR DESCRIPTION
## Summary

Fix inconsistent content clearance at the shared horizontal border between a repeated table header and its first complete body row. Previously painting resolved the winning border after measurement, so pagination and final vertical alignment could still use the weaker authored edge.

## Changes

- Resolve both sides of each repeated header/body boundary before measuring the candidate. Reuse the existing border winner and table fallback rules, including explicit `nil` and grid spans.
- Keep per-cell insets local to that repeated occurrence, and carry the same insets through preflight, committed layout, and final vertical alignment.
- Measure the complete header/body candidate together; omit that repeat when the complete candidate cannot fit, without leaking its insets to later pages.
- Isolate speculative work from live caches, drawing/note sinks, line identifiers, and budget counters.

This preserves the current border-width policy and authored OOXML. It is intentionally limited to bounded, complete text rows. Positive cell spacing, vertical merges, split continuations, positioned tables, drawings, nested tables, vertical text, sparse grids, and unsupported markup retain the existing path. Original first-page header boundaries and ordinary body/body boundaries are not changed.

## Tests

Added 31 synthetic regression cases covering both winning-edge directions, auto/minimum/exact row heights, vertical alignment, spanning cells, table fallback and `nil`, occurrence-specific borders, actual border edits/undo with warm versus cold layouts, fields, joint-fit rejection, probe isolation, and conservative fallbacks. The source XML and all body rows are retained.

Final-source validation:

- Store: 2,558; layout: 2,430; binding: 172; output: 211; targeted paginated-table host tests: 8. **5,379 tests passed**.
- Core and DOM-free layout/store type checks; scoped ESLint/Prettier; line caps; `git diff --check`.
- Core ESM/CJS/DTS build and API snapshot/check; no public API snapshot changes.
- Feature matrix, fidelity guide, and changeset updated.

All fixtures are synthetic. No private reports, PDFs, photos, fonts, or signatures are included. The full monorepo/browser E2E suite and broad visual document certification were not run for this independent branch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/755"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791255090&installation_model_id=422592&pr_number=755&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F755&signature=3423db27cd362c68eea7053efc745626f4e948c0bb810701d94ff66d0c957c39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->