### PR TITLE
feat: find text inside anchored text boxes

### DIFF
--- a/.changeset/green-frames-search.md
+++ b/.changeset/green-frames-search.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': patch
 ---
 
-Search text-box stories and select their anchoring drawings during Find navigation. Fixes #711
+Search body, header, and footer text-box stories during Find navigation. Fixes #711

--- a/.changeset/green-frames-search.md
+++ b/.changeset/green-frames-search.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Search text-box stories and select their anchoring drawings during Find navigation. Fixes #711

--- a/docs/api/docx-editor-core/contracts-editor.api.md
+++ b/docs/api/docx-editor-core/contracts-editor.api.md
@@ -1039,6 +1039,8 @@ export type EditorScope = {
     id: string;
     kind: 'note';
 } | {
+    drawingNodeId: string;
+    hostParagraphId: string;
     id: string;
     kind: 'frame';
     owner?: {
@@ -2011,8 +2013,6 @@ export interface TextMatch {
     // (undocumented)
     readonly contextAfter?: string;
     readonly contextBefore?: string;
-    readonly drawingNodeId?: string;
-    readonly hostParagraphId?: string;
     // (undocumented)
     readonly length: number;
     readonly paragraphIndex: number;

--- a/docs/api/docx-editor-core/contracts-editor.api.md
+++ b/docs/api/docx-editor-core/contracts-editor.api.md
@@ -1032,18 +1032,22 @@ export type EditorScope = {
 /**
 * A footnote/endnote region.
 *
-* `id` encodes kind + signed note id as `footnote:<id>` or `endnote:<id>`
-* (e.g. `footnote:2`). Use `formatNoteScopeId` / `parseNoteScopeId` from the
-* store package. Do not invent a parallel `{ noteKind, noteId }` scope arm.
+* `id` encodes kind and signed note id as `footnote:<id>` or `endnote:<id>`. Use
+* `formatNoteScopeId` or `parseNoteScopeId` from the store package.
 */
 | {
     id: string;
     kind: 'note';
-}
-/** A text box or floating frame with its own content, addressed by id. */
-| {
+} | {
     id: string;
     kind: 'frame';
+    owner?: {
+        kind: 'headerFooter';
+        rId: string;
+    } | {
+        id: string;
+        kind: 'note';
+    };
 }
 /** Read-only aggregate across every view. Valid for queries, not for writes. */
 | {
@@ -2007,6 +2011,8 @@ export interface TextMatch {
     // (undocumented)
     readonly contextAfter?: string;
     readonly contextBefore?: string;
+    readonly drawingNodeId?: string;
+    readonly hostParagraphId?: string;
     // (undocumented)
     readonly length: number;
     readonly paragraphIndex: number;

--- a/docs/api/docx-editor-core/contracts-interaction.api.md
+++ b/docs/api/docx-editor-core/contracts-interaction.api.md
@@ -14,18 +14,22 @@ export type EditorScope = {
 /**
 * A footnote/endnote region.
 *
-* `id` encodes kind + signed note id as `footnote:<id>` or `endnote:<id>`
-* (e.g. `footnote:2`). Use `formatNoteScopeId` / `parseNoteScopeId` from the
-* store package. Do not invent a parallel `{ noteKind, noteId }` scope arm.
+* `id` encodes kind and signed note id as `footnote:<id>` or `endnote:<id>`. Use
+* `formatNoteScopeId` or `parseNoteScopeId` from the store package.
 */
 | {
     id: string;
     kind: 'note';
-}
-/** A text box or floating frame with its own content, addressed by id. */
-| {
+} | {
     id: string;
     kind: 'frame';
+    owner?: {
+        kind: 'headerFooter';
+        rId: string;
+    } | {
+        id: string;
+        kind: 'note';
+    };
 }
 /** Read-only aggregate across every view. Valid for queries, not for writes. */
 | {

--- a/docs/api/docx-editor-core/contracts-interaction.api.md
+++ b/docs/api/docx-editor-core/contracts-interaction.api.md
@@ -21,6 +21,8 @@ export type EditorScope = {
     id: string;
     kind: 'note';
 } | {
+    drawingNodeId: string;
+    hostParagraphId: string;
     id: string;
     kind: 'frame';
     owner?: {

--- a/docs/api/docx-editor-core/editor.api.md
+++ b/docs/api/docx-editor-core/editor.api.md
@@ -1526,6 +1526,7 @@ export interface PaginatedSurface {
     sectionProperties(): SectionProperties;
     sectionPropertiesAt(paragraphId: string): SectionProperties;
     selectAll(): void;
+    selectDrawing?(drawingNodeId: string, hostParagraphId: string): boolean;
     selectedText(): string;
     // (undocumented)
     readonly session: TreeDocxSessionView;

--- a/docs/api/docx-editor-core/editor.api.md
+++ b/docs/api/docx-editor-core/editor.api.md
@@ -1526,7 +1526,7 @@ export interface PaginatedSurface {
     sectionProperties(): SectionProperties;
     sectionPropertiesAt(paragraphId: string): SectionProperties;
     selectAll(): void;
-    selectDrawing?(drawingNodeId: string, hostParagraphId: string): boolean;
+    selectDrawing(drawingNodeId: string, hostParagraphId: string): boolean;
     selectedText(): string;
     // (undocumented)
     readonly session: TreeDocxSessionView;
@@ -1914,7 +1914,7 @@ export type SectionAnchor =
     readonly kind: 'unaddressable';
 };
 
-// @public (undocumented)
+// @public
 export type SectionBreakInsertType = 'nextPage' | 'continuous';
 
 // @public

--- a/docs/api/docx-editor-core/editor.api.md
+++ b/docs/api/docx-editor-core/editor.api.md
@@ -1914,7 +1914,7 @@ export type SectionAnchor =
     readonly kind: 'unaddressable';
 };
 
-// @public
+// @public (undocumented)
 export type SectionBreakInsertType = 'nextPage' | 'continuous';
 
 // @public

--- a/docs/api/docx-editor-core/index.api.md
+++ b/docs/api/docx-editor-core/index.api.md
@@ -1718,6 +1718,8 @@ export type EditorScope = {
     id: string;
     kind: 'note';
 } | {
+    drawingNodeId: string;
+    hostParagraphId: string;
     id: string;
     kind: 'frame';
     owner?: {
@@ -2878,8 +2880,6 @@ export interface TextMatch {
     // (undocumented)
     readonly contextAfter?: string;
     readonly contextBefore?: string;
-    readonly drawingNodeId?: string;
-    readonly hostParagraphId?: string;
     // (undocumented)
     readonly length: number;
     readonly paragraphIndex: number;

--- a/docs/api/docx-editor-core/index.api.md
+++ b/docs/api/docx-editor-core/index.api.md
@@ -1711,18 +1711,22 @@ export type EditorScope = {
 /**
 * A footnote/endnote region.
 *
-* `id` encodes kind + signed note id as `footnote:<id>` or `endnote:<id>`
-* (e.g. `footnote:2`). Use `formatNoteScopeId` / `parseNoteScopeId` from the
-* store package. Do not invent a parallel `{ noteKind, noteId }` scope arm.
+* `id` encodes kind and signed note id as `footnote:<id>` or `endnote:<id>`. Use
+* `formatNoteScopeId` or `parseNoteScopeId` from the store package.
 */
 | {
     id: string;
     kind: 'note';
-}
-/** A text box or floating frame with its own content, addressed by id. */
-| {
+} | {
     id: string;
     kind: 'frame';
+    owner?: {
+        kind: 'headerFooter';
+        rId: string;
+    } | {
+        id: string;
+        kind: 'note';
+    };
 }
 /** Read-only aggregate across every view. Valid for queries, not for writes. */
 | {
@@ -2874,6 +2878,8 @@ export interface TextMatch {
     // (undocumented)
     readonly contextAfter?: string;
     readonly contextBefore?: string;
+    readonly drawingNodeId?: string;
+    readonly hostParagraphId?: string;
     // (undocumented)
     readonly length: number;
     readonly paragraphIndex: number;

--- a/docs/api/docx-editor-core/store.api.md
+++ b/docs/api/docx-editor-core/store.api.md
@@ -4006,6 +4006,16 @@ export type TabStopWrite = ParagraphTabStop;
 export type TargetMode = 'Internal' | 'External';
 
 // @public
+export function textboxStoriesInPart(part: OoxmlPart): readonly TextboxStoryRoot[];
+
+// @public
+export interface TextboxStoryRoot {
+    readonly drawingNodeId: string;
+    readonly hostParagraphId: string;
+    readonly root: OoxmlElement;
+}
+
+// @public
 export function textContent(node: Extract<XmlNode, {
     type: 'element';
 }>): string;

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -1035,7 +1035,8 @@ export const wordFeatures: WordFeature[] = [
     rendering: 'full',
     roundTrip: 'full',
     tier: 'community',
-    notes: 'Searches headers, footers, footnotes, endnotes, table cells, and saved field results.',
+    notes:
+      'Searches headers, footers, footnotes, endnotes, text boxes, table cells, and saved field results. A text-box match selects the text box instead of placing the caret inside it.',
   },
   {
     id: 'collab.clipboard',

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -1036,7 +1036,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'Searches headers, footers, footnotes, endnotes, text boxes, table cells, and saved field results. A text-box match selects the text box instead of placing the caret inside it.',
+      'Searches headers, footers, footnotes, endnotes, body, header, and footer text boxes, table cells, and saved field results. Note-owned text boxes are excluded until their drawings are selectable. A text-box match selects the text box instead of placing the caret inside it.',
   },
   {
     id: 'collab.clipboard',

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -1036,7 +1036,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'Searches headers, footers, footnotes, endnotes, body, header, and footer text boxes, table cells, and saved field results. Note-owned text boxes are excluded until their drawings are selectable. A text-box match selects the text box instead of placing the caret inside it.',
+      'Searches headers, footers, footnotes, endnotes, body, header, and footer text boxes, table cells, and saved field results. Only anchored text boxes are searched, because an inline one paints no story. Note-owned text boxes are excluded until their drawings are selectable. A text-box match selects the text box instead of placing the caret inside it.',
   },
   {
     id: 'collab.clipboard',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -341,7 +341,6 @@ export default [
   {
     files: [
       'packages/core/src/editor/chrome-controls.ts',
-      'packages/core/src/editor/paginated-surface-contract.ts',
       'packages/core/src/layout/semantic-table.ts',
       'packages/core/src/store/__tests__/table-resize-ops.test.ts',
       'packages/core/src/store/__tests__/table-row-ops.test.ts',

--- a/packages/core/src/binding/__tests__/document-search-stories.test.ts
+++ b/packages/core/src/binding/__tests__/document-search-stories.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from 'bun:test';
 import { strToU8, zipSync } from 'fflate';
 import { MAX_NOTES_PER_PART } from '../../store/package/note-nodes.ts';
 import { openTreeSession, type TreeDocxSession } from '../tree-session.ts';
+import { textboxStoriesInPart } from '../../store/package/textbox-stories.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
@@ -41,7 +42,7 @@ function fixture(): Uint8Array {
     `xmlns:a="${A}" xmlns:wps="${WPS}"><w:body>` +
     p('needle body') +
     '<w:p><w:r><w:footnoteReference w:id="1"/><w:endnoteReference w:id="2"/></w:r></w:p>' +
-    `<w:p>${textbox('needle textbox')}<w:pPr>${section}</w:pPr></w:p>` +
+    `<w:p><w:pPr>${section}</w:pPr>${textbox('needle textbox')}</w:p>` +
     section +
     '</w:body></w:document>';
   const contentTypes =
@@ -66,7 +67,11 @@ function fixture(): Uint8Array {
     ),
     'word/document.xml': strToU8(document),
     'word/_rels/document.xml.rels': strToU8(relationships),
-    'word/header1.xml': strToU8(`<w:hdr xmlns:w="${W}">${p('needle header')}</w:hdr>`),
+    'word/header1.xml': strToU8(
+      `<w:hdr xmlns:w="${W}" xmlns:wp="${WP}" xmlns:a="${A}" xmlns:wps="${WPS}">` +
+        p('needle header') +
+        `<w:p>${textbox('needle header textbox')}</w:p></w:hdr>`
+    ),
     'word/footer1.xml': strToU8(`<w:ftr xmlns:w="${W}">${p('needle footer')}</w:ftr>`),
     'word/footnotes.xml': strToU8(
       `<w:footnotes xmlns:w="${W}">` +
@@ -208,11 +213,16 @@ describe('navigation Find stories', () => {
   test('searches stories in order with scopes and deduplicated furniture parts', () => {
     const matches = open().findText('needle').matches;
 
-    expect(matches.map((match) => match.text)).toEqual(Array(5).fill('needle'));
-    expect(matches.map((match) => match.paragraphIndex)).toEqual([0, 0, 0, 0, 0]);
+    expect(matches.map((match) => match.text)).toEqual(Array(7).fill('needle'));
+    expect(matches.map((match) => match.paragraphIndex)).toEqual([0, 0, 0, 0, 0, 0, 0]);
     expect(matches.map((match) => match.scope)).toEqual([
       undefined,
+      expect.objectContaining({ kind: 'frame' }),
       { kind: 'headerFooter', rId: 'rHeader' },
+      expect.objectContaining({
+        kind: 'frame',
+        owner: { kind: 'headerFooter', rId: 'rHeader' },
+      }),
       { kind: 'headerFooter', rId: 'rFooter' },
       { kind: 'note', id: 'footnote:1' },
       { kind: 'note', id: 'endnote:2' },
@@ -280,8 +290,16 @@ describe('navigation Find stories', () => {
     expect(session.findText('outside cap').matches).toEqual([]);
   });
 
-  test('skips text-box stories until the surface can address them', () => {
-    expect(open().findText('needle textbox').matches).toEqual([]);
+  test('searches body text-box stories after body paragraphs', () => {
+    const session = open();
+    const [root] = textboxStoriesInPart(session.part());
+    const matches = session.findText('needle').matches;
+    const frame = matches[1]!;
+
+    expect(frame.scope).toEqual({ kind: 'frame', id: root?.root.id });
+    expect(frame.drawingNodeId).toBe(root?.drawingNodeId);
+    expect(frame.hostParagraphId).toBe(root?.hostParagraphId);
+    expect(frame.text).toBe('needle');
   });
 
   test.each([
@@ -312,6 +330,12 @@ describe('navigation Find stories', () => {
     const result = open().findText('needle', { limit: 4 });
 
     expect(result.matches).toHaveLength(4);
+    expect(result.matches.map((match) => match.scope?.kind ?? 'body')).toEqual([
+      'body',
+      'frame',
+      'headerFooter',
+      'frame',
+    ]);
     expect(result.truncated).toBe(true);
   });
 });

--- a/packages/core/src/binding/__tests__/document-search-stories.test.ts
+++ b/packages/core/src/binding/__tests__/document-search-stories.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, test } from 'bun:test';
 import { strToU8, zipSync } from 'fflate';
 import { MAX_NOTES_PER_PART, resolvableNotesOf } from '../../store/package/note-nodes.ts';
+import { paragraphTextOf } from '../../store/store/tree-op-apply.ts';
 import { readOoxmlPart } from '../../store/package/ooxml-tree.ts';
 import {
   expandSelectableTextboxStories,
@@ -22,7 +23,7 @@ const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
 
 const p = (text: string) => `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
 
-function textbox(text: string): string {
+function textbox(text: string, story = p(text)): string {
   return (
     '<w:r><w:drawing><wp:anchor distT="0" distB="0" distL="0" distR="0" simplePos="0" ' +
     'relativeHeight="1" behindDoc="0" locked="0" layoutInCell="1" allowOverlap="1">' +
@@ -34,7 +35,7 @@ function textbox(text: string): string {
     `<a:graphic><a:graphicData uri="${WPS}"><wps:wsp>` +
     '<wps:spPr><a:xfrm><a:ext cx="914400" cy="457200"/></a:xfrm>' +
     '<a:prstGeom prst="rect"><a:avLst/></a:prstGeom></wps:spPr>' +
-    `<wps:txbx><w:txbxContent>${p(text)}</w:txbxContent></wps:txbx>` +
+    `<wps:txbx><w:txbxContent>${story}</w:txbxContent></wps:txbx>` +
     '<wps:bodyPr/></wps:wsp></a:graphicData></a:graphic></wp:anchor></w:drawing></w:r>'
   );
 }
@@ -151,6 +152,28 @@ function footnoteFixture(notes: string, referenceIds: readonly number[] = [1]): 
       'word/footnotes.xml': strToU8(
         `<w:footnotes xmlns:w="${W}" xmlns:wp="${WP}" xmlns:a="${A}" ` +
           `xmlns:wps="${WPS}">${notes}</w:footnotes>`
+      ),
+    },
+    { level: 0 }
+  );
+}
+
+/** A body-only package, for questions that need no furniture or notes. */
+function bodyFixture(body: string): Uint8Array {
+  return zipSync(
+    {
+      '[Content_Types].xml': strToU8(
+        `<Types xmlns="${CT}">` +
+          '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+          '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+          '</Types>'
+      ),
+      '_rels/.rels': strToU8(
+        `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
+      ),
+      'word/document.xml': strToU8(
+        `<w:document xmlns:w="${W}" xmlns:wp="${WP}" xmlns:a="${A}" ` +
+          `xmlns:wps="${WPS}"><w:body>${body}</w:body></w:document>`
       ),
     },
     { level: 0 }
@@ -305,13 +328,30 @@ describe('navigation Find stories', () => {
     const matches = session.findText('needle').matches;
     const frame = matches[1]!;
 
-    expect(frame.scope).toEqual({ kind: 'frame', id: root?.root.id });
-    expect(frame.drawingNodeId).toBe(root?.drawingNodeId);
-    expect(frame.hostParagraphId).toBe(root?.hostParagraphId);
+    expect(frame.scope).toEqual({
+      kind: 'frame',
+      id: root?.root.id ?? '',
+      drawingNodeId: root?.drawingNodeId ?? '',
+      hostParagraphId: root?.hostParagraphId ?? '',
+    });
     expect(frame.text).toBe('needle');
   });
 
-  test('indexes thousands of note text boxes once and looks up each note once', () => {
+  test('reports frame offsets in the shared paragraph vocabulary', () => {
+    // A tab and a break each occupy one unit of paragraph text, so a frame match that
+    // computed its own offsets instead of using the shared index would land short here.
+    const story =
+      '<w:p><w:r><w:tab/><w:br/><w:t xml:space="preserve">before needle</w:t></w:r></w:p>';
+    const session = open(bodyFixture(`<w:p>${textbox('', story)}</w:p>`));
+    const match = session.findText('needle').matches.find((hit) => hit.scope?.kind === 'frame');
+    if (!match) throw new Error('frame match missing');
+    const raw = paragraphTextOf(session.part(), match.blockId);
+
+    expect(raw).toBe('\t\nbefore needle');
+    expect(raw.slice(match.start, match.start + match.length)).toBe('needle');
+  });
+
+  test('charges thousands of notes nothing, because a note owns no selectable frame', () => {
     const count = 2_000;
     const notes = Array.from(
       { length: count },
@@ -331,7 +371,7 @@ describe('navigation Find stories', () => {
     const work: TextboxStoryExpansionWork = { indexBuilds: 0, hostLookups: 0, indexedFrames: 0 };
 
     expect(expandSelectableTextboxStories(stories, work)).toEqual(stories);
-    expect(work).toEqual({ indexBuilds: 1, hostLookups: count, indexedFrames: count });
+    expect(work).toEqual({ indexBuilds: 0, hostLookups: 0, indexedFrames: 0 });
   });
 
   test('indexes and expands a very large frame list without varargs', () => {

--- a/packages/core/src/binding/__tests__/document-search-stories.test.ts
+++ b/packages/core/src/binding/__tests__/document-search-stories.test.ts
@@ -334,6 +334,26 @@ describe('navigation Find stories', () => {
     expect(work).toEqual({ indexBuilds: 1, hostLookups: count, indexedFrames: count });
   });
 
+  test('indexes and expands a very large frame list without varargs', () => {
+    const count = 150_000;
+    const parsed = readOoxmlPart(
+      `<w:document xmlns:w="${W}"><w:body>${p('host')}</w:body></w:document>`,
+      { name: '/word/document.xml', contentType: 'application/xml' }
+    );
+    if (!parsed.ok) throw new Error(parsed.reason);
+    const root = parsed.part.root.children.find((child) => child.kind === 'body');
+    if (!root) throw new Error('body missing');
+    const paragraph = root.children.find((child) => child.kind === 'paragraph');
+    if (!paragraph) throw new Error('host paragraph missing');
+    const frame = { root: paragraph, drawingNodeId: 'drawing', hostParagraphId: paragraph.id };
+    const frames = Array(count).fill(frame) as (typeof frame)[];
+    const work: TextboxStoryExpansionWork = { indexBuilds: 0, hostLookups: 0, indexedFrames: 0 };
+    const stories: SearchStory[] = [{ part: parsed.part, root }];
+
+    expect(expandSelectableTextboxStories(stories, work, () => frames)).toHaveLength(count + 1);
+    expect(work).toEqual({ indexBuilds: 1, hostLookups: 1, indexedFrames: count });
+  });
+
   test('excludes a text box owned by a footnote', () => {
     const notes =
       `<w:footnote w:id="1">${p('ordinary note')}` +

--- a/packages/core/src/binding/__tests__/document-search-stories.test.ts
+++ b/packages/core/src/binding/__tests__/document-search-stories.test.ts
@@ -2,9 +2,15 @@
 
 import { describe, expect, test } from 'bun:test';
 import { strToU8, zipSync } from 'fflate';
-import { MAX_NOTES_PER_PART } from '../../store/package/note-nodes.ts';
-import { openTreeSession, type TreeDocxSession } from '../tree-session.ts';
+import { MAX_NOTES_PER_PART, resolvableNotesOf } from '../../store/package/note-nodes.ts';
+import { readOoxmlPart } from '../../store/package/ooxml-tree.ts';
+import {
+  expandSelectableTextboxStories,
+  type SearchStory,
+  type TextboxStoryExpansionWork,
+} from '../document-search-frames.ts';
 import { textboxStoriesInPart } from '../../store/package/textbox-stories.ts';
+import { openTreeSession, type TreeDocxSession } from '../tree-session.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
@@ -142,7 +148,10 @@ function footnoteFixture(notes: string, referenceIds: readonly number[] = [1]): 
       'word/_rels/document.xml.rels': strToU8(
         `<Relationships xmlns="${REL}"><Relationship Id="rFootnotes" Type="${R}/footnotes" Target="footnotes.xml"/></Relationships>`
       ),
-      'word/footnotes.xml': strToU8(`<w:footnotes xmlns:w="${W}">${notes}</w:footnotes>`),
+      'word/footnotes.xml': strToU8(
+        `<w:footnotes xmlns:w="${W}" xmlns:wp="${WP}" xmlns:a="${A}" ` +
+          `xmlns:wps="${WPS}">${notes}</w:footnotes>`
+      ),
     },
     { level: 0 }
   );
@@ -300,6 +309,39 @@ describe('navigation Find stories', () => {
     expect(frame.drawingNodeId).toBe(root?.drawingNodeId);
     expect(frame.hostParagraphId).toBe(root?.hostParagraphId);
     expect(frame.text).toBe('needle');
+  });
+
+  test('indexes thousands of note text boxes once and looks up each note once', () => {
+    const count = 2_000;
+    const notes = Array.from(
+      { length: count },
+      (_, index) => `<w:footnote w:id="${index + 1}"><w:p>${textbox('boxed')}</w:p></w:footnote>`
+    ).join('');
+    const parsed = readOoxmlPart(
+      `<w:footnotes xmlns:w="${W}" xmlns:wp="${WP}" xmlns:a="${A}" ` +
+        `xmlns:wps="${WPS}">${notes}</w:footnotes>`,
+      { name: '/word/footnotes.xml', contentType: 'application/xml' }
+    );
+    if (!parsed.ok) throw new Error(parsed.reason);
+    const stories: SearchStory[] = resolvableNotesOf(parsed.part.root).map((root, index) => ({
+      part: parsed.part,
+      root,
+      scope: { kind: 'note', id: `footnote:${index + 1}` },
+    }));
+    const work: TextboxStoryExpansionWork = { indexBuilds: 0, hostLookups: 0, indexedFrames: 0 };
+
+    expect(expandSelectableTextboxStories(stories, work)).toEqual(stories);
+    expect(work).toEqual({ indexBuilds: 1, hostLookups: count, indexedFrames: count });
+  });
+
+  test('excludes a text box owned by a footnote', () => {
+    const notes =
+      `<w:footnote w:id="1">${p('ordinary note')}` +
+      `<w:p>${textbox('note boxed needle')}</w:p></w:footnote>`;
+    const session = open(footnoteFixture(notes));
+
+    expect(session.findText('ordinary note').matches).toHaveLength(1);
+    expect(session.findText('note boxed needle').matches).toEqual([]);
   });
 
   test.each([

--- a/packages/core/src/binding/document-search-frames.ts
+++ b/packages/core/src/binding/document-search-frames.ts
@@ -22,10 +22,15 @@ export interface TextboxStoryExpansionWork {
 }
 
 type FrameIndex = ReadonlyMap<string, readonly TextboxStoryRoot[]>;
+type TextboxStoriesOf = (part: OoxmlPart) => readonly TextboxStoryRoot[];
 
-function indexFramesByHost(part: OoxmlPart, work?: TextboxStoryExpansionWork): FrameIndex {
+function indexFramesByHost(
+  part: OoxmlPart,
+  work: TextboxStoryExpansionWork | undefined,
+  textboxStoriesOf: TextboxStoriesOf
+): FrameIndex {
   const mutable = new Map<string, TextboxStoryRoot[]>();
-  const frames = textboxStoriesInPart(part);
+  const frames = textboxStoriesOf(part);
   for (const frame of frames) {
     const atHost = mutable.get(frame.hostParagraphId);
     if (atHost) atHost.push(frame);
@@ -46,7 +51,9 @@ function framesInStory(
   const frames: TextboxStoryRoot[] = [];
   for (const paragraph of storyParagraphs(story.root)) {
     if (work) work.hostLookups += 1;
-    frames.push(...(index.get(paragraph.id) ?? []));
+    const atHost = index.get(paragraph.id);
+    if (!atHost) continue;
+    for (const frame of atHost) frames.push(frame);
   }
   return frames;
 }
@@ -58,7 +65,8 @@ function framesInStory(
  */
 export function expandSelectableTextboxStories(
   stories: readonly SearchStory[],
-  work?: TextboxStoryExpansionWork
+  work?: TextboxStoryExpansionWork,
+  textboxStoriesOf: TextboxStoriesOf = textboxStoriesInPart
 ): SearchStory[] {
   const expanded: SearchStory[] = [];
   const indexes = new Map<OoxmlPart, FrameIndex>();
@@ -66,7 +74,7 @@ export function expandSelectableTextboxStories(
     expanded.push(story);
     let index = indexes.get(story.part);
     if (!index) {
-      index = indexFramesByHost(story.part, work);
+      index = indexFramesByHost(story.part, work, textboxStoriesOf);
       indexes.set(story.part, index);
     }
     const frames = framesInStory(story, index, work);

--- a/packages/core/src/binding/document-search-frames.ts
+++ b/packages/core/src/binding/document-search-frames.ts
@@ -1,0 +1,90 @@
+// Text-box story expansion for navigation Find, indexed once per owning package part.
+
+import type { ViewScope } from '../contracts/editor.ts';
+import { storyParagraphs } from '../store/package/story-blocks.ts';
+import { textboxStoriesInPart, type TextboxStoryRoot } from '../store/package/textbox-stories.ts';
+import type { OoxmlNode, OoxmlPart } from '../store/package/ooxml-tree.ts';
+
+/** One root searched by navigation Find. Internal to the binding lane. */
+export interface SearchStory {
+  readonly part: OoxmlPart;
+  readonly root: OoxmlNode;
+  readonly scope?: ViewScope;
+  readonly drawingNodeId?: string;
+  readonly hostParagraphId?: string;
+}
+
+/** Work counters used by the linear-complexity regression test. */
+export interface TextboxStoryExpansionWork {
+  indexBuilds: number;
+  hostLookups: number;
+  indexedFrames: number;
+}
+
+type FrameIndex = ReadonlyMap<string, readonly TextboxStoryRoot[]>;
+
+function indexFramesByHost(part: OoxmlPart, work?: TextboxStoryExpansionWork): FrameIndex {
+  const mutable = new Map<string, TextboxStoryRoot[]>();
+  const frames = textboxStoriesInPart(part);
+  for (const frame of frames) {
+    const atHost = mutable.get(frame.hostParagraphId);
+    if (atHost) atHost.push(frame);
+    else mutable.set(frame.hostParagraphId, [frame]);
+  }
+  if (work) {
+    work.indexBuilds += 1;
+    work.indexedFrames += frames.length;
+  }
+  return mutable;
+}
+
+function framesInStory(
+  story: SearchStory,
+  index: FrameIndex,
+  work?: TextboxStoryExpansionWork
+): readonly TextboxStoryRoot[] {
+  const frames: TextboxStoryRoot[] = [];
+  for (const paragraph of storyParagraphs(story.root)) {
+    if (work) work.hostLookups += 1;
+    frames.push(...(index.get(paragraph.id) ?? []));
+  }
+  return frames;
+}
+
+/**
+ * Add selectable body and furniture text-box stories after their owning story.
+ *
+ * Note text boxes remain excluded until note drawing layout and overlay lookup support them.
+ */
+export function expandSelectableTextboxStories(
+  stories: readonly SearchStory[],
+  work?: TextboxStoryExpansionWork
+): SearchStory[] {
+  const expanded: SearchStory[] = [];
+  const indexes = new Map<OoxmlPart, FrameIndex>();
+  for (const story of stories) {
+    expanded.push(story);
+    let index = indexes.get(story.part);
+    if (!index) {
+      index = indexFramesByHost(story.part, work);
+      indexes.set(story.part, index);
+    }
+    const frames = framesInStory(story, index, work);
+    if (story.scope?.kind === 'note') continue;
+    for (const frame of frames) {
+      const owner = story.scope;
+      expanded.push({
+        part: story.part,
+        root: frame.root,
+        scope: {
+          kind: 'frame',
+          id: frame.root.id,
+          ...(owner?.kind === 'headerFooter' ? { owner } : {}),
+        },
+        drawingNodeId: frame.drawingNodeId,
+        hostParagraphId: frame.hostParagraphId,
+      });
+    }
+  }
+  return expanded;
+}

--- a/packages/core/src/binding/document-search-frames.ts
+++ b/packages/core/src/binding/document-search-frames.ts
@@ -10,8 +10,6 @@ export interface SearchStory {
   readonly part: OoxmlPart;
   readonly root: OoxmlNode;
   readonly scope?: ViewScope;
-  readonly drawingNodeId?: string;
-  readonly hostParagraphId?: string;
 }
 
 /** Work counters used by the linear-complexity regression test. */
@@ -62,6 +60,7 @@ function framesInStory(
  * Add selectable body and furniture text-box stories after their owning story.
  *
  * Note text boxes remain excluded until note drawing layout and overlay lookup support them.
+ * The enumeration itself lists only boxes layout can paint and an overlay can resolve.
  */
 export function expandSelectableTextboxStories(
   stories: readonly SearchStory[],
@@ -72,14 +71,14 @@ export function expandSelectableTextboxStories(
   const indexes = new Map<OoxmlPart, FrameIndex>();
   for (const story of stories) {
     expanded.push(story);
+    // A note owns no selectable frame, so it earns neither the index nor the paragraph walk.
+    if (story.scope?.kind === 'note') continue;
     let index = indexes.get(story.part);
     if (!index) {
       index = indexFramesByHost(story.part, work, textboxStoriesOf);
       indexes.set(story.part, index);
     }
-    const frames = framesInStory(story, index, work);
-    if (story.scope?.kind === 'note') continue;
-    for (const frame of frames) {
+    for (const frame of framesInStory(story, index, work)) {
       const owner = story.scope;
       expanded.push({
         part: story.part,
@@ -87,10 +86,10 @@ export function expandSelectableTextboxStories(
         scope: {
           kind: 'frame',
           id: frame.root.id,
+          drawingNodeId: frame.drawingNodeId,
+          hostParagraphId: frame.hostParagraphId,
           ...(owner?.kind === 'headerFooter' ? { owner } : {}),
         },
-        drawingNodeId: frame.drawingNodeId,
-        hostParagraphId: frame.hostParagraphId,
       });
     }
   }

--- a/packages/core/src/binding/document-search.ts
+++ b/packages/core/src/binding/document-search.ts
@@ -18,7 +18,7 @@
 //
 // WHAT IS SEARCHED: body, furniture, footnotes, then endnotes. Each story uses the shared
 // paragraph walk, which descends into tables, nested tables, and block controls. Text-box
-// stories remain excluded until the surface can place a caret inside them.
+// stories follow the owning story; navigation selects their anchoring drawing, not their text.
 
 import {
   SEARCH_MATCH_LIMIT,
@@ -40,6 +40,7 @@ import {
 } from '../store/package/note-nodes.ts';
 import { isFldSimple } from '../store/package/field-nodes.ts';
 import { bodyStoryRoot, storyParagraphs, storyRootsOf } from '../store/package/story-blocks.ts';
+import { textboxStoriesInPart } from '../store/package/textbox-stories.ts';
 import { walkParagraphInline } from '../store/package/content-control-walk.ts';
 import type { OoxmlNode, OoxmlParagraphNode, OoxmlPart } from '../store/package/ooxml-tree.ts';
 import { projectVisibleParagraphText } from '../store/store/text-projection.ts';
@@ -81,6 +82,10 @@ export interface DocumentSearchMatch {
   readonly runOffset: number;
   /** Story containing the match. Omitted for the body. */
   readonly scope?: ViewScope;
+  /** Drawing that hosts a frame match. */
+  readonly drawingNodeId?: string;
+  /** Paragraph that anchors the drawing for a frame match. */
+  readonly hostParagraphId?: string;
   /** The matched text as it appears in the document, control characters flattened. */
   readonly text: string;
   /** Paragraph text immediately before the match, bounded and flattened. */
@@ -155,6 +160,8 @@ interface SearchStory {
   readonly part: OoxmlPart;
   readonly root: OoxmlNode;
   readonly scope?: ViewScope;
+  readonly drawingNodeId?: string;
+  readonly hostParagraphId?: string;
 }
 
 function bodyStories(part: OoxmlPart): SearchStory[] {
@@ -209,20 +216,45 @@ function noteStories(
 
 function searchStories(part: OoxmlPart, sources?: DocumentSearchSources): SearchStory[] {
   const stories = bodyStories(part);
-  if (!sources) return stories;
-  const seen = new Set<OoxmlPart>();
-  for (const story of furnitureStories(sources.headerFooterBySection, seen)) stories.push(story);
-  for (const story of noteStories(
-    sources.footnotes,
-    'footnote',
-    sources.referencedNoteIds.footnote
-  )) {
-    stories.push(story);
+  if (sources) {
+    const seen = new Set<OoxmlPart>();
+    for (const story of furnitureStories(sources.headerFooterBySection, seen)) stories.push(story);
+    for (const story of noteStories(
+      sources.footnotes,
+      'footnote',
+      sources.referencedNoteIds.footnote
+    )) {
+      stories.push(story);
+    }
+    for (const story of noteStories(
+      sources.endnotes,
+      'endnote',
+      sources.referencedNoteIds.endnote
+    )) {
+      stories.push(story);
+    }
   }
-  for (const story of noteStories(sources.endnotes, 'endnote', sources.referencedNoteIds.endnote)) {
-    stories.push(story);
+  const expanded: SearchStory[] = [];
+  for (const story of stories) {
+    expanded.push(story);
+    const hostParagraphIds = new Set(storyParagraphs(story.root).map((node) => node.id));
+    for (const frame of textboxStoriesInPart(story.part)) {
+      if (!hostParagraphIds.has(frame.hostParagraphId)) continue;
+      const owner = story.scope;
+      expanded.push({
+        part: story.part,
+        root: frame.root,
+        scope: {
+          kind: 'frame',
+          id: frame.root.id,
+          ...(owner?.kind === 'headerFooter' || owner?.kind === 'note' ? { owner } : {}),
+        },
+        drawingNodeId: frame.drawingNodeId,
+        hostParagraphId: frame.hostParagraphId,
+      });
+    }
   }
-  return stories;
+  return expanded;
 }
 
 /** The run a paragraph offset falls in, and the offset inside it. */
@@ -314,6 +346,8 @@ export function collectTextMatches(
           runIndex: address.index,
           runOffset: address.offset,
           ...(story.scope ? { scope: story.scope } : {}),
+          ...(story.drawingNodeId ? { drawingNodeId: story.drawingNodeId } : {}),
+          ...(story.hostParagraphId ? { hostParagraphId: story.hostParagraphId } : {}),
           text: bounded(projected.text.slice(occurrence.start, projectedEnd), SEARCH_QUERY_MAX),
           contextBefore: bounded(
             projected.text.slice(Math.max(0, occurrence.start - CONTEXT_RADIUS), occurrence.start),

--- a/packages/core/src/binding/document-search.ts
+++ b/packages/core/src/binding/document-search.ts
@@ -18,7 +18,8 @@
 //
 // WHAT IS SEARCHED: body, furniture, footnotes, then endnotes. Each story uses the shared
 // paragraph walk, which descends into tables, nested tables, and block controls. Selectable
-// body and furniture text boxes follow their owners. Note-owned text boxes remain excluded.
+// body and furniture text boxes follow their owners: ANCHORED ones only, because layout paints
+// no story for an inline box. Note-owned text boxes remain excluded.
 
 import {
   SEARCH_MATCH_LIMIT,
@@ -82,10 +83,6 @@ export interface DocumentSearchMatch {
   readonly runOffset: number;
   /** Story containing the match. Omitted for the body. */
   readonly scope?: ViewScope;
-  /** Drawing that hosts a frame match. */
-  readonly drawingNodeId?: string;
-  /** Paragraph that anchors the drawing for a frame match. */
-  readonly hostParagraphId?: string;
   /** The matched text as it appears in the document, control characters flattened. */
   readonly text: string;
   /** Paragraph text immediately before the match, bounded and flattened. */
@@ -318,8 +315,6 @@ export function collectTextMatches(
           runIndex: address.index,
           runOffset: address.offset,
           ...(story.scope ? { scope: story.scope } : {}),
-          ...(story.drawingNodeId ? { drawingNodeId: story.drawingNodeId } : {}),
-          ...(story.hostParagraphId ? { hostParagraphId: story.hostParagraphId } : {}),
           text: bounded(projected.text.slice(occurrence.start, projectedEnd), SEARCH_QUERY_MAX),
           contextBefore: bounded(
             projected.text.slice(Math.max(0, occurrence.start - CONTEXT_RADIUS), occurrence.start),

--- a/packages/core/src/binding/document-search.ts
+++ b/packages/core/src/binding/document-search.ts
@@ -17,8 +17,8 @@
 // projection, so a field result can be longer than the editable model range it maps to.
 //
 // WHAT IS SEARCHED: body, furniture, footnotes, then endnotes. Each story uses the shared
-// paragraph walk, which descends into tables, nested tables, and block controls. Text-box
-// stories follow the owning story; navigation selects their anchoring drawing, not their text.
+// paragraph walk, which descends into tables, nested tables, and block controls. Selectable
+// body and furniture text boxes follow their owners. Note-owned text boxes remain excluded.
 
 import {
   SEARCH_MATCH_LIMIT,
@@ -40,11 +40,11 @@ import {
 } from '../store/package/note-nodes.ts';
 import { isFldSimple } from '../store/package/field-nodes.ts';
 import { bodyStoryRoot, storyParagraphs, storyRootsOf } from '../store/package/story-blocks.ts';
-import { textboxStoriesInPart } from '../store/package/textbox-stories.ts';
 import { walkParagraphInline } from '../store/package/content-control-walk.ts';
-import type { OoxmlNode, OoxmlParagraphNode, OoxmlPart } from '../store/package/ooxml-tree.ts';
+import type { OoxmlParagraphNode, OoxmlPart } from '../store/package/ooxml-tree.ts';
 import { projectVisibleParagraphText } from '../store/store/text-projection.ts';
 import { paragraphOffsetIndex } from '../store/store/tree-op-segments.ts';
+import { expandSelectableTextboxStories, type SearchStory } from './document-search-frames.ts';
 
 export { SEARCH_MATCH_LIMIT, SEARCH_QUERY_MAX };
 
@@ -156,14 +156,6 @@ function runStarts(paragraph: OoxmlParagraphNode): RunStart[] {
   return starts;
 }
 
-interface SearchStory {
-  readonly part: OoxmlPart;
-  readonly root: OoxmlNode;
-  readonly scope?: ViewScope;
-  readonly drawingNodeId?: string;
-  readonly hostParagraphId?: string;
-}
-
 function bodyStories(part: OoxmlPart): SearchStory[] {
   const body = bodyStoryRoot(part);
   return body ? [{ part, root: body }] : [];
@@ -234,27 +226,7 @@ function searchStories(part: OoxmlPart, sources?: DocumentSearchSources): Search
       stories.push(story);
     }
   }
-  const expanded: SearchStory[] = [];
-  for (const story of stories) {
-    expanded.push(story);
-    const hostParagraphIds = new Set(storyParagraphs(story.root).map((node) => node.id));
-    for (const frame of textboxStoriesInPart(story.part)) {
-      if (!hostParagraphIds.has(frame.hostParagraphId)) continue;
-      const owner = story.scope;
-      expanded.push({
-        part: story.part,
-        root: frame.root,
-        scope: {
-          kind: 'frame',
-          id: frame.root.id,
-          ...(owner?.kind === 'headerFooter' || owner?.kind === 'note' ? { owner } : {}),
-        },
-        drawingNodeId: frame.drawingNodeId,
-        hostParagraphId: frame.hostParagraphId,
-      });
-    }
-  }
-  return expanded;
+  return expandSelectableTextboxStories(stories);
 }
 
 /** The run a paragraph offset falls in, and the offset inside it. */

--- a/packages/core/src/contracts/editor-scope.ts
+++ b/packages/core/src/contracts/editor-scope.ts
@@ -15,9 +15,18 @@ export type EditorScope =
    */
   | { kind: 'note'; id: string }
   | {
-      /** A text box or floating frame with its own content. */
+      /**
+       * A text box or floating frame with its own content.
+       *
+       * Addressing one takes the drawing that hosts it as well as the story root: a frame is
+       * reached THROUGH its drawing, and nothing can reveal or select it from `id` alone.
+       */
       kind: 'frame';
       id: string;
+      /** The drawing that hosts this frame. */
+      drawingNodeId: string;
+      /** The paragraph that anchors that drawing. */
+      hostParagraphId: string;
       /** Furniture or note story that owns this frame. Absence means the body story. */
       owner?: { kind: 'headerFooter'; rId: string } | { kind: 'note'; id: string };
     }

--- a/packages/core/src/contracts/editor-scope.ts
+++ b/packages/core/src/contracts/editor-scope.ts
@@ -1,0 +1,28 @@
+/**
+ * The editor is N+1 editing views: one body plus one per header/footer relationship, plus
+ * footnotes, text boxes, and other addressable regions. Commands must name their target.
+ *
+ * This set is open-ended. Treat it as non-exhaustive as more regions become addressable.
+ */
+export type EditorScope =
+  | { kind: 'body' }
+  | { kind: 'headerFooter'; rId: string }
+  /**
+   * A footnote/endnote region.
+   *
+   * `id` encodes kind and signed note id as `footnote:<id>` or `endnote:<id>`. Use
+   * `formatNoteScopeId` or `parseNoteScopeId` from the store package.
+   */
+  | { kind: 'note'; id: string }
+  | {
+      /** A text box or floating frame with its own content. */
+      kind: 'frame';
+      id: string;
+      /** Furniture or note story that owns this frame. Absence means the body story. */
+      owner?: { kind: 'headerFooter'; rId: string } | { kind: 'note'; id: string };
+    }
+  /** Read-only aggregate across every view. Valid for queries, not for writes. */
+  | { kind: 'all' };
+
+/** A concrete editing view. */
+export type ViewScope = Exclude<EditorScope, { kind: 'all' }>;

--- a/packages/core/src/contracts/editor.ts
+++ b/packages/core/src/contracts/editor.ts
@@ -12,6 +12,8 @@
  */
 
 import type { ContentControlSummary, DocEdits, DocQueries, DocQueryResults } from './document.ts';
+import type { EditorScope, ViewScope } from './editor-scope.ts';
+export type { EditorScope, ViewScope } from './editor-scope.ts';
 // Type-only, so the adapters reach the review vocabulary through THIS contract rather than
 // naming the store lane, which they are not allowed to import.
 import type {
@@ -241,35 +243,6 @@ export interface DocumentChange {
 }
 
 /**
- * The editor is N+1 editing views: one body plus one per header/footer
- * relationship, plus footnotes, text boxes, and other addressable regions.
- * Commands must say which one they target, or they silently hit the wrong
- * surface when a header is focused.
- *
- * Intentionally open-ended: this set is expected to grow (notes, frames, and
- * whatever regions later prove addressable), so treat it as non-exhaustive
- * rather than a closed enum.
- */
-export type EditorScope =
-  | { kind: 'body' }
-  | { kind: 'headerFooter'; rId: string }
-  /**
-   * A footnote/endnote region.
-   *
-   * `id` encodes kind + signed note id as `footnote:<id>` or `endnote:<id>`
-   * (e.g. `footnote:2`). Use `formatNoteScopeId` / `parseNoteScopeId` from the
-   * store package. Do not invent a parallel `{ noteKind, noteId }` scope arm.
-   */
-  | { kind: 'note'; id: string }
-  /** A text box or floating frame with its own content, addressed by id. */
-  | { kind: 'frame'; id: string }
-  /** Read-only aggregate across every view. Valid for queries, not for writes. */
-  | { kind: 'all' };
-
-/** A concrete editing view — every scope except the read-only `all` aggregate. */
-export type ViewScope = Exclude<EditorScope, { kind: 'all' }>;
-
-/**
  * What a fit mode fits the page to.
  *
  * One member today. It is a union rather than a boolean because Word's other two — the whole
@@ -477,10 +450,10 @@ export interface Editor {
   } | null;
 
   /**
-   * Find across body, headers, footers, footnotes, then endnotes. Shared parts appear once.
+   * Find across body, headers, footers, footnotes, endnotes, and their text boxes.
    *
-   * The search narrows to the body when the surface cannot open other stories. This includes
-   * viewing mode and surfaces without header, footer, or note entry methods.
+   * The search narrows to the body and its selectable text boxes when other stories cannot open.
+   * This includes viewing mode and surfaces without header, footer, or note entry methods.
    */
   findMatches(
     query: string,
@@ -1458,6 +1431,7 @@ export interface EditorQueryResults extends DocQueryResults {
  *
  * A match can span runs when formatting changes mid-word; the run address is where it
  * STARTS. `scope` identifies a non-body story so navigation opens the correct surface.
+ * A frame scope selects its anchoring drawing and never places a caret inside its story.
  * A match inside a field result reports the field atom's model range. Its `length` is one,
  * while `text` carries the visible match and can be longer. Select with `start` and `length`.
  * Never derive the selected length from `text.length`.
@@ -1477,6 +1451,10 @@ export interface TextMatch {
   readonly runOffset: number;
   /** Story containing the match. Absence means the body. */
   readonly scope?: ViewScope;
+  /** Drawing that hosts a frame match. Omitted for ordinary story matches. */
+  readonly drawingNodeId?: string;
+  /** Paragraph that anchors the drawing for a frame match. Omitted for other matches. */
+  readonly hostParagraphId?: string;
   /** The matched text as it appears in the document. */
   readonly text: string;
   /**

--- a/packages/core/src/contracts/editor.ts
+++ b/packages/core/src/contracts/editor.ts
@@ -450,10 +450,11 @@ export interface Editor {
   } | null;
 
   /**
-   * Find across body, headers, footers, footnotes, endnotes, and their text boxes.
+   * Find across body, headers, footers, footnotes, endnotes, and selectable text boxes.
    *
    * The search narrows to the body and its selectable text boxes when other stories cannot open.
    * This includes viewing mode and surfaces without header, footer, or note entry methods.
+   * Text boxes in footnotes and endnotes remain excluded until their drawings are selectable.
    */
   findMatches(
     query: string,

--- a/packages/core/src/contracts/editor.ts
+++ b/packages/core/src/contracts/editor.ts
@@ -1452,10 +1452,6 @@ export interface TextMatch {
   readonly runOffset: number;
   /** Story containing the match. Absence means the body. */
   readonly scope?: ViewScope;
-  /** Drawing that hosts a frame match. Omitted for ordinary story matches. */
-  readonly drawingNodeId?: string;
-  /** Paragraph that anchors the drawing for a frame match. Omitted for other matches. */
-  readonly hostParagraphId?: string;
   /** The matched text as it appears in the document. */
   readonly text: string;
   /**

--- a/packages/core/src/editor/__tests__/document-search-facade.test.ts
+++ b/packages/core/src/editor/__tests__/document-search-facade.test.ts
@@ -3,8 +3,12 @@ if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
 
 import { describe, expect, test } from 'bun:test';
 import { strFromU8, strToU8, unzipSync, zipSync } from 'fflate';
+import { findDrawingOverlayFrameInLayout } from '../../layout/semantic-hit-test.ts';
 import { createDocxEditor } from '../docx-editor.ts';
-import { selectedDrawingOverlayTargetOf } from '../docx-editor-images.ts';
+import {
+  resolveSelectedDrawingRecord,
+  selectedDrawingOverlayTargetOf,
+} from '../docx-editor-images.ts';
 import { FOOTNOTE_SCOPE_ID, HEADER_R_ID, storyParityDocx } from './story-parity-fixture.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
@@ -15,6 +19,7 @@ const DOC_REL = 'http://schemas.openxmlformats.org/officeDocument/2006/relations
 const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
 const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
 const WPS = 'http://schemas.microsoft.com/office/word/2010/wordprocessingShape';
+const MC = 'http://schemas.openxmlformats.org/markup-compatibility/2006';
 
 function textbox(text: string): string {
   return (
@@ -33,13 +38,23 @@ function textbox(text: string): string {
   );
 }
 
+function wrappedTextbox(text: string): string {
+  const run = textbox(text);
+  const drawing = run.slice('<w:r>'.length, -'</w:r>'.length);
+  return (
+    `<w:r><mc:AlternateContent xmlns:mc="${MC}" xmlns:wps="${WPS}">` +
+    `<mc:Choice Requires="wps">${drawing}</mc:Choice>` +
+    '<mc:Fallback><w:pict/></mc:Fallback></mc:AlternateContent></w:r>'
+  );
+}
+
 function textboxDocx(inHeader = false, includeBodyFrame = !inHeader): Uint8Array {
   const headerReference = inHeader
     ? '<w:sectPr><w:headerReference w:type="default" r:id="rHeader"/></w:sectPr>'
     : '';
   const body =
     '<w:p><w:r><w:t>body</w:t></w:r></w:p>' +
-    (includeBodyFrame ? `<w:p>${textbox('boxed needle')}</w:p>` : '') +
+    (includeBodyFrame ? `<w:p>${wrappedTextbox('boxed needle')}</w:p>` : '') +
     headerReference;
   const files: Record<string, Uint8Array> = {
     '[Content_Types].xml': strToU8(
@@ -93,7 +108,7 @@ function storyParityDocxWithBodyTable(): Uint8Array {
 }
 
 describe('document search facade', () => {
-  test('selects a body text-box drawing without selecting its story text', () => {
+  test('selects a wrapped body text-box drawing without selecting its story text', () => {
     const editor = createDocxEditor({
       container: document.createElement('div'),
       document: textboxDocx(),
@@ -118,7 +133,10 @@ describe('document search facade', () => {
       kind: 'pointer',
       drawingNodeId: match.drawingNodeId,
     });
-    expect(selectedDrawingOverlayTargetOf(editor.surface)?.id).toBe(match.drawingNodeId);
+    expect(
+      findDrawingOverlayFrameInLayout(editor.surface.layout(), match.drawingNodeId)
+    ).not.toBeNull();
+    expect(resolveSelectedDrawingRecord(editor.surface)?.drawingNodeId).toBe(match.drawingNodeId);
 
     expect(editor.exec({ type: 'insertText', text: 'X' }).ok).toBe(true);
     expect(editor.findMatches('boxed needle')[0]?.blockId).toBe(match.blockId);
@@ -161,7 +179,7 @@ describe('document search facade', () => {
     expect(match.scope?.kind === 'frame' ? match.scope.owner : undefined).toBeUndefined();
     expect(editor.findMatches('needle')).toHaveLength(1);
     expect(editor.selectMatch(match)).toEqual({ ok: true, changed: false });
-    expect(selectedDrawingOverlayTargetOf(editor.surface)?.id).toBe(match.drawingNodeId);
+    expect(resolveSelectedDrawingRecord(editor.surface)?.drawingNodeId).toBe(match.drawingNodeId);
     editor.destroy();
   });
 

--- a/packages/core/src/editor/__tests__/document-search-facade.test.ts
+++ b/packages/core/src/editor/__tests__/document-search-facade.test.ts
@@ -21,15 +21,15 @@ const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
 const WPS = 'http://schemas.microsoft.com/office/word/2010/wordprocessingShape';
 const MC = 'http://schemas.openxmlformats.org/markup-compatibility/2006';
 
-function textbox(text: string): string {
+function textbox(text: string, id = 7, topOffsetEmu = 0): string {
   return (
     `<w:r><w:drawing xmlns:wp="${WP}" xmlns:a="${A}" xmlns:wps="${WPS}">` +
     '<wp:anchor distT="0" distB="0" distL="0" distR="0" simplePos="0" relativeHeight="1" ' +
     'behindDoc="0" locked="0" layoutInCell="1" allowOverlap="1"><wp:simplePos x="0" y="0"/>' +
     '<wp:positionH relativeFrom="page"><wp:posOffset>0</wp:posOffset></wp:positionH>' +
-    '<wp:positionV relativeFrom="page"><wp:posOffset>0</wp:posOffset></wp:positionV>' +
+    `<wp:positionV relativeFrom="page"><wp:posOffset>${topOffsetEmu}</wp:posOffset></wp:positionV>` +
     '<wp:extent cx="914400" cy="457200"/><wp:effectExtent l="0" t="0" r="0" b="0"/>' +
-    '<wp:wrapNone/><wp:docPr id="7" name="Find text box"/>' +
+    `<wp:wrapNone/><wp:docPr id="${id}" name="Find text box ${id}"/>` +
     `<a:graphic><a:graphicData uri="${WPS}"><wps:wsp>` +
     '<wps:spPr><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></wps:spPr>' +
     `<wps:txbx><w:txbxContent><w:p><w:r><w:t>${text}</w:t></w:r></w:p>` +
@@ -48,7 +48,11 @@ function wrappedTextbox(text: string): string {
   );
 }
 
-function textboxDocx(inHeader = false, includeBodyFrame = !inHeader): Uint8Array {
+function textboxDocx(
+  inHeader = false,
+  includeBodyFrame = !inHeader,
+  headerTopOffsetEmu = 0
+): Uint8Array {
   const headerReference = inHeader
     ? '<w:sectPr><w:headerReference w:type="default" r:id="rHeader"/></w:sectPr>'
     : '';
@@ -77,7 +81,7 @@ function textboxDocx(inHeader = false, includeBodyFrame = !inHeader): Uint8Array
       `<Relationships xmlns="${REL}"><Relationship Id="rHeader" Type="${DOC_REL}/header" Target="header1.xml"/></Relationships>`
     );
     files['word/header1.xml'] = strToU8(
-      `<w:hdr xmlns:w="${W}"><w:p>${textbox('boxed needle')}</w:p></w:hdr>`
+      `<w:hdr xmlns:w="${W}"><w:p>${textbox('boxed needle', 7, headerTopOffsetEmu)}</w:p></w:hdr>`
     );
   }
   return zipSync(files);
@@ -115,7 +119,8 @@ describe('document search facade', () => {
     });
     if (!editor.surface) throw new Error('surface did not open');
     const match = editor.findMatches('needle')[0];
-    if (!match?.drawingNodeId || !match.hostParagraphId) throw new Error('frame match missing');
+    const frame = match?.scope?.kind === 'frame' ? match.scope : null;
+    if (!match || !frame) throw new Error('frame match missing');
     let revealed: string | null = null;
     const revealParagraph = editor.surface.revealParagraph.bind(editor.surface);
     editor.surface.revealParagraph = (paragraphId, options) => {
@@ -124,19 +129,19 @@ describe('document search facade', () => {
     };
 
     expect(editor.selectMatch(match)).toEqual({ ok: true, changed: false });
-    expect(revealed).toBe(match.hostParagraphId);
+    expect(revealed).toBe(frame.hostParagraphId);
     expect(editor.surface.state().selection).toEqual({
-      anchor: { paragraphId: match.hostParagraphId, offset: 0 },
-      head: { paragraphId: match.hostParagraphId, offset: 0 },
+      anchor: { paragraphId: frame.hostParagraphId, offset: 0 },
+      head: { paragraphId: frame.hostParagraphId, offset: 0 },
     });
     expect(editor.surface.drawingSelectionIntent()).toEqual({
       kind: 'pointer',
-      drawingNodeId: match.drawingNodeId,
+      drawingNodeId: frame.drawingNodeId,
     });
     expect(
-      findDrawingOverlayFrameInLayout(editor.surface.layout(), match.drawingNodeId)
+      findDrawingOverlayFrameInLayout(editor.surface.layout(), frame.drawingNodeId)
     ).not.toBeNull();
-    expect(resolveSelectedDrawingRecord(editor.surface)?.drawingNodeId).toBe(match.drawingNodeId);
+    expect(resolveSelectedDrawingRecord(editor.surface)?.drawingNodeId).toBe(frame.drawingNodeId);
 
     expect(editor.exec({ type: 'insertText', text: 'X' }).ok).toBe(true);
     expect(editor.findMatches('boxed needle')[0]?.blockId).toBe(match.blockId);
@@ -150,7 +155,8 @@ describe('document search facade', () => {
     });
     if (!editor.surface) throw new Error('surface did not open');
     const match = editor.findMatches('needle')[0];
-    if (!match?.drawingNodeId || !match.hostParagraphId) throw new Error('frame match missing');
+    const frame = match?.scope?.kind === 'frame' ? match.scope : null;
+    if (!match || !frame) throw new Error('frame match missing');
 
     expect(match.scope).toMatchObject({
       kind: 'frame',
@@ -160,9 +166,61 @@ describe('document search facade', () => {
     expect(editor.getActiveScope()).toEqual({ kind: 'headerFooter', rId: 'rHeader' });
     expect(editor.surface.drawingSelectionIntent()).toEqual({
       kind: 'pointer',
-      drawingNodeId: match.drawingNodeId,
+      drawingNodeId: frame.drawingNodeId,
     });
-    expect(selectedDrawingOverlayTargetOf(editor.surface)?.id).toBe(match.drawingNodeId);
+    expect(selectedDrawingOverlayTargetOf(editor.surface)?.id).toBe(frame.drawingNodeId);
+    editor.destroy();
+  });
+
+  test('selects the second of two text boxes anchored to one paragraph', () => {
+    // Both anchors sit in the same paragraph at adjacent offsets, so resolving the drawing by
+    // offset alone answers with the first one and the second can never be addressed.
+    const editor = createDocxEditor({
+      container: document.createElement('div'),
+      document: docx(`<w:p>${textbox('alpha needle', 7)}${textbox('beta needle', 8)}</w:p>`),
+    });
+    if (!editor.surface) throw new Error('surface did not open');
+    const [alpha, beta] = editor.findMatches('needle');
+    const first = alpha?.scope?.kind === 'frame' ? alpha.scope : null;
+    const second = beta?.scope?.kind === 'frame' ? beta.scope : null;
+    if (!alpha || !beta || !first || !second) throw new Error('two frame matches missing');
+
+    expect(first.drawingNodeId).not.toBe(second.drawingNodeId);
+    expect(editor.selectMatch(beta)).toEqual({ ok: true, changed: false });
+    expect(selectedDrawingOverlayTargetOf(editor.surface)?.id).toBe(second.drawingNodeId);
+    expect(editor.selectMatch(alpha)).toEqual({ ok: true, changed: false });
+    expect(selectedDrawingOverlayTargetOf(editor.surface)?.id).toBe(first.drawingNodeId);
+    editor.destroy();
+  });
+
+  test('leaves the header closed when its text box has no painted frame', () => {
+    const editor = createDocxEditor({
+      container: document.createElement('div'),
+      document: textboxDocx(true, false, 12_000_000),
+    });
+    if (!editor.surface) throw new Error('surface did not open');
+    const match = editor.findMatches('needle')[0];
+    if (!match) throw new Error('frame match missing');
+    const before = editor.surface.state().selection;
+
+    expect(editor.selectMatch(match)).toEqual({
+      ok: false,
+      code: 'unsupported',
+      reason: 'the text box drawing could not be selected',
+    });
+    expect(editor.getActiveScope()).toEqual({ kind: 'body' });
+    expect(editor.surface.state().selection).toEqual(before);
+    editor.destroy();
+  });
+
+  test('does not report a match inside an inline text box, which paints no story', () => {
+    const inline = textbox('inline needle').replace(/wp:anchor/g, 'wp:inline');
+    const editor = createDocxEditor({
+      container: document.createElement('div'),
+      document: docx(`<w:p><w:r><w:t>body needle</w:t></w:r></w:p><w:p>${inline}</w:p>`),
+    });
+
+    expect(editor.findMatches('needle').map((match) => match.scope?.kind)).toEqual([undefined]);
     editor.destroy();
   });
 
@@ -173,13 +231,13 @@ describe('document search facade', () => {
       mode: 'view',
     });
     const match = editor.findMatches('needle')[0];
-    if (!match) throw new Error('frame match missing');
+    const frame = match?.scope?.kind === 'frame' ? match.scope : null;
+    if (!match || !frame) throw new Error('frame match missing');
 
-    expect(match.scope?.kind).toBe('frame');
-    expect(match.scope?.kind === 'frame' ? match.scope.owner : undefined).toBeUndefined();
+    expect(frame.owner).toBeUndefined();
     expect(editor.findMatches('needle')).toHaveLength(1);
     expect(editor.selectMatch(match)).toEqual({ ok: true, changed: false });
-    expect(resolveSelectedDrawingRecord(editor.surface)?.drawingNodeId).toBe(match.drawingNodeId);
+    expect(resolveSelectedDrawingRecord(editor.surface)?.drawingNodeId).toBe(frame.drawingNodeId);
     editor.destroy();
   });
 

--- a/packages/core/src/editor/__tests__/document-search-facade.test.ts
+++ b/packages/core/src/editor/__tests__/document-search-facade.test.ts
@@ -4,12 +4,69 @@ if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
 import { describe, expect, test } from 'bun:test';
 import { strFromU8, strToU8, unzipSync, zipSync } from 'fflate';
 import { createDocxEditor } from '../docx-editor.ts';
+import { selectedDrawingOverlayTargetOf } from '../docx-editor-images.ts';
 import { FOOTNOTE_SCOPE_ID, HEADER_R_ID, storyParityDocx } from './story-parity-fixture.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
 const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
 const OD = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+const DOC_REL = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
+const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+const WPS = 'http://schemas.microsoft.com/office/word/2010/wordprocessingShape';
+
+function textbox(text: string): string {
+  return (
+    `<w:r><w:drawing xmlns:wp="${WP}" xmlns:a="${A}" xmlns:wps="${WPS}">` +
+    '<wp:anchor distT="0" distB="0" distL="0" distR="0" simplePos="0" relativeHeight="1" ' +
+    'behindDoc="0" locked="0" layoutInCell="1" allowOverlap="1"><wp:simplePos x="0" y="0"/>' +
+    '<wp:positionH relativeFrom="page"><wp:posOffset>0</wp:posOffset></wp:positionH>' +
+    '<wp:positionV relativeFrom="page"><wp:posOffset>0</wp:posOffset></wp:positionV>' +
+    '<wp:extent cx="914400" cy="457200"/><wp:effectExtent l="0" t="0" r="0" b="0"/>' +
+    '<wp:wrapNone/><wp:docPr id="7" name="Find text box"/>' +
+    `<a:graphic><a:graphicData uri="${WPS}"><wps:wsp>` +
+    '<wps:spPr><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></wps:spPr>' +
+    `<wps:txbx><w:txbxContent><w:p><w:r><w:t>${text}</w:t></w:r></w:p>` +
+    '</w:txbxContent></wps:txbx><wps:bodyPr/></wps:wsp></a:graphicData></a:graphic>' +
+    '</wp:anchor></w:drawing></w:r>'
+  );
+}
+
+function textboxDocx(inHeader = false, includeBodyFrame = !inHeader): Uint8Array {
+  const headerReference = inHeader
+    ? '<w:sectPr><w:headerReference w:type="default" r:id="rHeader"/></w:sectPr>'
+    : '';
+  const body =
+    '<w:p><w:r><w:t>body</w:t></w:r></w:p>' +
+    (includeBodyFrame ? `<w:p>${textbox('boxed needle')}</w:p>` : '') +
+    headerReference;
+  const files: Record<string, Uint8Array> = {
+    '[Content_Types].xml': strToU8(
+      `<Types xmlns="${CT}"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        (inHeader
+          ? '<Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>'
+          : '') +
+        '</Types>'
+    ),
+    '_rels/.rels': strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${OD}" Target="word/document.xml"/></Relationships>`
+    ),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="${W}" xmlns:r="${DOC_REL}"><w:body>${body}</w:body></w:document>`
+    ),
+  };
+  if (inHeader) {
+    files['word/_rels/document.xml.rels'] = strToU8(
+      `<Relationships xmlns="${REL}"><Relationship Id="rHeader" Type="${DOC_REL}/header" Target="header1.xml"/></Relationships>`
+    );
+    files['word/header1.xml'] = strToU8(
+      `<w:hdr xmlns:w="${W}"><w:p>${textbox('boxed needle')}</w:p></w:hdr>`
+    );
+  }
+  return zipSync(files);
+}
 
 function docx(body: string): Uint8Array {
   return zipSync({
@@ -36,6 +93,78 @@ function storyParityDocxWithBodyTable(): Uint8Array {
 }
 
 describe('document search facade', () => {
+  test('selects a body text-box drawing without selecting its story text', () => {
+    const editor = createDocxEditor({
+      container: document.createElement('div'),
+      document: textboxDocx(),
+    });
+    if (!editor.surface) throw new Error('surface did not open');
+    const match = editor.findMatches('needle')[0];
+    if (!match?.drawingNodeId || !match.hostParagraphId) throw new Error('frame match missing');
+    let revealed: string | null = null;
+    const revealParagraph = editor.surface.revealParagraph.bind(editor.surface);
+    editor.surface.revealParagraph = (paragraphId, options) => {
+      revealed = paragraphId;
+      return revealParagraph(paragraphId, options);
+    };
+
+    expect(editor.selectMatch(match)).toEqual({ ok: true, changed: false });
+    expect(revealed).toBe(match.hostParagraphId);
+    expect(editor.surface.state().selection).toEqual({
+      anchor: { paragraphId: match.hostParagraphId, offset: 0 },
+      head: { paragraphId: match.hostParagraphId, offset: 0 },
+    });
+    expect(editor.surface.drawingSelectionIntent()).toEqual({
+      kind: 'pointer',
+      drawingNodeId: match.drawingNodeId,
+    });
+    expect(selectedDrawingOverlayTargetOf(editor.surface)?.id).toBe(match.drawingNodeId);
+
+    expect(editor.exec({ type: 'insertText', text: 'X' }).ok).toBe(true);
+    expect(editor.findMatches('boxed needle')[0]?.blockId).toBe(match.blockId);
+    editor.destroy();
+  });
+
+  test('opens a header before selecting its text-box drawing', () => {
+    const editor = createDocxEditor({
+      container: document.createElement('div'),
+      document: textboxDocx(true),
+    });
+    if (!editor.surface) throw new Error('surface did not open');
+    const match = editor.findMatches('needle')[0];
+    if (!match?.drawingNodeId || !match.hostParagraphId) throw new Error('frame match missing');
+
+    expect(match.scope).toMatchObject({
+      kind: 'frame',
+      owner: { kind: 'headerFooter', rId: 'rHeader' },
+    });
+    expect(editor.selectMatch(match)).toEqual({ ok: true, changed: false });
+    expect(editor.getActiveScope()).toEqual({ kind: 'headerFooter', rId: 'rHeader' });
+    expect(editor.surface.drawingSelectionIntent()).toEqual({
+      kind: 'pointer',
+      drawingNodeId: match.drawingNodeId,
+    });
+    expect(selectedDrawingOverlayTargetOf(editor.surface)?.id).toBe(match.drawingNodeId);
+    editor.destroy();
+  });
+
+  test('keeps body text-box Find navigation available in viewing mode', () => {
+    const editor = createDocxEditor({
+      container: document.createElement('div'),
+      document: textboxDocx(true, true),
+      mode: 'view',
+    });
+    const match = editor.findMatches('needle')[0];
+    if (!match) throw new Error('frame match missing');
+
+    expect(match.scope?.kind).toBe('frame');
+    expect(match.scope?.kind === 'frame' ? match.scope.owner : undefined).toBeUndefined();
+    expect(editor.findMatches('needle')).toHaveLength(1);
+    expect(editor.selectMatch(match)).toEqual({ ok: true, changed: false });
+    expect(selectedDrawingOverlayTargetOf(editor.surface)?.id).toBe(match.drawingNodeId);
+    editor.destroy();
+  });
+
   test('selects a match inside a table cell by paragraph id', () => {
     const body =
       '<w:tbl><w:tr><w:tc><w:p><w:r><w:t>one</w:t></w:r></w:p></w:tc>' +

--- a/packages/core/src/editor/docx-editor-images.ts
+++ b/packages/core/src/editor/docx-editor-images.ts
@@ -67,10 +67,28 @@ export type ImageMutationPreconditions = Readonly<{
   selectionOffset: number;
 }>;
 
+/**
+ * Whether a record answers to this caret, and to the drawing the caller named.
+ *
+ * One paragraph can anchor several drawings, and they occupy ADJACENT offsets, so the offset
+ * alone is ambiguous: the second box's anchor offset is also the first box's `start + 1`.
+ * A named drawing therefore decides the tie, or the scan returns whichever came first and the
+ * caller can never address the rest.
+ */
+function drawingAnswersTo(
+  drawing: { readonly drawingNodeId: string; readonly start: number },
+  offset: number,
+  wanted: string | null
+): boolean {
+  if (wanted !== null && drawing.drawingNodeId !== wanted) return false;
+  return drawing.start === offset || drawing.start + 1 === offset;
+}
+
 function inlineDrawingAtOffset(
   line: ReturnType<typeof lineAtPosition>,
   paragraphId: string,
-  offset: number
+  offset: number,
+  wanted: string | null
 ): InlineDrawingRecord | null {
   if (!line) return null;
   for (const drawing of line.drawings ?? []) {
@@ -78,7 +96,7 @@ function inlineDrawingAtOffset(
     // the join line and both count from zero, so an offset alone selected the other half's
     // image — and every later command addressed that one.
     if (drawing.paragraphId !== paragraphId) continue;
-    if (drawing.start === offset || drawing.start + 1 === offset) return drawing;
+    if (drawingAnswersTo(drawing, offset, wanted)) return drawing;
   }
   return null;
 }
@@ -86,27 +104,20 @@ function inlineDrawingAtOffset(
 function anchoredDrawingAtSelection(
   surface: PaginatedSurface,
   paragraphId: string,
-  offset: number
+  offset: number,
+  wanted: string | null
 ): AnchoredDrawingRecord | null {
   const layout = surface.layout();
   for (const page of layout.pages) {
     for (const drawing of page.anchoredDrawings ?? []) {
-      if (
-        drawing.anchorParagraphId === paragraphId &&
-        (drawing.start === offset || drawing.start + 1 === offset)
-      ) {
-        return drawing;
-      }
+      if (drawing.anchorParagraphId !== paragraphId) continue;
+      if (drawingAnswersTo(drawing, offset, wanted)) return drawing;
     }
     for (const story of [page.header, page.footer]) {
       if (!story) continue;
       for (const drawing of story.anchoredDrawings ?? []) {
-        if (
-          drawing.anchorParagraphId === paragraphId &&
-          (drawing.start === offset || drawing.start + 1 === offset)
-        ) {
-          return drawing;
-        }
+        if (drawing.anchorParagraphId !== paragraphId) continue;
+        if (drawingAnswersTo(drawing, offset, wanted)) return drawing;
       }
     }
   }
@@ -136,14 +147,14 @@ export function resolveSelectedDrawingRecord(
   const { anchor, head } = surface.state().selection;
   if (anchor.paragraphId !== head.paragraphId || anchor.offset !== head.offset) return null;
   const line = lineAtIndexedPosition(surface.layout(), anchor.paragraphId, anchor.offset);
-  const record =
-    inlineDrawingAtOffset(line, anchor.paragraphId, anchor.offset) ??
-    anchoredDrawingAtSelection(surface, anchor.paragraphId, anchor.offset);
-  if (!record) return null;
-  // A pointer press names its drawing, so a stale press can never claim a DIFFERENT
-  // drawing the caret later visits (a find jump that lands at another anchor).
-  if (intent.kind === 'pointer' && record.drawingNodeId !== intent.drawingNodeId) return null;
-  return record;
+  // A press names its drawing, so a stale press can never claim a DIFFERENT drawing the caret
+  // later visits (a find jump that lands at another anchor), and a paragraph anchoring several
+  // drawings resolves to the named one rather than to the first.
+  const wanted = intent.kind === 'pointer' ? intent.drawingNodeId : null;
+  return (
+    inlineDrawingAtOffset(line, anchor.paragraphId, anchor.offset, wanted) ??
+    anchoredDrawingAtSelection(surface, anchor.paragraphId, anchor.offset, wanted)
+  );
 }
 
 function projectDrawingForRecord(

--- a/packages/core/src/editor/docx-editor-story-navigation.ts
+++ b/packages/core/src/editor/docx-editor-story-navigation.ts
@@ -42,7 +42,7 @@ export function isScopedStory(scope: ViewScope | undefined): scope is ScopedStor
   return scope?.kind === 'headerFooter' || scope?.kind === 'note';
 }
 
-/** Whether navigation can open every story returned by document search. */
+/** Whether navigation can open every non-body story returned by document search. */
 export function searchStoriesForSurface(
   surface: PaginatedSurface,
   editingMode: DocumentEditingMode
@@ -73,6 +73,34 @@ export function selectDocumentSearchMatch(surface: PaginatedSurface, match: Text
     match.length < 0
   ) {
     return { ok: false, code: 'invalidArgs', reason: 'match must carry a blockId and offsets' };
+  }
+  if (match.scope?.kind === 'frame') {
+    if (
+      typeof match.drawingNodeId !== 'string' ||
+      match.drawingNodeId.length === 0 ||
+      typeof match.hostParagraphId !== 'string' ||
+      match.hostParagraphId.length === 0
+    ) {
+      return {
+        ok: false,
+        code: 'invalidArgs',
+        reason: 'a frame match must carry drawing and host paragraph ids',
+      };
+    }
+    const owner = match.scope.owner;
+    if (owner) {
+      const entered = enterStoryPosition(surface, owner, {
+        paragraphId: match.hostParagraphId,
+        offset: 0,
+      });
+      if (!entered.ok) return entered;
+    } else {
+      leaveScopeForBodyParagraph(surface, match.hostParagraphId);
+    }
+    surface.revealParagraph(match.hostParagraphId);
+    return surface.selectDrawing?.(match.drawingNodeId, match.hostParagraphId)
+      ? { ok: true, changed: false }
+      : { ok: false, code: 'unsupported', reason: 'the text box drawing could not be selected' };
   }
   const position = { paragraphId: match.blockId, offset: match.start };
   if (isScopedStory(match.scope)) {

--- a/packages/core/src/editor/docx-editor-story-navigation.ts
+++ b/packages/core/src/editor/docx-editor-story-navigation.ts
@@ -3,6 +3,7 @@
 import type { DocumentEditingMode, ExecResult, TextMatch, ViewScope } from '../contracts/editor.ts';
 import type { SemanticPosition } from '../layout/semantic-interaction.ts';
 import type { PaginatedSurface } from './paginated-surface-contract.ts';
+import { drawingSelectionPosition } from './surface-drawing-selection.ts';
 
 type ScopedStory =
   | {
@@ -75,11 +76,14 @@ export function selectDocumentSearchMatch(surface: PaginatedSurface, match: Text
     return { ok: false, code: 'invalidArgs', reason: 'match must carry a blockId and offsets' };
   }
   if (match.scope?.kind === 'frame') {
+    const { drawingNodeId, hostParagraphId } = match.scope;
+    // The types make an id-less frame scope unrepresentable, but a host calls this from
+    // JavaScript, where they are whatever it passed.
     if (
-      typeof match.drawingNodeId !== 'string' ||
-      match.drawingNodeId.length === 0 ||
-      typeof match.hostParagraphId !== 'string' ||
-      match.hostParagraphId.length === 0
+      typeof drawingNodeId !== 'string' ||
+      drawingNodeId.length === 0 ||
+      typeof hostParagraphId !== 'string' ||
+      hostParagraphId.length === 0
     ) {
       return {
         ok: false,
@@ -87,20 +91,31 @@ export function selectDocumentSearchMatch(surface: PaginatedSurface, match: Text
         reason: 'a frame match must carry drawing and host paragraph ids',
       };
     }
+    // Resolve BEFORE opening anything. A text box can be enumerated and still have no painted
+    // frame — clipped to nothing, or positioned off the page — and entering a header only to
+    // fail would leave the reader in a story they never asked to open, caret moved.
+    const unselectable: ExecResult = {
+      ok: false,
+      code: 'unsupported',
+      reason: 'the text box drawing could not be selected',
+    };
+    if (!drawingSelectionPosition(surface.layout(), drawingNodeId, hostParagraphId)) {
+      return unselectable;
+    }
     const owner = match.scope.owner;
     if (owner) {
       const entered = enterStoryPosition(surface, owner, {
-        paragraphId: match.hostParagraphId,
+        paragraphId: hostParagraphId,
         offset: 0,
       });
       if (!entered.ok) return entered;
     } else {
-      leaveScopeForBodyParagraph(surface, match.hostParagraphId);
+      leaveScopeForBodyParagraph(surface, hostParagraphId);
     }
-    surface.revealParagraph(match.hostParagraphId);
-    return surface.selectDrawing?.(match.drawingNodeId, match.hostParagraphId)
+    surface.revealParagraph(hostParagraphId);
+    return surface.selectDrawing(drawingNodeId, hostParagraphId)
       ? { ok: true, changed: false }
-      : { ok: false, code: 'unsupported', reason: 'the text box drawing could not be selected' };
+      : unselectable;
   }
   const position = { paragraphId: match.blockId, offset: match.start };
   if (isScopedStory(match.scope)) {

--- a/packages/core/src/editor/paginated-surface-contract.ts
+++ b/packages/core/src/editor/paginated-surface-contract.ts
@@ -1,14 +1,7 @@
 // The paginated surface's public contract owns the types a host programs against.
 // paginated-surface.ts implements and re-exports them, so importers keep one entry point.
 
-import type { IndentFormatting } from '../contracts/types.ts';
-import type {
-  ParagraphDisagreements,
-  ParagraphFlags,
-  SurfaceParagraphFormat,
-  ParagraphPropertyEdit,
-  ParagraphTabStop,
-} from './paragraph-format-contract.ts';
+import type { SurfaceParagraphFormat, ParagraphPropertyEdit } from './paragraph-format-contract.ts';
 import type { TreeApplyResult, TreeDocxSessionView } from '@docx-editor.dev/core/binding';
 import type { BookmarkIndex, StoryScope, TreeDocOp } from '@docx-editor.dev/core/store';
 import type {
@@ -24,7 +17,6 @@ import type {
   ReviewModuleContribution,
   CollaborationModuleContribution,
 } from '../contracts/modules.ts';
-import type { CollaborationStatus } from '../collaboration/index.ts';
 import type { HyperlinkOps } from './surface-hyperlinks.ts';
 import type { EquationActivation, EquationOps } from './surface-equations.ts';
 import type { HyperlinkActivation, SurfaceNavigation } from './surface-navigation.ts';
@@ -187,165 +179,20 @@ export interface PaginatedSurfaceOptions {
   readonly tocLabels?: { readonly title: string };
 }
 
-/**
- * What the selection is currently formatted as.
- *
- * A value is present only when EVERY span in the selection agrees on it: a selection running
- * from 11pt into 14pt has no font size, and a toolbar should show a blank rather than pick
- * one of the two and imply the whole selection is that.
- */
-export interface SurfaceFormatting {
-  readonly bold: boolean;
-  readonly italic: boolean;
-  readonly underline: boolean;
-  readonly strikethrough: boolean;
-  readonly superscript: boolean;
-  readonly subscript: boolean;
-  readonly fontFamily: string | null;
-  /** Half-points, the unit OOXML stores and the picker expects. */
-  readonly fontSizeHalfPoints: number | null;
-  readonly color: string | null;
-  readonly highlight: string | null;
-  readonly alignment: 'left' | 'center' | 'right' | 'both' | null;
-  readonly styleId: string | null;
-  /**
-   * `w:spacing`'s line rule and its value: LINES for `multiple`, points for the other two
-   * (`w:line` is 240ths of a line under `auto` and twentieths of a point otherwise).
-   * Null when the selection's paragraphs disagree, or state no line spacing at all.
-   */
-  readonly lineSpacing: {
-    readonly rule: 'multiple' | 'exact' | 'atLeast';
-    readonly value: number;
-  } | null;
-  /** `w:spacing/@w:before` and `@w:after` in points, null when the selection disagrees. */
-  readonly spaceBeforePt: number | null;
-  readonly spaceAfterPt: number | null;
-  /**
-   * Effective indent at the selection, in twips, or null with no selection or inside a
-   * table.
-   *
-   * The one field here that does NOT go null on disagreement: the values are the FIRST
-   * touched paragraph's and `mixed` reports the disagreement per field, because a ruler
-   * must draw its handles somewhere and Word draws them at the first selected paragraph.
-   */
-  readonly indent: IndentFormatting | null;
-  /**
-   * The paragraph flags the Paragraph dialog shows as checkboxes, or null when the
-   * selection's paragraphs disagree about that one.
-   *
-   * `contextualSpacing` is "Don't add space between paragraphs of the same style"; the
-   * other four are its Pagination block. Each is read from the cascade, so a flag a STYLE
-   * sets reads as on — which is what a checkbox has to show.
-   */
-  readonly paragraphFlags: ParagraphFlags;
-  /**
-   * The paragraph's resolved custom tab stops, cascade included, or null when the selection
-   * disagrees or nothing is loaded. Positions in TWIPS, like every other measurement a
-   * control writes back.
-   */
-  readonly tabStops: readonly ParagraphTabStop[] | null;
-  /**
-   * Which of the paragraph-level reads above are `null` because the selection DISAGREES,
-   * as opposed to because nothing states them. See {@link ParagraphDisagreements}.
-   */
-  readonly disagrees: ParagraphDisagreements;
-}
+import type {
+  DrawingSelectionIntent,
+  PaginatedSurfaceState,
+  RevealOptions,
+  SurfaceFormatting,
+} from './paginated-surface-state.ts';
 
-/** How a reveal places its target in the viewport. */
-export interface RevealOptions {
-  /**
-   * `'start'` puts the target near the top (a heading the user jumped to), `'center'`
-   * centres it, `'nearest'` scrolls only when it is out of view — and only far enough to
-   * clear the edge, which parks the target flush against it. `'centerIfNeeded'` is the one
-   * a jump-to-next-thing control wants: silent while the target is already on screen, and
-   * centred when it has to move, so the reader lands looking AT the thing rather than at
-   * the bottom line of the window. Default `'start'`.
-   */
-  readonly block?: 'start' | 'center' | 'centerIfNeeded' | 'nearest';
-  /** Padding above the target, in CSS pixels. Default 24. */
-  readonly offsetPx?: number;
-  readonly behavior?: ScrollBehavior;
-}
+export type {
+  SurfaceFormatting,
+  RevealOptions,
+  DrawingSelectionIntent,
+  PaginatedSurfaceState,
+} from './paginated-surface-state.ts';
 
-/**
- * How the current selection came to address a drawing — see
- * {@link PaginatedSurface.drawingSelectionIntent}.
- */
-export type DrawingSelectionIntent =
-  | { readonly kind: 'none' }
-  | { readonly kind: 'pointer'; readonly drawingNodeId: string }
-  | { readonly kind: 'programmatic' };
-
-/**
- * Everything observable about the surface right now, as one immutable value.
- *
- * `revision` is the change token: it moves whenever anything else here does, which is what lets
- * `snapshot()` hand back the same reference until state actually changes.
- */
-export interface PaginatedSurfaceState {
-  readonly revision: number;
-  readonly pageCount: number;
-  readonly selection: SemanticSelection;
-  /**
-   * The rectangle of table cells a drag across cells selected, or null.
-   *
-   * `selection` always holds the equivalent TEXT range, so a reader that does not care about
-   * rectangles needs no branch. This is for the ones that do — the highlight, and table
-   * commands that act on cells rather than characters.
-   */
-  readonly cellSelection: CellSelection | null;
-  readonly canUndo: boolean;
-  readonly canRedo: boolean;
-  /**
-   * Lifecycle of the attached replica, or `'inactive'` when no collaboration
-   * module is registered on this surface.
-   */
-  readonly collaborationStatus: CollaborationStatus | 'inactive';
-  readonly lastRejection: string | null;
-  /**
-   * The typing format armed at the caret (Word's stored marks), or null.
-   *
-   * NOT document state — nothing is written until the next characters are typed — but it
-   * IS observable state: `formatting()` reports it, so a host that reflects the toolbar
-   * has to learn when it moves. Reference-stable while unchanged, so a host can compare
-   * it to decide whether to re-derive. See `toggleRunProperty` for the lane itself.
-   */
-  readonly pendingFormat: readonly { readonly localName: string }[] | null;
-  /**
-   * Content-control chrome and form-fill mode.
-   *
-   * Surface-owned (not document bytes). Updates report through the same `onChange` path as
-   * selection moves — hosts must not maintain a parallel channel.
-   */
-  readonly contentControls: ContentControlSurfaceState;
-  /**
-   * The TOC the last right-click landed on, or null.
-   *
-   * A right-click deliberately does not move the caret, and a TOC refuses the caret
-   * entirely, so `selection` can never say which table of contents the user is pointing at.
-   * This is how a host's context menu learns it. Surface chrome, not document state.
-   */
-  readonly contextTocId: string | null;
-  /**
-   * Format painter arming, and the level of what it holds.
-   *
-   * Surface chrome, not document bytes — the lane `contentControls` above sits in, reported
-   * through the same `onChange` so a toolbar's pressed state has exactly one source.
-   */
-  readonly formatPainter: FormatPainterSurfaceState;
-  /** Timing and reuse counters for the last pass. Diagnostics, not document state. */
-  readonly perf: PaginatedSurfacePerf;
-}
-
-/**
- * Where the section after an inserted break begins — Word's Layout > Breaks menu.
- *
- * The two the engine paginates. `evenPage` / `oddPage` are readable in a file but not
- * offered here, because layout does not skip the blank sheet they need yet, and a menu
- * entry that silently behaves like `nextPage` is the lie this vocabulary exists to avoid.
- *
- * @public
- */
 export type SectionBreakInsertType = 'nextPage' | 'continuous';
 
 /**

--- a/packages/core/src/editor/paginated-surface-contract.ts
+++ b/packages/core/src/editor/paginated-surface-contract.ts
@@ -193,6 +193,15 @@ export type {
   PaginatedSurfaceState,
 } from './paginated-surface-state.ts';
 
+/**
+ * Where the section after an inserted break begins — Word's Layout > Breaks menu.
+ *
+ * The two the engine paginates. `evenPage` / `oddPage` are readable in a file but not
+ * offered here, because layout does not skip the blank sheet they need yet, and a menu
+ * entry that silently behaves like `nextPage` is the lie this vocabulary exists to avoid.
+ *
+ * @public
+ */
 export type SectionBreakInsertType = 'nextPage' | 'continuous';
 
 /**
@@ -380,8 +389,13 @@ export interface PaginatedSurface {
   revealPosition(position: SemanticPosition, options?: RevealOptions): boolean;
   /** Set the selection directly, for a host driving the surface programmatically. */
   setSelection(next: SemanticSelection): void;
-  /** Select one painted drawing at its host paragraph, as a pointer press would. */
-  selectDrawing?(drawingNodeId: string, hostParagraphId: string): boolean;
+  /**
+   * Select one painted drawing at its host paragraph, as a pointer press would.
+   *
+   * False when the layout paints no such drawing on that paragraph, in which case nothing
+   * moves: the caller decides what to do rather than being left mid-way.
+   */
+  selectDrawing(drawingNodeId: string, hostParagraphId: string): boolean;
   /**
    * Select a rectangle of table cells, or clear one with null.
    *

--- a/packages/core/src/editor/paginated-surface-contract.ts
+++ b/packages/core/src/editor/paginated-surface-contract.ts
@@ -533,6 +533,8 @@ export interface PaginatedSurface {
   revealPosition(position: SemanticPosition, options?: RevealOptions): boolean;
   /** Set the selection directly, for a host driving the surface programmatically. */
   setSelection(next: SemanticSelection): void;
+  /** Select one painted drawing at its host paragraph, as a pointer press would. */
+  selectDrawing?(drawingNodeId: string, hostParagraphId: string): boolean;
   /**
    * Select a rectangle of table cells, or clear one with null.
    *

--- a/packages/core/src/editor/paginated-surface-state.ts
+++ b/packages/core/src/editor/paginated-surface-state.ts
@@ -1,0 +1,187 @@
+// What the paginated surface REPORTS: the selection's formatting, the reveal options, and
+// the one immutable state value a host subscribes to.
+//
+// Split out of `paginated-surface-contract.ts`, which sits at its line cap: these types are
+// the read side of that contract and change together. The contract re-exports them, so every
+// importer keeps one entry point.
+
+import type { ContentControlSurfaceState } from './surface-content-control-contract.ts';
+import type { FormatPainterSurfaceState } from './surface-format-painter-contract.ts';
+import type { PaginatedSurfacePerf } from './surface-perf-contract.ts';
+import type { IndentFormatting } from '../contracts/types.ts';
+import type {
+  ParagraphDisagreements,
+  ParagraphFlags,
+  ParagraphTabStop,
+} from './paragraph-format-contract.ts';
+import type { CollaborationStatus } from '../collaboration/index.ts';
+import type { CellSelection, SemanticSelection } from '@docx-editor.dev/core/layout';
+
+/**
+ * How an edit is written.
+ *
+ * `'suggest'` is the one that changes what the ops MEAN: the same keystroke becomes a `w:ins`
+ * and the same Backspace becomes a `w:del` over the words it would have removed. `'view'`
+ * refuses edits outright.
+ */
+
+/**
+ * What the selection is currently formatted as.
+ *
+ * A value is present only when EVERY span in the selection agrees on it: a selection running
+ * from 11pt into 14pt has no font size, and a toolbar should show a blank rather than pick
+ * one of the two and imply the whole selection is that.
+ */
+
+export interface SurfaceFormatting {
+  readonly bold: boolean;
+  readonly italic: boolean;
+  readonly underline: boolean;
+  readonly strikethrough: boolean;
+  readonly superscript: boolean;
+  readonly subscript: boolean;
+  readonly fontFamily: string | null;
+  /** Half-points, the unit OOXML stores and the picker expects. */
+  readonly fontSizeHalfPoints: number | null;
+  readonly color: string | null;
+  readonly highlight: string | null;
+  readonly alignment: 'left' | 'center' | 'right' | 'both' | null;
+  readonly styleId: string | null;
+  /**
+   * `w:spacing`'s line rule and its value: LINES for `multiple`, points for the other two
+   * (`w:line` is 240ths of a line under `auto` and twentieths of a point otherwise).
+   * Null when the selection's paragraphs disagree, or state no line spacing at all.
+   */
+  readonly lineSpacing: {
+    readonly rule: 'multiple' | 'exact' | 'atLeast';
+    readonly value: number;
+  } | null;
+  /** `w:spacing/@w:before` and `@w:after` in points, null when the selection disagrees. */
+  readonly spaceBeforePt: number | null;
+  readonly spaceAfterPt: number | null;
+  /**
+   * Effective indent at the selection, in twips, or null with no selection or inside a
+   * table.
+   *
+   * The one field here that does NOT go null on disagreement: the values are the FIRST
+   * touched paragraph's and `mixed` reports the disagreement per field, because a ruler
+   * must draw its handles somewhere and Word draws them at the first selected paragraph.
+   */
+  readonly indent: IndentFormatting | null;
+  /**
+   * The paragraph flags the Paragraph dialog shows as checkboxes, or null when the
+   * selection's paragraphs disagree about that one.
+   *
+   * `contextualSpacing` is "Don't add space between paragraphs of the same style"; the
+   * other four are its Pagination block. Each is read from the cascade, so a flag a STYLE
+   * sets reads as on — which is what a checkbox has to show.
+   */
+  readonly paragraphFlags: ParagraphFlags;
+  /**
+   * The paragraph's resolved custom tab stops, cascade included, or null when the selection
+   * disagrees or nothing is loaded. Positions in TWIPS, like every other measurement a
+   * control writes back.
+   */
+  readonly tabStops: readonly ParagraphTabStop[] | null;
+  /**
+   * Which of the paragraph-level reads above are `null` because the selection DISAGREES,
+   * as opposed to because nothing states them. See {@link ParagraphDisagreements}.
+   */
+  readonly disagrees: ParagraphDisagreements;
+}
+
+/** How a reveal places its target in the viewport. */
+export interface RevealOptions {
+  /**
+   * `'start'` puts the target near the top (a heading the user jumped to), `'center'`
+   * centres it, `'nearest'` scrolls only when it is out of view — and only far enough to
+   * clear the edge, which parks the target flush against it. `'centerIfNeeded'` is the one
+   * a jump-to-next-thing control wants: silent while the target is already on screen, and
+   * centred when it has to move, so the reader lands looking AT the thing rather than at
+   * the bottom line of the window. Default `'start'`.
+   */
+  readonly block?: 'start' | 'center' | 'centerIfNeeded' | 'nearest';
+  /** Padding above the target, in CSS pixels. Default 24. */
+  readonly offsetPx?: number;
+  readonly behavior?: ScrollBehavior;
+}
+
+/**
+ * How the current selection came to address a drawing — see
+ * {@link PaginatedSurface.drawingSelectionIntent}.
+ */
+export type DrawingSelectionIntent =
+  | { readonly kind: 'none' }
+  | { readonly kind: 'pointer'; readonly drawingNodeId: string }
+  | { readonly kind: 'programmatic' };
+
+/**
+ * Everything observable about the surface right now, as one immutable value.
+ *
+ * `revision` is the change token: it moves whenever anything else here does, which is what lets
+ * `snapshot()` hand back the same reference until state actually changes.
+ */
+export interface PaginatedSurfaceState {
+  readonly revision: number;
+  readonly pageCount: number;
+  readonly selection: SemanticSelection;
+  /**
+   * The rectangle of table cells a drag across cells selected, or null.
+   *
+   * `selection` always holds the equivalent TEXT range, so a reader that does not care about
+   * rectangles needs no branch. This is for the ones that do — the highlight, and table
+   * commands that act on cells rather than characters.
+   */
+  readonly cellSelection: CellSelection | null;
+  readonly canUndo: boolean;
+  readonly canRedo: boolean;
+  /**
+   * Lifecycle of the attached replica, or `'inactive'` when no collaboration
+   * module is registered on this surface.
+   */
+  readonly collaborationStatus: CollaborationStatus | 'inactive';
+  readonly lastRejection: string | null;
+  /**
+   * The typing format armed at the caret (Word's stored marks), or null.
+   *
+   * NOT document state — nothing is written until the next characters are typed — but it
+   * IS observable state: `formatting()` reports it, so a host that reflects the toolbar
+   * has to learn when it moves. Reference-stable while unchanged, so a host can compare
+   * it to decide whether to re-derive. See `toggleRunProperty` for the lane itself.
+   */
+  readonly pendingFormat: readonly { readonly localName: string }[] | null;
+  /**
+   * Content-control chrome and form-fill mode.
+   *
+   * Surface-owned (not document bytes). Updates report through the same `onChange` path as
+   * selection moves — hosts must not maintain a parallel channel.
+   */
+  readonly contentControls: ContentControlSurfaceState;
+  /**
+   * The TOC the last right-click landed on, or null.
+   *
+   * A right-click deliberately does not move the caret, and a TOC refuses the caret
+   * entirely, so `selection` can never say which table of contents the user is pointing at.
+   * This is how a host's context menu learns it. Surface chrome, not document state.
+   */
+  readonly contextTocId: string | null;
+  /**
+   * Format painter arming, and the level of what it holds.
+   *
+   * Surface chrome, not document bytes — the lane `contentControls` above sits in, reported
+   * through the same `onChange` so a toolbar's pressed state has exactly one source.
+   */
+  readonly formatPainter: FormatPainterSurfaceState;
+  /** Timing and reuse counters for the last pass. Diagnostics, not document state. */
+  readonly perf: PaginatedSurfacePerf;
+}
+
+/**
+ * Where the section after an inserted break begins — Word's Layout > Breaks menu.
+ *
+ * The two the engine paginates. `evenPage` / `oddPage` are readable in a file but not
+ * offered here, because layout does not skip the blank sheet they need yet, and a menu
+ * entry that silently behaves like `nextPage` is the lie this vocabulary exists to avoid.
+ *
+ * @public
+ */

--- a/packages/core/src/editor/paginated-surface-state.ts
+++ b/packages/core/src/editor/paginated-surface-state.ts
@@ -18,14 +18,6 @@ import type { CollaborationStatus } from '../collaboration/index.ts';
 import type { CellSelection, SemanticSelection } from '@docx-editor.dev/core/layout';
 
 /**
- * How an edit is written.
- *
- * `'suggest'` is the one that changes what the ops MEAN: the same keystroke becomes a `w:ins`
- * and the same Backspace becomes a `w:del` over the words it would have removed. `'view'`
- * refuses edits outright.
- */
-
-/**
  * What the selection is currently formatted as.
  *
  * A value is present only when EVERY span in the selection agrees on it: a selection running
@@ -175,13 +167,3 @@ export interface PaginatedSurfaceState {
   /** Timing and reuse counters for the last pass. Diagnostics, not document state. */
   readonly perf: PaginatedSurfacePerf;
 }
-
-/**
- * Where the section after an inserted break begins — Word's Layout > Breaks menu.
- *
- * The two the engine paginates. `evenPage` / `oddPage` are readable in a file but not
- * offered here, because layout does not skip the blank sheet they need yet, and a menu
- * entry that silently behaves like `nextPage` is the lie this vocabulary exists to avoid.
- *
- * @public
- */

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -30,6 +30,7 @@ import {
   type TreeModelChange,
 } from '@docx-editor.dev/core/store';
 import { resolveSelectedDrawingRecord } from './docx-editor-images.ts';
+import { drawingSelectionPosition } from './surface-drawing-selection.ts';
 import { syncActiveFieldShading } from './surface-field-shading.ts';
 import {
   createLayoutScheduler,
@@ -40,7 +41,6 @@ import {
   keyedRangeRects,
   formatPageNumber,
   emptyTocPlaceholderParagraphIds,
-  findDrawingOverlayFrameInLayout,
   paragraphFragmentsOf,
   paragraphFragmentsOfBlocks,
   reviewItemKey,
@@ -5100,9 +5100,9 @@ export function mountPaginatedSurface(
 
     selectDrawing(drawingNodeId, hostParagraphId) {
       flushLayout();
-      const found = findDrawingOverlayFrameInLayout(currentLayout, drawingNodeId);
-      if (!found || found.record.paragraphId !== hostParagraphId) return false;
-      const next = collapsedAt({ paragraphId: hostParagraphId, offset: found.record.start });
+      const at = drawingSelectionPosition(currentLayout, drawingNodeId, hostParagraphId);
+      if (!at) return false;
+      const next = collapsedAt(at);
       setDrawingIntent({ kind: 'pointer', drawingNodeId }, selectionsEqual(next, selection));
       setSelection(next);
       return resolveSelectedDrawingRecord(surface)?.drawingNodeId === drawingNodeId;

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -40,6 +40,7 @@ import {
   keyedRangeRects,
   formatPageNumber,
   emptyTocPlaceholderParagraphIds,
+  findDrawingOverlayFrameInLayout,
   paragraphFragmentsOf,
   paragraphFragmentsOfBlocks,
   reviewItemKey,
@@ -5095,6 +5096,16 @@ export function mountPaginatedSurface(
       // (the carried initialDrawingSelectionIntent already preserves a real one).
       if (!selectionsEqual(next, selection)) setDrawingIntent({ kind: 'programmatic' }, false);
       setSelection(next);
+    },
+
+    selectDrawing(drawingNodeId, hostParagraphId) {
+      flushLayout();
+      const found = findDrawingOverlayFrameInLayout(currentLayout, drawingNodeId);
+      if (!found || found.record.paragraphId !== hostParagraphId) return false;
+      const next = collapsedAt({ paragraphId: hostParagraphId, offset: found.record.start });
+      setDrawingIntent({ kind: 'pointer', drawingNodeId }, selectionsEqual(next, selection));
+      setSelection(next);
+      return resolveSelectedDrawingRecord(surface)?.drawingNodeId === drawingNodeId;
     },
 
     revealPage(pageIndex, options) {

--- a/packages/core/src/editor/surface-drawing-selection.ts
+++ b/packages/core/src/editor/surface-drawing-selection.ts
@@ -1,0 +1,26 @@
+// Selecting one painted drawing: where the caret goes.
+//
+// Its own module because both callers sit at their line caps, and because "which offset does
+// this drawing occupy" is a layout question, separate from the image command surface.
+
+import { findDrawingOverlayFrameInLayout } from '../layout/semantic-hit-test.ts';
+import type { SemanticLayout } from '../layout/semantic-records.ts';
+
+/**
+ * Where selecting one painted drawing puts the caret, or null when the layout has no such
+ * frame on that paragraph.
+ *
+ * A drawing is selected by collapsing the selection onto the offset its record occupies, the
+ * same position a pointer press resolves to. Returning the position rather than performing
+ * the selection keeps this out of the surface, which is at its line cap.
+ */
+export function drawingSelectionPosition(
+  layout: SemanticLayout | null,
+  drawingNodeId: string,
+  hostParagraphId: string
+): { readonly paragraphId: string; readonly offset: number } | null {
+  if (!layout) return null;
+  const found = findDrawingOverlayFrameInLayout(layout, drawingNodeId);
+  if (!found || found.record.paragraphId !== hostParagraphId) return null;
+  return { paragraphId: hostParagraphId, offset: found.record.start };
+}

--- a/packages/core/src/store/__tests__/textbox-stories.test.ts
+++ b/packages/core/src/store/__tests__/textbox-stories.test.ts
@@ -6,6 +6,7 @@ import {
   readOoxmlPart,
   storyParagraphs,
   textboxStoriesInPart,
+  type OoxmlElement,
   type OoxmlNode,
   type OoxmlPart,
 } from '../index.ts';
@@ -15,6 +16,7 @@ const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
 const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
 const WPS = 'http://schemas.microsoft.com/office/word/2010/wordprocessingShape';
+const MC = 'http://schemas.openxmlformats.org/markup-compatibility/2006';
 
 const paragraph = (text: string): string => `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
 
@@ -34,6 +36,29 @@ function textbox(content: string, id: number): string {
   );
 }
 
+function wrappedTextbox(content: string, id: number): string {
+  const run = textbox(content, id);
+  const drawing = run.slice('<w:r>'.length, -'</w:r>'.length);
+  return (
+    `<w:r><mc:AlternateContent><mc:Choice Requires="wps">${drawing}</mc:Choice>` +
+    '<mc:Fallback><w:pict/></mc:Fallback></mc:AlternateContent></w:r>'
+  );
+}
+
+function elementNamed(
+  root: OoxmlNode,
+  namespaceUri: string,
+  localName: string
+): OoxmlElement | null {
+  if (root.kind === 'textValue') return null;
+  if (root.namespaceUri === namespaceUri && root.localName === localName) return root;
+  for (const child of root.children) {
+    const found = elementNamed(child, namespaceUri, localName);
+    if (found) return found;
+  }
+  return null;
+}
+
 function parse(root: string, name = '/word/document.xml'): OoxmlPart {
   const result = readOoxmlPart(root, { name, contentType: 'application/xml' });
   if (!result.ok) throw new Error(result.reason);
@@ -42,7 +67,8 @@ function parse(root: string, name = '/word/document.xml'): OoxmlPart {
 
 function documentPart(body: string): OoxmlPart {
   return parse(
-    `<w:document xmlns:w="${W}" xmlns:wp="${WP}" xmlns:a="${A}" xmlns:wps="${WPS}">` +
+    `<w:document xmlns:w="${W}" xmlns:wp="${WP}" xmlns:a="${A}" xmlns:wps="${WPS}" ` +
+      `xmlns:mc="${MC}">` +
       `<w:body>${body}</w:body></w:document>`
   );
 }
@@ -86,6 +112,18 @@ describe('textboxStoriesInPart', () => {
     expect(stories[0]!.drawingNodeId).not.toBe(stories[1]!.drawingNodeId);
     expect(stories[0]!.hostParagraphId).not.toBe(stories[1]!.hostParagraphId);
     expect(textboxStoriesInPart(part)).toBe(stories);
+  });
+
+  test('uses the layout atom id for a drawing inside mc:AlternateContent', () => {
+    const part = documentPart(`<w:p>${wrappedTextbox(paragraph('wrapped'), 5)}</w:p>`);
+    const wrapper = elementNamed(part.root, MC, 'AlternateContent');
+    const drawing = elementNamed(part.root, W, 'drawing');
+    const [story] = textboxStoriesInPart(part);
+
+    expect(wrapper).toBeDefined();
+    expect(drawing).toBeDefined();
+    expect(story?.drawingNodeId).toBe(wrapper?.id);
+    expect(story?.drawingNodeId).not.toBe(drawing?.id);
   });
 
   test('lists a header text box and exposes table and block-control paragraphs', () => {

--- a/packages/core/src/store/__tests__/textbox-stories.test.ts
+++ b/packages/core/src/store/__tests__/textbox-stories.test.ts
@@ -1,0 +1,117 @@
+// Lightweight text-box story enumeration, including ordering, block content, and walk bounds.
+
+import { describe, expect, test } from 'bun:test';
+import {
+  paragraphTextOf,
+  readOoxmlPart,
+  storyParagraphs,
+  textboxStoriesInPart,
+  type OoxmlNode,
+  type OoxmlPart,
+} from '../index.ts';
+import { MAX_XML_DEPTH } from '../package/ooxml-drawing-rules.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
+const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+const WPS = 'http://schemas.microsoft.com/office/word/2010/wordprocessingShape';
+
+const paragraph = (text: string): string => `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+
+function textbox(content: string, id: number): string {
+  return (
+    '<w:r><w:drawing><wp:anchor distT="0" distB="0" distL="0" distR="0" simplePos="0" ' +
+    'relativeHeight="1" behindDoc="0" locked="0" layoutInCell="1" allowOverlap="1">' +
+    '<wp:simplePos x="0" y="0"/>' +
+    '<wp:positionH relativeFrom="page"><wp:posOffset>0</wp:posOffset></wp:positionH>' +
+    '<wp:positionV relativeFrom="page"><wp:posOffset>0</wp:posOffset></wp:positionV>' +
+    '<wp:extent cx="914400" cy="457200"/><wp:effectExtent l="0" t="0" r="0" b="0"/>' +
+    `<wp:wrapNone/><wp:docPr id="${id}" name="Box ${id}"/>` +
+    `<a:graphic><a:graphicData uri="${WPS}"><wps:wsp>` +
+    '<wps:spPr><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></wps:spPr>' +
+    `<wps:txbx><w:txbxContent>${content}</w:txbxContent></wps:txbx>` +
+    '<wps:bodyPr/></wps:wsp></a:graphicData></a:graphic></wp:anchor></w:drawing></w:r>'
+  );
+}
+
+function parse(root: string, name = '/word/document.xml'): OoxmlPart {
+  const result = readOoxmlPart(root, { name, contentType: 'application/xml' });
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+function documentPart(body: string): OoxmlPart {
+  return parse(
+    `<w:document xmlns:w="${W}" xmlns:wp="${WP}" xmlns:a="${A}" xmlns:wps="${WPS}">` +
+      `<w:body>${body}</w:body></w:document>`
+  );
+}
+
+function replaceDrawingWithDeepChain(part: OoxmlPart): OoxmlPart {
+  const replace = (node: OoxmlNode): OoxmlNode => {
+    if (node.kind === 'textValue') return node;
+    if (node.kind === 'drawing') {
+      let child: OoxmlNode = node;
+      for (let depth = 0; depth < MAX_XML_DEPTH; depth += 1) {
+        child = {
+          kind: 'generic',
+          id: `deep-${depth}`,
+          namespaceUri: 'urn:docx-editor:test',
+          localName: 'wrapper',
+          namespaceBindings: [],
+          attributes: [],
+          children: [child],
+        };
+      }
+      return child;
+    }
+    return { ...node, children: node.children.map(replace) } as OoxmlNode;
+  };
+  return { ...part, root: replace(part.root) as OoxmlPart['root'] };
+}
+
+describe('textboxStoriesInPart', () => {
+  test('lists body roots in drawing order with their drawing and host paragraph ids', () => {
+    const part = documentPart(
+      `<w:p>${textbox(paragraph('first'), 1)}</w:p>` +
+        paragraph('between') +
+        `<w:p>${textbox(paragraph('second'), 2)}</w:p>`
+    );
+    const stories = textboxStoriesInPart(part);
+
+    expect(stories).toHaveLength(2);
+    expect(
+      stories.map((story) => paragraphTextOf(part, storyParagraphs(story.root)[0]!.id))
+    ).toEqual(['first', 'second']);
+    expect(stories[0]!.drawingNodeId).not.toBe(stories[1]!.drawingNodeId);
+    expect(stories[0]!.hostParagraphId).not.toBe(stories[1]!.hostParagraphId);
+    expect(textboxStoriesInPart(part)).toBe(stories);
+  });
+
+  test('lists a header text box and exposes table and block-control paragraphs', () => {
+    const content =
+      `<w:tbl><w:tr><w:tc>${paragraph('table')}` +
+      `<w:tbl><w:tr><w:tc>${paragraph('nested table')}</w:tc></w:tr></w:tbl>` +
+      '</w:tc></w:tr></w:tbl>' +
+      `<w:sdt><w:sdtContent>${paragraph('control')}</w:sdtContent></w:sdt>`;
+    const part = parse(
+      `<w:hdr xmlns:w="${W}" xmlns:wp="${WP}" xmlns:a="${A}" xmlns:wps="${WPS}">` +
+        `<w:p>${textbox(content, 3)}</w:p></w:hdr>`,
+      '/word/header1.xml'
+    );
+    const [story] = textboxStoriesInPart(part);
+
+    expect(story).toBeDefined();
+    expect(storyParagraphs(story!.root).map((node) => paragraphTextOf(part, node.id))).toEqual([
+      'table',
+      'nested table',
+      'control',
+    ]);
+  });
+
+  test('stops before a drawing beyond the XML depth bound', () => {
+    const part = documentPart(`<w:p>${textbox(paragraph('deep'), 4)}</w:p>`);
+
+    expect(textboxStoriesInPart(replaceDrawingWithDeepChain(part))).toEqual([]);
+  });
+});

--- a/packages/core/src/store/__tests__/textbox-stories.test.ts
+++ b/packages/core/src/store/__tests__/textbox-stories.test.ts
@@ -36,6 +36,13 @@ function textbox(content: string, id: number): string {
   );
 }
 
+/** The same box with one anchor detail rewritten, to cover what layout refuses to paint. */
+function textboxWith(content: string, id: number, from: string, to: string): string {
+  const markup = textbox(content, id);
+  if (!markup.includes(from)) throw new Error(`anchor markup has no ${from}`);
+  return markup.replace(from, to);
+}
+
 function wrappedTextbox(content: string, id: number): string {
   const run = textbox(content, id);
   const drawing = run.slice('<w:r>'.length, -'</w:r>'.length);
@@ -162,6 +169,18 @@ describe('textboxStoriesInPart', () => {
       'nested table',
       'control',
     ]);
+  });
+
+  test('skips a hidden box, which layout never paints', () => {
+    const hidden = textboxWith(paragraph('boxed'), 1, 'name="Box 1"', 'name="Box 1" hidden="1"');
+
+    expect(textboxStoriesInPart(documentPart(`<w:p>${hidden}</w:p>`))).toEqual([]);
+  });
+
+  test('skips a zero-sized box, which no overlay can resolve', () => {
+    const flat = textboxWith(paragraph('boxed'), 1, 'cx="914400" cy="457200"', 'cx="0" cy="0"');
+
+    expect(textboxStoriesInPart(documentPart(`<w:p>${flat}</w:p>`))).toEqual([]);
   });
 
   test('stops before a drawing beyond the XML depth bound', () => {

--- a/packages/core/src/store/__tests__/textbox-stories.test.ts
+++ b/packages/core/src/store/__tests__/textbox-stories.test.ts
@@ -45,6 +45,15 @@ function wrappedTextbox(content: string, id: number): string {
   );
 }
 
+function wrapperWithInactiveTextbox(content: string, id: number): string {
+  const run = textbox(content, id);
+  const drawing = run.slice('<w:r>'.length, -'</w:r>'.length);
+  return (
+    '<w:r><mc:AlternateContent><mc:Choice Requires="wps"><w:pict/></mc:Choice>' +
+    `<mc:Fallback>${drawing}</mc:Fallback></mc:AlternateContent></w:r>`
+  );
+}
+
 function elementNamed(
   root: OoxmlNode,
   namespaceUri: string,
@@ -118,12 +127,20 @@ describe('textboxStoriesInPart', () => {
     const part = documentPart(`<w:p>${wrappedTextbox(paragraph('wrapped'), 5)}</w:p>`);
     const wrapper = elementNamed(part.root, MC, 'AlternateContent');
     const drawing = elementNamed(part.root, W, 'drawing');
-    const [story] = textboxStoriesInPart(part);
+    const stories = textboxStoriesInPart(part);
+    const [story] = stories;
 
+    expect(stories).toHaveLength(1);
     expect(wrapper).toBeDefined();
     expect(drawing).toBeDefined();
     expect(story?.drawingNodeId).toBe(wrapper?.id);
     expect(story?.drawingNodeId).not.toBe(drawing?.id);
+  });
+
+  test('does not descend into inactive mc:AlternateContent branches', () => {
+    const part = documentPart(`<w:p>${wrapperWithInactiveTextbox(paragraph('inactive'), 6)}</w:p>`);
+
+    expect(textboxStoriesInPart(part)).toEqual([]);
   });
 
   test('lists a header text box and exposes table and block-control paragraphs', () => {

--- a/packages/core/src/store/package/drawing-anchor-extent.ts
+++ b/packages/core/src/store/package/drawing-anchor-extent.ts
@@ -1,0 +1,46 @@
+// The EMU boxes a drawing anchor declares: its own extent, and the effect bleed around it.
+
+import { schemaAttributeValue } from './ooxml-drawing-rules.ts';
+import { findDirectKind } from './drawing-projection-walk.ts';
+import { findDirectChild, parseEmu } from './drawing-shape-projection.ts';
+import { WP_NAMESPACE_URI, type OoxmlElement } from './ooxml-tree.ts';
+
+/** The shadow, glow or reflection bleed one node declares, or null when it declares none. */
+export function readEffectExtentFromNode(
+  node: OoxmlElement | null,
+  compatibilityMode: boolean
+): Readonly<{ top: number; right: number; bottom: number; left: number }> | null {
+  if (!node) return null;
+  const effect =
+    findDirectKind(node.children, 'drawingEffectExtent') ??
+    (compatibilityMode
+      ? findDirectChild(node.children, {
+          namespaceUri: WP_NAMESPACE_URI,
+          localName: 'effectExtent',
+        })
+      : null);
+  if (!effect) return null;
+  return Object.freeze({
+    left: parseEmu(schemaAttributeValue(effect.attributes, 'l'), false) ?? 0,
+    top: parseEmu(schemaAttributeValue(effect.attributes, 't'), false) ?? 0,
+    right: parseEmu(schemaAttributeValue(effect.attributes, 'r'), false) ?? 0,
+    bottom: parseEmu(schemaAttributeValue(effect.attributes, 'b'), false) ?? 0,
+  });
+}
+
+/** The anchor's own painted size, or null when it declares none or declares it unreadably. */
+export function readExtent(
+  anchor: OoxmlElement,
+  compatibilityMode: boolean
+): Readonly<{ cx: number; cy: number }> | null {
+  const extent =
+    findDirectKind(anchor.children, 'drawingExtent') ??
+    (compatibilityMode
+      ? findDirectChild(anchor.children, { namespaceUri: WP_NAMESPACE_URI, localName: 'extent' })
+      : null);
+  if (!extent) return null;
+  const cx = parseEmu(schemaAttributeValue(extent.attributes, 'cx'));
+  const cy = parseEmu(schemaAttributeValue(extent.attributes, 'cy'));
+  if (cx === null || cy === null) return null;
+  return Object.freeze({ cx, cy });
+}

--- a/packages/core/src/store/package/drawing-projection.ts
+++ b/packages/core/src/store/package/drawing-projection.ts
@@ -44,6 +44,7 @@ import {
   type OoxmlNode,
   type OoxmlPart,
 } from './ooxml-tree.ts';
+import { readEffectExtentFromNode, readExtent } from './drawing-anchor-extent.ts';
 import type { OoxmlPackage } from './ooxml-package.ts';
 import { createPackageShapeThemeResolvers } from './theme-color-resolution.ts';
 import {
@@ -750,28 +751,6 @@ function readDistances(
   });
 }
 
-function readEffectExtentFromNode(
-  node: OoxmlElement | null,
-  compatibilityMode: boolean
-): Readonly<{ top: number; right: number; bottom: number; left: number }> | null {
-  if (!node) return null;
-  const effect =
-    findDirectKind(node.children, 'drawingEffectExtent') ??
-    (compatibilityMode
-      ? findDirectChild(node.children, {
-          namespaceUri: WP_NAMESPACE_URI,
-          localName: 'effectExtent',
-        })
-      : null);
-  if (!effect) return null;
-  return Object.freeze({
-    left: parseEmu(schemaAttributeValue(effect.attributes, 'l'), false) ?? 0,
-    top: parseEmu(schemaAttributeValue(effect.attributes, 't'), false) ?? 0,
-    right: parseEmu(schemaAttributeValue(effect.attributes, 'r'), false) ?? 0,
-    bottom: parseEmu(schemaAttributeValue(effect.attributes, 'b'), false) ?? 0,
-  });
-}
-
 function readEffectExtent(
   anchor: OoxmlElement,
   wrapElement: OoxmlElement | null,
@@ -785,22 +764,6 @@ function readEffectExtent(
   const fromAnchor = readEffectExtentFromNode(anchor, compatibilityMode);
   if (fromAnchor) return fromAnchor;
   return EMPTY_EDGES;
-}
-
-function readExtent(
-  anchor: OoxmlElement,
-  compatibilityMode: boolean
-): Readonly<{ cx: number; cy: number }> | null {
-  const extent =
-    findDirectKind(anchor.children, 'drawingExtent') ??
-    (compatibilityMode
-      ? findDirectChild(anchor.children, { namespaceUri: WP_NAMESPACE_URI, localName: 'extent' })
-      : null);
-  if (!extent) return null;
-  const cx = parseEmu(schemaAttributeValue(extent.attributes, 'cx'));
-  const cy = parseEmu(schemaAttributeValue(extent.attributes, 'cy'));
-  if (cx === null || cy === null) return null;
-  return Object.freeze({ cx, cy });
 }
 
 function readPositionAxis<H extends string>(
@@ -1074,6 +1037,20 @@ function readDocPrMetadata(
       schemaAttributeValue(anchor.attributes, 'hidden') === '1',
     hyperlinkHref,
   });
+}
+
+/**
+ * Whether an anchor's own metadata keeps its drawing off the page.
+ *
+ * Layout skips a hidden drawing outright, and hit testing rejects a zero-sized one, so a
+ * derivation that lists drawings for SELECTION must apply the same two rules. Without them it
+ * reports a drawing that no page paints and no overlay can resolve. A missing `wp:extent`
+ * demotes the drawing to generic at read time, so it never reaches here.
+ */
+export function anchorHidesDrawing(anchor: OoxmlElement, compatibilityMode: boolean): boolean {
+  if (readDocPrMetadata(anchor, compatibilityMode).hidden) return true;
+  const extent = readExtent(anchor, compatibilityMode);
+  return extent !== null && (extent.cx <= 0 || extent.cy <= 0);
 }
 
 function parseLumPercent(value: string | undefined): number | null {

--- a/packages/core/src/store/package/index.ts
+++ b/packages/core/src/store/package/index.ts
@@ -504,6 +504,7 @@ export {
   type OoxmlStoryKind,
   type OoxmlStoryRoot,
 } from './story-blocks.ts';
+export { textboxStoriesInPart, type TextboxStoryRoot } from './textbox-stories.ts';
 export {
   CUSTOM_XML_PROPS_REL,
   CUSTOM_XML_PROPS_TYPE,

--- a/packages/core/src/store/package/textbox-stories.ts
+++ b/packages/core/src/store/package/textbox-stories.ts
@@ -1,0 +1,154 @@
+// Lightweight text-box story enumeration for search and other read-only derivations.
+
+import { MAX_XML_DEPTH, schemaAttributeValue } from './ooxml-drawing-rules.ts';
+import {
+  emptyNamespaceScope,
+  isMcAlternateContent,
+  namespaceScopeForNode,
+  resolveRunLevelMcAtom,
+  DEFAULT_DRAWING_PROJECTION_LIMITS,
+  DEFAULT_SUPPORTED_MC_REQUIRES,
+  MAX_PART_SCAN_ELEMENTS,
+} from './drawing-projection.ts';
+import { findDirectChild } from './drawing-shape-projection.ts';
+import { findDirectKind, isElement } from './drawing-projection-walk.ts';
+import { WML_NAMESPACE_URI } from './ooxml-shared.ts';
+import {
+  DRAWINGML_MAIN_NAMESPACE_URI,
+  WP_NAMESPACE_URI,
+  type OoxmlDrawingNode,
+  type OoxmlElement,
+  type OoxmlNode,
+  type OoxmlPart,
+} from './ooxml-tree.ts';
+
+const WPS_NAMESPACE_URI = 'http://schemas.microsoft.com/office/word/2010/wordprocessingShape';
+const WPS_GRAPHIC_DATA_URI = WPS_NAMESPACE_URI;
+
+/** One searchable text-box story and the drawing location that can reveal it. */
+export interface TextboxStoryRoot {
+  /** The `w:txbxContent` story root. */
+  readonly root: OoxmlElement;
+  /** Canonical node id of the drawing that owns the story. */
+  readonly drawingNodeId: string;
+  /** Canonical node id of the paragraph that anchors the drawing. */
+  readonly hostParagraphId: string;
+}
+
+function compatibleDirectChild(
+  parent: OoxmlElement,
+  typedKind: string,
+  namespaceUri: string,
+  localName: string
+): OoxmlElement | null {
+  return (
+    findDirectKind(parent.children, typedKind) ??
+    findDirectChild(parent.children, { namespaceUri, localName })
+  );
+}
+
+/** Read only the direct WPS path that holds a drawing's text-box story. */
+function textboxContentOf(drawing: OoxmlDrawingNode): OoxmlElement | null {
+  let anchor: OoxmlElement | null = null;
+  for (const child of drawing.children) {
+    if (!isElement(child)) continue;
+    if (
+      child.kind === 'inlineDrawing' ||
+      child.kind === 'anchoredDrawing' ||
+      (child.namespaceUri === WP_NAMESPACE_URI &&
+        (child.localName === 'inline' || child.localName === 'anchor'))
+    ) {
+      anchor = child;
+      break;
+    }
+  }
+  if (!anchor) return null;
+  const graphic = compatibleDirectChild(
+    anchor,
+    'drawingGraphic',
+    DRAWINGML_MAIN_NAMESPACE_URI,
+    'graphic'
+  );
+  if (!graphic) return null;
+  const data = compatibleDirectChild(
+    graphic,
+    'drawingGraphicData',
+    DRAWINGML_MAIN_NAMESPACE_URI,
+    'graphicData'
+  );
+  if (!data || schemaAttributeValue(data.attributes, 'uri') !== WPS_GRAPHIC_DATA_URI) return null;
+  const wsp = findDirectChild(data.children, {
+    namespaceUri: WPS_NAMESPACE_URI,
+    localName: 'wsp',
+  });
+  const txbx = wsp
+    ? findDirectChild(wsp.children, { namespaceUri: WPS_NAMESPACE_URI, localName: 'txbx' })
+    : null;
+  return txbx
+    ? findDirectChild(txbx.children, {
+        namespaceUri: WML_NAMESPACE_URI,
+        localName: 'txbxContent',
+      })
+    : null;
+}
+
+interface WalkFrame {
+  readonly node: OoxmlNode;
+  readonly paragraphId: string | null;
+  readonly namespaceScope: ReadonlyMap<string, string>;
+  readonly depth: number;
+}
+
+const textboxStoriesCache = new WeakMap<OoxmlElement, readonly TextboxStoryRoot[]>();
+
+/**
+ * List the text-box stories in one part, in document order.
+ *
+ * The bounded walk stops at drawings. It does not project pictures, shape geometry, or story
+ * content. Results are memoized by immutable part-root identity.
+ */
+export function textboxStoriesInPart(part: OoxmlPart): readonly TextboxStoryRoot[] {
+  const cached = textboxStoriesCache.get(part.root);
+  if (cached) return cached;
+  const stories: TextboxStoryRoot[] = [];
+  const stack: WalkFrame[] = [
+    { node: part.root, paragraphId: null, namespaceScope: emptyNamespaceScope(), depth: 0 },
+  ];
+  let visited = 0;
+  while (stack.length > 0) {
+    const frame = stack.pop()!;
+    if (!isElement(frame.node)) continue;
+    visited += 1;
+    if (visited > MAX_PART_SCAN_ELEMENTS) break;
+    if (frame.depth > MAX_XML_DEPTH) continue;
+    const scope = namespaceScopeForNode(frame.namespaceScope, frame.node);
+    const paragraphId = frame.node.kind === 'paragraph' ? frame.node.id : frame.paragraphId;
+    let drawing: OoxmlDrawingNode | null = frame.node.kind === 'drawing' ? frame.node : null;
+    if (!drawing && isMcAlternateContent(frame.node)) {
+      drawing = resolveRunLevelMcAtom(
+        frame.node,
+        scope,
+        DEFAULT_SUPPORTED_MC_REQUIRES,
+        DEFAULT_DRAWING_PROJECTION_LIMITS
+      ).drawing;
+    }
+    if (drawing) {
+      const root = paragraphId ? textboxContentOf(drawing) : null;
+      if (root && paragraphId) {
+        stories.push(
+          Object.freeze({ root, drawingNodeId: drawing.id, hostParagraphId: paragraphId })
+        );
+      }
+      continue;
+    }
+    if (frame.depth >= MAX_XML_DEPTH) continue;
+    for (let index = frame.node.children.length - 1; index >= 0; index -= 1) {
+      const child = frame.node.children[index];
+      if (!isElement(child)) continue;
+      stack.push({ node: child, paragraphId, namespaceScope: scope, depth: frame.depth + 1 });
+    }
+  }
+  const frozen = Object.freeze(stories);
+  textboxStoriesCache.set(part.root, frozen);
+  return frozen;
+}

--- a/packages/core/src/store/package/textbox-stories.ts
+++ b/packages/core/src/store/package/textbox-stories.ts
@@ -29,7 +29,7 @@ const WPS_GRAPHIC_DATA_URI = WPS_NAMESPACE_URI;
 export interface TextboxStoryRoot {
   /** The `w:txbxContent` story root. */
   readonly root: OoxmlElement;
-  /** Canonical node id of the drawing that owns the story. */
+  /** Layout atom id used to select the drawing, including an MC wrapper when present. */
   readonly drawingNodeId: string;
   /** Canonical node id of the paragraph that anchors the drawing. */
   readonly hostParagraphId: string;
@@ -124,19 +124,22 @@ export function textboxStoriesInPart(part: OoxmlPart): readonly TextboxStoryRoot
     const scope = namespaceScopeForNode(frame.namespaceScope, frame.node);
     const paragraphId = frame.node.kind === 'paragraph' ? frame.node.id : frame.paragraphId;
     let drawing: OoxmlDrawingNode | null = frame.node.kind === 'drawing' ? frame.node : null;
+    let layoutAtomId = drawing?.id ?? null;
     if (!drawing && isMcAlternateContent(frame.node)) {
-      drawing = resolveRunLevelMcAtom(
+      const resolved = resolveRunLevelMcAtom(
         frame.node,
         scope,
         DEFAULT_SUPPORTED_MC_REQUIRES,
         DEFAULT_DRAWING_PROJECTION_LIMITS
-      ).drawing;
+      );
+      drawing = resolved.drawing;
+      layoutAtomId = drawing ? resolved.segmentNode.id : null;
     }
     if (drawing) {
       const root = paragraphId ? textboxContentOf(drawing) : null;
-      if (root && paragraphId) {
+      if (root && paragraphId && layoutAtomId) {
         stories.push(
-          Object.freeze({ root, drawingNodeId: drawing.id, hostParagraphId: paragraphId })
+          Object.freeze({ root, drawingNodeId: layoutAtomId, hostParagraphId: paragraphId })
         );
       }
       continue;

--- a/packages/core/src/store/package/textbox-stories.ts
+++ b/packages/core/src/store/package/textbox-stories.ts
@@ -2,6 +2,7 @@
 
 import { MAX_XML_DEPTH, schemaAttributeValue } from './ooxml-drawing-rules.ts';
 import {
+  anchorHidesDrawing,
   emptyNamespaceScope,
   isMcAlternateContent,
   namespaceScopeForNode,
@@ -47,22 +48,29 @@ function compatibleDirectChild(
   );
 }
 
-/** Read only the direct WPS path that holds a drawing's text-box story. */
+/**
+ * Read only the direct WPS path that holds a drawing's text-box story.
+ *
+ * ANCHORED only. Layout carries a text-box story on an anchored drawing record alone, so an
+ * inline box paints as a placeholder with its text nowhere on the page. Listing one would
+ * report a match the reader cannot see.
+ */
 function textboxContentOf(drawing: OoxmlDrawingNode): OoxmlElement | null {
   let anchor: OoxmlElement | null = null;
   for (const child of drawing.children) {
     if (!isElement(child)) continue;
     if (
-      child.kind === 'inlineDrawing' ||
       child.kind === 'anchoredDrawing' ||
-      (child.namespaceUri === WP_NAMESPACE_URI &&
-        (child.localName === 'inline' || child.localName === 'anchor'))
+      (child.namespaceUri === WP_NAMESPACE_URI && child.localName === 'anchor')
     ) {
       anchor = child;
       break;
     }
   }
   if (!anchor) return null;
+  // Selection is the point of this list, so a drawing layout never paints has no story to
+  // offer: the match would be reported and then refuse to select.
+  if (anchorHidesDrawing(anchor, true)) return null;
   const graphic = compatibleDirectChild(
     anchor,
     'drawingGraphic',

--- a/packages/core/src/store/package/textbox-stories.ts
+++ b/packages/core/src/store/package/textbox-stories.ts
@@ -101,6 +101,18 @@ interface WalkFrame {
 
 const textboxStoriesCache = new WeakMap<OoxmlElement, readonly TextboxStoryRoot[]>();
 
+function appendTextboxStory(
+  stories: TextboxStoryRoot[],
+  drawing: OoxmlDrawingNode,
+  drawingNodeId: string,
+  hostParagraphId: string | null
+): void {
+  if (!hostParagraphId) return;
+  const root = textboxContentOf(drawing);
+  if (!root) return;
+  stories.push(Object.freeze({ root, drawingNodeId, hostParagraphId }));
+}
+
 /**
  * List the text-box stories in one part, in document order.
  *
@@ -123,25 +135,21 @@ export function textboxStoriesInPart(part: OoxmlPart): readonly TextboxStoryRoot
     if (frame.depth > MAX_XML_DEPTH) continue;
     const scope = namespaceScopeForNode(frame.namespaceScope, frame.node);
     const paragraphId = frame.node.kind === 'paragraph' ? frame.node.id : frame.paragraphId;
-    let drawing: OoxmlDrawingNode | null = frame.node.kind === 'drawing' ? frame.node : null;
-    let layoutAtomId = drawing?.id ?? null;
-    if (!drawing && isMcAlternateContent(frame.node)) {
+    if (frame.node.kind === 'drawing') {
+      appendTextboxStory(stories, frame.node, frame.node.id, paragraphId);
+      continue;
+    }
+    if (isMcAlternateContent(frame.node)) {
       const resolved = resolveRunLevelMcAtom(
         frame.node,
         scope,
         DEFAULT_SUPPORTED_MC_REQUIRES,
         DEFAULT_DRAWING_PROJECTION_LIMITS
       );
-      drawing = resolved.drawing;
-      layoutAtomId = drawing ? resolved.segmentNode.id : null;
-    }
-    if (drawing) {
-      const root = paragraphId ? textboxContentOf(drawing) : null;
-      if (root && paragraphId && layoutAtomId) {
-        stories.push(
-          Object.freeze({ root, drawingNodeId: layoutAtomId, hostParagraphId: paragraphId })
-        );
+      if (resolved.drawing) {
+        appendTextboxStory(stories, resolved.drawing, resolved.segmentNode.id, paragraphId);
       }
+      // Layout treats the wrapper as one atom, even when its selected branch is unsupported.
       continue;
     }
     if (frame.depth >= MAX_XML_DEPTH) continue;

--- a/scripts/check-eslint-max-lines-globs.mjs
+++ b/scripts/check-eslint-max-lines-globs.mjs
@@ -42,7 +42,7 @@ const SLACK_EXEMPT = new Map([
  * diff where a reviewer sees it, instead of the file quietly gaining a thousand lines.
  */
 const BLANKET_DISABLES = new Map([
-  ['packages/core/src/editor/paginated-surface.ts', 6260],
+  ['packages/core/src/editor/paginated-surface.ts', 6265],
   ['packages/core/src/store/store/tree-op-apply.ts', 3495],
   ['packages/core/src/output/semantic-paint.ts', 3009],
   ['packages/core/src/layout/note-pagination.ts', 2954],


### PR DESCRIPTION
A `w:drawing` can anchor a text box whose `w:txbxContent` holds real paragraphs, and layout paints those paragraphs as their own story. Find never walked them, so a word in a text box was unfindable even though it was on the page.

Find now walks the text-box stories that belong to the body and to headers and footers, in document order after their owning story. A match reports a `frame` scope naming the drawing that hosts it, and selecting the match reveals that drawing and selects it.

## What is not covered

- A match selects the text box rather than placing the caret inside it, because the surface cannot yet put a caret in a text-box story.
- Only anchored text boxes are searched. Layout carries a story on an anchored drawing alone, so an inline box paints as a placeholder with its text nowhere on the page.
- Text boxes owned by footnotes or endnotes are excluded, because their drawings are not selectable.
- A box nested inside another box is not searched.
- A legacy VML text box is not searched, because layout paints no story for one either.
- A box that layout refuses to paint is not searched: one hidden through Word's Selection Pane, or clipped to zero size.

## Public API

`EditorScope`'s `frame` arm takes the two ids that address a frame, `drawingNodeId` and `hostParagraphId`, so a frame scope that cannot be revealed is unrepresentable. `PaginatedSurface.selectDrawing` is required, like the other entry points beside it. Both are type-level breaks for code that constructs a frame scope or implements the surface, and no command accepted a frame scope before this change.

Fixes #711

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C3mzHcQeGoaxSkK5791272

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/759"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791293958&installation_model_id=422592&pr_number=759&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F759&signature=03fe6b1eb4194e7b4fe00836dddc4e4d619f87914e762ccc8d0e9d2f16ff6b12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->