### PR TITLE
fix: follow-ups from the rendering batch (#733 to #743)

### DIFF
--- a/.changeset/picture-bilevel-color-mode.md
+++ b/.changeset/picture-bilevel-color-mode.md
@@ -1,5 +1,5 @@
 ---
-'@docx-editor.dev/core': minor
+'@docx-editor.dev/core': patch
 ---
 
-Project the optional DrawingML bilevel threshold and paint black/white picture colour mode with a bounded SVG filter. Preserve image alpha and original media, and invalidate retained image paint when the threshold changes or is removed.
+Render the DrawingML bilevel picture color mode.

--- a/.changeset/rendering-batch-followups.md
+++ b/.changeset/rendering-batch-followups.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Justify lines that end in clipped space runs, honor `w:hint="eastAsia"` for punctuation and symbol ranges, repaint connectors when only a path closure or line end changes, read EXIF orientation from the first Exif block only, and let clicks beside a legacy centered PAGE footer frame reach the anchor paragraph.

--- a/.changeset/rendering-batch-followups.md
+++ b/.changeset/rendering-batch-followups.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': patch
 ---
 
-Justify lines that end in clipped space runs, honor `w:hint="eastAsia"` for punctuation and symbol ranges, repaint connectors when only a path closure or line end changes, read EXIF orientation from the first Exif block only, and let clicks beside a legacy centered PAGE footer frame reach the anchor paragraph.
+Improve fidelity for justified lines that end in space runs, punctuation under East Asian font hints, DrawingML connector updates, EXIF-oriented JPEG photos, and clicks beside legacy centered PAGE footer frames.

--- a/.changeset/rendering-batch-followups.md
+++ b/.changeset/rendering-batch-followups.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': patch
 ---
 
-Improve fidelity for justified lines that end in space runs, punctuation under East Asian font hints, DrawingML connector updates, EXIF-oriented JPEG photos, and clicks beside legacy centered PAGE footer frames.
+Improve fidelity for justified lines, East Asian font hints, explicit symbol fonts, drawing and textbox updates, EXIF-oriented JPEG photos, and clicks beside legacy centered PAGE footer frames.

--- a/docs/site/content/guides/images.mdx
+++ b/docs/site/content/guides/images.mdx
@@ -84,8 +84,7 @@ editor.snapshot().image; // reference-stable until selection or image fields mov
 | `inFront`      | Places the picture in front of document content | `wrapNone`, `@behindDoc="0"` |
 
 Images in front of or behind text can paint beyond their anchor cells. Their cell-relative
-position is preserved, but the cell does not crop these overlays. Page-relative images
-are clipped to the physical sheet, including below a shortened continuous-section band.
+position is preserved, but the cell does not crop these overlays.
 
 The `resourceStatus` field reports image availability:
 

--- a/docs/site/content/guides/images.mdx
+++ b/docs/site/content/guides/images.mdx
@@ -84,7 +84,8 @@ editor.snapshot().image; // reference-stable until selection or image fields mov
 | `inFront`      | Places the picture in front of document content | `wrapNone`, `@behindDoc="0"` |
 
 Images in front of or behind text can paint beyond their anchor cells. Their cell-relative
-position is preserved, but the cell does not crop these overlays.
+position is preserved, but the cell does not crop these overlays. Page-relative images are
+clipped to the physical sheet, including its margins.
 
 The `resourceStatus` field reports image availability:
 

--- a/docs/site/content/word-fidelity.mdx
+++ b/docs/site/content/word-fidelity.mdx
@@ -108,6 +108,10 @@ East Asian layout keeps punctuation, graphemes, and full-width number groups
 together across formatting changes. Justified lines distribute inter-character
 spacing through the same geometry used for paint and caret placement.
 
+East Asian font hints select the document's East Asian face for supported punctuation,
+symbols, Greek, and Cyrillic ranges. Combining marks keep the selected slot across text runs.
+Explicit symbol fonts retain their selected face.
+
 Existing document settings control kinsoku, Japanese strict rules, custom
 language-specific break restrictions, Korean character wrapping, punctuation
 overflow, and punctuation or kana compression. Compression uses deterministic

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -493,7 +493,7 @@ export const wordFeatures: WordFeature[] = [
     tier: 'community',
     docsLink: '/docs/2.x/guides/images',
     notes:
-      'Nine wrap modes, exclusion reflow, z-order, and drag and resize in both adapters. In-front and behind-text overlays can paint beyond their anchor cells. Page-relative images clip to the physical sheet rather than a shortened continuous-section band. Both share setImageWrapType and toolbarCommandState.',
+      'Nine wrap modes, exclusion reflow, z-order, and drag and resize in both adapters. In-front and behind-text overlays are not cropped by their anchor cell. Both share setImageWrapType and toolbarCommandState.',
   },
   {
     id: 'images.bmp-webp',

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -227,7 +227,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'Protects graphemes, punctuation, and full-width number groups across run boundaries. Reads kinsoku, wordWrap, overflowPunct, strictFirstAndLastChars, language-specific custom line-break sets, and characterSpacingControl. Korean character wrapping follows wordWrap. Compression uses deterministic punctuation and kana advance reductions; font-specific optical compression and vertical Japanese composition are not modeled. Typography settings have no dedicated UI.',
+      'Protects graphemes, punctuation, and full-width number groups across run boundaries. East Asian font hints cover supported punctuation, symbols, Greek, and Cyrillic ranges while preserving explicit symbol fonts. Reads kinsoku, wordWrap, overflowPunct, strictFirstAndLastChars, language-specific custom line-break sets, and characterSpacingControl. Korean character wrapping follows wordWrap. Compression uses deterministic punctuation and kana advance reductions; font-specific optical compression and vertical Japanese composition are not modeled. Typography settings have no dedicated UI.',
   },
   {
     id: 'paragraphs.spacing',

--- a/packages/core/src/editor/__tests__/browser-image-decode-port.test.ts
+++ b/packages/core/src/editor/__tests__/browser-image-decode-port.test.ts
@@ -30,6 +30,41 @@ test('decode asks createImageBitmap for EXIF-oriented pixels', async () => {
   expect(closed).toBe(1);
 });
 
+test('an engine that rejects the orientation option is retried without it', async () => {
+  const calls: unknown[][] = [];
+  let closed = 0;
+  const port = tryCreateBrowserImageDecodePort(
+    fakeDocument(async (...args) => {
+      calls.push(args);
+      if (args.length > 1) {
+        const error = new Error('not a valid enumeration value');
+        error.name = 'TypeError';
+        throw error;
+      }
+      return { width: 40, height: 20, close: () => (closed += 1) };
+    })
+  )!;
+  const result = await port.decode(Uint8Array.of(0xff, 0xd8, 0xff, 0xd9), 'image/jpeg', LIMITS);
+  expect(result).toEqual({ pixelWidth: 40, pixelHeight: 20, dpiX: 96, dpiY: 96 });
+  expect(calls).toHaveLength(2);
+  expect(calls[1]).toHaveLength(1);
+  expect(closed).toBe(1);
+});
+
+test('a decode failure that is not the option rejection is not retried', async () => {
+  let calls = 0;
+  const port = tryCreateBrowserImageDecodePort(
+    fakeDocument(async () => {
+      calls += 1;
+      throw new Error('The source image could not be decoded.');
+    })
+  )!;
+  await expect(port.decode(Uint8Array.of(0xff, 0xd8), 'image/jpeg', LIMITS)).rejects.toThrow(
+    'could not be decoded'
+  );
+  expect(calls).toBe(1);
+});
+
 test('a bitmap past the pixel cap is refused and still closed', async () => {
   let closed = 0;
   const port = tryCreateBrowserImageDecodePort(

--- a/packages/core/src/editor/__tests__/browser-image-decode-port.test.ts
+++ b/packages/core/src/editor/__tests__/browser-image-decode-port.test.ts
@@ -1,0 +1,44 @@
+// The browser decode port reports the extent `createImageBitmap` produces, and the JPEG
+// header validation reports the extent AFTER EXIF orientation. The two agree only when the
+// bitmap is asked for oriented pixels explicitly, so the option is part of the contract.
+
+import { expect, test } from 'bun:test';
+import { tryCreateBrowserImageDecodePort } from '../browser-image-decode-port.ts';
+import { resolveImageResourceLimits } from '../../store/runtime/limits.ts';
+
+const LIMITS = resolveImageResourceLimits();
+
+function fakeDocument(createImageBitmap?: (...args: unknown[]) => Promise<unknown>): Document {
+  return { defaultView: { createImageBitmap } } as unknown as Document;
+}
+
+test('decode asks createImageBitmap for EXIF-oriented pixels', async () => {
+  const calls: unknown[][] = [];
+  let closed = 0;
+  const port = tryCreateBrowserImageDecodePort(
+    fakeDocument(async (...args) => {
+      calls.push(args);
+      return { width: 20, height: 40, close: () => (closed += 1) };
+    })
+  );
+  expect(port).not.toBeNull();
+  const result = await port!.decode(Uint8Array.of(0xff, 0xd8, 0xff, 0xd9), 'image/jpeg', LIMITS);
+  expect(result).toEqual({ pixelWidth: 20, pixelHeight: 40, dpiX: 96, dpiY: 96 });
+  expect(calls).toHaveLength(1);
+  expect(calls[0]![0]).toBeInstanceOf(Blob);
+  expect(calls[0]![1]).toEqual({ imageOrientation: 'from-image' });
+  expect(closed).toBe(1);
+});
+
+test('a bitmap past the pixel cap is refused and still closed', async () => {
+  let closed = 0;
+  const port = tryCreateBrowserImageDecodePort(
+    fakeDocument(async () => ({ width: 200_000, height: 200_000, close: () => (closed += 1) }))
+  )!;
+  await expect(port.decode(Uint8Array.of(0xff, 0xd8), 'image/jpeg', LIMITS)).rejects.toThrow();
+  expect(closed).toBe(1);
+});
+
+test('a document without createImageBitmap gets no browser port', () => {
+  expect(tryCreateBrowserImageDecodePort(fakeDocument())).toBeNull();
+});

--- a/packages/core/src/editor/__tests__/editor-css-tokens.test.ts
+++ b/packages/core/src/editor/__tests__/editor-css-tokens.test.ts
@@ -137,4 +137,12 @@ describe('editor stylesheet custom properties', () => {
     // ring the caret read as a slab that overlapped neighbouring glyphs.
     expect(rule![1]).toMatch(/width:\s*1\.5px/);
   });
+
+  test('the painted image rule applies EXIF orientation rather than the browser default', () => {
+    // The resource extent is the EXIF-oriented one; a browser that ignores EXIF would
+    // paint a portrait photo sideways inside a portrait frame.
+    const rule = /\.docx-drawing-image\s*\{([^}]*)\}/.exec(withoutComments);
+    expect(rule).not.toBeNull();
+    expect(rule![1]).toMatch(/image-orientation:\s*from-image/);
+  });
 });

--- a/packages/core/src/editor/browser-image-decode-port.ts
+++ b/packages/core/src/editor/browser-image-decode-port.ts
@@ -30,8 +30,16 @@ export function tryCreateBrowserImageDecodePort(ownerDocument: Document): ImageD
     async decode(bytes: Uint8Array, mime: SupportedImageMime, limits: ImageResourceLimits) {
       const blob = new Blob([new Uint8Array(bytes)], { type: mime });
       // `validateJpegHeader` reports the extent AFTER EXIF orientation; the bitmap must be
-      // oriented the same way or the two disagree on portrait photos.
-      const bitmap = await view.createImageBitmap!(blob, { imageOrientation: 'from-image' });
+      // oriented the same way or the two disagree on portrait photos. An engine whose
+      // `ImageOrientation` enum predates `from-image` rejects the dictionary with a
+      // TypeError; there the option-less call already orients from the image, so retry.
+      let bitmap: ImageBitmap;
+      try {
+        bitmap = await view.createImageBitmap!(blob, { imageOrientation: 'from-image' });
+      } catch (error) {
+        if ((error as { name?: unknown } | null)?.name !== 'TypeError') throw error;
+        bitmap = await view.createImageBitmap!(blob);
+      }
       try {
         const pixelWidth = bitmap.width;
         const pixelHeight = bitmap.height;

--- a/packages/core/src/editor/browser-image-decode-port.ts
+++ b/packages/core/src/editor/browser-image-decode-port.ts
@@ -32,7 +32,8 @@ export function tryCreateBrowserImageDecodePort(ownerDocument: Document): ImageD
       // `validateJpegHeader` reports the extent AFTER EXIF orientation; the bitmap must be
       // oriented the same way or the two disagree on portrait photos. An engine whose
       // `ImageOrientation` enum predates `from-image` rejects the dictionary with a
-      // TypeError; there the option-less call already orients from the image, so retry.
+      // TypeError; retry without it and take whatever orientation that engine applies,
+      // which is the same result the port produced before the option existed.
       let bitmap: ImageBitmap;
       try {
         bitmap = await view.createImageBitmap!(blob, { imageOrientation: 'from-image' });

--- a/packages/core/src/editor/browser-image-decode-port.ts
+++ b/packages/core/src/editor/browser-image-decode-port.ts
@@ -29,7 +29,9 @@ export function tryCreateBrowserImageDecodePort(ownerDocument: Document): ImageD
   return Object.freeze({
     async decode(bytes: Uint8Array, mime: SupportedImageMime, limits: ImageResourceLimits) {
       const blob = new Blob([new Uint8Array(bytes)], { type: mime });
-      const bitmap = await view.createImageBitmap!(blob);
+      // `validateJpegHeader` reports the extent AFTER EXIF orientation; the bitmap must be
+      // oriented the same way or the two disagree on portrait photos.
+      const bitmap = await view.createImageBitmap!(blob, { imageOrientation: 'from-image' });
       try {
         const pixelWidth = bitmap.width;
         const pixelHeight = bitmap.height;

--- a/packages/core/src/editor/browser-image-decode-port.ts
+++ b/packages/core/src/editor/browser-image-decode-port.ts
@@ -32,8 +32,8 @@ export function tryCreateBrowserImageDecodePort(ownerDocument: Document): ImageD
       // `validateJpegHeader` reports the extent AFTER EXIF orientation; the bitmap must be
       // oriented the same way or the two disagree on portrait photos. An engine whose
       // `ImageOrientation` enum predates `from-image` rejects the dictionary with a
-      // TypeError; retry without it and take whatever orientation that engine applies,
-      // which is the same result the port produced before the option existed.
+      // TypeError; retry without it to preserve the existing decode path. The resource
+      // layer still rejects a bitmap whose dimensions disagree with the oriented header.
       let bitmap: ImageBitmap;
       try {
         bitmap = await view.createImageBitmap!(blob, { imageOrientation: 'from-image' });

--- a/packages/core/src/layout/__tests__/east-asia-symbol-hint.test.ts
+++ b/packages/core/src/layout/__tests__/east-asia-symbol-hint.test.ts
@@ -1,8 +1,14 @@
 import { expect, test } from 'bun:test';
-import { hasEastAsiaSymbolHint, isEastAsiaHintSymbol } from '../east-asia-symbol-hint.ts';
+import {
+  hasEastAsiaSymbolHint,
+  hasTimesNewRomanEastAsiaException,
+  isEastAsiaHintSymbol,
+} from '../east-asia-symbol-hint.ts';
 import { applyEastAsiaFontSlots, type FieldAwarePiece } from '../field-pieces.ts';
 import { resolveRunStyle } from '../run-style.ts';
-import type { OoxmlProperty } from '@docx-editor.dev/core/store';
+import { eastAsiaRunsOfSegments } from '../script-itemization.ts';
+import { createFixedMeasurer, layoutSemanticDocument, linesOf } from '../index.ts';
+import { readOoxmlPart, type OoxmlProperty } from '@docx-editor.dev/core/store';
 
 const fonts: OoxmlProperty = {
   localName: 'rFonts',
@@ -18,13 +24,76 @@ function piece(text: string, props: OoxmlProperty[] = [fonts], projected = false
     ...(projected ? { projected: true } : {}),
   };
 }
-test('the Latin-1 hint table accepts exactly the unconditional symbols, not accented letters', () => {
-  const expected = [
+test('the hint table accepts exactly the unconditional symbols, not accented letters', () => {
+  const latin1 = [
     0xa1, 0xa4, 0xa7, 0xa8, 0xaa, 0xad, 0xaf, 0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb6, 0xb7, 0xb8, 0xb9,
     0xba, 0xbc, 0xbd, 0xbe, 0xbf, 0xd7, 0xf7,
   ];
-  for (let code = 0; code <= 0x2ff; code++)
-    expect(isEastAsiaHintSymbol(code)).toBe(expected.includes(code));
+  const inTable = (code: number) =>
+    latin1.includes(code) || (code >= 0x2b0 && code <= 0x36f) || (code >= 0x2000 && code <= 0x27bf);
+  for (let code = 0; code <= 0x2fff; code++) expect(isEastAsiaHintSymbol(code)).toBe(inTable(code));
+  // Private use and the Latin presentation forms, up to the first Hebrew ligature.
+  expect(isEastAsiaHintSymbol(0xe000)).toBe(true);
+  expect(isEastAsiaHintSymbol(0xf8ff)).toBe(true);
+  expect(isEastAsiaHintSymbol(0xfb00)).toBe(true);
+  expect(isEastAsiaHintSymbol(0xfb1c)).toBe(true);
+  expect(isEastAsiaHintSymbol(0xfb1d)).toBe(false);
+  expect(isEastAsiaHintSymbol(0xdfff)).toBe(false);
+  expect(isEastAsiaHintSymbol(0xf900)).toBe(false);
+  // CJK radicals are strong East Asian text without any hint, so the table leaves them out.
+  expect(eastAsiaRunsOfSegments(['⺀'], [false])).toEqual([{ segment: 0, from: 0, to: 1 }]);
+});
+test('hinted quotes, dashes and enclosed digits resolve the East Asian slot in layout', () => {
+  const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+  const spansOf = (text: string, hint: string) => {
+    const parsed = readOoxmlPart(
+      `<w:document xmlns:w="${W}"><w:body><w:p><w:r><w:rPr>` +
+        `<w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:eastAsia="SimSun"${hint}/>` +
+        `</w:rPr><w:t>${text}</w:t></w:r></w:p></w:body></w:document>`,
+      { name: '/word/document.xml', contentType: 'app/xml' }
+    );
+    if (!parsed.ok) throw new Error(parsed.reason);
+    const layout = layoutSemanticDocument(parsed.part, 1, { measurer: createFixedMeasurer(6, 14) });
+    return linesOf(layout).flatMap((line) => line.spans);
+  };
+  for (const text of ['“”', '——', '①', '·']) {
+    const hinted = spansOf(text, ' w:hint="eastAsia"');
+    expect(hinted.map((span) => span.text)).toEqual([text]);
+    expect(hinted[0]!.fontSlot).toBe('eastAsia');
+    expect(hinted[0]!.style.fontFamily).toBe('Arial');
+    const unhinted = spansOf(text, '');
+    expect(unhinted[0]!.fontSlot).toBeUndefined();
+  }
+});
+test('the Times New Roman exception needs matching ascii and hAnsi faces', () => {
+  const timesNewRoman = (ascii: string, hAnsi: string): OoxmlProperty[] => [
+    {
+      localName: 'rFonts',
+      attributes: { ascii, hAnsi, eastAsia: 'Times New Roman', hint: 'eastAsia' },
+    },
+  ];
+  const distinct = piece('·', timesNewRoman('Arial', 'Calibri'));
+  expect(applyEastAsiaFontSlots([distinct])[0]!.fontSlot).toBe('eastAsia');
+  const same = piece('·', timesNewRoman('Arial', 'Arial'));
+  expect(applyEastAsiaFontSlots([same])[0]).toBe(same);
+  expect(
+    hasTimesNewRomanEastAsiaException(timesNewRoman('Arial', 'Calibri'), 'Times New Roman')
+  ).toBe(false);
+  expect(
+    hasTimesNewRomanEastAsiaException(timesNewRoman('Arial', 'Arial'), 'Times New Roman')
+  ).toBe(true);
+  // The face compared is the resolved one; a distinct East Asian face never triggers it.
+  expect(hasTimesNewRomanEastAsiaException(timesNewRoman('Arial', 'Arial'), 'SimSun')).toBe(false);
+  // Last specified value wins per attribute across the cascade, like the hint itself.
+  expect(
+    hasTimesNewRomanEastAsiaException(
+      [
+        ...timesNewRoman('Arial', 'Arial'),
+        { localName: 'rFonts', attributes: { hAnsi: 'Calibri' } },
+      ],
+      'Times New Roman'
+    )
+  ).toBe(false);
 });
 test('hinted middle dots keep their East Asian face without changing ASCII or offsets', () => {
   const input = piece('·   · 1×2÷3 20°C'),

--- a/packages/core/src/layout/__tests__/east-asia-symbol-hint.test.ts
+++ b/packages/core/src/layout/__tests__/east-asia-symbol-hint.test.ts
@@ -29,12 +29,27 @@ test('the hint table accepts exactly the unconditional symbols, not accented let
     0xa1, 0xa4, 0xa7, 0xa8, 0xaa, 0xad, 0xaf, 0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb6, 0xb7, 0xb8, 0xb9,
     0xba, 0xbc, 0xbd, 0xbe, 0xbf, 0xd7, 0xf7,
   ];
+  // Combining marks and format characters stay with their base character, so a grapheme
+  // cluster is never split across two faces.
+  const excluded = (code: number) =>
+    (code >= 0x300 && code <= 0x36f) ||
+    (code >= 0x200b && code <= 0x200f) ||
+    (code >= 0x2028 && code <= 0x202f) ||
+    (code >= 0x2060 && code <= 0x206f) ||
+    (code >= 0x20d0 && code <= 0x20ff);
   const inTable = (code: number) =>
-    latin1.includes(code) || (code >= 0x2b0 && code <= 0x36f) || (code >= 0x2000 && code <= 0x27bf);
+    !excluded(code) &&
+    (latin1.includes(code) ||
+      (code >= 0x2b0 && code <= 0x36f) ||
+      (code >= 0x2000 && code <= 0x27bf));
   for (let code = 0; code <= 0x2fff; code++) expect(isEastAsiaHintSymbol(code)).toBe(inTable(code));
-  // Private use and the Latin presentation forms, up to the first Hebrew ligature.
-  expect(isEastAsiaHintSymbol(0xe000)).toBe(true);
-  expect(isEastAsiaHintSymbol(0xf8ff)).toBe(true);
+  expect(isEastAsiaHintSymbol(0x301)).toBe(false);
+  expect(isEastAsiaHintSymbol(0x200d)).toBe(false);
+  // The private use area belongs to symbol fonts, never to the East Asian face.
+  expect(isEastAsiaHintSymbol(0xe000)).toBe(false);
+  expect(isEastAsiaHintSymbol(0xf0fc)).toBe(false);
+  expect(isEastAsiaHintSymbol(0xf8ff)).toBe(false);
+  // Latin presentation forms, up to the first Hebrew ligature.
   expect(isEastAsiaHintSymbol(0xfb00)).toBe(true);
   expect(isEastAsiaHintSymbol(0xfb1c)).toBe(true);
   expect(isEastAsiaHintSymbol(0xfb1d)).toBe(false);
@@ -167,4 +182,50 @@ test('a hint without a distinct East Asian face leaves the original piece untouc
     },
   ]);
   expect(applyEastAsiaFontSlots([fallback])[0]).toBe(fallback);
+});
+test('the Times New Roman exception falls back to ignoring the hint when faces cannot compare', () => {
+  const rFonts = (attributes: Record<string, string>): OoxmlProperty => ({
+    localName: 'rFonts',
+    attributes,
+  });
+  const theme = rFonts({ asciiTheme: 'minorHAnsi', hAnsiTheme: 'minorHAnsi' });
+  const override = rFonts({ hAnsi: 'Calibri', eastAsia: 'Times New Roman', hint: 'eastAsia' });
+  // One theme slot beside one explicit name: Word compares resolved faces, this reader
+  // cannot, so it keeps the exception (hint ignored), which was the behavior before.
+  expect(hasTimesNewRomanEastAsiaException([theme, override], 'Times New Roman')).toBe(true);
+  expect(applyEastAsiaFontSlots([piece('·', [theme, override])])[0]!.fontSlot).toBeUndefined();
+  // Two theme slots compare by slot name; explicit names compare case-insensitively.
+  expect(hasTimesNewRomanEastAsiaException([theme], 'Times New Roman')).toBe(true);
+  expect(
+    hasTimesNewRomanEastAsiaException(
+      [rFonts({ asciiTheme: 'majorHAnsi', hAnsiTheme: 'minorHAnsi' })],
+      'Times New Roman'
+    )
+  ).toBe(false);
+  expect(
+    hasTimesNewRomanEastAsiaException(
+      [rFonts({ ascii: 'arial', hAnsi: 'Arial' })],
+      'Times New Roman'
+    )
+  ).toBe(true);
+  // A face left unspecified cannot be compared either.
+  expect(hasTimesNewRomanEastAsiaException([rFonts({ ascii: 'Arial' })], 'Times New Roman')).toBe(
+    true
+  );
+});
+test('symbol-encoded faces keep their glyphs under the hint', () => {
+  const wingdings = piece('✔', [
+    {
+      localName: 'rFonts',
+      attributes: { ascii: 'Wingdings', hAnsi: 'Wingdings', eastAsia: 'SimSun', hint: 'eastAsia' },
+    },
+  ]);
+  expect(wingdings.style.fontFamily).toBe('Wingdings');
+  expect(applyEastAsiaFontSlots([wingdings])[0]).toBe(wingdings);
+});
+test('combining marks and joiners stay with their base character under the hint', () => {
+  const nfd = piece('cafe\u0301 a\u{1F468}\u200D\u{1F469}b');
+  const out = applyEastAsiaFontSlots([nfd]);
+  expect(out).toHaveLength(1);
+  expect(out[0]).toBe(nfd);
 });

--- a/packages/core/src/layout/__tests__/east-asia-symbol-hint.test.ts
+++ b/packages/core/src/layout/__tests__/east-asia-symbol-hint.test.ts
@@ -190,12 +190,29 @@ test('the Times New Roman exception falls back to ignoring the hint when faces c
   });
   const theme = rFonts({ asciiTheme: 'minorHAnsi', hAnsiTheme: 'minorHAnsi' });
   const override = rFonts({ hAnsi: 'Calibri', eastAsia: 'Times New Roman', hint: 'eastAsia' });
-  // One theme slot beside one explicit name: Word compares resolved faces, this reader
-  // cannot, so it keeps the exception (hint ignored), which was the behavior before.
+  // One theme slot beside one explicit name and no resolver: Word compares resolved faces,
+  // this reader cannot, so it keeps the exception (hint ignored), the behavior before.
   expect(hasTimesNewRomanEastAsiaException([theme, override], 'Times New Roman')).toBe(true);
   expect(applyEastAsiaFontSlots([piece('·', [theme, override])])[0]!.fontSlot).toBeUndefined();
-  // Two theme slots compare by slot name; explicit names compare case-insensitively.
+  // With the document's theme fonts the token resolves and the faces compare as Word does.
+  const calibri = { major: 'Cambria', minor: 'Calibri' };
+  expect(hasTimesNewRomanEastAsiaException([theme, override], 'Times New Roman', calibri)).toBe(
+    true
+  );
+  const arial = rFonts({ ascii: 'Arial', eastAsia: 'Times New Roman', hint: 'eastAsia' });
+  expect(hasTimesNewRomanEastAsiaException([theme, arial], 'Times New Roman', calibri)).toBe(false);
+  expect(applyEastAsiaFontSlots([piece('·', [theme, arial])], calibri)[0]!.fontSlot).toBe(
+    'eastAsia'
+  );
+  // Two theme tokens compare by the face they stand for: the ascii and hAnsi tokens of one
+  // theme face are the same face, and a resolver is not needed to know that.
   expect(hasTimesNewRomanEastAsiaException([theme], 'Times New Roman')).toBe(true);
+  expect(
+    hasTimesNewRomanEastAsiaException(
+      [rFonts({ asciiTheme: 'minorAscii', hAnsiTheme: 'minorHAnsi' })],
+      'Times New Roman'
+    )
+  ).toBe(true);
   expect(
     hasTimesNewRomanEastAsiaException(
       [rFonts({ asciiTheme: 'majorHAnsi', hAnsiTheme: 'minorHAnsi' })],
@@ -212,6 +229,20 @@ test('the Times New Roman exception falls back to ignoring the hint when faces c
   expect(hasTimesNewRomanEastAsiaException([rFonts({ ascii: 'Arial' })], 'Times New Roman')).toBe(
     true
   );
+});
+test('a hinted symbol never lends East Asian strength to an unhinted neighbour', () => {
+  // The trademark sign takes the East Asian face under the hint, but the NBSP and © of the
+  // next, unhinted run stay in their own face: a hinted symbol is not strong text.
+  expect(eastAsiaRunsOfSegments(['Word™', ' © next'], [true, false])).toEqual([
+    { segment: 0, from: 4, to: 5 },
+  ]);
+  expect(eastAsiaRunsOfSegments(['© ', '— x'], [false, true])).toEqual([
+    { segment: 1, from: 0, to: 1 },
+  ]);
+  // Inside one hinted run, a Common character beside a hinted symbol keeps its face too.
+  expect(eastAsiaRunsOfSegments(['·©'], [true])).toEqual([{ segment: 0, from: 0, to: 1 }]);
+  // Real East Asian text still resolves the Common characters around it, as before.
+  expect(eastAsiaRunsOfSegments(['中©'], [false])).toEqual([{ segment: 0, from: 0, to: 2 }]);
 });
 test('symbol-encoded faces keep their glyphs under the hint', () => {
   const wingdings = piece('✔', [

--- a/packages/core/src/layout/__tests__/east-asia-symbol-hint.test.ts
+++ b/packages/core/src/layout/__tests__/east-asia-symbol-hint.test.ts
@@ -7,6 +7,7 @@ import {
 import { applyEastAsiaFontSlots, type FieldAwarePiece } from '../field-pieces.ts';
 import { resolveRunStyle } from '../run-style.ts';
 import { eastAsiaRunsOfSegments } from '../script-itemization.ts';
+import { symbolRunStyle } from '../symbol-run.ts';
 import { createFixedMeasurer, layoutSemanticDocument, linesOf } from '../index.ts';
 import { readOoxmlPart, type OoxmlProperty } from '@docx-editor.dev/core/store';
 
@@ -213,12 +214,17 @@ test('the Times New Roman exception falls back to ignoring the hint when faces c
       'Times New Roman'
     )
   ).toBe(true);
+  // Two different tokens compare only through a resolver; unresolved, the exception stays.
+  const majorMinor = [rFonts({ asciiTheme: 'majorHAnsi', hAnsiTheme: 'minorHAnsi' })];
+  expect(hasTimesNewRomanEastAsiaException(majorMinor, 'Times New Roman')).toBe(true);
+  expect(hasTimesNewRomanEastAsiaException(majorMinor, 'Times New Roman', calibri)).toBe(false);
   expect(
     hasTimesNewRomanEastAsiaException(
-      [rFonts({ asciiTheme: 'majorHAnsi', hAnsiTheme: 'minorHAnsi' })],
-      'Times New Roman'
+      [rFonts({ asciiTheme: 'minorHAnsi', hAnsiTheme: 'minorEastAsia' })],
+      'Times New Roman',
+      calibri
     )
-  ).toBe(false);
+  ).toBe(true);
   expect(
     hasTimesNewRomanEastAsiaException(
       [rFonts({ ascii: 'arial', hAnsi: 'Arial' })],
@@ -243,6 +249,23 @@ test('a hinted symbol never lends East Asian strength to an unhinted neighbour',
   expect(eastAsiaRunsOfSegments(['·©'], [true])).toEqual([{ segment: 0, from: 0, to: 1 }]);
   // Real East Asian text still resolves the Common characters around it, as before.
   expect(eastAsiaRunsOfSegments(['中©'], [false])).toEqual([{ segment: 0, from: 0, to: 2 }]);
+  // Leading Common text resolved by later strong text, with a hinted symbol in between,
+  // still comes back in document order as one merged range.
+  expect(eastAsiaRunsOfSegments(['（—中'], [true])).toEqual([{ segment: 0, from: 0, to: 3 }]);
+  const pieces = applyEastAsiaFontSlots([piece('（—中')]);
+  expect(pieces.map((item) => item.text).join('')).toBe('（—中');
+  expect(pieces.map((item) => [item.start, item.end])).toEqual([[0, 3]]);
+  // A combining mark or variation selector stays on the hinted symbol it decorates.
+  expect(eastAsiaRunsOfSegments(['°́'], [true])).toEqual([{ segment: 0, from: 0, to: 2 }]);
+  expect(eastAsiaRunsOfSegments(['✔️'], [true])).toEqual([{ segment: 0, from: 0, to: 2 }]);
+  expect(applyEastAsiaFontSlots([piece('✔️')]).map((item) => item.text)).toEqual(['✔️']);
+});
+test('a w:sym glyph keeps the font it names under an inherited hint', () => {
+  const glyph = { text: '✓', font: 'Segoe UI Symbol', unicode: true };
+  const { props, style } = symbolRunStyle([fonts], glyph);
+  const sym: FieldAwarePiece = { text: '✓', props, style, start: 0, end: 1 };
+  expect(style.fontFamily).toBe('Segoe UI Symbol');
+  expect(applyEastAsiaFontSlots([sym])[0]).toBe(sym);
 });
 test('symbol-encoded faces keep their glyphs under the hint', () => {
   const wingdings = piece('✔', [

--- a/packages/core/src/layout/__tests__/east-asia-symbol-hint.test.ts
+++ b/packages/core/src/layout/__tests__/east-asia-symbol-hint.test.ts
@@ -42,6 +42,8 @@ test('the hint table accepts exactly the unconditional symbols, not accented let
     !excluded(code) &&
     (latin1.includes(code) ||
       (code >= 0x2b0 && code <= 0x36f) ||
+      (code >= 0x370 && code <= 0x3cf) ||
+      (code >= 0x400 && code <= 0x4ff) ||
       (code >= 0x2000 && code <= 0x27bf));
   for (let code = 0; code <= 0x2fff; code++) expect(isEastAsiaHintSymbol(code)).toBe(inTable(code));
   expect(isEastAsiaHintSymbol(0x301)).toBe(false);
@@ -282,4 +284,79 @@ test('combining marks and joiners stay with their base character under the hint'
   const out = applyEastAsiaFontSlots([nfd]);
   expect(out).toHaveLength(1);
   expect(out[0]).toBe(nfd);
+});
+
+test('hinted symbols retain combining marks across text segments', () => {
+  for (const hints of [
+    [true, true],
+    [true, false],
+  ]) {
+    expect(eastAsiaRunsOfSegments(['°', '\u0301x'], hints)).toEqual([
+      { segment: 0, from: 0, to: 1 },
+      { segment: 1, from: 0, to: 1 },
+    ]);
+  }
+  expect(eastAsiaRunsOfSegments(['✔', '', '\uFE0F', '\u0301© x'], [true])).toEqual([
+    { segment: 0, from: 0, to: 1 },
+    { segment: 2, from: 0, to: 1 },
+    { segment: 3, from: 0, to: 1 },
+  ]);
+  // ASCII terminates the combining sequence, including the fast path for pure ASCII segments.
+  expect(eastAsiaRunsOfSegments(['°', ' ', '\u0301x'], [true])).toEqual([
+    { segment: 0, from: 0, to: 1 },
+  ]);
+});
+test('the Times New Roman exception compares explicit fallback faces for unresolved themes', () => {
+  const props: OoxmlProperty[] = [
+    {
+      localName: 'rFonts',
+      attributes: {
+        asciiTheme: 'minorAscii',
+        ascii: 'Arial',
+        hAnsiTheme: 'minorHAnsi',
+        hAnsi: 'Calibri',
+        eastAsia: 'Times New Roman',
+        hint: 'eastAsia',
+      },
+    },
+  ];
+  expect(resolveRunStyle(props).fontFamily).toBe('Arial');
+  expect(hasTimesNewRomanEastAsiaException(props, 'Times New Roman')).toBe(false);
+  expect(applyEastAsiaFontSlots([piece('°', props)])[0]!.fontSlot).toBe('eastAsia');
+  expect(
+    hasTimesNewRomanEastAsiaException(props, 'Times New Roman', {
+      major: null,
+      minor: null,
+    })
+  ).toBe(false);
+  expect(
+    hasTimesNewRomanEastAsiaException(props, 'Times New Roman', {
+      major: 'Cambria',
+      minor: 'Calibri',
+    })
+  ).toBe(true);
+});
+test('the unconditional Greek and Cyrillic hint ranges use the East Asian face', () => {
+  const text = 'ΑΩαωАЯая';
+  expect(eastAsiaRunsOfSegments([text], [true])).toEqual([
+    { segment: 0, from: 0, to: text.length },
+  ]);
+  expect(eastAsiaRunsOfSegments([text])).toEqual([]);
+  expect(eastAsiaRunsOfSegments(['\u03d0\u0500'], [true])).toEqual([]);
+});
+
+test('hinted strong text retains its base strength around Common characters and Han', () => {
+  for (const strong of ['α', 'я', 'ﬀ', '×']) {
+    expect(eastAsiaRunsOfSegments(['中', strong, '©'], [false, true, false])).toEqual([
+      { segment: 0, from: 0, to: 1 },
+      { segment: 1, from: 0, to: 1 },
+    ]);
+    expect(eastAsiaRunsOfSegments(['©', strong, '中'], [false, true, false])).toEqual([
+      { segment: 1, from: 0, to: 1 },
+      { segment: 2, from: 0, to: 1 },
+    ]);
+    expect(eastAsiaRunsOfSegments(['中' + strong + '\u0301©'], [true])).toEqual([
+      { segment: 0, from: 0, to: 3 },
+    ]);
+  }
 });

--- a/packages/core/src/layout/__tests__/field-symbol-projection.test.ts
+++ b/packages/core/src/layout/__tests__/field-symbol-projection.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, test } from 'bun:test';
 import { readOoxmlPart, type OoxmlNode, type OoxmlPart } from '@docx-editor.dev/core/store';
 import { piecesOfParagraph } from '../field-projection.ts';
+import { styleForFontSlot } from '../script-itemization.ts';
 import type { RevisionDisplayMode } from '../revision-projection.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
@@ -51,6 +52,34 @@ function complexField(instr: string, result = '', chromeRpr = ''): string {
 }
 
 describe('a complex SYMBOL field', () => {
+  test('an explicit font survives neighboring Han while an inherited font follows its slot', () => {
+    const props = '<w:rPr><w:rFonts w:ascii="Arial" w:eastAsia="SimSun"/></w:rPr>';
+    for (const explicit of [false, true]) {
+      const instruction = ` SYMBOL 10003 ${explicit ? '\\f "Segoe UI Symbol" ' : ''}\\u `;
+      for (const leading of [false, true]) {
+        const han = `<w:r>${props}<w:t>中</w:t></w:r>`;
+        const field = complexField(instruction, '', props);
+        const pieces = project(`<w:p>${leading ? field + han : han + field}</w:p>`);
+        const symbol = pieces.find((piece) => piece.text === '✓')!;
+        expect(styleForFontSlot(symbol.style, symbol.fontSlot).fontFamily).toBe(
+          explicit ? 'Segoe UI Symbol' : 'SimSun'
+        );
+      }
+    }
+  });
+
+  test('keeps an explicit Unicode symbol face under an inherited East Asian hint', () => {
+    const props =
+      '<w:rPr><w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:eastAsia="SimSun" w:hint="eastAsia"/></w:rPr>';
+    const pieces = project(
+      `<w:p>${complexField(' SYMBOL 10003 \\f "Segoe UI Symbol" \\u ', '', props)}</w:p>`
+    );
+    expect(pieces).toHaveLength(1);
+    expect(pieces[0]).toMatchObject({ text: '✓', projected: true });
+    expect(pieces[0]!.style.fontFamily).toBe('Segoe UI Symbol');
+    expect(pieces[0]!.fontSlot).toBeUndefined();
+  });
+
   test('paints the mapped glyph over one atom unit with the \\f family', () => {
     const pieces = project(
       '<w:p><w:r><w:t>A</w:t></w:r>' +

--- a/packages/core/src/layout/__tests__/floating-image-clipping.test.ts
+++ b/packages/core/src/layout/__tests__/floating-image-clipping.test.ts
@@ -62,7 +62,7 @@ test('square wrapping retains cell clipping', () => {
 });
 
 test('layoutInCell=false still permits overflow', () => {
-  const drawing = inCell('<wp:wrapNone/>', false, false);
+  const drawing = inCell('<wp:wrapSquare wrapText="bothSides"/>', false, false);
   expect(drawing.layoutInCell).toBe(false);
   expect(drawing.paintBounds.width).toBeCloseTo(drawing.width, 4);
 });

--- a/packages/core/src/layout/__tests__/inline-drawing-source.test.ts
+++ b/packages/core/src/layout/__tests__/inline-drawing-source.test.ts
@@ -510,3 +510,141 @@ test('a theme-part swap refuses the slot even though the document part is identi
 
   expect(fill()).toBe('79C9B1');
 });
+
+// Tree edits retain the package resource substrate. The slot must still replace projections
+// when drawing spacing, textbox properties, or hosted text changes.
+describe('drawing slot invalidation after tree edits', () => {
+  const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+  const WPS = 'http://schemas.microsoft.com/office/word/2010/wordprocessingShape';
+  const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+  const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+  const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+  const owner = '/word/document.xml';
+
+  for (const edit of [
+    'distance',
+    'inset',
+    'anchor',
+    'text',
+    'title',
+    'lock',
+    'brightness',
+    'fill',
+    'diagnostic',
+  ] as const) {
+    test(`refreshes the retained projection after a ${edit} edit`, () => {
+      const isPicture = edit === 'brightness' || edit === 'fill';
+      const hasTextbox = !isPicture && edit !== 'diagnostic';
+      const graphic =
+        edit === 'diagnostic'
+          ? '<a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart"><c:chart xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"/></a:graphicData></a:graphic>'
+          : isPicture
+            ? `<a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture"><pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">` +
+              '<pic:nvPicPr><pic:cNvPr id="1" name="picture"/><pic:cNvPicPr/></pic:nvPicPr>' +
+              `<pic:blipFill><a:blip xmlns:r="${R}" r:embed="rIdImage"><a:lum bright="0" contrast="0"/></a:blip><a:stretch/></pic:blipFill>` +
+              '<pic:spPr/></pic:pic></a:graphicData></a:graphic>'
+            : `<a:graphic><a:graphicData uri="${WPS}"><wps:wsp><wps:spPr>` +
+              '<a:xfrm><a:off x="0" y="0"/><a:ext cx="1270000" cy="635000"/></a:xfrm>' +
+              '<a:prstGeom prst="rect"/><a:noFill/></wps:spPr>' +
+              '<wps:txbx><w:txbxContent><w:p><w:r><w:t>Before</w:t></w:r></w:p></w:txbxContent></wps:txbx>' +
+              '<wps:bodyPr lIns="91440" anchor="t"/></wps:wsp></a:graphicData></a:graphic>';
+      const loaded = readOoxmlPackage(
+        zipSync({
+          '[Content_Types].xml': strToU8(
+            `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+              `<Override PartName="${owner}" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>`
+          ),
+          '_rels/.rels': strToU8(
+            `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
+          ),
+          'word/document.xml': strToU8(
+            `<w:document xmlns:w="${W}" xmlns:wp="${WP}" xmlns:a="${A}" xmlns:wps="${WPS}"><w:body><w:p><w:r><w:drawing>` +
+              '<wp:inline distL="0"><wp:extent cx="1270000" cy="635000"/><wp:docPr id="1" name="box" title="Before"/>' +
+              '<wp:cNvGraphicFramePr><a:graphicFrameLocks noResize="0"/></wp:cNvGraphicFramePr>' +
+              graphic +
+              '</wp:inline></w:drawing></w:r></w:p></w:body></w:document>'
+          ),
+        })
+      );
+      if (!loaded.ok) throw new Error(loaded.reason);
+      let pkg = loaded.package;
+      let revision = 0;
+      const session = {
+        packageRevision: () => revision,
+        currentPackage: () => pkg,
+        part: () => pkg.parts.get(owner)!,
+      };
+      const resourceLookup: ImageResourceLookup = {
+        resolveEmbedded: async () => ({ kind: 'missing' }),
+        resolveLinked: () => ({ kind: 'missing' }),
+        resolveForProjection: async () => ({ kind: 'missing' }),
+        liveReferenceCount: () => 0,
+        dispose: () => {},
+      };
+      const bundle = createInlineDrawingLayoutBundle({
+        session,
+        decodePort: {
+          decode: async () => {
+            throw new Error('unused');
+          },
+        },
+        resourceLookup,
+        onResourcesChanged: () => {},
+      });
+      const atomId = [...drawingAtomIdentities(session.part())!.keys()][0]!;
+      const before = bundle.bodyContext.projectionForAtom!(atomId)!;
+      if (hasTextbox) expect(before.textboxStory).not.toBeNull();
+      const beforeToken = drawingProjectionLayoutToken(before);
+      const change = (node: OoxmlNode): OoxmlNode => {
+        if (node.kind === 'textValue') {
+          return edit === 'text' && node.value === 'Before' ? { ...node, value: 'After' } : node;
+        }
+        if (edit === 'diagnostic' && node.localName === 'graphic')
+          return { ...node, kind: 'generic', localName: 'unsupportedGraphic' } as OoxmlNode;
+        if (edit === 'fill' && node.localName === 'stretch')
+          return { ...node, kind: 'pictureTile', localName: 'tile' } as OoxmlNode;
+        const attributes = node.attributes.map((attr) => {
+          const value =
+            edit === 'distance' && node.localName === 'inline' && attr.localName === 'distL'
+              ? '127000'
+              : edit === 'inset' && node.localName === 'bodyPr' && attr.localName === 'lIns'
+                ? '127000'
+                : edit === 'anchor' && node.localName === 'bodyPr' && attr.localName === 'anchor'
+                  ? 'b'
+                  : edit === 'title' && node.localName === 'docPr' && attr.localName === 'title'
+                    ? 'After'
+                    : edit === 'lock' &&
+                        node.localName === 'graphicFrameLocks' &&
+                        attr.localName === 'noResize'
+                      ? '1'
+                      : edit === 'brightness' &&
+                          node.localName === 'lum' &&
+                          attr.localName === 'bright'
+                        ? '50000'
+                        : attr.value;
+          return value === attr.value ? attr : { ...attr, value };
+        });
+        const children = node.children.map(change);
+        if (
+          attributes.every((attr, index) => attr === node.attributes[index]) &&
+          children.every((child, index) => child === node.children[index])
+        )
+          return node;
+        return { ...node, attributes, children } as OoxmlNode;
+      };
+      const part = session.part();
+      const nextPart = { ...part, root: change(part.root) as typeof part.root };
+      pkg = { ...pkg, parts: new Map(pkg.parts).set(owner, nextPart) };
+      revision += 1;
+      bundle.sync(session);
+      const after = bundle.bodyContext.projectionForAtom!(atomId)!;
+      const expected = indexInlineDrawingProjectionsInPart(nextPart).get(atomId)!;
+      expect(after).toEqual(expected);
+      expect(drawingProjectionLayoutToken(after)).not.toBe(beforeToken);
+      // Property edits preserve the content root; their own token fields must invalidate.
+      if (edit !== 'text' && hasTextbox)
+        expect(after.textboxStory!.content).toBe(before.textboxStory!.content);
+      bundle.dispose();
+    });
+  }
+});

--- a/packages/core/src/layout/__tests__/inline-drawing-source.test.ts
+++ b/packages/core/src/layout/__tests__/inline-drawing-source.test.ts
@@ -6,6 +6,7 @@ import {
   type OoxmlNode,
 } from '@docx-editor.dev/core/store';
 import { zipSync, strToU8 } from 'fflate';
+import { indexInlineDrawingProjectionsInPart } from '../../store/package/drawing-projection.ts';
 import {
   createInlineDrawingLayoutBundle,
   drawingAtomIdentities,
@@ -255,16 +256,21 @@ describe('vector shape layout token', () => {
       readonly extraComponent: boolean;
       readonly splitSubpaths: boolean;
       readonly splitAt: number;
+      readonly open: boolean;
+      readonly arrowheads: readonly (readonly Readonly<{ x: number; y: number }>[])[];
     }> = {}
   ) => {
     const points = overrides.points ?? [point(0, 0), point(100, 0), point(100, 50.5)];
+    const subpathsEmu =
+      overrides.splitAt !== undefined
+        ? [points.slice(0, overrides.splitAt), points.slice(overrides.splitAt)]
+        : overrides.splitSubpaths
+          ? [points.slice(0, 1), points.slice(1)]
+          : [points];
     const component = {
-      subpathsEmu:
-        overrides.splitAt !== undefined
-          ? [points.slice(0, overrides.splitAt), points.slice(overrides.splitAt)]
-          : overrides.splitSubpaths
-            ? [points.slice(0, 1), points.slice(1)]
-            : [points],
+      subpathsEmu,
+      ...(overrides.open ? { subpathsClosed: subpathsEmu.map(() => false) } : {}),
+      ...(overrides.arrowheads ? { arrowheadsEmu: overrides.arrowheads } : {}),
       fillHex: overrides.fillHex === undefined ? '4472C4' : overrides.fillHex,
       fillAlpha: overrides.fillAlpha ?? 1,
       strokeHex: overrides.strokeHex ?? null,
@@ -313,12 +319,65 @@ describe('vector shape layout token', () => {
       'a stroke width': shape({ strokeWidthEmu: 12_700 }),
       'a different extent': shape({ cx: 1001 }),
       'a second component': shape({ extraComponent: true }),
+      'an open subpath': shape({ open: true }),
+      'a line-end triangle': shape({ arrowheads: [[point(0, 0), point(5, 5), point(-5, 5)]] }),
     };
     for (const [label, changed] of Object.entries(differences)) {
       expect(`${label} collides: ${vectorShapeLayoutToken(changed) === baseline}`).toBe(
         `${label} collides: false`
       );
     }
+  });
+
+  test('line-end triangles separate by count and by vertex', () => {
+    const one = shape({ arrowheads: [[point(0, 0), point(5, 5), point(-5, 5)]] });
+    const moved = shape({ arrowheads: [[point(0, 0), point(5, 5), point(-5, 5.5)]] });
+    const two = shape({
+      arrowheads: [
+        [point(0, 0), point(5, 5), point(-5, 5)],
+        [point(100, 50.5), point(95, 45), point(105, 45)],
+      ],
+    });
+    expect(vectorShapeLayoutToken(one)).toBe(vectorShapeLayoutToken(one));
+    expect(vectorShapeLayoutToken(moved)).not.toBe(vectorShapeLayoutToken(one));
+    expect(vectorShapeLayoutToken(two)).not.toBe(vectorShapeLayoutToken(one));
+  });
+
+  // Projected from markup rather than hand-built: `a:close` and `a:tailEnd` move no vertex
+  // of the authored path, so only the close flags and the generated triangle can tell the
+  // shapes apart. A token blind to either reuses a stale record across the edit.
+  test('projections that differ only by a close command or a line end differ', () => {
+    const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+    const WPS = 'http://schemas.microsoft.com/office/word/2010/wordprocessingShape';
+    const project = (options: { close?: boolean; tailEnd?: boolean }) => {
+      const xml =
+        `<w:document xmlns:w="${W}" xmlns:wp="${WP}" xmlns:a="${A}" xmlns:wps="${WPS}"><w:body><w:p><w:r>` +
+        '<w:drawing><wp:inline><wp:extent cx="1270000" cy="635000"/><wp:docPr id="1" name="c"/>' +
+        `<a:graphic><a:graphicData uri="${WPS}"><wps:wsp><wps:spPr>` +
+        '<a:xfrm><a:off x="0" y="0"/><a:ext cx="1270000" cy="635000"/></a:xfrm>' +
+        '<a:custGeom><a:pathLst><a:path w="1000" h="1000"><a:moveTo><a:pt x="0" y="0"/></a:moveTo>' +
+        '<a:lnTo><a:pt x="1000" y="1000"/></a:lnTo><a:lnTo><a:pt x="0" y="1000"/></a:lnTo>' +
+        `${options.close ? '<a:close/>' : ''}</a:path></a:pathLst></a:custGeom>` +
+        '<a:noFill/><a:ln w="12700"><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill>' +
+        `${options.tailEnd ? '<a:tailEnd type="triangle"/>' : ''}</a:ln>` +
+        '</wps:spPr></wps:wsp></a:graphicData></a:graphic></wp:inline></w:drawing>' +
+        '</w:r></w:p></w:body></w:document>';
+      const parsed = readOoxmlPart(xml, { name: '/word/document.xml', contentType: 'app/xml' });
+      if (!parsed.ok) throw new Error(parsed.reason);
+      const projections = [...indexInlineDrawingProjectionsInPart(parsed.part).values()];
+      expect(projections).toHaveLength(1);
+      const vector = projections[0]!.vectorShape;
+      if (!vector) throw new Error('expected a vector shape projection');
+      return vector;
+    };
+    const open = project({});
+    const closed = project({ close: true });
+    const arrow = project({ tailEnd: true });
+    expect(closed.components[0]!.subpathsEmu).toEqual(open.components[0]!.subpathsEmu);
+    expect(arrow.components[0]!.subpathsEmu).toEqual(open.components[0]!.subpathsEmu);
+    expect(vectorShapeLayoutToken(project({}))).toBe(vectorShapeLayoutToken(open));
+    expect(vectorShapeLayoutToken(closed)).not.toBe(vectorShapeLayoutToken(open));
+    expect(vectorShapeLayoutToken(arrow)).not.toBe(vectorShapeLayoutToken(open));
   });
 
   test('the token stays small for a shape at the point budget', () => {

--- a/packages/core/src/layout/__tests__/inline-drawing-source.test.ts
+++ b/packages/core/src/layout/__tests__/inline-drawing-source.test.ts
@@ -12,6 +12,7 @@ import {
   drawingAtomIdentities,
   drawingTokenForTableBlock,
   drawingTokenForTableBlockMemo,
+  drawingProjectionLayoutToken,
   vectorShapeLayoutToken,
 } from '../inline-drawing-source.ts';
 
@@ -378,6 +379,35 @@ describe('vector shape layout token', () => {
     expect(vectorShapeLayoutToken(project({}))).toBe(vectorShapeLayoutToken(open));
     expect(vectorShapeLayoutToken(closed)).not.toBe(vectorShapeLayoutToken(open));
     expect(vectorShapeLayoutToken(arrow)).not.toBe(vectorShapeLayoutToken(open));
+  });
+
+  test('a moved wrap polygon vertex or a flipped anchor flag separates the drawing token', () => {
+    const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+    const PIC = 'http://schemas.openxmlformats.org/drawingml/2006/picture';
+    const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+    const project = (options: { vertexX?: number; allowOverlap?: boolean; behind?: boolean }) => {
+      const xml =
+        `<w:document xmlns:w="${W}" xmlns:wp="${WP}" xmlns:a="${A}" xmlns:pic="${PIC}" xmlns:r="${R}"><w:body><w:p><w:r><w:drawing>` +
+        `<wp:anchor simplePos="0" behindDoc="${options.behind ? 1 : 0}" layoutInCell="1" allowOverlap="${options.allowOverlap === false ? 0 : 1}" locked="0" relativeHeight="1">` +
+        '<wp:simplePos x="0" y="0"/><wp:positionH relativeFrom="column"><wp:posOffset>0</wp:posOffset></wp:positionH>' +
+        '<wp:positionV relativeFrom="paragraph"><wp:posOffset>0</wp:posOffset></wp:positionV>' +
+        '<wp:extent cx="1270000" cy="635000"/><wp:wrapTight wrapText="bothSides"><wp:wrapPolygon edited="0">' +
+        `<wp:start x="0" y="0"/><wp:lineTo x="${options.vertexX ?? 21600}" y="0"/><wp:lineTo x="21600" y="21600"/><wp:lineTo x="0" y="21600"/><wp:lineTo x="0" y="0"/>` +
+        '</wp:wrapPolygon></wp:wrapTight><wp:docPr id="1" name="p"/>' +
+        `<a:graphic><a:graphicData uri="${PIC}"><pic:pic><pic:nvPicPr><pic:cNvPr id="1" name="p"/><pic:cNvPicPr/></pic:nvPicPr>` +
+        '<pic:blipFill><a:blip r:embed="rId9"/></pic:blipFill><pic:spPr/></pic:pic></a:graphicData></a:graphic>' +
+        '</wp:anchor></w:drawing></w:r></w:p></w:body></w:document>';
+      const parsed = readOoxmlPart(xml, { name: '/word/document.xml', contentType: 'app/xml' });
+      if (!parsed.ok) throw new Error(parsed.reason);
+      const projections = [...indexInlineDrawingProjectionsInPart(parsed.part).values()];
+      expect(projections).toHaveLength(1);
+      return projections[0]!;
+    };
+    const base = drawingProjectionLayoutToken(project({}));
+    expect(drawingProjectionLayoutToken(project({}))).toBe(base);
+    expect(drawingProjectionLayoutToken(project({ vertexX: 10000 }))).not.toBe(base);
+    expect(drawingProjectionLayoutToken(project({ allowOverlap: false }))).not.toBe(base);
+    expect(drawingProjectionLayoutToken(project({ behind: true }))).not.toBe(base);
   });
 
   test('the token stays small for a shape at the point budget', () => {

--- a/packages/core/src/layout/__tests__/legacy-footer-fixed-frame.test.ts
+++ b/packages/core/src/layout/__tests__/legacy-footer-fixed-frame.test.ts
@@ -146,17 +146,20 @@ test('supports fully contained fields and independent valid anchor decoration', 
 
 test('accepts the switches Word writes after PAGE in a fixed frame', () => {
   const plain = paragraphs(layout())[0]!;
-  for (const instruction of [
-    ' PAGE \\* MERGEFORMAT ',
-    'PAGE \\* roman \\* MERGEFORMAT',
-    ' page ',
-  ]) {
+  for (const instruction of [' PAGE \\* MERGEFORMAT ', ' PAGE \\# "0" ', ' page ']) {
     const [framed, anchor] = paragraphs(layout(body.replaceAll(' PAGE ', instruction)));
     expect(framed!.clipToBox).toBe(true);
     expect(framed!.box).toEqual(plain.box);
     expect(anchor!.box.y).toBe(0);
   }
-  for (const instruction of [' PAGEREF anchor ', ' PAGE \\# "0" ', ' PAGE MERGEFORMAT ']) {
+  // Switches the page-field projection does not evaluate stay in ordinary flow with their
+  // cached text: the frame lane must never claim a field whose value it cannot refresh.
+  for (const instruction of [
+    ' PAGEREF anchor ',
+    'PAGE \\* roman \\* MERGEFORMAT',
+    ' PAGE \\* Arabic ',
+    ' PAGE MERGEFORMAT ',
+  ]) {
     expect(
       paragraphs(layout(body.replaceAll(' PAGE ', instruction)))[0]!.clipToBox
     ).toBeUndefined();

--- a/packages/core/src/layout/__tests__/legacy-footer-fixed-frame.test.ts
+++ b/packages/core/src/layout/__tests__/legacy-footer-fixed-frame.test.ts
@@ -144,6 +144,25 @@ test('supports fully contained fields and independent valid anchor decoration', 
   expect(paragraphs(layout(differentDecoration))[0]!.clipToBox).toBe(true);
 });
 
+test('accepts the switches Word writes after PAGE in a fixed frame', () => {
+  const plain = paragraphs(layout())[0]!;
+  for (const instruction of [
+    ' PAGE \\* MERGEFORMAT ',
+    'PAGE \\* roman \\* MERGEFORMAT',
+    ' page ',
+  ]) {
+    const [framed, anchor] = paragraphs(layout(body.replaceAll(' PAGE ', instruction)));
+    expect(framed!.clipToBox).toBe(true);
+    expect(framed!.box).toEqual(plain.box);
+    expect(anchor!.box.y).toBe(0);
+  }
+  for (const instruction of [' PAGEREF anchor ', ' PAGE \\# "0" ', ' PAGE MERGEFORMAT ']) {
+    expect(
+      paragraphs(layout(body.replaceAll(' PAGE ', instruction)))[0]!.clipToBox
+    ).toBeUndefined();
+  }
+});
+
 test('an empty anchor retains its line and clips the fixed frame without deleting its PAGE field', () => {
   const split = body.indexOf('</w:p>') + 6;
   const empty = body.slice(0, split) + body.slice(split).replace(decorated, '');

--- a/packages/core/src/layout/__tests__/legacy-footer-page-frame.test.ts
+++ b/packages/core/src/layout/__tests__/legacy-footer-page-frame.test.ts
@@ -153,11 +153,7 @@ test('does not overlay meaningful, left-aligned or field-bearing anchor content'
 
 test('accepts the switches Word writes after PAGE without moving the frame', () => {
   const plain = layoutHeaderFooterStory(partOf(), 400, measurer, 'plain');
-  for (const instruction of [
-    ' PAGE \\* MERGEFORMAT ',
-    'PAGE \\* roman \\* MERGEFORMAT',
-    ' page ',
-  ]) {
+  for (const instruction of [' PAGE \\* MERGEFORMAT ', ' PAGE \\# "0" ', ' page ']) {
     const story = layoutHeaderFooterStory(
       partOf(body.replace(' PAGE ', instruction)),
       400,
@@ -171,6 +167,33 @@ test('accepts the switches Word writes after PAGE without moving the frame', () 
     expect(first.box).toEqual(plain.fragments[0]!.box);
     expect(second.box.y).toBe(0);
     expect(story.flowHeight).toBeCloseTo(plain.flowHeight, 4);
+  }
+});
+
+test('an instruction split across instrText runs still takes the frame lane', () => {
+  const split = body.replace(
+    '<w:instrText xml:space="preserve"> PAGE </w:instrText></w:r>',
+    '<w:instrText xml:space="preserve"> PAGE </w:instrText></w:r><w:r><w:instrText>\\* MERGEFORMAT</w:instrText></w:r>'
+  );
+  expect(split).not.toBe(body);
+  const [first, second] = layoutHeaderFooterStory(partOf(split), 400, measurer, 'split').fragments;
+  if (first?.kind !== 'paragraph' || second?.kind !== 'paragraph')
+    throw new Error('paragraphs required');
+  expect(first.alignment).toBe('center');
+  expect(second.box.y).toBe(0);
+});
+
+test('switches the page-field projection does not evaluate stay in ordinary flow', () => {
+  // The lane must never claim a field whose value the page context will not refresh; the
+  // cached text would then repeat on every page.
+  for (const instruction of ['PAGE \\* roman \\* MERGEFORMAT', ' PAGE \\* Arabic ']) {
+    const story = layoutHeaderFooterStory(
+      partOf(body.replace(' PAGE ', instruction)),
+      400,
+      measurer,
+      'unevaluated'
+    );
+    expect(story.fragments[1]!.box.y).toBeGreaterThan(0);
   }
 });
 

--- a/packages/core/src/layout/__tests__/legacy-footer-page-frame.test.ts
+++ b/packages/core/src/layout/__tests__/legacy-footer-page-frame.test.ts
@@ -6,6 +6,8 @@ import {
 } from '../../store/package/ooxml-tree.ts';
 import { createFixedMeasurer } from '../fixed-measurer.ts';
 import { layoutHeaderFooterStory } from '../hf-layout.ts';
+import { hitTestFragments } from '../semantic-hit-test.ts';
+import type { SemanticLayout } from '../semantic-records.ts';
 
 const frame =
   '<w:framePr w:wrap="around" w:vAnchor="text" w:hAnchor="margin" w:xAlign="center" w:y="1"/>';
@@ -23,6 +25,28 @@ function partOf(content = body, header = false) {
   });
   if (!parsed.ok) throw new Error(parsed.reason);
   return parsed.part;
+}
+
+function documentOf(story: ReturnType<typeof layoutHeaderFooterStory>): SemanticLayout {
+  return {
+    revision: 0,
+    pages: [
+      {
+        index: 0,
+        box: { x: 0, y: 0, width: 544, height: 792 },
+        contentBox: { x: 72, y: 72, width: 400, height: 648 },
+        fragments: [],
+        footer: {
+          kind: 'footer',
+          variant: 'default',
+          partName: story.partName,
+          part: story.part,
+          box: { x: 72, y: 730, width: 400, height: story.flowHeight },
+          fragments: story.fragments,
+        },
+      },
+    ],
+  } as SemanticLayout;
 }
 
 test('centers the legacy PAGE frame without charging its empty anchor paragraph twice', () => {
@@ -67,6 +91,7 @@ test('leaves other frame structures in ordinary flow', () => {
     body.replace('w:y="1"', 'w:y="200"'),
     body.replace('w:y="1"', 'w:y="1" w:w="200"'),
     body.replace(' PAGE ', ' NUMPAGES '),
+    body.replace(' PAGE ', ' PAGEREF anchor '),
     body.replace('</w:pPr></w:p>', '</w:pPr><w:r><w:t>not empty</w:t></w:r></w:p>'),
     body.replace('<w:t>1</w:t>', '<w:t>Page 1</w:t>'),
     body.replace(frame, frame + '<w:spacing w:after="200"/>'),
@@ -124,4 +149,68 @@ test('does not overlay meaningful, left-aligned or field-bearing anchor content'
   expect(
     layoutHeaderFooterStory(partOf(fieldAnchor), 400, measurer, 'field-anchor').fragments[1]!.box.y
   ).toBeGreaterThan(0);
+});
+
+test('accepts the switches Word writes after PAGE without moving the frame', () => {
+  const plain = layoutHeaderFooterStory(partOf(), 400, measurer, 'plain');
+  for (const instruction of [
+    ' PAGE \\* MERGEFORMAT ',
+    'PAGE \\* roman \\* MERGEFORMAT',
+    ' page ',
+  ]) {
+    const story = layoutHeaderFooterStory(
+      partOf(body.replace(' PAGE ', instruction)),
+      400,
+      measurer,
+      'switch'
+    );
+    const [first, second] = story.fragments;
+    if (first?.kind !== 'paragraph' || second?.kind !== 'paragraph')
+      throw new Error('paragraphs required');
+    expect(first.alignment).toBe('center');
+    expect(first.box).toEqual(plain.fragments[0]!.box);
+    expect(second.box.y).toBe(0);
+    expect(story.flowHeight).toBeCloseTo(plain.flowHeight, 4);
+  }
+});
+
+test('the frame box is its ink, so clicks beside it reach the anchor paragraph', () => {
+  const story = layoutHeaderFooterStory(partOf(), 400, measurer, 'hit');
+  for (const pageNumber of [1, 123]) {
+    const projected = story.withPageContext({ pageNumber, pageCount: 200, sectionPageCount: 200 });
+    const [framed, anchor] = projected.fragments;
+    if (framed?.kind !== 'paragraph' || anchor?.kind !== 'paragraph')
+      throw new Error('paragraphs required');
+    const spans = framed.lines[0]!.spans;
+    const ink = spans.reduce((sum, span) => sum + span.box.width, 0);
+    expect(framed.box.width).toBeCloseTo(ink, 4);
+    expect(framed.box.x).toBeCloseTo(spans[0]!.box.x, 4);
+    expect(framed.box.x + framed.box.width / 2).toBeCloseTo(200, 4);
+    expect(anchor.box).toMatchObject({ x: 0, width: 400 });
+    const model = documentOf(projected);
+    const inside = hitTestFragments(model, 0, projected.fragments, { x: 200, y: 3 });
+    expect(inside?.position.paragraphId).toBe(framed.paragraphId);
+    for (const x of [20, framed.box.x - 1, framed.box.x + framed.box.width + 1, 380]) {
+      const beside = hitTestFragments(model, 0, projected.fragments, { x, y: 3 });
+      expect(beside?.position.paragraphId).toBe(anchor.paragraphId);
+    }
+  }
+});
+
+test('clicks on the middle-dot decoration reach the anchor paragraph', () => {
+  const decorated = body.replace(
+    '</w:pPr></w:p>',
+    '<w:jc w:val="center"/></w:pPr><w:r><w:t xml:space="preserve">·   ·</w:t></w:r></w:p>'
+  );
+  const story = layoutHeaderFooterStory(partOf(decorated), 400, measurer, 'dots');
+  const [framed, anchor] = story.fragments;
+  if (framed?.kind !== 'paragraph' || anchor?.kind !== 'paragraph')
+    throw new Error('paragraphs required');
+  const dot = anchor.lines[0]!.spans[0]!;
+  expect(dot.box.x).toBeLessThan(framed.box.x);
+  const model = documentOf(story);
+  const onDot = hitTestFragments(model, 0, story.fragments, { x: dot.box.x + 1, y: 3 });
+  expect(onDot?.position).toEqual({ paragraphId: anchor.paragraphId, offset: 0 });
+  const onPage = hitTestFragments(model, 0, story.fragments, { x: 200, y: 3 });
+  expect(onPage?.position.paragraphId).toBe(framed.paragraphId);
 });

--- a/packages/core/src/layout/__tests__/symbol-run-projection.test.ts
+++ b/packages/core/src/layout/__tests__/symbol-run-projection.test.ts
@@ -15,6 +15,7 @@ import {
 } from '@docx-editor.dev/core/store';
 import { piecesOfParagraph } from '../field-projection.ts';
 import { symbolGlyphOf } from '../symbol-run.ts';
+import { styleForFontSlot } from '../script-itemization.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
@@ -85,6 +86,23 @@ describe('a w:sym between two text nodes', () => {
 });
 
 describe('symbol-font encodings', () => {
+  test('an explicit font survives neighboring Han while an inherited font follows its slot', () => {
+    const props = '<w:rPr><w:rFonts w:ascii="Arial" w:eastAsia="SimSun"/></w:rPr>';
+    for (const explicit of [false, true]) {
+      const glyph = `<w:sym ${explicit ? 'w:font="Segoe UI Symbol" ' : ''}w:char="2713"/>`;
+      for (const leading of [false, true]) {
+        const han = '<w:t>中</w:t>';
+        const pieces = project(
+          `<w:p><w:r>${props}${leading ? glyph + han : han + glyph}</w:r></w:p>`
+        );
+        const symbol = pieces.find((piece) => piece.text === '✓')!;
+        expect(styleForFontSlot(symbol.style, symbol.fontSlot).fontFamily).toBe(
+          explicit ? 'Segoe UI Symbol' : 'SimSun'
+        );
+      }
+    }
+  });
+
   test('a bare byte on a symbol font maps like its 0xF000-page twin', () => {
     // Word accepts both `w:char="F046"` and `w:char="46"` for the same Wingdings glyph.
     const bare = project('<w:p><w:r><w:sym w:font="Wingdings" w:char="6C"/></w:r></w:p>');

--- a/packages/core/src/layout/__tests__/wrapped-space-run.test.ts
+++ b/packages/core/src/layout/__tests__/wrapped-space-run.test.ts
@@ -1,21 +1,69 @@
 import { describe, expect, test } from 'bun:test';
 import { readOoxmlPart, serializeOoxmlPart } from '@docx-editor.dev/core/store';
+import {
+  DEFAULT_DRAWING_PROJECTION_LIMITS,
+  indexInlineDrawingProjectionsInPart,
+  projectDrawing,
+} from '../../store/package/drawing-projection.ts';
+import type { ImageResourceState } from '../../store/package/image-resources.ts';
+import type { InlineDrawingLayoutContext } from '../drawing-layout.ts';
 import { createFixedMeasurer, layoutSemanticDocument, linesOf } from '../index.ts';
 import { spanOffsetX } from '../semantic-hit-test.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
+const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+const PIC = 'http://schemas.openxmlformats.org/drawingml/2006/picture';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const OWNER = '/word/document.xml';
 const run = (text: string, bold = false) =>
   `<w:r><w:rPr><w:sz w:val="22"/>${bold ? '<w:b/>' : ''}</w:rPr><w:t xml:space="preserve">${text}</w:t></w:r>`;
+/** An inline picture `widthPt` wide, so a line can start with a drawing and no text. */
+const picture = (widthPt: number) => {
+  const cx = widthPt * 12700;
+  const cy = 10 * 12700;
+  return (
+    '<w:r><w:drawing><wp:inline distT="0" distB="0" distL="0" distR="0">' +
+    `<wp:extent cx="${cx}" cy="${cy}"/><wp:docPr id="1" name="picture"/>` +
+    `<a:graphic><a:graphicData uri="${PIC}"><pic:pic>` +
+    '<pic:nvPicPr><pic:cNvPr id="1" name=""/><pic:cNvPicPr/></pic:nvPicPr>' +
+    '<pic:blipFill><a:blip r:embed="rId1"/><a:stretch><a:fillRect/></a:stretch></pic:blipFill>' +
+    `<pic:spPr><a:xfrm><a:ext cx="${cx}" cy="${cy}"/></a:xfrm><a:prstGeom prst="rect"/></pic:spPr>` +
+    '</pic:pic></a:graphicData></a:graphic></wp:inline></w:drawing></w:r>'
+  );
+};
+const READY: ImageResourceState = Object.freeze({
+  kind: 'ready',
+  partName: '/word/media/image1.png',
+  contentId: 'image1',
+  resourceKey: 'k1',
+  mime: 'image/png',
+  pixelWidth: 40,
+  pixelHeight: 10,
+  dpiX: 96,
+  dpiY: 96,
+});
 const measurer = createFixedMeasurer(10, 12);
-function layout(body: string, width = 25) {
+function layout(body: string, width = 25, paragraphProperties = '') {
   const parsed = readOoxmlPart(
-    `<w:document xmlns:w="${W}"><w:body><w:p>${body}</w:p></w:body></w:document>`,
-    { name: '/word/document.xml', contentType: 'app/xml' }
+    `<w:document xmlns:w="${W}" xmlns:wp="${WP}" xmlns:a="${A}" xmlns:pic="${PIC}" xmlns:r="${R}">` +
+      `<w:body><w:p>${paragraphProperties}${body}</w:p></w:body></w:document>`,
+    { name: OWNER, contentType: 'app/xml' }
   );
   if (!parsed.ok) throw new Error(parsed.reason);
   const original = serializeOoxmlPart(parsed.part);
+  const atoms = indexInlineDrawingProjectionsInPart(parsed.part);
+  const inlineDrawingLayout: InlineDrawingLayoutContext = {
+    ownerPartName: OWNER,
+    projectionForAtom: (atomId) => atoms.get(atomId) ?? null,
+    project: (node) =>
+      atoms.get(node.id) ??
+      projectDrawing(node, { ownerPartName: OWNER, limits: DEFAULT_DRAWING_PROJECTION_LIMITS }),
+    resourceOf: () => READY,
+  };
   const result = layoutSemanticDocument(parsed.part, 1, {
     measurer,
+    inlineDrawingLayout,
     geometry: { width, height: 300, margin: { top: 0, right: 0, bottom: 0, left: 0 } },
   });
   expect(serializeOoxmlPart(parsed.part)).toBe(original);
@@ -58,5 +106,35 @@ describe('separate whitespace runs at a soft-wrap margin', () => {
     expect(
       lines.flatMap((line) => line.spans).find((span) => span.text === '\u00a0')!.box.width
     ).toBe(10);
+  });
+  test('hangs an overflowing space run after an inline drawing that starts the line', () => {
+    // The drawing is the only content so far; the space still hangs instead of wrapping.
+    const lines = layout(picture(30) + run(' ', true) + run('CD'), 35);
+    expect(texts(lines)).toEqual([' ', 'CD']);
+    expect(lines[0]!.drawings).toHaveLength(1);
+    const space = lines[0]!.spans[0]!;
+    expect(space.lineEndWhitespace).toBe(true);
+    expect(space.box.x + space.box.width).toBeLessThanOrEqual(35);
+    expect(lines[1]!.spans[0]!.box.x).toBe(0);
+  });
+});
+
+describe('justified lines ending in clipped space runs', () => {
+  const justified = '<w:pPr><w:jc w:val="both"/></w:pPr>';
+  const endOfB = (lines: ReturnType<typeof layout>) => {
+    const b = lines[0]!.spans.find((span) => span.text === 'B')!;
+    return spanOffsetX(b, b.range.end, measurer);
+  };
+  test('stretches the line the same way with one or two hanging space runs', () => {
+    const one = layout(run('A B') + run(' ', true) + run('CD'), 35, justified);
+    const two = layout(run('A B') + run(' ', true) + run(' ') + run('CD'), 35, justified);
+    expect(texts(one)).toEqual(['A B ', 'CD']);
+    expect(texts(two)).toEqual(['A B  ', 'CD']);
+    // `B` is flush with the measure on the first line either way.
+    expect(endOfB(one)).toBe(35);
+    expect(endOfB(two)).toBe(35);
+    // The last line stays flush left.
+    expect(one[1]!.spans[0]!.box.x).toBe(0);
+    expect(two[1]!.spans[0]!.box.x).toBe(0);
   });
 });

--- a/packages/core/src/layout/drawing-page-clip.ts
+++ b/packages/core/src/layout/drawing-page-clip.ts
@@ -1,18 +1,21 @@
-import type { DrawingAnchorFrameContext } from './drawing-layout.ts';
 import type { LayoutBox } from './semantic-records.ts';
+
+/** The frame fields a page clip reads: a structural subset of the anchor frame context. */
+export interface PageClipFrame {
+  readonly pageWidth: number;
+  readonly pageHeight?: number | undefined;
+  readonly marginLeft: number;
+  readonly contentInsetTop: number;
+  readonly contentInsetBottom: number;
+  readonly contentBandHeight: number;
+}
 
 /**
  * Full physical page clip, including margins and all columns. A continuous section's
  * content band can end before the sheet does; it must not crop page-relative artwork.
  * Callers without physical height retain the full-band fallback.
  */
-export function pageClipRegion(
-  frameBase: Pick<
-    DrawingAnchorFrameContext,
-    'pageWidth' | 'marginLeft' | 'contentInsetTop' | 'contentInsetBottom' | 'contentBandHeight'
-  > &
-    Partial<Pick<DrawingAnchorFrameContext, 'pageHeight'>>
-): LayoutBox {
+export function pageClipRegion(frameBase: PageClipFrame): LayoutBox {
   const height = frameBase.pageHeight;
   return Object.freeze({
     x: -frameBase.marginLeft,

--- a/packages/core/src/layout/east-asia-symbol-hint.ts
+++ b/packages/core/src/layout/east-asia-symbol-hint.ts
@@ -18,8 +18,40 @@ export function hasEastAsiaSymbolHint(properties: readonly OoxmlProperty[]): boo
 }
 
 /**
- * MS-OI29500 2.1.88: the unconditional Latin-1 symbol exceptions for hint=eastAsia.
- * ASCII and language/charset-dependent accented letters are deliberately excluded.
+ * MS-OI29500 2.1.88: Word ignores `hint="eastAsia"` when the East Asian face is Times New
+ * Roman AND the ascii and hAnsi faces are the same.
+ *
+ * `eastAsiaFace` is the run's RESOLVED East Asian face, so a theme slot that resolves to
+ * Times New Roman counts. The Latin faces are read from the same cascaded properties as
+ * {@link hasEastAsiaSymbolHint}, last specified value per attribute winning, with a theme
+ * attribute standing in for the explicit name beside it (§17.3.2.26).
+ */
+export function hasTimesNewRomanEastAsiaException(
+  properties: readonly OoxmlProperty[],
+  eastAsiaFace: string | null
+): boolean {
+  if (eastAsiaFace?.toLowerCase() !== 'times new roman') return false;
+  let ascii: string | undefined;
+  let hAnsi: string | undefined;
+  for (const property of properties) {
+    if (property.localName !== 'rFonts') continue;
+    const attributes = property.attributes;
+    const nextAscii = attributes?.asciiTheme ?? attributes?.ascii;
+    const nextHAnsi = attributes?.hAnsiTheme ?? attributes?.hAnsi;
+    if (nextAscii !== undefined) ascii = nextAscii;
+    if (nextHAnsi !== undefined) hAnsi = nextHAnsi;
+  }
+  return ascii === hAnsi;
+}
+
+/**
+ * MS-OI29500 2.1.88: the code points that resolve through the East Asian face
+ * unconditionally under `hint="eastAsia"`.
+ *
+ * Latin-1 keeps only the symbol exceptions; ASCII and the language/charset-dependent
+ * accented letters are deliberately excluded, and so are Greek and Cyrillic. The CJK
+ * radicals at U+2E80-U+2EFF are in the same table but already classify as strong East
+ * Asian text without a hint, so they are not repeated here.
  */
 export function isEastAsiaHintSymbol(codePoint: number): boolean {
   return (
@@ -33,6 +65,14 @@ export function isEastAsiaHintSymbol(codePoint: number): boolean {
     (codePoint >= 0xb6 && codePoint <= 0xba) ||
     (codePoint >= 0xbc && codePoint <= 0xbf) ||
     codePoint === 0xd7 ||
-    codePoint === 0xf7
+    codePoint === 0xf7 ||
+    // Spacing modifier letters and combining diacritical marks.
+    (codePoint >= 0x2b0 && codePoint <= 0x36f) ||
+    // General punctuation through Dingbats: quotes, dashes, arrows, enclosed alphanumerics.
+    (codePoint >= 0x2000 && codePoint <= 0x27bf) ||
+    // Private use area.
+    (codePoint >= 0xe000 && codePoint <= 0xf8ff) ||
+    // Alphabetic presentation forms up to, not including, the Hebrew ligatures.
+    (codePoint >= 0xfb00 && codePoint <= 0xfb1c)
   );
 }

--- a/packages/core/src/layout/east-asia-symbol-hint.ts
+++ b/packages/core/src/layout/east-asia-symbol-hint.ts
@@ -23,8 +23,11 @@ export function hasEastAsiaSymbolHint(properties: readonly OoxmlProperty[]): boo
  *
  * `eastAsiaFace` is the run's RESOLVED East Asian face, so a theme slot that resolves to
  * Times New Roman counts. The Latin faces are read from the same cascaded properties as
- * {@link hasEastAsiaSymbolHint}, last specified value per attribute winning, with a theme
- * attribute standing in for the explicit name beside it (§17.3.2.26).
+ * {@link hasEastAsiaSymbolHint}, last specified value per attribute winning (§17.3.2.26).
+ * Word compares resolved faces. This reader has no theme resolver, so it compares explicit
+ * names case-insensitively, treats two theme slots by slot name, and falls back to the
+ * exception (hint ignored, the pre-widening behavior) whenever the two sides cannot be
+ * compared: one theme slot beside one explicit name, or a face left unspecified.
  */
 export function hasTimesNewRomanEastAsiaException(
   properties: readonly OoxmlProperty[],
@@ -33,15 +36,28 @@ export function hasTimesNewRomanEastAsiaException(
   if (eastAsiaFace?.toLowerCase() !== 'times new roman') return false;
   let ascii: string | undefined;
   let hAnsi: string | undefined;
+  let asciiIsTheme = false;
+  let hAnsiIsTheme = false;
   for (const property of properties) {
     if (property.localName !== 'rFonts') continue;
     const attributes = property.attributes;
-    const nextAscii = attributes?.asciiTheme ?? attributes?.ascii;
-    const nextHAnsi = attributes?.hAnsiTheme ?? attributes?.hAnsi;
-    if (nextAscii !== undefined) ascii = nextAscii;
-    if (nextHAnsi !== undefined) hAnsi = nextHAnsi;
+    if (attributes?.asciiTheme !== undefined) {
+      ascii = attributes.asciiTheme;
+      asciiIsTheme = true;
+    } else if (attributes?.ascii !== undefined) {
+      ascii = attributes.ascii;
+      asciiIsTheme = false;
+    }
+    if (attributes?.hAnsiTheme !== undefined) {
+      hAnsi = attributes.hAnsiTheme;
+      hAnsiIsTheme = true;
+    } else if (attributes?.hAnsi !== undefined) {
+      hAnsi = attributes.hAnsi;
+      hAnsiIsTheme = false;
+    }
   }
-  return ascii === hAnsi;
+  if (ascii === undefined || hAnsi === undefined || asciiIsTheme !== hAnsiIsTheme) return true;
+  return ascii.toLowerCase() === hAnsi.toLowerCase();
 }
 
 /**
@@ -52,6 +68,13 @@ export function hasTimesNewRomanEastAsiaException(
  * accented letters are deliberately excluded, and so are Greek and Cyrillic. The CJK
  * radicals at U+2E80-U+2EFF are in the same table but already classify as strong East
  * Asian text without a hint, so they are not repeated here.
+ *
+ * Two parts of the table are left out on purpose. Combining marks and format characters
+ * (U+0300-U+036F, U+200B-U+200F, U+2028-U+202F, U+2060-U+206F, U+20D0-U+20FF) must stay in
+ * the font of the base character they attach to: slicing them into their own span splits a
+ * grapheme cluster across two faces. The Private Use Area (U+E000-U+F8FF) is where symbol
+ * fonts (Wingdings, Symbol) keep their glyphs, and those runs are already routed by
+ * `symbol-run.ts`; sending them to the East Asian face paints notdef boxes.
  */
 export function isEastAsiaHintSymbol(codePoint: number): boolean {
   return (
@@ -66,12 +89,15 @@ export function isEastAsiaHintSymbol(codePoint: number): boolean {
     (codePoint >= 0xbc && codePoint <= 0xbf) ||
     codePoint === 0xd7 ||
     codePoint === 0xf7 ||
-    // Spacing modifier letters and combining diacritical marks.
-    (codePoint >= 0x2b0 && codePoint <= 0x36f) ||
-    // General punctuation through Dingbats: quotes, dashes, arrows, enclosed alphanumerics.
-    (codePoint >= 0x2000 && codePoint <= 0x27bf) ||
-    // Private use area.
-    (codePoint >= 0xe000 && codePoint <= 0xf8ff) ||
+    // Spacing modifier letters (not the combining marks that follow them).
+    (codePoint >= 0x2b0 && codePoint <= 0x2ff) ||
+    // General punctuation through Dingbats, minus format characters and combining marks:
+    // quotes, dashes, arrows, enclosed alphanumerics, box drawing, geometric shapes.
+    (codePoint >= 0x2000 && codePoint <= 0x200a) ||
+    (codePoint >= 0x2010 && codePoint <= 0x2027) ||
+    (codePoint >= 0x2030 && codePoint <= 0x205f) ||
+    (codePoint >= 0x2070 && codePoint <= 0x20cf) ||
+    (codePoint >= 0x2100 && codePoint <= 0x27bf) ||
     // Alphabetic presentation forms up to, not including, the Hebrew ligatures.
     (codePoint >= 0xfb00 && codePoint <= 0xfb1c)
   );

--- a/packages/core/src/layout/east-asia-symbol-hint.ts
+++ b/packages/core/src/layout/east-asia-symbol-hint.ts
@@ -1,4 +1,6 @@
 import type { OoxmlProperty } from '@docx-editor.dev/core/store';
+import { themeFontFamilyOf } from '../store/package/theme-font-scheme.ts';
+import type { ThemeFonts } from './run-style.ts';
 
 /** Last specified hint wins across the already-cascaded run properties. */
 export function hasEastAsiaSymbolHint(properties: readonly OoxmlProperty[]): boolean {
@@ -17,47 +19,55 @@ export function hasEastAsiaSymbolHint(properties: readonly OoxmlProperty[]): boo
   return hint === 'eastAsia' && !cs && !rtl;
 }
 
+/** One Latin face slot as authored: a theme token or an explicit name, last specified wins. */
+interface LatinFace {
+  readonly value: string;
+  readonly theme: boolean;
+}
+
+/** The resolved family for comparison, or the theme token itself when nothing resolves it. */
+function comparableFace(face: LatinFace, themeFonts: ThemeFonts | undefined): string {
+  if (!face.theme) return face.value.toLowerCase();
+  const resolved = themeFonts ? themeFontFamilyOf(face.value, themeFonts) : null;
+  // Without a resolver, `minorAscii` and `minorHAnsi` (and the major pair) still name the
+  // same theme face, so the token compares by the face it stands for.
+  return (resolved ?? face.value.replace(/Ascii$/, 'HAnsi')).toLowerCase();
+}
+
 /**
  * MS-OI29500 2.1.88: Word ignores `hint="eastAsia"` when the East Asian face is Times New
  * Roman AND the ascii and hAnsi faces are the same.
  *
  * `eastAsiaFace` is the run's RESOLVED East Asian face, so a theme slot that resolves to
  * Times New Roman counts. The Latin faces are read from the same cascaded properties as
- * {@link hasEastAsiaSymbolHint}, last specified value per attribute winning (§17.3.2.26).
- * Word compares resolved faces. This reader has no theme resolver, so it compares explicit
- * names case-insensitively, treats two theme slots by slot name, and falls back to the
- * exception (hint ignored, the pre-widening behavior) whenever the two sides cannot be
- * compared: one theme slot beside one explicit name, or a face left unspecified.
+ * {@link hasEastAsiaSymbolHint}, last specified value per attribute winning (§17.3.2.26),
+ * and compared as resolved faces through `themeFonts`, the way Word compares them. When a
+ * theme token cannot be resolved against an explicit name, or a face is left unspecified,
+ * the comparison falls back to the exception (hint ignored), which is the conservative
+ * pre-widening behavior.
  */
 export function hasTimesNewRomanEastAsiaException(
   properties: readonly OoxmlProperty[],
-  eastAsiaFace: string | null
+  eastAsiaFace: string | null,
+  themeFonts?: ThemeFonts
 ): boolean {
   if (eastAsiaFace?.toLowerCase() !== 'times new roman') return false;
-  let ascii: string | undefined;
-  let hAnsi: string | undefined;
-  let asciiIsTheme = false;
-  let hAnsiIsTheme = false;
+  let ascii: LatinFace | undefined;
+  let hAnsi: LatinFace | undefined;
   for (const property of properties) {
     if (property.localName !== 'rFonts') continue;
     const attributes = property.attributes;
-    if (attributes?.asciiTheme !== undefined) {
-      ascii = attributes.asciiTheme;
-      asciiIsTheme = true;
-    } else if (attributes?.ascii !== undefined) {
-      ascii = attributes.ascii;
-      asciiIsTheme = false;
-    }
-    if (attributes?.hAnsiTheme !== undefined) {
-      hAnsi = attributes.hAnsiTheme;
-      hAnsiIsTheme = true;
-    } else if (attributes?.hAnsi !== undefined) {
-      hAnsi = attributes.hAnsi;
-      hAnsiIsTheme = false;
-    }
+    if (attributes?.asciiTheme !== undefined) ascii = { value: attributes.asciiTheme, theme: true };
+    else if (attributes?.ascii !== undefined) ascii = { value: attributes.ascii, theme: false };
+    if (attributes?.hAnsiTheme !== undefined) hAnsi = { value: attributes.hAnsiTheme, theme: true };
+    else if (attributes?.hAnsi !== undefined) hAnsi = { value: attributes.hAnsi, theme: false };
   }
-  if (ascii === undefined || hAnsi === undefined || asciiIsTheme !== hAnsiIsTheme) return true;
-  return ascii.toLowerCase() === hAnsi.toLowerCase();
+  if (ascii === undefined || hAnsi === undefined) return true;
+  if (ascii.theme !== hAnsi.theme) {
+    const themed = ascii.theme ? ascii : hAnsi;
+    if (!themeFonts || themeFontFamilyOf(themed.value, themeFonts) === null) return true;
+  }
+  return comparableFace(ascii, themeFonts) === comparableFace(hAnsi, themeFonts);
 }
 
 /**

--- a/packages/core/src/layout/east-asia-symbol-hint.ts
+++ b/packages/core/src/layout/east-asia-symbol-hint.ts
@@ -25,13 +25,17 @@ interface LatinFace {
   readonly theme: boolean;
 }
 
-/** The resolved family for comparison, or the theme token itself when nothing resolves it. */
-function comparableFace(face: LatinFace, themeFonts: ThemeFonts | undefined): string {
+/** The resolved family for comparison, or null when a theme token cannot be resolved. */
+function comparableFace(face: LatinFace, themeFonts: ThemeFonts | undefined): string | null {
   if (!face.theme) return face.value.toLowerCase();
   const resolved = themeFonts ? themeFontFamilyOf(face.value, themeFonts) : null;
-  // Without a resolver, `minorAscii` and `minorHAnsi` (and the major pair) still name the
-  // same theme face, so the token compares by the face it stands for.
-  return (resolved ?? face.value.replace(/Ascii$/, 'HAnsi')).toLowerCase();
+  return resolved?.toLowerCase() ?? null;
+}
+
+/** `minorAscii` and `minorHAnsi` (and the major pair) name one theme face by two tokens. */
+function sameThemeToken(a: string, b: string): boolean {
+  const canonical = (token: string) => token.replace(/Ascii$/, 'HAnsi').toLowerCase();
+  return canonical(a) === canonical(b);
 }
 
 /**
@@ -63,11 +67,12 @@ export function hasTimesNewRomanEastAsiaException(
     else if (attributes?.hAnsi !== undefined) hAnsi = { value: attributes.hAnsi, theme: false };
   }
   if (ascii === undefined || hAnsi === undefined) return true;
-  if (ascii.theme !== hAnsi.theme) {
-    const themed = ascii.theme ? ascii : hAnsi;
-    if (!themeFonts || themeFontFamilyOf(themed.value, themeFonts) === null) return true;
-  }
-  return comparableFace(ascii, themeFonts) === comparableFace(hAnsi, themeFonts);
+  if (ascii.theme && hAnsi.theme && sameThemeToken(ascii.value, hAnsi.value)) return true;
+  const asciiFace = comparableFace(ascii, themeFonts);
+  const hAnsiFace = comparableFace(hAnsi, themeFonts);
+  // A token nothing resolves cannot be compared with anything; keep the exception.
+  if (asciiFace === null || hAnsiFace === null) return true;
+  return asciiFace === hAnsiFace;
 }
 
 /**

--- a/packages/core/src/layout/east-asia-symbol-hint.ts
+++ b/packages/core/src/layout/east-asia-symbol-hint.ts
@@ -19,25 +19,6 @@ export function hasEastAsiaSymbolHint(properties: readonly OoxmlProperty[]): boo
   return hint === 'eastAsia' && !cs && !rtl;
 }
 
-/** One Latin face slot as authored: a theme token or an explicit name, last specified wins. */
-interface LatinFace {
-  readonly value: string;
-  readonly theme: boolean;
-}
-
-/** The resolved family for comparison, or null when a theme token cannot be resolved. */
-function comparableFace(face: LatinFace, themeFonts: ThemeFonts | undefined): string | null {
-  if (!face.theme) return face.value.toLowerCase();
-  const resolved = themeFonts ? themeFontFamilyOf(face.value, themeFonts) : null;
-  return resolved?.toLowerCase() ?? null;
-}
-
-/** `minorAscii` and `minorHAnsi` (and the major pair) name one theme face by two tokens. */
-function sameThemeToken(a: string, b: string): boolean {
-  const canonical = (token: string) => token.replace(/Ascii$/, 'HAnsi').toLowerCase();
-  return canonical(a) === canonical(b);
-}
-
 /**
  * MS-OI29500 2.1.88: Word ignores `hint="eastAsia"` when the East Asian face is Times New
  * Roman AND the ascii and hAnsi faces are the same.
@@ -46,7 +27,7 @@ function sameThemeToken(a: string, b: string): boolean {
  * Times New Roman counts. The Latin faces are read from the same cascaded properties as
  * {@link hasEastAsiaSymbolHint}, last specified value per attribute winning (§17.3.2.26),
  * and compared as resolved faces through `themeFonts`, the way Word compares them. When a
- * theme token cannot be resolved against an explicit name, or a face is left unspecified,
+ * theme token has no resolved or explicit fallback face, or a face is left unspecified,
  * the comparison falls back to the exception (hint ignored), which is the conservative
  * pre-widening behavior.
  */
@@ -56,23 +37,23 @@ export function hasTimesNewRomanEastAsiaException(
   themeFonts?: ThemeFonts
 ): boolean {
   if (eastAsiaFace?.toLowerCase() !== 'times new roman') return false;
-  let ascii: LatinFace | undefined;
-  let hAnsi: LatinFace | undefined;
+  let ascii: string | null | undefined;
+  let hAnsi: string | null | undefined;
+  const face = (token: string | undefined, explicit: string | undefined): string | null =>
+    ((themeFonts ? themeFontFamilyOf(token, themeFonts) : null) ?? explicit)?.toLowerCase() ?? null;
   for (const property of properties) {
     if (property.localName !== 'rFonts') continue;
     const attributes = property.attributes;
-    if (attributes?.asciiTheme !== undefined) ascii = { value: attributes.asciiTheme, theme: true };
-    else if (attributes?.ascii !== undefined) ascii = { value: attributes.ascii, theme: false };
-    if (attributes?.hAnsiTheme !== undefined) hAnsi = { value: attributes.hAnsiTheme, theme: true };
-    else if (attributes?.hAnsi !== undefined) hAnsi = { value: attributes.hAnsi, theme: false };
+    if (attributes?.asciiTheme !== undefined || attributes?.ascii !== undefined) {
+      ascii = face(attributes.asciiTheme, attributes.ascii);
+    }
+    if (attributes?.hAnsiTheme !== undefined || attributes?.hAnsi !== undefined) {
+      hAnsi = face(attributes.hAnsiTheme, attributes.hAnsi);
+    }
   }
-  if (ascii === undefined || hAnsi === undefined) return true;
-  if (ascii.theme && hAnsi.theme && sameThemeToken(ascii.value, hAnsi.value)) return true;
-  const asciiFace = comparableFace(ascii, themeFonts);
-  const hAnsiFace = comparableFace(hAnsi, themeFonts);
-  // A token nothing resolves cannot be compared with anything; keep the exception.
-  if (asciiFace === null || hAnsiFace === null) return true;
-  return asciiFace === hAnsiFace;
+  // Missing faces and unresolved tokens cannot establish a difference.
+  if (ascii == null || hAnsi == null) return true;
+  return ascii === hAnsi;
 }
 
 /**
@@ -80,8 +61,8 @@ export function hasTimesNewRomanEastAsiaException(
  * unconditionally under `hint="eastAsia"`.
  *
  * Latin-1 keeps only the symbol exceptions; ASCII and the language/charset-dependent
- * accented letters are deliberately excluded, and so are Greek and Cyrillic. The CJK
- * radicals at U+2E80-U+2EFF are in the same table but already classify as strong East
+ * accented letters are deliberately excluded. Greek and Cyrillic use the exact table
+ * ranges. The CJK radicals at U+2E80-U+2EFF are in the same table but already classify as strong East
  * Asian text without a hint, so they are not repeated here.
  *
  * Two parts of the table are left out on purpose. Combining marks and format characters
@@ -106,6 +87,8 @@ export function isEastAsiaHintSymbol(codePoint: number): boolean {
     codePoint === 0xf7 ||
     // Spacing modifier letters (not the combining marks that follow them).
     (codePoint >= 0x2b0 && codePoint <= 0x2ff) ||
+    (codePoint >= 0x370 && codePoint <= 0x3cf) ||
+    (codePoint >= 0x400 && codePoint <= 0x4ff) ||
     // General punctuation through Dingbats, minus format characters and combining marks:
     // quotes, dashes, arrows, enclosed alphanumerics, box drawing, geometric shapes.
     (codePoint >= 0x2000 && codePoint <= 0x200a) ||

--- a/packages/core/src/layout/field-pieces.ts
+++ b/packages/core/src/layout/field-pieces.ts
@@ -25,6 +25,7 @@ import type { AutonumFieldSpec } from './field-autonum.ts';
 import type { HyperlinkFieldSpec } from './field-link.ts';
 import type { PageRefFieldProjection, RefFieldSpec } from './field-ref.ts';
 import type { SymbolFieldSpec } from './field-symbol.ts';
+import { isSymbolEncodedFamily } from './symbol-encoding.ts';
 import type { RevisionAttribution } from './revision-projection.ts';
 import type { ResolvedRunStyle } from './run-style.ts';
 import type { SpanLinkRecord } from './semantic-records.ts';
@@ -452,9 +453,12 @@ export function applyEastAsiaFontSlots(pieces: FieldAwarePiece[]): FieldAwarePie
     if (piece.text.length === 0) continue;
     streamed.push(index);
     segments.push(piece.text);
-    // Leave the special Times New Roman East Asian fallback to existing resolution.
+    // Leave the special Times New Roman East Asian fallback to existing resolution, and never
+    // move a symbol-encoded face (Wingdings, Symbol, a `w:sym` piece): its glyphs live in
+    // the symbol font, and the East Asian face would paint them as notdef boxes.
     hintedSegments.push(
       hasEastAsiaSymbolHint(piece.props) &&
+        !isSymbolEncodedFamily(piece.style.fontFamily) &&
         !hasTimesNewRomanEastAsiaException(piece.props, piece.style.fontFamilyEastAsia)
     );
   }

--- a/packages/core/src/layout/field-pieces.ts
+++ b/packages/core/src/layout/field-pieces.ts
@@ -13,7 +13,10 @@ import type { HardBreakKind } from '@docx-editor.dev/core/store';
 import type { LegacyFormFieldData } from '../store/package/field-nodes.ts';
 import type { InlineDrawingLayoutInput } from './drawing-layout.ts';
 import { eastAsiaRunsOfSegments, type FontSlot } from './script-itemization.ts';
-import { hasEastAsiaSymbolHint } from './east-asia-symbol-hint.ts';
+import {
+  hasEastAsiaSymbolHint,
+  hasTimesNewRomanEastAsiaException,
+} from './east-asia-symbol-hint.ts';
 import type { ButtonFieldSpec } from './field-button.ts';
 import type { DocPropertyField } from './field-doc-property.ts';
 import type { FormFieldKind } from './field-form.ts';
@@ -451,8 +454,8 @@ export function applyEastAsiaFontSlots(pieces: FieldAwarePiece[]): FieldAwarePie
     segments.push(piece.text);
     // Leave the special Times New Roman East Asian fallback to existing resolution.
     hintedSegments.push(
-      piece.style.fontFamilyEastAsia?.toLowerCase() !== 'times new roman' &&
-        hasEastAsiaSymbolHint(piece.props)
+      hasEastAsiaSymbolHint(piece.props) &&
+        !hasTimesNewRomanEastAsiaException(piece.props, piece.style.fontFamilyEastAsia)
     );
   }
   const ranges = eastAsiaRunsOfSegments(segments, hintedSegments);

--- a/packages/core/src/layout/field-pieces.ts
+++ b/packages/core/src/layout/field-pieces.ts
@@ -27,7 +27,7 @@ import type { PageRefFieldProjection, RefFieldSpec } from './field-ref.ts';
 import type { SymbolFieldSpec } from './field-symbol.ts';
 import { isSymbolEncodedFamily } from './symbol-encoding.ts';
 import type { RevisionAttribution } from './revision-projection.ts';
-import type { ResolvedRunStyle } from './run-style.ts';
+import type { ResolvedRunStyle, ThemeFonts } from './run-style.ts';
 import type { SpanLinkRecord } from './semantic-records.ts';
 import type { OmmlEquationProjection } from '@docx-editor.dev/core/store';
 
@@ -428,7 +428,10 @@ function fontSlotSlice(
  * The style objects are untouched: a piece carries the run's real resolution and the slot
  * beside it, and the face is derived at the measurer/paint boundary via `styleForFontSlot`.
  */
-export function applyEastAsiaFontSlots(pieces: FieldAwarePiece[]): FieldAwarePiece[] {
+export function applyEastAsiaFontSlots(
+  pieces: FieldAwarePiece[],
+  themeFonts?: ThemeFonts
+): FieldAwarePiece[] {
   // Nothing to resolve unless some run authors a DISTINCT East Asian face. This is the
   // cheap common-case exit for Latin-defaulted documents; documents whose docDefaults
   // author one for every run instead lean on the pure-ASCII prescan inside
@@ -459,7 +462,7 @@ export function applyEastAsiaFontSlots(pieces: FieldAwarePiece[]): FieldAwarePie
     hintedSegments.push(
       hasEastAsiaSymbolHint(piece.props) &&
         !isSymbolEncodedFamily(piece.style.fontFamily) &&
-        !hasTimesNewRomanEastAsiaException(piece.props, piece.style.fontFamilyEastAsia)
+        !hasTimesNewRomanEastAsiaException(piece.props, piece.style.fontFamilyEastAsia, themeFonts)
     );
   }
   const ranges = eastAsiaRunsOfSegments(segments, hintedSegments);

--- a/packages/core/src/layout/field-projection.ts
+++ b/packages/core/src/layout/field-projection.ts
@@ -874,7 +874,7 @@ export function piecesOfParagraph(
    * their nesting. Content-control nesting shares {@link MAX_CONTENT_CONTROL_NESTING} with
    * block flattening; field-scan depth stays separate.
    */
-  if (!consumeScanNode(budget)) return applyEastAsiaFontSlots(pieces);
+  if (!consumeScanNode(budget)) return applyEastAsiaFontSlots(pieces, themeFonts);
   const paragraphScope = emptyNamespaceScope();
 
   /**
@@ -995,5 +995,5 @@ export function piecesOfParagraph(
 
   // Slot resolution is a paragraph-wide question (Common characters inherit across run
   // boundaries), so it runs after the walk, over the assembled pieces.
-  return applyEastAsiaFontSlots(pieces);
+  return applyEastAsiaFontSlots(pieces, themeFonts);
 }

--- a/packages/core/src/layout/field-symbol.ts
+++ b/packages/core/src/layout/field-symbol.ts
@@ -172,7 +172,12 @@ export function symbolFieldGlyph(
 ): SymbolFieldGlyph | null {
   const overrides: OoxmlProperty[] = [];
   if (spec.font) {
-    overrides.push({ localName: 'rFonts', attributes: { ascii: spec.font, hAnsi: spec.font } });
+    // Like w:sym, the explicit face also owns the East Asian slot: neighboring Han can
+    // select that slot even after the inherited hint is reset.
+    overrides.push({
+      localName: 'rFonts',
+      attributes: { ascii: spec.font, hAnsi: spec.font, eastAsia: spec.font, hint: 'default' },
+    });
   }
   if (spec.sizePt !== null) {
     overrides.push({ localName: 'sz', attributes: { val: String(spec.sizePt * 2) } });

--- a/packages/core/src/layout/inline-drawing-source.ts
+++ b/packages/core/src/layout/inline-drawing-source.ts
@@ -322,6 +322,32 @@ function foldPointsInto(points: EmuPoints, hash: Uint32Array): void {
   hash[1] = hashB;
 }
 
+// A story root is immutable. Identity detects text and formatting edits without walking
+// the entire hosted story each time a drawing token is requested.
+const textboxContentIdentities = new WeakMap<OoxmlNode, number>();
+let textboxContentIdentityCounter = 0;
+
+function textboxLayoutToken(story: NonNullable<DrawingProjection['textboxStory']>): string {
+  let identity = textboxContentIdentities.get(story.content);
+  if (identity === undefined) {
+    identity = ++textboxContentIdentityCounter;
+    textboxContentIdentities.set(story.content, identity);
+  }
+  return framedTokenJoin([
+    String(identity),
+    story.contentNodeId,
+    String(story.insetsEmu.top),
+    String(story.insetsEmu.right),
+    String(story.insetsEmu.bottom),
+    String(story.insetsEmu.left),
+    story.verticalAnchor,
+    story.autofit,
+    story.fillHex ?? '',
+    story.strokeHex ?? '',
+    String(story.strokeWidthEmu),
+  ]);
+}
+
 function drawingProjectionLayoutToken(projection: DrawingProjection): string {
   const position = projection.position;
   const anchor = projection.anchor;
@@ -332,32 +358,70 @@ function drawingProjectionLayoutToken(projection: DrawingProjection): string {
   // are verbatim file values, so a printable field separator would let two different
   // picture references serialize to one token — and `isCompatibleWith` compares
   // projections by this token alone when the resource substrate is unchanged.
-  return framedTokenJoin([
-    projection.drawingNodeId,
-    projection.ownerPartName,
-    projection.kind,
-    projection.hidden ? '1' : '0',
-    String(projection.extentEmu.cx),
-    String(projection.extentEmu.cy),
-    String(projection.effectExtentEmu.top),
-    String(projection.effectExtentEmu.right),
-    String(projection.effectExtentEmu.bottom),
-    String(projection.effectExtentEmu.left),
-    projection.compatibilityBranchNodeId ?? '',
-    anchor?.simplePos ? 'sp' : 'pv',
-    anchor ? String(anchor.relativeHeight) : '',
-    anchor ? (anchor.layoutInCell ? '1' : '0') : '',
-    anchor ? (anchor.allowOverlap ? '1' : '0') : '',
-    anchor ? (anchor.behindDocument ? '1' : '0') : '',
-    picture
+  // This also validates retained projections used by paint and drawing controls. Every
+  // top-level field needs a token decision, including diagnostics used for placeholders.
+  const fields = {
+    drawingNodeId: projection.drawingNodeId,
+    ownerPartName: projection.ownerPartName,
+    kind: projection.kind,
+    diagnostics: framedTokenJoin(
+      projection.diagnostics.map((diagnostic) =>
+        framedTokenJoin([diagnostic.code, diagnostic.nodeId, diagnostic.detail ?? ''])
+      )
+    ),
+    relationshipId: projection.relationshipId ?? '',
+    docPrId: String(projection.docPrId ?? ''),
+    name: projection.name,
+    title: projection.title,
+    description: projection.description,
+    hyperlinkHref: projection.hyperlinkHref ?? '',
+    hidden: String(projection.hidden),
+    extentEmu: framedTokenJoin([String(projection.extentEmu.cx), String(projection.extentEmu.cy)]),
+    effectExtentEmu: framedTokenJoin([
+      String(projection.effectExtentEmu.top),
+      String(projection.effectExtentEmu.right),
+      String(projection.effectExtentEmu.bottom),
+      String(projection.effectExtentEmu.left),
+    ]),
+    inlineDistancesEmu: framedTokenJoin([
+      String(projection.inlineDistancesEmu.top),
+      String(projection.inlineDistancesEmu.right),
+      String(projection.inlineDistancesEmu.bottom),
+      String(projection.inlineDistancesEmu.left),
+    ]),
+    wrap: projection.wrap,
+    textboxStory: projection.textboxStory ? textboxLayoutToken(projection.textboxStory) : '',
+    compatibilityBranchNodeId: projection.compatibilityBranchNodeId ?? '',
+    anchor: anchor
+      ? framedTokenJoin([
+          String(anchor.simplePos),
+          String(anchor.relativeHeight),
+          String(anchor.layoutInCell),
+          String(anchor.allowOverlap),
+          String(anchor.behindDocument),
+        ])
+      : '',
+    locks: framedTokenJoin([
+      String(projection.locks.select),
+      String(projection.locks.move),
+      String(projection.locks.resize),
+      String(projection.locks.changeAspect),
+    ]),
+    effects: framedTokenJoin([
+      String(projection.effects.grayscale),
+      String(projection.effects.brightness),
+      String(projection.effects.contrast),
+      String(projection.effects.bilevel ?? ''),
+    ]),
+    picture: picture
       ? framedTokenJoin([
           String(picture.crop.left),
           String(picture.crop.top),
           String(picture.crop.right),
           String(picture.crop.bottom),
           String(picture.transform.rotationDegrees),
-          picture.transform.flipHorizontal ? '1' : '0',
-          picture.transform.flipVertical ? '1' : '0',
+          String(picture.transform.flipHorizontal),
+          String(picture.transform.flipVertical),
           String(picture.transform.offsetEmu.x),
           String(picture.transform.offsetEmu.y),
           String(picture.transform.extentEmu.cx),
@@ -365,10 +429,11 @@ function drawingProjectionLayoutToken(projection: DrawingProjection): string {
           picture.embeddedRelationshipId ?? '',
           picture.linkedRelationshipId ?? '',
           picture.presetGeometry ?? '',
+          picture.fillMode,
         ])
       : '',
-    vector ? vectorShapeLayoutToken(vector) : '',
-    wrap
+    vectorShape: vector ? vectorShapeLayoutToken(vector) : '',
+    wrapGeometry: wrap
       ? framedTokenJoin([
           wrap.element,
           wrap.textSide,
@@ -376,12 +441,11 @@ function drawingProjectionLayoutToken(projection: DrawingProjection): string {
           String(wrap.distancesEmu.right),
           String(wrap.distancesEmu.bottom),
           String(wrap.distancesEmu.left),
-          // The vertex count alone let a moved vertex reuse the old exclusion polygon.
           String(wrap.polygon.length),
           pointsDigest(wrap.polygon),
         ])
       : '',
-    position
+    position: position
       ? framedTokenJoin([
           position.horizontal.relativeFrom,
           position.horizontal.align ?? '',
@@ -393,7 +457,8 @@ function drawingProjectionLayoutToken(projection: DrawingProjection): string {
           String(position.simplePosition.yEmu),
         ])
       : '',
-  ]);
+  } satisfies Record<keyof DrawingProjection, string>;
+  return framedTokenJoin(Object.values(fields));
 }
 
 // Length-framed where a field embeds file text (resource keys carry relationship ids and

--- a/packages/core/src/layout/inline-drawing-source.ts
+++ b/packages/core/src/layout/inline-drawing-source.ts
@@ -251,8 +251,8 @@ const COORDINATE_BITS = new Uint32Array(COORDINATE_SCRATCH.buffer);
 export function vectorShapeLayoutToken(
   vector: NonNullable<DrawingProjection['vectorShape']>
 ): string {
-  let hashA = 0x811c_9dc5;
-  let hashB = 0x1000_0193;
+  HASH_SCRATCH[0] = 0x811c_9dc5;
+  HASH_SCRATCH[1] = 0x1000_0193;
   const scalars: string[] = [];
   for (const component of vector.components) {
     scalars.push(
@@ -263,33 +263,23 @@ export function vectorShapeLayoutToken(
       String(component.strokeWidthEmu),
       String(component.subpathsEmu.length)
     );
-    component.subpathsEmu.forEach((subpath, index) => {
+    const subpaths = component.subpathsEmu;
+    for (let index = 0; index < subpaths.length; index += 1) {
+      const subpath = subpaths[index]!;
       // An omitted close flag paints closed, exactly like `true`; only `false` leaves the
       // path open, so that is the one value that must separate two otherwise equal shapes.
       scalars.push(String(subpath.length), component.subpathsClosed?.[index] === false ? '0' : '1');
-      for (const point of subpath) {
-        COORDINATE_SCRATCH[0] = point.x;
-        hashA = Math.imul(hashA ^ COORDINATE_BITS[0]!, 0x0100_0193);
-        hashB = Math.imul(hashB ^ COORDINATE_BITS[1]!, 0x0100_01b3);
-        COORDINATE_SCRATCH[0] = point.y;
-        hashA = Math.imul(hashA ^ COORDINATE_BITS[1]!, 0x0100_0193);
-        hashB = Math.imul(hashB ^ COORDINATE_BITS[0]!, 0x0100_01b3);
-      }
-    });
+      foldPointsInto(subpath, HASH_SCRATCH);
+    }
     // Line-end triangles are generated geometry the painter fills separately, so a changed
     // `a:headEnd`/`a:tailEnd` moves nothing in the subpath stream. Their vertices join the
     // same accumulators, framed by their counts, so the token cannot reuse a stale record.
-    const arrowheads = component.arrowheadsEmu ?? [];
-    scalars.push(String(arrowheads.length));
-    for (const arrowhead of arrowheads) {
-      scalars.push(String(arrowhead.length));
-      for (const point of arrowhead) {
-        COORDINATE_SCRATCH[0] = point.x;
-        hashA = Math.imul(hashA ^ COORDINATE_BITS[0]!, 0x0100_0193);
-        hashB = Math.imul(hashB ^ COORDINATE_BITS[1]!, 0x0100_01b3);
-        COORDINATE_SCRATCH[0] = point.y;
-        hashA = Math.imul(hashA ^ COORDINATE_BITS[1]!, 0x0100_0193);
-        hashB = Math.imul(hashB ^ COORDINATE_BITS[0]!, 0x0100_01b3);
+    const arrowheads = component.arrowheadsEmu;
+    scalars.push(String(arrowheads?.length ?? 0));
+    if (arrowheads) {
+      for (const arrowhead of arrowheads) {
+        scalars.push(String(arrowhead.length));
+        foldPointsInto(arrowhead, HASH_SCRATCH);
       }
     }
   }
@@ -298,9 +288,32 @@ export function vectorShapeLayoutToken(
     String(vector.extentEmu.cy),
     String(vector.components.length),
     scalars.join(','),
-    (hashA >>> 0).toString(36),
-    (hashB >>> 0).toString(36),
+    HASH_SCRATCH[0]!.toString(36),
+    HASH_SCRATCH[1]!.toString(36),
   ].join(';');
+}
+
+/** The two FNV-1a accumulators {@link vectorShapeLayoutToken} folds every point stream into. */
+const HASH_SCRATCH = new Uint32Array(2);
+
+type VectorPoints = NonNullable<
+  DrawingProjection['vectorShape']
+>['components'][number]['subpathsEmu'][number];
+
+/** One fold shared by subpaths and line ends, so both hash the same way. */
+function foldPointsInto(points: VectorPoints, hash: Uint32Array): void {
+  let hashA = hash[0]!;
+  let hashB = hash[1]!;
+  for (const point of points) {
+    COORDINATE_SCRATCH[0] = point.x;
+    hashA = Math.imul(hashA ^ COORDINATE_BITS[0]!, 0x0100_0193);
+    hashB = Math.imul(hashB ^ COORDINATE_BITS[1]!, 0x0100_01b3);
+    COORDINATE_SCRATCH[0] = point.y;
+    hashA = Math.imul(hashA ^ COORDINATE_BITS[1]!, 0x0100_0193);
+    hashB = Math.imul(hashB ^ COORDINATE_BITS[0]!, 0x0100_01b3);
+  }
+  hash[0] = hashA;
+  hash[1] = hashB;
 }
 
 function drawingProjectionLayoutToken(projection: DrawingProjection): string {

--- a/packages/core/src/layout/inline-drawing-source.ts
+++ b/packages/core/src/layout/inline-drawing-source.ts
@@ -296,12 +296,18 @@ export function vectorShapeLayoutToken(
 /** The two FNV-1a accumulators {@link vectorShapeLayoutToken} folds every point stream into. */
 const HASH_SCRATCH = new Uint32Array(2);
 
-type VectorPoints = NonNullable<
-  DrawingProjection['vectorShape']
->['components'][number]['subpathsEmu'][number];
+type EmuPoints = readonly Readonly<{ x: number; y: number }>[];
 
-/** One fold shared by subpaths and line ends, so both hash the same way. */
-function foldPointsInto(points: VectorPoints, hash: Uint32Array): void {
+/** A standalone digest of one point list, for the wrap polygon. */
+function pointsDigest(points: EmuPoints): string {
+  HASH_SCRATCH[0] = 0x811c_9dc5;
+  HASH_SCRATCH[1] = 0x1000_0193;
+  foldPointsInto(points, HASH_SCRATCH);
+  return `${HASH_SCRATCH[0]!.toString(36)}:${HASH_SCRATCH[1]!.toString(36)}`;
+}
+
+/** One fold shared by subpaths, line ends and wrap polygons, so all hash the same way. */
+function foldPointsInto(points: EmuPoints, hash: Uint32Array): void {
   let hashA = hash[0]!;
   let hashB = hash[1]!;
   for (const point of points) {
@@ -341,6 +347,8 @@ function drawingProjectionLayoutToken(projection: DrawingProjection): string {
     anchor?.simplePos ? 'sp' : 'pv',
     anchor ? String(anchor.relativeHeight) : '',
     anchor ? (anchor.layoutInCell ? '1' : '0') : '',
+    anchor ? (anchor.allowOverlap ? '1' : '0') : '',
+    anchor ? (anchor.behindDocument ? '1' : '0') : '',
     picture
       ? framedTokenJoin([
           String(picture.crop.left),
@@ -368,7 +376,9 @@ function drawingProjectionLayoutToken(projection: DrawingProjection): string {
           String(wrap.distancesEmu.right),
           String(wrap.distancesEmu.bottom),
           String(wrap.distancesEmu.left),
+          // The vertex count alone let a moved vertex reuse the old exclusion polygon.
           String(wrap.polygon.length),
+          pointsDigest(wrap.polygon),
         ])
       : '',
     position

--- a/packages/core/src/layout/inline-drawing-source.ts
+++ b/packages/core/src/layout/inline-drawing-source.ts
@@ -263,9 +263,27 @@ export function vectorShapeLayoutToken(
       String(component.strokeWidthEmu),
       String(component.subpathsEmu.length)
     );
-    for (const subpath of component.subpathsEmu) {
-      scalars.push(String(subpath.length));
+    component.subpathsEmu.forEach((subpath, index) => {
+      // An omitted close flag paints closed, exactly like `true`; only `false` leaves the
+      // path open, so that is the one value that must separate two otherwise equal shapes.
+      scalars.push(String(subpath.length), component.subpathsClosed?.[index] === false ? '0' : '1');
       for (const point of subpath) {
+        COORDINATE_SCRATCH[0] = point.x;
+        hashA = Math.imul(hashA ^ COORDINATE_BITS[0]!, 0x0100_0193);
+        hashB = Math.imul(hashB ^ COORDINATE_BITS[1]!, 0x0100_01b3);
+        COORDINATE_SCRATCH[0] = point.y;
+        hashA = Math.imul(hashA ^ COORDINATE_BITS[1]!, 0x0100_0193);
+        hashB = Math.imul(hashB ^ COORDINATE_BITS[0]!, 0x0100_01b3);
+      }
+    });
+    // Line-end triangles are generated geometry the painter fills separately, so a changed
+    // `a:headEnd`/`a:tailEnd` moves nothing in the subpath stream. Their vertices join the
+    // same accumulators, framed by their counts, so the token cannot reuse a stale record.
+    const arrowheads = component.arrowheadsEmu ?? [];
+    scalars.push(String(arrowheads.length));
+    for (const arrowhead of arrowheads) {
+      scalars.push(String(arrowhead.length));
+      for (const point of arrowhead) {
         COORDINATE_SCRATCH[0] = point.x;
         hashA = Math.imul(hashA ^ COORDINATE_BITS[0]!, 0x0100_0193);
         hashB = Math.imul(hashB ^ COORDINATE_BITS[1]!, 0x0100_01b3);

--- a/packages/core/src/layout/legacy-footer-fixed-frame.ts
+++ b/packages/core/src/layout/legacy-footer-fixed-frame.ts
@@ -26,10 +26,10 @@ function one(node: OoxmlElement, name: string): OoxmlElement | undefined {
 }
 /**
  * A PAGE instruction the live page-field projection evaluates: bare `PAGE`, with the
- * `\* MERGEFORMAT` Word appends, or a `\#` numeric picture. It is the same allowlist
- * `hf-layout.ts` uses to compute the value, so the frame lanes never claim a field whose
- * result the page context will not refresh (`\* roman`, `\* Arabic` and every other switch
- * stay in ordinary flow with their cached text).
+ * `\* MERGEFORMAT` Word appends, or a `\#` numeric picture. It is the allowlist
+ * `field-instruction.ts` evaluates the projected value through, so the frame lanes never
+ * claim a field whose result the page context will not refresh (`\* roman`, `\* Arabic`
+ * and every other switch stay in ordinary flow with their cached text).
  */
 function isPageInstruction(instruction: string): boolean {
   return allowlistedPageField(instruction) === 'PAGE';

--- a/packages/core/src/layout/legacy-footer-fixed-frame.ts
+++ b/packages/core/src/layout/legacy-footer-fixed-frame.ts
@@ -4,7 +4,7 @@ import {
   type OoxmlNode,
   type OoxmlPart,
 } from '../store/package/ooxml-tree.ts';
-import { matchAllowlistedPageField } from './field-instruction.ts';
+import { allowlistedPageField } from './field-instruction.ts';
 import { shiftParagraphFragment } from './note-fragment-geometry.ts';
 import type { BlockFragmentRecord, ParagraphFragmentRecord } from './semantic-records.ts';
 
@@ -31,8 +31,8 @@ function one(node: OoxmlElement, name: string): OoxmlElement | undefined {
  * result the page context will not refresh (`\* roman`, `\* Arabic` and every other switch
  * stay in ordinary flow with their cached text).
  */
-export function isPageInstruction(instruction: string): boolean {
-  return matchAllowlistedPageField(instruction)?.kind === 'PAGE';
+function isPageInstruction(instruction: string): boolean {
+  return allowlistedPageField(instruction) === 'PAGE';
 }
 function twips(value: string | undefined): number | undefined {
   if (value === undefined || !/^\d{1,5}$/.test(value)) return undefined;

--- a/packages/core/src/layout/legacy-footer-fixed-frame.ts
+++ b/packages/core/src/layout/legacy-footer-fixed-frame.ts
@@ -23,6 +23,13 @@ function one(node: OoxmlElement, name: string): OoxmlElement | undefined {
   const matches = elements(node).filter((child) => child.localName === name);
   return matches.length === 1 && isW(matches[0]!, name) ? matches[0] : undefined;
 }
+/**
+ * A PAGE instruction, tolerant of the switches Word writes after it (`PAGE \* MERGEFORMAT`,
+ * `PAGE \* roman`). The switches only format the result; the frame never depends on it.
+ */
+export function isPageInstruction(instruction: string): boolean {
+  return /^page(?:\s+\\\*\s*[a-z]{1,32})*$/i.test(instruction.trim());
+}
 function twips(value: string | undefined): number | undefined {
   if (value === undefined || !/^\d{1,5}$/.test(value)) return undefined;
   const pt = Number(value) / 20;
@@ -55,7 +62,7 @@ function pageText(paragraph: OoxmlElement, leadingTab: boolean): string | undefi
       if (isW(node, 'fldChar') && !node.children.length) {
         const type = attr(node, 'fldCharType');
         if (state === 0 && type === 'begin') state = 1;
-        else if (state === 1 && type === 'separate' && instruction.trim() === 'PAGE') state = 2;
+        else if (state === 1 && type === 'separate' && isPageInstruction(instruction)) state = 2;
         else if (state === 2 && type === 'end') state = 3;
         else return undefined;
         continue;
@@ -71,7 +78,7 @@ function pageText(paragraph: OoxmlElement, leadingTab: boolean): string | undefi
     }
   }
   return state === 3 &&
-    instruction.trim() === 'PAGE' &&
+    isPageInstruction(instruction) &&
     tabs === Number(leadingTab) &&
     ((!prefix && !suffix) || (prefix === '- ' && suffix === ' -'))
     ? prefix + suffix

--- a/packages/core/src/layout/legacy-footer-fixed-frame.ts
+++ b/packages/core/src/layout/legacy-footer-fixed-frame.ts
@@ -4,6 +4,7 @@ import {
   type OoxmlNode,
   type OoxmlPart,
 } from '../store/package/ooxml-tree.ts';
+import { matchAllowlistedPageField } from './field-instruction.ts';
 import { shiftParagraphFragment } from './note-fragment-geometry.ts';
 import type { BlockFragmentRecord, ParagraphFragmentRecord } from './semantic-records.ts';
 
@@ -24,11 +25,14 @@ function one(node: OoxmlElement, name: string): OoxmlElement | undefined {
   return matches.length === 1 && isW(matches[0]!, name) ? matches[0] : undefined;
 }
 /**
- * A PAGE instruction, tolerant of the switches Word writes after it (`PAGE \* MERGEFORMAT`,
- * `PAGE \* roman`). The switches only format the result; the frame never depends on it.
+ * A PAGE instruction the live page-field projection evaluates: bare `PAGE`, with the
+ * `\* MERGEFORMAT` Word appends, or a `\#` numeric picture. It is the same allowlist
+ * `hf-layout.ts` uses to compute the value, so the frame lanes never claim a field whose
+ * result the page context will not refresh (`\* roman`, `\* Arabic` and every other switch
+ * stay in ordinary flow with their cached text).
  */
 export function isPageInstruction(instruction: string): boolean {
-  return /^page(?:\s+\\\*\s*[a-z]{1,32})*$/i.test(instruction.trim());
+  return matchAllowlistedPageField(instruction)?.kind === 'PAGE';
 }
 function twips(value: string | undefined): number | undefined {
   if (value === undefined || !/^\d{1,5}$/.test(value)) return undefined;

--- a/packages/core/src/layout/legacy-footer-page-frame.ts
+++ b/packages/core/src/layout/legacy-footer-page-frame.ts
@@ -5,7 +5,8 @@ import {
   type OoxmlPart,
 } from '../store/package/ooxml-tree.ts';
 import { shiftParagraphFragment } from './note-fragment-geometry.ts';
-import { isPageInstruction, positionFixedFooterPageFrame } from './legacy-footer-fixed-frame.ts';
+import { allowlistedPageField } from './field-instruction.ts';
+import { positionFixedFooterPageFrame } from './legacy-footer-fixed-frame.ts';
 import type { BlockFragmentRecord, ParagraphFragmentRecord } from './semantic-records.ts';
 
 const isElement = (node: OoxmlNode): node is OoxmlElement => node.kind !== 'textValue';
@@ -70,7 +71,7 @@ function containsOnlyPageField(paragraph: OoxmlElement): boolean {
           state === 1 &&
           kind === 'separate' &&
           instruction !== null &&
-          isPageInstruction(instruction)
+          allowlistedPageField(instruction) === 'PAGE'
         )
           state = 2;
         else if (state === 2 && kind === 'end') state = 3;
@@ -87,7 +88,7 @@ function containsOnlyPageField(paragraph: OoxmlElement): boolean {
       } else return false;
     }
   }
-  return state === 3 && instruction !== null && isPageInstruction(instruction);
+  return state === 3 && instruction !== null && allowlistedPageField(instruction) === 'PAGE';
 }
 
 function framePair(

--- a/packages/core/src/layout/legacy-footer-page-frame.ts
+++ b/packages/core/src/layout/legacy-footer-page-frame.ts
@@ -75,8 +75,12 @@ function containsOnlyPageField(paragraph: OoxmlElement): boolean {
           state = 2;
         else if (state === 2 && kind === 'end') state = 3;
         else return false;
-      } else if (isW(node, 'instrText') && state === 1 && instruction === null) {
-        instruction = text(node)?.trim() ?? null;
+      } else if (isW(node, 'instrText') && state === 1) {
+        // Word may split one instruction across runs (` PAGE ` + `\* MERGEFORMAT`); the
+        // fixed-width lane and the field projection concatenate them, so this lane must too.
+        const value = text(node);
+        if (value === null) return false;
+        instruction = (instruction ?? '') + value;
       } else if (isW(node, 't') && state === 2) {
         const value = text(node);
         if (value === null || !/^\d*$/.test(value)) return false;
@@ -206,6 +210,7 @@ export function positionLegacyFooterPageFrame<
     lines: [
       {
         ...line,
+        box: { ...line.box, x: left + dx, width: right - left },
         contentX: line.contentX + dx,
         spans: line.spans.map((span) => ({ ...span, box: { ...span.box, x: span.box.x + dx } })),
       },

--- a/packages/core/src/layout/legacy-footer-page-frame.ts
+++ b/packages/core/src/layout/legacy-footer-page-frame.ts
@@ -5,7 +5,7 @@ import {
   type OoxmlPart,
 } from '../store/package/ooxml-tree.ts';
 import { shiftParagraphFragment } from './note-fragment-geometry.ts';
-import { positionFixedFooterPageFrame } from './legacy-footer-fixed-frame.ts';
+import { isPageInstruction, positionFixedFooterPageFrame } from './legacy-footer-fixed-frame.ts';
 import type { BlockFragmentRecord, ParagraphFragmentRecord } from './semantic-records.ts';
 
 const isElement = (node: OoxmlNode): node is OoxmlElement => node.kind !== 'textValue';
@@ -66,7 +66,13 @@ function containsOnlyPageField(paragraph: OoxmlElement): boolean {
       if (isW(node, 'fldChar') && node.children.length === 0) {
         const kind = attr(node, 'fldCharType');
         if (state === 0 && kind === 'begin') state = 1;
-        else if (state === 1 && kind === 'separate' && instruction === 'PAGE') state = 2;
+        else if (
+          state === 1 &&
+          kind === 'separate' &&
+          instruction !== null &&
+          isPageInstruction(instruction)
+        )
+          state = 2;
         else if (state === 2 && kind === 'end') state = 3;
         else return false;
       } else if (isW(node, 'instrText') && state === 1 && instruction === null) {
@@ -77,7 +83,7 @@ function containsOnlyPageField(paragraph: OoxmlElement): boolean {
       } else return false;
     }
   }
-  return state === 3 && instruction === 'PAGE';
+  return state === 3 && instruction !== null && isPageInstruction(instruction);
 }
 
 function framePair(
@@ -190,9 +196,13 @@ export function positionLegacyFooterPageFrame<
   const last = line.spans.at(-1);
   const right = last ? last.box.x + last.box.width : left;
   const dx = (contentWidth - (right - left)) / 2 - left;
+  // The frame is auto-sized, so its box is the ink it holds, not the story width. Hit testing
+  // is containment-first, and a full-width box here would claim every click in the band and
+  // leave the anchor paragraph (and its decoration) unreachable by mouse.
   const centered: ParagraphFragmentRecord = {
     ...framed,
     alignment: 'center',
+    box: { ...framed.box, x: left + dx, width: right - left },
     lines: [
       {
         ...line,

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -502,6 +502,11 @@ export function alignSpans(
     trailingStart -= 1;
   }
   const lastContentSpan = spans[trailingEnd - 1];
+  // Clipped whitespace runs hang past the content: with two of them the last one is a
+  // zero-width span AT the measure, so last-span arithmetic reports no slack at all. The
+  // content ends where the first hanging span starts, whatever hangs after it.
+  const hangingStart =
+    trailingStart < spans.length ? spans[trailingStart]!.box.x - indentLeft : undefined;
   const spansReachLineEnd =
     lineUsedWidth !== undefined &&
     lastContentSpan !== undefined &&
@@ -512,8 +517,7 @@ export function alignSpans(
     spansReachLineEnd &&
     (alignment === 'center' || alignment === 'right')
   ) {
-    const used = spans[trailingStart]!.box.x - indentLeft;
-    const slack = available - used;
+    const slack = available - hangingStart!;
     if (slack <= 0) return spans;
     const offset = alignment === 'center' ? slack / 2 : slack;
     const clipsAtMargin = (lineUsedWidth ?? 0) >= available - OVERFLOW_TOLERANCE_PT;
@@ -531,26 +535,22 @@ export function alignSpans(
   // Trailing whitespace hangs into the margin rather than pushing the text off-centre, which
   // is what Word does and what stops a line ending in a space from looking misaligned.
   const last = spans[spans.length - 1]!;
-  const visible = last.text.replace(/\s+$/, '');
   // `box.width` was reserved from the DRAWN text, so the visible part has to be measured the
   // same way: the difference is what the trailing whitespace measures, and mixing a drawn
   // total with a source-measured visible part reports nearly the whole span as whitespace.
   // Centre and right pass `lineUsedWidth` and never read this; the path that does is a
   // JUSTIFIED non-last line, where an over-reported `trailing` inflates `slack` and
-  // over-stretches the line.
-  const trailing =
-    visible === last.text
-      ? 0
-      : last.box.width -
-        measureDisplayText(visible, styleForFontSlot(last.style, last.fontSlot), measurer);
-  // Clipped whitespace runs hang past the content: with two of them the last one is a
-  // zero-width span AT the measure, so the last-span arithmetic reports no slack at all.
-  // The content ends where the first hanging span starts, whatever hangs after it.
-  const used =
-    lineUsedWidth ??
-    (trailingStart < spans.length
-      ? spans[trailingStart]!.box.x - indentLeft
-      : last.box.x - indentLeft + last.box.width - trailing);
+  // over-stretches the line. Measured only on that path.
+  const contentEndWithoutTrailingWhitespace = (): number => {
+    const visible = last.text.replace(/\s+$/, '');
+    const trailing =
+      visible === last.text
+        ? 0
+        : last.box.width -
+          measureDisplayText(visible, styleForFontSlot(last.style, last.fontSlot), measurer);
+    return last.box.x - indentLeft + last.box.width - trailing;
+  };
+  const used = lineUsedWidth ?? hangingStart ?? contentEndWithoutTrailingWhitespace();
   const slack = available - used;
   if (slack <= 0) return spans;
 

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -1,4 +1,9 @@
-// Shared body/cell line breaking. Paragraph-relative spans keep cached breaks position-independent.
+// Paragraph measuring and breaking, shared between the body flow and table cells.
+//
+// Extracted from `semantic-layout.ts` unchanged so a cell paragraph breaks exactly like a
+// body paragraph: same pieces, same word boundaries, same cache discipline. The BREAK is
+// position-independent — span x offsets are relative to the paragraph origin — which is
+// what lets one cached break serve the same content at any x (body or any cell).
 
 import {
   PAGE_BREAK_CHAR,
@@ -538,7 +543,14 @@ export function alignSpans(
       ? 0
       : last.box.width -
         measureDisplayText(visible, styleForFontSlot(last.style, last.fontSlot), measurer);
-  const used = lineUsedWidth ?? last.box.x - indentLeft + last.box.width - trailing;
+  // Clipped whitespace runs hang past the content: with two of them the last one is a
+  // zero-width span AT the measure, so the last-span arithmetic reports no slack at all.
+  // The content ends where the first hanging span starts, whatever hangs after it.
+  const used =
+    lineUsedWidth ??
+    (trailingStart < spans.length
+      ? spans[trailingStart]!.box.x - indentLeft
+      : last.box.x - indentLeft + last.box.width - trailing);
   const slack = available - used;
   if (slack <= 0) return spans;
 
@@ -549,9 +561,10 @@ export function alignSpans(
     if (justified) return justified;
     // Only boundaries after an expandable space receive slack — the same slots paint stretches
     // with `word-spacing`. A uniform step across every span pair invented gaps before tabs and
-    // run splits and drifted every later caret by N×step.
+    // run splits and drifted every later caret by N×step. Hanging whitespace runs are not
+    // slots either: a boundary between two of them took a share of the slack from the words.
     const gapBefore: number[] = [];
-    for (let index = 1; index < spans.length; index += 1) {
+    for (let index = 1; index < trailingStart; index += 1) {
       if (endsWithExpandableSpace(spans[index - 1]!.text)) gapBefore.push(index);
     }
     if (gapBefore.length === 0) return spans;
@@ -1496,7 +1509,7 @@ export function breakParagraph(
         isCollapsibleLineEndWhitespace(candidate) &&
         (placeableSuffixes[pieceIndex]![boundary] !== 1 ||
           (!layoutOwned &&
-            line.spans.length > 0 &&
+            (line.spans.length > 0 || line.drawings.length > 0) &&
             line.width + width > lineAvailable() + OVERFLOW_TOLERANCE_PT));
       if (lineEndWhitespace) {
         width = Math.min(width, Math.max(0, lineAvailable() - line.width));

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -1,7 +1,7 @@
 // Paragraph measuring and breaking, shared between the body flow and table cells.
 //
-// Extracted from `semantic-layout.ts` unchanged so a cell paragraph breaks exactly like a
-// body paragraph: same pieces, same word boundaries, same cache discipline. The BREAK is
+// Extracted from `semantic-layout.ts` so a cell paragraph breaks exactly like a body
+// paragraph: same pieces, same word boundaries, same cache discipline. The BREAK is
 // position-independent — span x offsets are relative to the paragraph origin — which is
 // what lets one cached break serve the same content at any x (body or any cell).
 

--- a/packages/core/src/layout/script-itemization.ts
+++ b/packages/core/src/layout/script-itemization.ts
@@ -356,10 +356,18 @@ export function eastAsiaRunsOfSegments(
       const to = from + (codePoint > 0xffff ? 2 : 1);
       // A hinted symbol takes the East Asian face for itself only. It is not strong text:
       // it neither resolves the Common units before it nor pulls the Common units after it,
-      // so the hint on one run never reaches the `©` or NBSP of an unhinted neighbour.
+      // so the hint on one run never reaches the `©` or NBSP of an unhinted neighbour. The
+      // marks that extend its grapheme cluster (a combining accent, an emoji variation
+      // selector) do travel with it: a cluster is shaped as one unit or not at all.
       if (hintedSegments[segment] && isEastAsiaHintSymbol(codePoint)) {
-        addEastAsia(segment, from, to);
-        from = to;
+        let clusterEnd = to;
+        while (clusterEnd < text.length) {
+          const next = text.codePointAt(clusterEnd)!;
+          if (!isClusterExtender(next)) break;
+          clusterEnd += next > 0xffff ? 2 : 1;
+        }
+        addEastAsia(segment, from, clusterEnd);
+        from = clusterEnd;
         continue;
       }
       const slotClass = slotClassOf(codePoint);
@@ -379,5 +387,38 @@ export function eastAsiaRunsOfSegments(
   }
   // A sequence of nothing but Common text has no strong item to inherit from on either
   // side; it stays in the base slots, exactly as it did before slot resolution existed.
-  return out;
+  //
+  // Leading Common units resolve only once the strong item AFTER them arrives, and a hinted
+  // symbol between the two is emitted first, so the list can be out of document order.
+  // The consumer slices pieces with a monotonic cursor, so order and merge here.
+  if (out.length < 2) return out;
+  out.sort((a, b) => a.segment - b.segment || a.from - b.from);
+  const merged: { segment: number; from: number; to: number }[] = [out[0]!];
+  for (let index = 1; index < out.length; index += 1) {
+    const range = out[index]!;
+    const previous = merged[merged.length - 1]!;
+    if (previous.segment === range.segment && range.from <= previous.to) {
+      if (range.to > previous.to) merged[merged.length - 1] = { ...previous, to: range.to };
+    } else {
+      merged.push(range);
+    }
+  }
+  return merged;
+}
+
+/**
+ * A code point that extends the grapheme cluster of the base before it: combining marks
+ * and variation selectors. Kept deliberately narrow (no ZWJ sequences), because the only
+ * job here is to keep a mark on the face of the symbol it decorates.
+ */
+function isClusterExtender(codePoint: number): boolean {
+  return (
+    (codePoint >= 0x300 && codePoint <= 0x36f) ||
+    (codePoint >= 0x1ab0 && codePoint <= 0x1aff) ||
+    (codePoint >= 0x1dc0 && codePoint <= 0x1dff) ||
+    (codePoint >= 0x20d0 && codePoint <= 0x20ff) ||
+    (codePoint >= 0xfe00 && codePoint <= 0xfe0f) ||
+    (codePoint >= 0xfe20 && codePoint <= 0xfe2f) ||
+    (codePoint >= 0xe0100 && codePoint <= 0xe01ef)
+  );
 }

--- a/packages/core/src/layout/script-itemization.ts
+++ b/packages/core/src/layout/script-itemization.ts
@@ -331,6 +331,8 @@ export function eastAsiaRunsOfSegments(
 
   /** Strongly classified text seen so far, or null while only Common text has streamed by. */
   let precedingStrong: Exclude<SlotClass, 'common'> | null = null;
+  // A w:t boundary does not end the preceding symbol's combining sequence.
+  let extendsHintedSymbol = false;
   /** Leading Common units waiting for the FOLLOWING strong item; `ascii` blocks eastAsia. */
   const pending: { segment: number; from: number; to: number; ascii: boolean }[] = [];
   const resolvePending = (strong: Exclude<SlotClass, 'common'>): void => {
@@ -343,6 +345,7 @@ export function eastAsiaRunsOfSegments(
   for (let segment = 0; segment < segments.length; segment += 1) {
     const text = segments[segment]!;
     if (pureAscii(text)) {
+      if (text.length > 0) extendsHintedSymbol = false;
       // Never eastAsia, so only the strong/Common distinction matters: any alphanumeric
       // is a strong Latin item; pure punctuation and whitespace stay transparent.
       if (/[0-9A-Za-z]/.test(text)) {
@@ -354,22 +357,26 @@ export function eastAsiaRunsOfSegments(
     for (let from = 0; from < text.length; ) {
       const codePoint = text.codePointAt(from)!;
       const to = from + (codePoint > 0xffff ? 2 : 1);
-      // A hinted symbol takes the East Asian face for itself only. It is not strong text:
-      // it neither resolves the Common units before it nor pulls the Common units after it,
-      // so the hint on one run never reaches the `©` or NBSP of an unhinted neighbour. The
-      // marks that extend its grapheme cluster (a combining accent, an emoji variation
-      // selector) do travel with it: a cluster is shaped as one unit or not at all.
-      if (hintedSegments[segment] && isEastAsiaHintSymbol(codePoint)) {
-        let clusterEnd = to;
-        while (clusterEnd < text.length) {
-          const next = text.codePointAt(clusterEnd)!;
-          if (!isClusterExtender(next)) break;
-          clusterEnd += next > 0xffff ? 2 : 1;
+      // The hint changes this character's face, not its underlying script strength.
+      // Common symbols remain transparent; Greek and Cyrillic still stop surrounding
+      // Common characters from inheriting a preceding or following Han character.
+      // Combining marks and variation selectors retain their hinted base's face across
+      // segment boundaries without changing the preceding strong classification.
+      const hinted = hintedSegments[segment] && isEastAsiaHintSymbol(codePoint);
+      if (hinted || (extendsHintedSymbol && isClusterExtender(codePoint))) {
+        if (hinted) {
+          const underlyingClass = slotClassOf(codePoint);
+          if (underlyingClass !== 'common') {
+            resolvePending(underlyingClass);
+            precedingStrong = underlyingClass;
+          }
         }
-        addEastAsia(segment, from, clusterEnd);
-        from = clusterEnd;
+        addEastAsia(segment, from, to);
+        extendsHintedSymbol = true;
+        from = to;
         continue;
       }
+      extendsHintedSymbol = false;
       const slotClass = slotClassOf(codePoint);
       if (slotClass === 'common') {
         if (precedingStrong === null) {

--- a/packages/core/src/layout/script-itemization.ts
+++ b/packages/core/src/layout/script-itemization.ts
@@ -354,10 +354,15 @@ export function eastAsiaRunsOfSegments(
     for (let from = 0; from < text.length; ) {
       const codePoint = text.codePointAt(from)!;
       const to = from + (codePoint > 0xffff ? 2 : 1);
-      const slotClass =
-        hintedSegments[segment] && isEastAsiaHintSymbol(codePoint)
-          ? 'eastAsia'
-          : slotClassOf(codePoint);
+      // A hinted symbol takes the East Asian face for itself only. It is not strong text:
+      // it neither resolves the Common units before it nor pulls the Common units after it,
+      // so the hint on one run never reaches the `©` or NBSP of an unhinted neighbour.
+      if (hintedSegments[segment] && isEastAsiaHintSymbol(codePoint)) {
+        addEastAsia(segment, from, to);
+        from = to;
+        continue;
+      }
+      const slotClass = slotClassOf(codePoint);
       if (slotClass === 'common') {
         if (precedingStrong === null) {
           pending.push({ segment, from, to, ascii: codePoint <= 0x7f });

--- a/packages/core/src/layout/symbol-run.ts
+++ b/packages/core/src/layout/symbol-run.ts
@@ -123,11 +123,14 @@ export function symbolRunStyle(
   themeFonts?: ThemeFonts
 ): { readonly props: readonly OoxmlProperty[]; readonly style: ResolvedRunStyle } {
   if (!glyph.font) return { props: runProps, style: resolveRunStyle(runProps, themeFonts) };
-  // The glyph names its own font, so an inherited `w:hint="eastAsia"` must not move it to
-  // the run's East Asian face: the hint is reset beside the override.
+  // The glyph names its own font. Reset the hint and override the East Asian slot too,
+  // because neighboring Han can select that slot independently of the hint.
   const props: readonly OoxmlProperty[] = [
     ...runProps,
-    { localName: 'rFonts', attributes: { ascii: glyph.font, hAnsi: glyph.font, hint: 'default' } },
+    {
+      localName: 'rFonts',
+      attributes: { ascii: glyph.font, hAnsi: glyph.font, eastAsia: glyph.font, hint: 'default' },
+    },
   ];
   return { props, style: resolveRunStyle(props, themeFonts) };
 }

--- a/packages/core/src/layout/symbol-run.ts
+++ b/packages/core/src/layout/symbol-run.ts
@@ -123,9 +123,11 @@ export function symbolRunStyle(
   themeFonts?: ThemeFonts
 ): { readonly props: readonly OoxmlProperty[]; readonly style: ResolvedRunStyle } {
   if (!glyph.font) return { props: runProps, style: resolveRunStyle(runProps, themeFonts) };
+  // The glyph names its own font, so an inherited `w:hint="eastAsia"` must not move it to
+  // the run's East Asian face: the hint is reset beside the override.
   const props: readonly OoxmlProperty[] = [
     ...runProps,
-    { localName: 'rFonts', attributes: { ascii: glyph.font, hAnsi: glyph.font } },
+    { localName: 'rFonts', attributes: { ascii: glyph.font, hAnsi: glyph.font, hint: 'default' } },
   ];
   return { props, style: resolveRunStyle(props, themeFonts) };
 }

--- a/packages/core/src/output/__tests__/drawing-connectors.test.ts
+++ b/packages/core/src/output/__tests__/drawing-connectors.test.ts
@@ -124,6 +124,9 @@ test('semantic painter leaves an open path open and fills its separate arrowhead
   expect(arrow.getAttribute('fill')).toBe('#FF0000');
   expect(element.querySelectorAll('path')).toHaveLength(2);
   expect(element.querySelector('image')).toBeNull();
+  // The triangle's wings reach past the authored extent; the outer box at `paintBounds`
+  // is the only clip, so the svg itself must not cut them off.
+  expect(element.querySelector('svg')!.style.overflow).toBe('visible');
 });
 
 test('generated arrowhead vertices count against the existing per-drawing point budget', () => {

--- a/packages/core/src/output/semantic-paint-drawings.ts
+++ b/packages/core/src/output/semantic-paint-drawings.ts
@@ -551,6 +551,10 @@ function paintVectorShape(
   svg.setAttribute('width', '100%');
   svg.setAttribute('height', '100%');
   svg.style.display = 'block';
+  // A non-root `<svg>` clips to its viewport by default. Line-end triangles are generated
+  // past the authored extent, and layout already widens `paintBounds` by the effect extent
+  // for them, so the clip belongs to the outer box alone.
+  svg.style.overflow = 'visible';
 
   // `components` is the paint authority and is always non-empty; the top-level `fillHex`
   // and `strokeHex` describe a one-component shape only.

--- a/packages/core/src/output/semantic-paint-drawings.ts
+++ b/packages/core/src/output/semantic-paint-drawings.ts
@@ -551,9 +551,10 @@ function paintVectorShape(
   svg.setAttribute('width', '100%');
   svg.setAttribute('height', '100%');
   svg.style.display = 'block';
-  // A non-root `<svg>` clips to its viewport by default. Line-end triangles are generated
-  // past the authored extent, and layout already widens `paintBounds` by the effect extent
-  // for them, so the clip belongs to the outer box alone.
+  // A non-root `<svg>` clips to its viewport by default. Line-end triangles can extend past
+  // the authored extent; Word records that overhang in `wp:effectExtent`, which layout folds
+  // into `paintBounds`, so the clip belongs to the outer box alone. A file with no effect
+  // extent still clips at the extent, which is what Word shows for it too.
   svg.style.overflow = 'visible';
 
   // `components` is the paint authority and is always non-empty; the top-level `fillHex`

--- a/packages/core/src/store/__tests__/jpeg-metadata.test.ts
+++ b/packages/core/src/store/__tests__/jpeg-metadata.test.ts
@@ -113,6 +113,12 @@ describe('JPEG metadata before the frame header', () => {
     expect(
       validateJpegHeader(jpeg([segment(0xe1, exif(6)), segment(0xe1, exif(1)), frame()]))
     ).toEqual(portrait);
+    // A bare six-byte `Exif\0\0` stub is skipped by decoders, which read the next block.
+    expect(
+      validateJpegHeader(
+        jpeg([segment(0xe1, strToU8('Exif\0\0')), segment(0xe1, exif(6)), frame()])
+      )
+    ).toEqual(portrait);
   });
 
   test('rejects invalid marker lengths, truncated frames, and zero dimensions', () => {

--- a/packages/core/src/store/__tests__/jpeg-metadata.test.ts
+++ b/packages/core/src/store/__tests__/jpeg-metadata.test.ts
@@ -102,8 +102,9 @@ describe('JPEG metadata before the frame header', () => {
   });
 
   test('takes the first APP1 that yields an orientation, as decoders do', () => {
-    // The first Exif block carries one entry that is not 0x0112, so it declares no
-    // orientation; decoders keep scanning and rotate by the second block.
+    // Regression guard for existing behavior: the first Exif block carries one entry that
+    // is not 0x0112, so it declares no orientation; decoders (Skia, Blink, WebKit) keep
+    // scanning and rotate by the second block, and so does this reader.
     const unoriented = exif(6);
     new DataView(unoriented.buffer).setUint16(16, 0x11a, true);
     expect(

--- a/packages/core/src/store/__tests__/jpeg-metadata.test.ts
+++ b/packages/core/src/store/__tests__/jpeg-metadata.test.ts
@@ -101,19 +101,19 @@ describe('JPEG metadata before the frame header', () => {
     ).toEqual(portrait);
   });
 
-  test('reads orientation only from the first Exif-signed APP1, as decoders do', () => {
+  test('takes the first APP1 that yields an orientation, as decoders do', () => {
     // The first Exif block carries one entry that is not 0x0112, so it declares no
-    // orientation; a browser decoder stops there and never rotates by the second block.
+    // orientation; decoders keep scanning and rotate by the second block.
     const unoriented = exif(6);
     new DataView(unoriented.buffer).setUint16(16, 0x11a, true);
     expect(
       validateJpegHeader(jpeg([segment(0xe1, unoriented), segment(0xe1, exif(6)), frame()]))
-    ).toEqual(landscape);
-    // An orientation the first Exif block DOES carry still wins over a later one.
+    ).toEqual(portrait);
+    // An orientation the first Exif block DOES carry wins over a later one.
     expect(
       validateJpegHeader(jpeg([segment(0xe1, exif(6)), segment(0xe1, exif(1)), frame()]))
     ).toEqual(portrait);
-    // A bare six-byte `Exif\0\0` stub is skipped by decoders, which read the next block.
+    // A bare six-byte `Exif\0\0` stub yields nothing and the next block is read.
     expect(
       validateJpegHeader(
         jpeg([segment(0xe1, strToU8('Exif\0\0')), segment(0xe1, exif(6)), frame()])

--- a/packages/core/src/store/__tests__/jpeg-metadata.test.ts
+++ b/packages/core/src/store/__tests__/jpeg-metadata.test.ts
@@ -101,6 +101,20 @@ describe('JPEG metadata before the frame header', () => {
     ).toEqual(portrait);
   });
 
+  test('reads orientation only from the first Exif-signed APP1, as decoders do', () => {
+    // The first Exif block carries one entry that is not 0x0112, so it declares no
+    // orientation; a browser decoder stops there and never rotates by the second block.
+    const unoriented = exif(6);
+    new DataView(unoriented.buffer).setUint16(16, 0x11a, true);
+    expect(
+      validateJpegHeader(jpeg([segment(0xe1, unoriented), segment(0xe1, exif(6)), frame()]))
+    ).toEqual(landscape);
+    // An orientation the first Exif block DOES carry still wins over a later one.
+    expect(
+      validateJpegHeader(jpeg([segment(0xe1, exif(6)), segment(0xe1, exif(1)), frame()]))
+    ).toEqual(portrait);
+  });
+
   test('rejects invalid marker lengths, truncated frames, and zero dimensions', () => {
     const zero = frame();
     zero[8] = 0;

--- a/packages/core/src/store/package/jpeg-header.ts
+++ b/packages/core/src/store/package/jpeg-header.ts
@@ -4,10 +4,14 @@ const MAX_MARKERS = 4096;
 const MAX_PADDING_BYTES = 4096;
 const MAX_EXIF_ENTRIES = 4096;
 
-/** Whether an APP1 payload opens with the `Exif\0\0` signature. */
+/**
+ * Whether an APP1 payload opens with the `Exif\0\0` signature AND carries a body. Decoders
+ * skip a bare six-byte stub and read the next Exif block, so a stub must not count as the
+ * first one here either.
+ */
 function hasExifSignature(bytes: Uint8Array, start: number, end: number): boolean {
   return (
-    end - start >= 6 &&
+    end - start > 6 &&
     bytes[start] === 0x45 &&
     bytes[start + 1] === 0x78 &&
     bytes[start + 2] === 0x69 &&

--- a/packages/core/src/store/package/jpeg-header.ts
+++ b/packages/core/src/store/package/jpeg-header.ts
@@ -4,22 +4,17 @@ const MAX_MARKERS = 4096;
 const MAX_PADDING_BYTES = 4096;
 const MAX_EXIF_ENTRIES = 4096;
 
-/** Whether an APP1 payload opens with the `Exif\0\0` signature. */
-function hasExifSignature(bytes: Uint8Array, start: number, end: number): boolean {
-  return (
-    end - start >= 6 &&
-    bytes[start] === 0x45 &&
-    bytes[start + 1] === 0x78 &&
-    bytes[start + 2] === 0x69 &&
-    bytes[start + 3] === 0x66 &&
-    bytes[start + 4] === 0 &&
-    bytes[start + 5] === 0
-  );
-}
-
-/** Orientation from one Exif-signed APP1 payload, or null when it declares none. */
 function exifOrientation(bytes: Uint8Array, start: number, end: number): number | null {
-  if (end - start < 14) return null;
+  if (
+    end - start < 14 ||
+    bytes[start] !== 0x45 ||
+    bytes[start + 1] !== 0x78 ||
+    bytes[start + 2] !== 0x69 ||
+    bytes[start + 3] !== 0x66 ||
+    bytes[start + 4] !== 0 ||
+    bytes[start + 5] !== 0
+  )
+    return null;
   const tiff = start + 6;
   const little = bytes[tiff] === 0x49 && bytes[tiff + 1] === 0x49;
   if (!little && !(bytes[tiff] === 0x4d && bytes[tiff + 1] === 0x4d)) return null;
@@ -65,11 +60,7 @@ export function validateJpegHeader(
     const length = (bytes[offset]! << 8) | bytes[offset + 1]!;
     const end = offset + length;
     if (length < 2 || end > bytes.length) return null;
-    // Decoders (Skia, Blink, WebKit) walk every APP1 and take the first that yields an
-    // orientation: a block with no 0x0112 tag, a bare `Exif\0\0` stub, or a non-Exif APP1
-    // (XMP) is skipped and the next block is read. Mirror that so the extent reported here
-    // is the extent the bitmap will have.
-    if (marker === 0xe1 && orientation === null && hasExifSignature(bytes, offset + 2, end)) {
+    if (marker === 0xe1 && orientation === null) {
       orientation = exifOrientation(bytes, offset + 2, end);
     }
     const isFrame =

--- a/packages/core/src/store/package/jpeg-header.ts
+++ b/packages/core/src/store/package/jpeg-header.ts
@@ -4,14 +4,10 @@ const MAX_MARKERS = 4096;
 const MAX_PADDING_BYTES = 4096;
 const MAX_EXIF_ENTRIES = 4096;
 
-/**
- * Whether an APP1 payload opens with the `Exif\0\0` signature AND carries a body. Decoders
- * skip a bare six-byte stub and read the next Exif block, so a stub must not count as the
- * first one here either.
- */
+/** Whether an APP1 payload opens with the `Exif\0\0` signature. */
 function hasExifSignature(bytes: Uint8Array, start: number, end: number): boolean {
   return (
-    end - start > 6 &&
+    end - start >= 6 &&
     bytes[start] === 0x45 &&
     bytes[start + 1] === 0x78 &&
     bytes[start + 2] === 0x69 &&
@@ -54,7 +50,6 @@ export function validateJpegHeader(
   let offset = 2;
   let padding = 0;
   let orientation: number | null = null;
-  let exifSeen = false;
   for (let markers = 0; markers < MAX_MARKERS && offset + 1 < bytes.length; markers += 1) {
     if (bytes[offset++] !== 0xff) return null;
     while (bytes[offset] === 0xff) {
@@ -70,10 +65,11 @@ export function validateJpegHeader(
     const length = (bytes[offset]! << 8) | bytes[offset + 1]!;
     const end = offset + length;
     if (length < 2 || end > bytes.length) return null;
-    // Browser decoders honour only the FIRST Exif-signed APP1, whatever it carries. A later
-    // one that names an orientation must not swap the extent the decoder will not swap.
-    if (marker === 0xe1 && !exifSeen && hasExifSignature(bytes, offset + 2, end)) {
-      exifSeen = true;
+    // Decoders (Skia, Blink, WebKit) walk every APP1 and take the first that yields an
+    // orientation: a block with no 0x0112 tag, a bare `Exif\0\0` stub, or a non-Exif APP1
+    // (XMP) is skipped and the next block is read. Mirror that so the extent reported here
+    // is the extent the bitmap will have.
+    if (marker === 0xe1 && orientation === null && hasExifSignature(bytes, offset + 2, end)) {
       orientation = exifOrientation(bytes, offset + 2, end);
     }
     const isFrame =

--- a/packages/core/src/store/package/jpeg-header.ts
+++ b/packages/core/src/store/package/jpeg-header.ts
@@ -4,17 +4,22 @@ const MAX_MARKERS = 4096;
 const MAX_PADDING_BYTES = 4096;
 const MAX_EXIF_ENTRIES = 4096;
 
+/** Whether an APP1 payload opens with the `Exif\0\0` signature. */
+function hasExifSignature(bytes: Uint8Array, start: number, end: number): boolean {
+  return (
+    end - start >= 6 &&
+    bytes[start] === 0x45 &&
+    bytes[start + 1] === 0x78 &&
+    bytes[start + 2] === 0x69 &&
+    bytes[start + 3] === 0x66 &&
+    bytes[start + 4] === 0 &&
+    bytes[start + 5] === 0
+  );
+}
+
+/** Orientation from one Exif-signed APP1 payload, or null when it declares none. */
 function exifOrientation(bytes: Uint8Array, start: number, end: number): number | null {
-  if (
-    end - start < 14 ||
-    bytes[start] !== 0x45 ||
-    bytes[start + 1] !== 0x78 ||
-    bytes[start + 2] !== 0x69 ||
-    bytes[start + 3] !== 0x66 ||
-    bytes[start + 4] !== 0 ||
-    bytes[start + 5] !== 0
-  )
-    return null;
+  if (end - start < 14) return null;
   const tiff = start + 6;
   const little = bytes[tiff] === 0x49 && bytes[tiff + 1] === 0x49;
   if (!little && !(bytes[tiff] === 0x4d && bytes[tiff + 1] === 0x4d)) return null;
@@ -45,6 +50,7 @@ export function validateJpegHeader(
   let offset = 2;
   let padding = 0;
   let orientation: number | null = null;
+  let exifSeen = false;
   for (let markers = 0; markers < MAX_MARKERS && offset + 1 < bytes.length; markers += 1) {
     if (bytes[offset++] !== 0xff) return null;
     while (bytes[offset] === 0xff) {
@@ -60,7 +66,10 @@ export function validateJpegHeader(
     const length = (bytes[offset]! << 8) | bytes[offset + 1]!;
     const end = offset + length;
     if (length < 2 || end > bytes.length) return null;
-    if (marker === 0xe1 && orientation === null) {
+    // Browser decoders honour only the FIRST Exif-signed APP1, whatever it carries. A later
+    // one that names an orientation must not swap the extent the decoder will not swap.
+    if (marker === 0xe1 && !exifSeen && hasExifSignature(bytes, offset + 2, end)) {
+      exifSeen = true;
       orientation = exifOrientation(bytes, offset + 2, end);
     }
     const isFrame =

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -1214,6 +1214,8 @@ a.docx-hyperlink:focus-visible {
   position: absolute;
   max-width: none;
   max-height: none;
+  /* The resource extent is the EXIF-oriented one; the pixels must be too. */
+  image-orientation: from-image;
 }
 
 .docx-editor.dark .docx-drawing-placeholder-card,


### PR DESCRIPTION
Fix rendering follow-ups from the merged rendering batch. Justified trailing spaces, East Asian font hints, explicit symbol fonts, connector clipping, JPEG decoding, and legacy PAGE footer hit testing now follow the intended behavior.

Drawing updates invalidate retained projections for geometry, textbox content, image effects, accessibility labels, hyperlinks, and locks. Regression tests cover the confirmed review findings.
