### PR TITLE
fix: honor engine element budgets and identify resource limits

### DIFF
--- a/.changeset/large-document-resource-limits.md
+++ b/.changeset/large-document-resource-limits.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/editor-api': minor
 ---
 
-Support larger formatted documents and identify exceeded resource limits when opening DOCX bytes. Fixes #693.
+Use the engine's configurable element budget when opening XML parts and identify exceeded resource limits in the server API. Fixes #693.

--- a/.changeset/large-document-resource-limits.md
+++ b/.changeset/large-document-resource-limits.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/editor-api': minor
+---
+
+Support larger formatted documents and identify exceeded resource limits when opening DOCX bytes. Fixes #693.

--- a/docs/api/docx-editor-core/automation.api.md
+++ b/docs/api/docx-editor-core/automation.api.md
@@ -1235,6 +1235,7 @@ export type ServerAutomationHostResult = {
     readonly ok: true;
 } | {
     readonly detail?: string;
+    readonly limit?: 'zip.maxTotalBytes' | 'zip.maxRatio';
     readonly ok: false;
     readonly reason: ServerAutomationHostRejection;
 };

--- a/docs/api/docx-editor-core/store.api.md
+++ b/docs/api/docx-editor-core/store.api.md
@@ -2890,6 +2890,7 @@ export type OoxmlPackageResult = {
     readonly package: OoxmlPackage;
 } | {
     readonly detail?: string;
+    readonly limit?: 'zip.maxTotalBytes' | 'zip.maxRatio';
     readonly ok: false;
     readonly reason: OoxmlPackageRejection;
 };
@@ -5091,6 +5092,7 @@ export type ZipReadResult = {
     readonly ok: true;
 } | {
     readonly detail?: string;
+    readonly limit?: 'zip.maxTotalBytes' | 'zip.maxRatio';
     readonly ok: false;
     readonly reason: ZipRejection;
 };

--- a/docs/api/docx-editor-core/store.api.md
+++ b/docs/api/docx-editor-core/store.api.md
@@ -5048,7 +5048,6 @@ export const XML_NAMESPACE_URI = "http://www.w3.org/XML/1998/namespace";
 export interface XmlLimits {
     // (undocumented)
     readonly maxBytes: number;
-    // (undocumented)
     readonly maxElements?: number;
 }
 

--- a/docs/api/docx-editor-editor-api/browser.api.md
+++ b/docs/api/docx-editor-editor-api/browser.api.md
@@ -321,6 +321,7 @@ export class DocxEditorError extends Error {
     readonly actualRevision?: number;
     readonly code: DocxEditorErrorCode;
     readonly expectedRevision?: number;
+    readonly limit?: DocxEditorErrorInit['limit'];
     readonly target?: string;
 }
 
@@ -343,6 +344,8 @@ export type DocxEditorErrorCode =
 | 'ObjectInUse'
 /** An argument or load option this API does not accept. */
 | 'InvalidArgument'
+/** Opening the document exceeded a bounded reader resource limit. */
+| 'ResourceLimitExceeded'
 /** The collection has no such item — `getFirst()` on an empty one. */
 | 'ItemNotFound'
 /** The host cannot do this at all — a capability it reports false. */
@@ -379,6 +382,7 @@ export interface DocxEditorErrorInit {
     readonly actualRevision?: number;
     readonly code: DocxEditorErrorCode;
     readonly expectedRevision?: number;
+    readonly limit?: 'zip.maxEntries' | 'zip.maxTotalBytes' | 'zip.maxRatio' | 'xml.maxBytes' | 'xml.maxElements' | 'xml.maxDepth' | 'maxXmlParts' | 'maxRelationships';
     readonly target?: string;
 }
 

--- a/docs/api/docx-editor-editor-api/index.api.md
+++ b/docs/api/docx-editor-editor-api/index.api.md
@@ -314,6 +314,7 @@ export class DocxEditorError extends Error {
     readonly actualRevision?: number;
     readonly code: DocxEditorErrorCode;
     readonly expectedRevision?: number;
+    readonly limit?: DocxEditorErrorInit['limit'];
     readonly target?: string;
 }
 
@@ -336,6 +337,8 @@ export type DocxEditorErrorCode =
 | 'ObjectInUse'
 /** An argument or load option this API does not accept. */
 | 'InvalidArgument'
+/** Opening the document exceeded a bounded reader resource limit. */
+| 'ResourceLimitExceeded'
 /** The collection has no such item — `getFirst()` on an empty one. */
 | 'ItemNotFound'
 /** The host cannot do this at all — a capability it reports false. */
@@ -372,6 +375,7 @@ export interface DocxEditorErrorInit {
     readonly actualRevision?: number;
     readonly code: DocxEditorErrorCode;
     readonly expectedRevision?: number;
+    readonly limit?: 'zip.maxEntries' | 'zip.maxTotalBytes' | 'zip.maxRatio' | 'xml.maxBytes' | 'xml.maxElements' | 'xml.maxDepth' | 'maxXmlParts' | 'maxRelationships';
     readonly target?: string;
 }
 

--- a/docs/site/content/editor-api/index.mdx
+++ b/docs/site/content/editor-api/index.mdx
@@ -21,8 +21,12 @@ project must resolve exactly one copy of it, shared with any editor adapter you 
 
 `DocxEditor.createServer` rejects with error code `ResourceLimitExceeded` when opening exceeds a resource cap.
 Catch `DocxEditorError` and inspect its `limit` field, such as `xml.maxElements` or `zip.maxRatio`.
-Each XML part supports up to 2,000,000 elements, 64 MiB, and 256 nesting levels.
-The `limits` option can set tighter budgets. Malformed input rejects with `InvalidArgument`.
+The XML reader uses the engine's default budget of 10,000,000 elements per part.
+Set `limits.xml.maxElements` to lower that budget for untrusted input or raise it for larger documents,
+up to the engine ceiling of 50,000,000. Set `limits.xml.maxBytes` alongside it.
+The 64 MiB per-part byte ceiling and 256-level depth ceiling still apply.
+These budgets do not guarantee that a document fits in the host's memory.
+Malformed input rejects with `InvalidArgument`.
 
 ## Choose a host
 

--- a/docs/site/content/editor-api/index.mdx
+++ b/docs/site/content/editor-api/index.mdx
@@ -19,6 +19,11 @@ npm install @docx-editor.dev/editor-api @docx-editor.dev/core
 `@docx-editor.dev/core` is a peer dependency: the engine holds identity-keyed state, so your
 project must resolve exactly one copy of it, shared with any editor adapter you install.
 
+`DocxEditor.createServer` rejects with error code `ResourceLimitExceeded` when opening exceeds a resource cap.
+Catch `DocxEditorError` and inspect its `limit` field, such as `xml.maxElements` or `zip.maxRatio`.
+Each XML part supports up to 2,000,000 elements, 64 MiB, and 256 nesting levels.
+The `limits` option can set tighter budgets. Malformed input rejects with `InvalidArgument`.
+
 ## Choose a host
 
 | `DocumentCapabilities` field | Server runtime | Browser runtime |

--- a/docs/site/content/editor-api/index.mdx
+++ b/docs/site/content/editor-api/index.mdx
@@ -26,7 +26,8 @@ Set `limits.xml.maxElements` to lower that budget for untrusted input or raise i
 up to the engine ceiling of 50,000,000. Set `limits.xml.maxBytes` alongside it.
 The 64 MiB per-part byte ceiling and 256-level depth ceiling still apply.
 These budgets do not guarantee that a document fits in the host's memory.
-Malformed input rejects with `InvalidArgument`.
+Counts and byte budgets must be finite nonnegative integers; compression ratios may be fractional.
+Malformed input and invalid budget options reject with `InvalidArgument`.
 
 ## Choose a host
 

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -1101,7 +1101,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'A batching object model shaped after a documented subset of the Word JavaScript API. The server entry works over bytes, and the browser entry works over an open editor. It ships no model integration, tool catalog, or MCP transport.',
+      'A batching object model shaped after a documented subset of the Word JavaScript API. The server entry works over bytes and reports exceeded resource limits with typed errors. The browser entry works over an open editor. It ships no model integration, tool catalog, or MCP transport.',
     docsLink: '/docs/2.x/editor-api',
   },
 ];

--- a/packages/core/src/automation/server-host.ts
+++ b/packages/core/src/automation/server-host.ts
@@ -80,6 +80,7 @@ export type ServerAutomationHostResult =
   | {
       readonly ok: false;
       readonly reason: ServerAutomationHostRejection;
+      readonly limit?: 'zip.maxTotalBytes' | 'zip.maxRatio';
       readonly detail?: string;
     };
 
@@ -120,6 +121,7 @@ export function createServerAutomationHost(
     return {
       ok: false,
       reason: loaded.reason,
+      ...(loaded.limit === undefined ? {} : { limit: loaded.limit }),
       ...(loaded.detail ? { detail: loaded.detail } : {}),
     };
   }

--- a/packages/core/src/automation/server-host.ts
+++ b/packages/core/src/automation/server-host.ts
@@ -91,10 +91,11 @@ export type ServerAutomationHostResult =
  */
 export interface ServerAutomationHostOptions {
   /**
-   * Tighter budgets for the bounded reader — zip ratio, part count, XML depth.
+   * Budgets for the bounded reader — archive size, part count, and XML elements.
    *
-   * Exposed because a server opening documents it did not author is exactly where a caller
-   * may want smaller limits than the defaults. Omitted means the engine's own defaults.
+   * Omitted means the engine defaults. Lower budgets for untrusted input, or raise
+   * `xml.maxElements` for larger documents when the host has sufficient memory.
+   * Engine ceilings still apply.
    */
   readonly limits?: OoxmlPackageLimits;
   /**

--- a/packages/core/src/store/__tests__/xml-reader.test.ts
+++ b/packages/core/src/store/__tests__/xml-reader.test.ts
@@ -4,7 +4,7 @@
 import { describe, expect, test } from 'bun:test';
 import {
   readXml,
-  XML_HARD_MAX_ELEMENTS,
+  XML_DEFAULT_MAX_ELEMENTS,
   findElement,
   childElements,
   textContent,
@@ -33,11 +33,14 @@ describe('trust boundary rejections', () => {
       reason: 'too-many-elements',
     });
   });
-  test('cannot raise the hard element ceiling with an override', () => {
-    const xml = '<x>' + '<a/>'.repeat(XML_HARD_MAX_ELEMENTS) + '</x>';
+  test('honors an element budget above the default before parser allocation', () => {
+    // Intentionally malformed: distinguish the element preflight from XML validation
+    // without allocating millions of parsed nodes in the test process.
+    const xml = '<x>' + '<a/>'.repeat(XML_DEFAULT_MAX_ELEMENTS) + '</x><unclosed';
+    expect(readXml(xml)).toMatchObject({ ok: false, reason: 'too-many-elements' });
     expect(
-      readXml(xml, { maxBytes: xml.length, maxElements: XML_HARD_MAX_ELEMENTS + 1 })
-    ).toMatchObject({ ok: false, reason: 'too-many-elements' });
+      readXml(xml, { maxBytes: xml.length, maxElements: XML_DEFAULT_MAX_ELEMENTS + 2 })
+    ).toMatchObject({ ok: false, reason: 'parse-error' });
   });
   test('counts elements before parser allocation and before full XML validation', () => {
     expect(readXml('<x><a/><b/><unclosed', { maxBytes: 100, maxElements: 2 })).toMatchObject({

--- a/packages/core/src/store/__tests__/xml-reader.test.ts
+++ b/packages/core/src/store/__tests__/xml-reader.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, test } from 'bun:test';
 import {
   readXml,
+  XML_HARD_MAX_ELEMENTS,
   findElement,
   childElements,
   textContent,
@@ -31,6 +32,12 @@ describe('trust boundary rejections', () => {
       ok: false,
       reason: 'too-many-elements',
     });
+  });
+  test('cannot raise the hard element ceiling with an override', () => {
+    const xml = '<x>' + '<a/>'.repeat(XML_HARD_MAX_ELEMENTS) + '</x>';
+    expect(
+      readXml(xml, { maxBytes: xml.length, maxElements: XML_HARD_MAX_ELEMENTS + 1 })
+    ).toMatchObject({ ok: false, reason: 'too-many-elements' });
   });
   test('counts elements before parser allocation and before full XML validation', () => {
     expect(readXml('<x><a/><b/><unclosed', { maxBytes: 100, maxElements: 2 })).toMatchObject({

--- a/packages/core/src/store/package/ooxml-package.ts
+++ b/packages/core/src/store/package/ooxml-package.ts
@@ -181,7 +181,12 @@ export type OoxmlPackageRejection =
 /** A loaded package, or a typed refusal. Never throws. */
 export type OoxmlPackageResult =
   | { readonly ok: true; readonly package: OoxmlPackage }
-  | { readonly ok: false; readonly reason: OoxmlPackageRejection; readonly detail?: string };
+  | {
+      readonly ok: false;
+      readonly reason: OoxmlPackageRejection;
+      readonly detail?: string;
+      readonly limit?: 'zip.maxTotalBytes' | 'zip.maxRatio';
+    };
 
 function isElement(node: XmlNode): node is Extract<XmlNode, { type: 'element' }> {
   return node.type === 'element';
@@ -302,20 +307,18 @@ function relsOwner(relsPartName: string): string | null {
   return `${dir}/${base}`;
 }
 
-function readContentTypes(xml: string, limits?: XmlLimits): ContentTypeIndex | null {
-  const parsed = readXml(xml, limits);
-  if (!parsed.ok) return null;
+function readContentTypes(nodes: readonly XmlNode[]): ContentTypeIndex | null {
   const defaults: DefaultRecord[] = [];
   const overrides: OverrideRecord[] = [];
   let order = 0;
   const emptyScope = new Map<string, string>();
-  for (const element of collectContentTypeElements(parsed.nodes, 'Default', emptyScope)) {
+  for (const element of collectContentTypeElements(nodes, 'Default', emptyScope)) {
     const extension = unqualifiedXmlAttribute(element, 'Extension');
     const contentType = unqualifiedXmlAttribute(element, 'ContentType');
     if (extension === undefined || contentType === undefined) continue;
     defaults.push({ extension, contentType, order: order++ });
   }
-  for (const element of collectContentTypeElements(parsed.nodes, 'Override', emptyScope)) {
+  for (const element of collectContentTypeElements(nodes, 'Override', emptyScope)) {
     const partName = unqualifiedXmlAttribute(element, 'PartName');
     const contentType = unqualifiedXmlAttribute(element, 'ContentType');
     if (partName === undefined || contentType === undefined) continue;
@@ -365,13 +368,31 @@ export function readOoxmlPackage(
 ): OoxmlPackageResult {
   packageReadCount += 1;
   const zip = readZip(bytes, limits.zip ?? DEFAULT_ZIP_LIMITS);
-  if (!zip.ok) return { ok: false, reason: zip.reason, detail: zip.detail };
+  if (!zip.ok)
+    return {
+      ok: false,
+      reason: zip.reason,
+      detail: zip.detail,
+      ...(zip.limit === undefined ? {} : { limit: zip.limit }),
+    };
 
   const contentTypeBytes = zip.entries.get(CONTENT_TYPES_PART);
   if (!contentTypeBytes) return { ok: false, reason: 'no-content-types' };
   const decodedContentTypes = decodeXmlBytes(contentTypeBytes, limits.xml);
   if (!decodedContentTypes.ok) return { ok: false, reason: decodedContentTypes.reason };
-  const contentTypes = readContentTypes(decodedContentTypes.xml, limits.xml);
+  const parsedContentTypes = readXml(decodedContentTypes.xml, limits.xml);
+  if (!parsedContentTypes.ok) {
+    // Preserve the existing malformed-content-types refusal, but retain resource failures.
+    const reason = parsedContentTypes.reason;
+    return {
+      ok: false,
+      reason:
+        reason === 'too-large' || reason === 'too-many-elements' || reason === 'too-deep'
+          ? reason
+          : 'bad-content-types',
+    };
+  }
+  const contentTypes = readContentTypes(parsedContentTypes.nodes);
   if (!contentTypes) return { ok: false, reason: 'bad-content-types' };
 
   const maxRelationships = limits.maxRelationships ?? DEFAULT_OOXML_PACKAGE_LIMITS.maxRelationships;

--- a/packages/core/src/store/package/xml-reader.ts
+++ b/packages/core/src/store/package/xml-reader.ts
@@ -7,6 +7,7 @@
 
 import { XMLParser, XMLValidator } from 'fast-xml-parser';
 import { isValidXmlText } from './sinks.ts';
+import { DEFAULT_LIMITS, HARD_CEILINGS } from '../runtime/limits.ts';
 
 /**
  * One parsed XML node, preserving significant order, whitespace and raw lexical values.
@@ -49,9 +50,10 @@ export type XmlRejection =
 export const MAX_XML_DEPTH = 256;
 const MAX_DEPTH = MAX_XML_DEPTH;
 export const XML_HARD_MAX_BYTES = 64 * 1024 * 1024;
-// Allows large formatted documents (including 101,322 paragraphs in issue #693),
-// while retaining a finite pre-parse allocation guard.
-export const XML_HARD_MAX_ELEMENTS = 2_000_000;
+// Share the engine's resource policy instead of imposing a second, smaller ceiling.
+// These are defensive budgets, not a guarantee that every document fits the host's memory.
+export const XML_DEFAULT_MAX_ELEMENTS = DEFAULT_LIMITS.maxElementCount;
+export const XML_HARD_MAX_ELEMENTS = HARD_CEILINGS.maxElementCount;
 
 /**
  * Decode ONLY the five predefined XML entities and numeric character references.
@@ -287,6 +289,7 @@ function preflightDepth(xml: string): XmlRejection | undefined {
 /** Per-part caps on size, element count and depth. Clamped into the hard ceilings. */
 export interface XmlLimits {
   readonly maxBytes: number;
+  /** Element budget; may raise or lower the engine default, up to its hard ceiling. */
   readonly maxElements?: number;
 }
 
@@ -321,7 +324,10 @@ export function readXml(
   )
     return { ok: false, reason: 'invalid-limits' };
   const maxBytes = Math.min(limits.maxBytes, XML_HARD_MAX_BYTES);
-  const maxElements = Math.min(limits.maxElements ?? XML_HARD_MAX_ELEMENTS, XML_HARD_MAX_ELEMENTS);
+  const maxElements = Math.min(
+    limits.maxElements ?? XML_DEFAULT_MAX_ELEMENTS,
+    XML_HARD_MAX_ELEMENTS
+  );
   if (exceedsUtf8Bytes(xml, maxBytes)) return { ok: false, reason: 'too-large' };
   const forbidden = preflightForbiddenXml(xml);
   if (forbidden) return { ok: false, reason: forbidden };

--- a/packages/core/src/store/package/xml-reader.ts
+++ b/packages/core/src/store/package/xml-reader.ts
@@ -49,7 +49,9 @@ export type XmlRejection =
 export const MAX_XML_DEPTH = 256;
 const MAX_DEPTH = MAX_XML_DEPTH;
 export const XML_HARD_MAX_BYTES = 64 * 1024 * 1024;
-export const XML_HARD_MAX_ELEMENTS = 1_000_000;
+// Allows large formatted documents (including 101,322 paragraphs in issue #693),
+// while retaining a finite pre-parse allocation guard.
+export const XML_HARD_MAX_ELEMENTS = 2_000_000;
 
 /**
  * Decode ONLY the five predefined XML entities and numeric character references.

--- a/packages/core/src/store/package/zip.ts
+++ b/packages/core/src/store/package/zip.ts
@@ -33,10 +33,18 @@ export const DEFAULT_ZIP_LIMITS: ZipLimits = {
 /** The read entries, or the typed refusal. Never throws — the bytes are untrusted. */
 export type ZipReadResult =
   | { readonly ok: true; readonly entries: ReadonlyMap<string, Uint8Array> }
-  | { readonly ok: false; readonly reason: ZipRejection; readonly detail?: string };
+  | {
+      readonly ok: false;
+      readonly reason: ZipRejection;
+      readonly detail?: string;
+      readonly limit?: 'zip.maxTotalBytes' | 'zip.maxRatio';
+    };
 
 class ZipViolation extends Error {
-  constructor(readonly reason: ZipRejection) {
+  constructor(
+    readonly reason: ZipRejection,
+    readonly limit?: 'zip.maxTotalBytes' | 'zip.maxRatio'
+  ) {
     super(reason);
   }
 }
@@ -79,14 +87,21 @@ export function readZip(bytes: Uint8Array, limits: ZipLimits = DEFAULT_ZIP_LIMIT
         seenNorms.add(key);
         // Compression-ratio zip-bomb guard, checked before decompressing.
         if (file.originalSize / Math.max(1, file.size) > maxRatio)
-          throw new ZipViolation('too-large');
+          throw new ZipViolation('too-large', 'zip.maxRatio');
         totalUncompressed += file.originalSize;
-        if (totalUncompressed > limits.maxTotalBytes) throw new ZipViolation('too-large');
+        if (totalUncompressed > limits.maxTotalBytes)
+          throw new ZipViolation('too-large', 'zip.maxTotalBytes');
         return true;
       },
     });
   } catch (e) {
-    if (e instanceof ZipViolation) return { ok: false, reason: e.reason, detail: badDetail };
+    if (e instanceof ZipViolation)
+      return {
+        ok: false,
+        reason: e.reason,
+        detail: badDetail,
+        ...(e.limit === undefined ? {} : { limit: e.limit }),
+      };
     return { ok: false, reason: 'inflate-error' };
   }
 

--- a/packages/editor-api/src/runtime/__tests__/runtime-resource-limits.test.ts
+++ b/packages/editor-api/src/runtime/__tests__/runtime-resource-limits.test.ts
@@ -77,6 +77,30 @@ describe('server resource limits', () => {
     ).rejects.toMatchObject({ code: 'ResourceLimitExceeded', limit: 'xml.maxDepth' });
   });
 
+  test.each<DocumentLimits>([
+    { zip: { maxEntries: -1, maxTotalBytes: 100_000 } },
+    { zip: { maxEntries: 10, maxTotalBytes: -1 } },
+    { zip: { maxEntries: 10, maxTotalBytes: 100_000, maxRatio: -1 } },
+    { maxXmlParts: -1 },
+    { maxRelationships: -1 },
+    { zip: { maxEntries: Infinity, maxTotalBytes: 100_000 } },
+    { zip: { maxEntries: 10, maxTotalBytes: 100_000, maxRatio: NaN } },
+    { maxRelationships: NaN },
+    { maxXmlParts: 0.5 },
+  ])('rejects invalid caller budgets as arguments: %j', async (limits) => {
+    await expect(DocxEditor.createServer(docx(p('text')), { limits })).rejects.toMatchObject({
+      code: 'InvalidArgument',
+      target: 'createServer',
+    });
+  });
+
+  test('accepts fractional compression-ratio budgets', async () => {
+    const runtime = await DocxEditor.createServer(docx(p('text')), {
+      limits: { zip: { maxEntries: 10, maxTotalBytes: 100_000, maxRatio: 200.5 } },
+    });
+    runtime.dispose();
+  });
+
   test('keeps malformed input and invalid limit configuration as InvalidArgument', async () => {
     for (const [bytes, limits] of [
       [new Uint8Array([1, 2, 3]), undefined],

--- a/packages/editor-api/src/runtime/__tests__/runtime-resource-limits.test.ts
+++ b/packages/editor-api/src/runtime/__tests__/runtime-resource-limits.test.ts
@@ -1,0 +1,92 @@
+/*
+Copyright (c) 2026 EigenPal, Inc. All rights reserved.
+Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/editor-api/LICENSE.md.
+Production use requires a commercial agreement: licensing@eigenpal.com
+*/
+import { describe, expect, test } from 'bun:test';
+import { strToU8, unzipSync, zipSync } from 'fflate';
+import { DocxEditor, DocxEditorError, type DocumentLimits } from '../../index.ts';
+import { docx, p } from './support/docx.ts';
+
+// Store entries without compression so synthetic repetition does not trip the ratio guard.
+function storedDocx(body: string): Uint8Array {
+  const entries = unzipSync(docx(''));
+  entries['word/document.xml'] = strToU8(
+    '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">' +
+      `<w:body>${body}</w:body></w:document>`
+  );
+  return zipSync(entries, { level: 0 });
+}
+
+describe('server resource limits', () => {
+  test('opens 101,322 formatted paragraphs with more than one million XML elements', async () => {
+    const count = 101_322;
+    // Eleven elements per paragraph: the old one-million-element ceiling rejects this.
+    const paragraph =
+      '<w:p><w:pPr><w:spacing w:after="0"/><w:jc w:val="left"/>' +
+      '<w:keepNext/></w:pPr><w:r><w:rPr><w:b/><w:i/><w:sz w:val="22"/></w:rPr>' +
+      '<w:t>large document</w:t></w:r></w:p>';
+    const bytes = storedDocx(paragraph.repeat(count));
+    await expect(
+      DocxEditor.createServer(bytes, {
+        limits: { xml: { maxBytes: 64 * 1024 * 1024, maxElements: 1_000_000 } },
+      })
+    ).rejects.toMatchObject({ code: 'ResourceLimitExceeded', limit: 'xml.maxElements' });
+    const runtime = await DocxEditor.createServer(bytes);
+    try {
+      await runtime.run(async (context) => {
+        const body = context.document.body;
+        body.load('text');
+        await context.sync();
+        expect(body.text.split('large document').length - 1).toBe(count);
+      });
+    } finally {
+      runtime.dispose();
+    }
+  }, 60_000);
+
+  const cases: [string, DocumentLimits, string][] = [
+    ['archive entries', { zip: { maxEntries: 1, maxTotalBytes: 100_000 } }, 'zip.maxEntries'],
+    ['archive bytes', { zip: { maxEntries: 10, maxTotalBytes: 1 } }, 'zip.maxTotalBytes'],
+    [
+      'compression ratio',
+      { zip: { maxEntries: 10, maxTotalBytes: 100_000, maxRatio: 1 } },
+      'zip.maxRatio',
+    ],
+    ['XML bytes', { xml: { maxBytes: 1 } }, 'xml.maxBytes'],
+    ['content types elements', { xml: { maxBytes: 100_000, maxElements: 1 } }, 'xml.maxElements'],
+    ['document elements', { xml: { maxBytes: 100_000, maxElements: 4 } }, 'xml.maxElements'],
+    ['XML parts', { maxXmlParts: 0 }, 'maxXmlParts'],
+    ['relationships', { maxRelationships: 0 }, 'maxRelationships'],
+  ];
+  test.each(cases)('identifies the exceeded %s limit', async (_, limits, limit) => {
+    const error = await DocxEditor.createServer(docx(p('private document text')), { limits }).catch(
+      (error: unknown) => error
+    );
+    expect(error).toBeInstanceOf(DocxEditorError);
+    expect(error).toMatchObject({ code: 'ResourceLimitExceeded', target: 'createServer', limit });
+    expect((error as Error).message).not.toContain('private document text');
+    expect((error as Error).message).not.toContain('word/document.xml');
+  });
+
+  test('identifies the hard XML depth limit', async () => {
+    await expect(
+      DocxEditor.createServer(
+        storedDocx('<w:sdt>'.repeat(256) + p('deep') + '</w:sdt>'.repeat(256))
+      )
+    ).rejects.toMatchObject({ code: 'ResourceLimitExceeded', limit: 'xml.maxDepth' });
+  });
+
+  test('keeps malformed input and invalid limit configuration as InvalidArgument', async () => {
+    for (const [bytes, limits] of [
+      [new Uint8Array([1, 2, 3]), undefined],
+      [docx(p('text')), { xml: { maxBytes: Number.NaN } }],
+      [storedDocx('<!DOCTYPE x><w:p/>'), undefined],
+    ] as const) {
+      await expect(DocxEditor.createServer(bytes, { limits })).rejects.toMatchObject({
+        code: 'InvalidArgument',
+        target: 'createServer',
+      });
+    }
+  });
+});

--- a/packages/editor-api/src/runtime/errors.ts
+++ b/packages/editor-api/src/runtime/errors.ts
@@ -43,6 +43,8 @@ export type DocxEditorErrorCode =
   | 'ObjectInUse'
   /** An argument or load option this API does not accept. */
   | 'InvalidArgument'
+  /** Opening the document exceeded a bounded reader resource limit. */
+  | 'ResourceLimitExceeded'
   /** The collection has no such item — `getFirst()` on an empty one. */
   | 'ItemNotFound'
   /** The host cannot do this at all — a capability it reports false. */
@@ -93,6 +95,7 @@ const MESSAGES: Readonly<Record<DocxEditorErrorCode, string>> = Object.freeze({
     'the object still belongs to a run that has not finished. Await that run before passing the ' +
     'object to another one.',
   InvalidArgument: 'the argument is not one this API accepts.',
+  ResourceLimitExceeded: 'the document exceeds a supported resource limit.',
   ItemNotFound: 'the collection has no such item.',
   NotSupported: 'this document host does not support that operation.',
   NotImplemented: 'this version does not implement that yet.',
@@ -114,6 +117,17 @@ const MESSAGES: Readonly<Record<DocxEditorErrorCode, string>> = Object.freeze({
 export interface DocxEditorErrorInit {
   /** Which refusal this is. The stable thing to branch on. */
   readonly code: DocxEditorErrorCode;
+  /** The resource limit exceeded while opening a document. */
+  readonly limit?:
+    | 'zip.maxEntries'
+    | 'zip.maxTotalBytes'
+    | 'zip.maxRatio'
+    | 'xml.maxBytes'
+    | 'xml.maxElements'
+    | 'xml.maxDepth'
+    | 'maxXmlParts'
+    | 'maxRelationships';
+
   /**
    * The consumer-facing path of the object or property involved — `document.body.text`, not a
    * handle. Omitted when there is nothing to name.
@@ -154,6 +168,8 @@ export interface DocxEditorErrorInit {
 export class DocxEditorError extends Error {
   /** Which refusal this is. Stable across versions; the thing to branch on. */
   readonly code: DocxEditorErrorCode;
+  /** For `ResourceLimitExceeded`: the resource limit that prevented opening. */
+  readonly limit?: DocxEditorErrorInit['limit'];
   /** Consumer-facing path of the object or property involved, when there is one to name. */
   readonly target?: string;
   /** For `StaleDocument`: the revision the context had read at. */
@@ -166,6 +182,7 @@ export class DocxEditorError extends Error {
     super(message);
     this.name = 'DocxEditorError';
     this.code = init.code;
+    if (init.limit !== undefined) this.limit = init.limit;
     if (init.target !== undefined) this.target = init.target;
     if (init.expectedRevision !== undefined) this.expectedRevision = init.expectedRevision;
     if (init.actualRevision !== undefined) this.actualRevision = init.actualRevision;

--- a/packages/editor-api/src/runtime/server.ts
+++ b/packages/editor-api/src/runtime/server.ts
@@ -59,11 +59,14 @@ export interface DocumentZipLimits {
 export interface DocumentXmlLimits {
   /** Most bytes any one XML part may be. */
   readonly maxBytes: number;
-  /** Most elements any one XML part may contain. */
+  /**
+   * Most elements any one XML part may contain. Defaults to the engine budget
+   * (10,000,000); callers may raise it up to the engine ceiling (50,000,000).
+   */
   readonly maxElements?: number;
 }
 
-/** Optional tighter limits applied while opening untrusted DOCX bytes. */
+/** Resource budgets applied while opening DOCX bytes, subject to engine ceilings. */
 export interface DocumentLimits {
   /** Archive-level caps. */
   readonly zip?: DocumentZipLimits;
@@ -95,10 +98,11 @@ export interface CreateServerOptions {
    */
   readonly modules?: readonly EditorModule[];
   /**
-   * Tighter budgets for the bounded reader — zip ratio, part count, XML depth.
+   * Budgets for the bounded reader — archive size, part count, and XML elements.
    *
-   * Exposed because a server opening documents it did not author is exactly where a caller may
-   * want smaller limits than the defaults. Omitted means the engine's own defaults.
+   * Omitted means the engine defaults. Lower budgets for untrusted input, or raise
+   * `xml.maxElements` for larger documents when the host has sufficient memory.
+   * Engine ceilings still apply.
    */
   readonly limits?: DocumentLimits;
   /**

--- a/packages/editor-api/src/runtime/server.ts
+++ b/packages/editor-api/src/runtime/server.ts
@@ -121,10 +121,30 @@ export interface CreateServerOptions {
   readonly revisionTextView?: RevisionTextView;
 }
 
+/** Invalid caller budgets are argument errors, not document resource refusals. */
+function validateDocumentLimits(limits: DocumentLimits | undefined): void {
+  const counts = [
+    limits?.zip?.maxEntries,
+    limits?.zip?.maxTotalBytes,
+    limits?.xml?.maxBytes,
+    limits?.xml?.maxElements,
+    limits?.maxXmlParts,
+    limits?.maxRelationships,
+  ];
+  const ratio = limits?.zip?.maxRatio;
+  if (
+    counts.some((value) => value !== undefined && (!Number.isInteger(value) || value < 0)) ||
+    (ratio !== undefined && (!Number.isFinite(ratio) || ratio < 0))
+  ) {
+    fail({ code: 'InvalidArgument', target: 'createServer' });
+  }
+}
+
 export async function createServer(
   bytes: Uint8Array,
   options: CreateServerOptions = {}
 ): Promise<DocxEditorServerRuntime> {
+  validateDocumentLimits(options.limits);
   const collaborationModel = collaborationModelOf(options.modules);
   const opened = createServerAutomationHost(bytes, {
     ...(options.limits === undefined ? {} : { limits: options.limits }),

--- a/packages/editor-api/src/runtime/server.ts
+++ b/packages/editor-api/src/runtime/server.ts
@@ -13,17 +13,15 @@ Production use requires a commercial agreement: licensing@eigenpal.com
 // UNTRUSTED BYTES. A `.docx` is a zip of XML an attacker controls end to end, and every one of
 // those defences lives in the core reader this calls: decompression-ratio and size caps, part and
 // relationship path validation, DTD/entity-free XML. This module adds no parsing of its own, and
-// a refusal comes back as `InvalidArgument` rather than as a throw from inside a zip decoder.
-// Nothing about WHY the document was refused is put in the message: a caller opening files they
-// did not author gets "not a document this API can open", and a probe cannot use the error to
-// learn about the reader's limits.
+// malformed input comes back as `InvalidArgument`. Resource refusals use a stable API limit
+// name without forwarding file-controlled details or internal parser messages.
 
 import { createServerAutomationHost } from '@docx-editor.dev/core/automation';
 import type {
   CollaborationModuleContribution,
   EditorCollaborationSession,
 } from '@docx-editor.dev/core/collaboration';
-import { fail } from './errors.ts';
+import { fail, type DocxEditorErrorInit } from './errors.ts';
 import { createRuntime, type DocxEditorServerRuntime, type RevisionTextView } from './runtime.ts';
 
 /**
@@ -81,10 +79,9 @@ export interface DocumentLimits {
  * How `DocxEditor.createServer` opens a document.
  *
  * Opening DOCX bytes is a bounded parse: decompression-ratio and size caps, part and relationship
- * path validation, DTD- and entity-free XML. A refusal comes back as `InvalidArgument` rather
- * than as a throw from inside a zip decoder, and says nothing about WHY — a caller opening files
- * they did not author gets "not a document this API can open", so a probe cannot use the error to
- * learn the reader's limits.
+ * path validation, DTD- and entity-free XML. Malformed input returns `InvalidArgument`.
+ * Resource refusals return `ResourceLimitExceeded`, with `limit` identifying the exceeded cap.
+ * File-controlled details and internal parser messages are never included.
  *
  * The bounded parse is complete when this promise resolves. The runtime does not retain the
  * caller's `Uint8Array`, so the caller may reuse or transfer that input buffer afterward.
@@ -129,7 +126,22 @@ export async function createServer(
     ...(options.limits === undefined ? {} : { limits: options.limits }),
     ...(collaborationModel === undefined ? {} : { collaborationModel }),
   });
-  if (!opened.ok) fail({ code: 'InvalidArgument', target: 'createServer' });
+  if (!opened.ok) {
+    const limits: Partial<Record<typeof opened.reason, DocxEditorErrorInit['limit']>> = {
+      'too-many-entries': 'zip.maxEntries',
+      'too-large': 'xml.maxBytes',
+      'too-many-elements': 'xml.maxElements',
+      'too-deep': 'xml.maxDepth',
+      'too-many-xml-parts': 'maxXmlParts',
+      'too-many-relationships': 'maxRelationships',
+    };
+    const limit = opened.limit ?? limits[opened.reason];
+    fail({
+      code: limit === undefined ? 'InvalidArgument' : 'ResourceLimitExceeded',
+      target: 'createServer',
+      ...(limit === undefined ? {} : { limit }),
+    });
+  }
   return createRuntime({
     host: opened.host,
     save: true,


### PR DESCRIPTION
Open larger DOCX files with `DocxEditor.createServer` and configure resource limits for your deployment.

By default, each XML part has a budget of 10,000,000 elements. Set `limits.xml.maxElements` to lower this budget or raise it to a maximum of 50,000,000. When you configure XML limits, also set `limits.xml.maxBytes`. Each part remains subject to the 64 MiB byte limit and 256-level nesting limit.

Choose limits that fit your deployment's available memory. A document can exceed available memory even when it meets the configured limits. Counts and byte budgets must be finite, nonnegative integers. Compression ratios can be fractional.

If opening a document fails, catch `DocxEditorError` and inspect its `code`:

- `ResourceLimitExceeded`: Inspect `error.limit` to identify the exceeded limit, such as `xml.maxElements` or `zip.maxRatio`.
- `InvalidArgument`: Check the input document and your limit options for invalid values.

Fixes #693
