### PR TITLE
fix(layout): preserve graphemes, trailing words, and terminal anchors

### DIFF
--- a/.changeset/drawingml-open-connectors.md
+++ b/.changeset/drawingml-open-connectors.md
@@ -1,5 +1,5 @@
 ---
-'@docx-editor.dev/core': minor
+'@docx-editor.dev/core': patch
 ---
 
-Project flipped DrawingML vector paths and straight connectors, preserve open versus closed paths, and render bounded triangular line ends without changing canonical XML.
+Render flipped DrawingML paths and open connectors with triangular line ends.

--- a/.changeset/floating-image-clipping.md
+++ b/.changeset/floating-image-clipping.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': patch
 ---
 
-Keep floating overlays visible beyond their anchor cells and clip page-relative images to the physical sheet instead of a shortened continuous-section band.
+Keep floating image overlays visible beyond their anchor cells while preserving page clipping.

--- a/.changeset/rendering-batch-final-review.md
+++ b/.changeset/rendering-batch-final-review.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Keep joined emoji and combining marks intact under East Asian font hints, avoid premature word wrapping at trailing spaces, and preserve terminal floating tables beside empty anchors with bookmarks or paragraph spacing.

--- a/.changeset/solid-text-outline.md
+++ b/.changeset/solid-text-outline.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': patch
 ---
 
-Read opaque solid Word 2010 run text outlines through the style cascade and paint their width and colour without changing font weight, text advances, model ranges or saved XML. Gradient/theme/alpha, dashed/compound/inset outlines are not supported; glyph joins use the browser's native text-stroke rasterization.
+Render opaque solid Word 2010 text outlines with explicit RGB colors.

--- a/docs/api/docx-editor-core/layout.api.md
+++ b/docs/api/docx-editor-core/layout.api.md
@@ -778,6 +778,18 @@ export interface DrawingGeometry {
 // @public (undocumented)
 export type DrawingHorizontalReferenceFrame = 'character' | 'column' | 'insideMargin' | 'leftMargin' | 'margin' | 'outsideMargin' | 'page' | 'rightMargin';
 
+// @public
+export interface DrawingImageEffects {
+    // (undocumented)
+    readonly bilevel?: number;
+    // (undocumented)
+    readonly brightness: number;
+    // (undocumented)
+    readonly contrast: number;
+    // (undocumented)
+    readonly grayscale: boolean;
+}
+
 // @public (undocumented)
 export interface DrawingInsets {
     // (undocumented)
@@ -1447,7 +1459,7 @@ export interface InlineDrawingRecord {
     // (undocumented)
     readonly drawingNodeId: string;
     // (undocumented)
-    readonly effects: DrawingProjection['effects'];
+    readonly effects: DrawingImageEffects;
     // (undocumented)
     readonly geometry: DrawingGeometry;
     // (undocumented)

--- a/docs/api/docx-editor-core/store.api.md
+++ b/docs/api/docx-editor-core/store.api.md
@@ -1139,6 +1139,18 @@ export interface DocumentViewSettings {
 }
 
 // @public
+export interface DrawingImageEffects {
+    // (undocumented)
+    readonly bilevel?: number;
+    // (undocumented)
+    readonly brightness: number;
+    // (undocumented)
+    readonly contrast: number;
+    // (undocumented)
+    readonly grayscale: boolean;
+}
+
+// @public
 export type DrawingKind = 'inline' | 'anchored';
 
 // @public

--- a/docs/api/docx-editor-docx-to-markdown/index.api.md
+++ b/docs/api/docx-editor-docx-to-markdown/index.api.md
@@ -366,7 +366,7 @@ export interface InlineDrawingRecord {
     // (undocumented)
     readonly drawingNodeId: string;
     // (undocumented)
-    readonly effects: DrawingProjection['effects'];
+    readonly effects: DrawingImageEffects;
     // (undocumented)
     readonly geometry: DrawingGeometry;
     // (undocumented)

--- a/docs/site/content/guides/images.mdx
+++ b/docs/site/content/guides/images.mdx
@@ -177,6 +177,10 @@ Alt text uses `@descr`, then `@title`; `@name` is never announced. A picture wit
 
 ## Drawing limits
 
+The editor renders brightness, contrast, grayscale, and bilevel black-and-white picture adjustments.
+It preserves image alpha and adjustment markup when you save.
+PDF export does not apply these adjustments.
+
 | Drawing content                                         | Status                                               |
 | ------------------------------------------------------- | ---------------------------------------------------- |
 | Solid shapes and bounded shape groups                   | Render geometry with sRGB or theme colors            |

--- a/docs/site/content/word-fidelity.mdx
+++ b/docs/site/content/word-fidelity.mdx
@@ -55,7 +55,8 @@ The matrix reports three separate support axes.
 
 A text-anchored table can share a terminal empty paragraph without shrinking that paragraph.
 This applies to simple tables that fit with the anchor inside one content box.
-Explicit page breaks, paragraph spacing, complex tables, and anchors with text retain their existing layout.
+Bookmarks, proofing markers, formatting-only runs, and paragraph spacing are supported in this case.
+Explicit page breaks, complex tables, and anchors with text retain their existing layout.
 Text wrapping beside floating tables is not supported.
 
 ### Images and drawings
@@ -95,6 +96,10 @@ often affect document evaluation.
 
 ## Rendering and pagination
 
+The editor renders opaque solid Word 2010 text outlines with explicit RGB colors.
+Other text effects remain preserved; the text-effects matrix lists the rendering limits.
+PDF export does not paint these outlines.
+
 The editor calculates document layout without browser flow layout. It uses
 document fonts, themes, section geometry, margins, and Word units.
 
@@ -109,7 +114,7 @@ together across formatting changes. Justified lines distribute inter-character
 spacing through the same geometry used for paint and caret placement.
 
 East Asian font hints select the document's East Asian face for supported punctuation,
-symbols, Greek, and Cyrillic ranges. Combining marks keep the selected slot across text runs.
+symbols, Greek, and Cyrillic ranges. Combining marks and joined emoji keep their base character's slot across text runs.
 Explicit symbol fonts retain their selected face.
 
 Existing document settings control kinsoku, Japanese strict rules, custom

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -166,11 +166,11 @@ export const wordFeatures: WordFeature[] = [
     name: 'Text effects (outline, shadow, emboss, emphasis mark)',
     category: 'text',
     editing: 'none',
-    rendering: 'full',
+    rendering: 'partial',
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'w:outline, w:shadow, w:emboss, w:imprint, and w:em render and round-trip. You cannot set them from the toolbar. w14 glow and gradient text fill are not supported.',
+      'Opaque solid w14:textOutline with an explicit RGB color renders. Theme-colored, transparent, gradient, dashed, compound, and inset outlines do not render. Legacy outline, shadow, emboss, imprint, and emphasis marks are preserved but do not render. Text effects have no toolbar controls.',
   },
   {
     id: 'text.hidden',
@@ -456,7 +456,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'An anchored table uses tblpXSpec or tblpX across the text, margin, or page box. It uses tblpY or tblpYSpec against the selected vertical anchor. Page-anchored and margin-anchored tables do not advance body flow. Simple text-anchored tables can share a terminal empty paragraph without adding a blank page when the complete group fits the same content box. Other text-anchored tables remain in flow. Text does not wrap beside them yet.',
+      'An anchored table uses tblpXSpec or tblpX across the text, margin, or page box. It uses tblpY or tblpYSpec against the selected vertical anchor. Page-anchored and margin-anchored tables do not advance body flow. Simple text-anchored tables can share a terminal empty paragraph without adding a blank page when the complete group fits the same content box, including paragraph spacing and inert bookmark or formatting markup. Other text-anchored tables remain in flow. Text does not wrap beside them yet.',
   },
   {
     id: 'tables.text-direction',
@@ -599,7 +599,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'Transparency, brightness, contrast, and grayscale project where supported. Authored adjustment markup is preserved on save.',
+      'Brightness, contrast, grayscale, and bilevel black-and-white adjustments render in the editor. Image alpha and authored adjustment markup are preserved. PDF export does not apply these adjustments.',
   },
   {
     id: 'images.effects',

--- a/packages/core/src/layout/__tests__/east-asia-symbol-hint.test.ts
+++ b/packages/core/src/layout/__tests__/east-asia-symbol-hint.test.ts
@@ -8,6 +8,7 @@ import { applyEastAsiaFontSlots, type FieldAwarePiece } from '../field-pieces.ts
 import { resolveRunStyle } from '../run-style.ts';
 import { eastAsiaRunsOfSegments } from '../script-itemization.ts';
 import { symbolRunStyle } from '../symbol-run.ts';
+import { intlGraphemeBoundary, resetGraphemeBoundary, setGraphemeBoundary } from '../grapheme.ts';
 import { createFixedMeasurer, layoutSemanticDocument, linesOf } from '../index.ts';
 import { readOoxmlPart, type OoxmlProperty } from '@docx-editor.dev/core/store';
 
@@ -358,5 +359,67 @@ test('hinted strong text retains its base strength around Common characters and 
     expect(eastAsiaRunsOfSegments(['中' + strong + '\u0301©'], [true])).toEqual([
       { segment: 0, from: 0, to: 3 },
     ]);
+  }
+});
+
+test('font hints select whole emoji and combining clusters in layout', () => {
+  const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+  for (const [text, expectedSlot] of [
+    ['❤️‍🔥', 'eastAsia'],
+    ['👩‍⚕️', undefined],
+    ['a\u0483', undefined],
+    ['Ԁ\u0483', undefined],
+  ] as const) {
+    const parsed = readOoxmlPart(
+      `<w:document xmlns:w="${W}"><w:body><w:p><w:r><w:rPr>` +
+        `<w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:eastAsia="SimSun" w:hint="eastAsia"/>` +
+        `</w:rPr><w:t>${text}</w:t></w:r></w:p></w:body></w:document>`,
+      { name: '/word/document.xml', contentType: 'app/xml' }
+    );
+    if (!parsed.ok) throw new Error(parsed.reason);
+    const spans = linesOf(
+      layoutSemanticDocument(parsed.part, 1, { measurer: createFixedMeasurer(6, 14) })
+    ).flatMap((line) => line.spans);
+    expect(spans.map((span) => span.text)).toEqual([text]);
+    expect(spans[0]!.fontSlot).toBe(expectedSlot);
+  }
+});
+
+test('the cluster base owns its hint across text segments without lending script strength', () => {
+  expect(eastAsiaRunsOfSegments(['❤️', '‍', '🔥', '©x'], [true])).toEqual([
+    { segment: 0, from: 0, to: 2 },
+    { segment: 1, from: 0, to: 1 },
+    { segment: 2, from: 0, to: 2 },
+  ]);
+  expect(eastAsiaRunsOfSegments(['👩', '‍⚕️'], [false, true])).toEqual([]);
+  expect(eastAsiaRunsOfSegments(['a', '\u0483'], [false, true])).toEqual([]);
+  expect(eastAsiaRunsOfSegments(['❤️', '‍🔥'], [false, true])).toEqual([]);
+  expect(eastAsiaRunsOfSegments(['（', '❤️‍🔥', '中'], [false, true])).toEqual([
+    { segment: 0, from: 0, to: 1 },
+    { segment: 1, from: 0, to: 5 },
+    { segment: 2, from: 0, to: 1 },
+  ]);
+});
+
+test('hinted cluster segmentation runs once and skips ordinary paragraphs', () => {
+  const calls: string[] = [];
+  setGraphemeBoundary({
+    segment(text) {
+      calls.push(text);
+      return intlGraphemeBoundary.segment(text);
+    },
+  });
+  try {
+    eastAsiaRunsOfSegments(['ASCII only'], [true]);
+    eastAsiaRunsOfSegments(['中❤️‍🔥'], [false]);
+    expect(calls).toHaveLength(0);
+    const segments = Array.from({ length: 1000 }, () => '❤️‍🔥');
+    eastAsiaRunsOfSegments(
+      segments,
+      segments.map(() => true)
+    );
+    expect(calls).toEqual([segments.join('')]);
+  } finally {
+    resetGraphemeBoundary();
   }
 });

--- a/packages/core/src/layout/__tests__/footnote-reserve-index-space.test.ts
+++ b/packages/core/src/layout/__tests__/footnote-reserve-index-space.test.ts
@@ -188,7 +188,8 @@ describe('multi-section reserve index space (#460)', () => {
     });
     expect(sortedKeys(session.notePageBottomReserves!)).toEqual([2]);
 
-    const { part: grownPart, notes: grownNotes } = notesFor(docWith(30), 3);
+    // Hanging same-run separators let 30 paragraphs fit one page; 40 forces the shift.
+    const { part: grownPart, notes: grownNotes } = notesFor(docWith(40), 3);
     const incremental = layoutSemanticDocument(grownPart, 2, {
       measurer: grownNotes.measurer,
       notes: grownNotes,
@@ -230,7 +231,8 @@ describe('multi-section reserve index space (#460)', () => {
     // reserve at the shared sheet's DOCUMENT page index, so the continued flow also stops
     // above the note area rather than filling the band the note needs.
     const bytes = zipFootnoteDoc(
-      paras('S0', 60, 18, 59) +
+      // Keep the citation on document page 2 after same-run separators can hang.
+      paras('S0', 80, 18, 79) +
         sectionBreak +
         paras('S1', 40, 18) +
         `<w:sectPr><w:type w:val="continuous"/>${SECT_GEOMETRY}</w:sectPr>`,

--- a/packages/core/src/layout/__tests__/pagination-keeps.test.ts
+++ b/packages/core/src/layout/__tests__/pagination-keeps.test.ts
@@ -557,6 +557,20 @@ describe('composeFlowKeys — the one composition, and its load-bearing order', 
     expect(composeFlowKeys(keys, none)).toBe(keys);
   });
 
+  test('a terminal table group folds before keep-next and changes all member keys', () => {
+    const keys = ['lead', 'table', 'anchor'];
+    const fold = (token: string) =>
+      composeFlowKeys(keys, {
+        ...none,
+        terminalTableGroup: { start: 1, anchorIndex: 2, token },
+        keepsNextAt: (index) => index === 0,
+      });
+    const before = fold('empty');
+    const after = fold('bookmarked');
+    expect(before[0]).toBe(`lead~kn~${before[1]}`);
+    for (let index = 0; index < keys.length; index++) expect(after[index]).not.toBe(before[index]);
+  });
+
   test('a keep-next chain head carries its successor POST-fold — every other fold first', () => {
     // Block 0 keeps with block 1; block 1 carries a marker, a contextual verdict and a
     // border-group verdict. The head must splice block 1's FINISHED key: run keepNext

--- a/packages/core/src/layout/__tests__/terminal-table-anchor.test.ts
+++ b/packages/core/src/layout/__tests__/terminal-table-anchor.test.ts
@@ -13,6 +13,7 @@ import {
 import { caretAt } from '../semantic-interaction.ts';
 import { pagesToMaterialize } from '../viewport.ts';
 import { isOutOfFlowTableFragment } from '../table-float-position.ts';
+import { createParagraphLayoutCache, tableCellBreakKeysOf } from '../layout-cache.ts';
 import type {
   ParagraphFragmentRecord,
   SemanticLayout,
@@ -183,7 +184,7 @@ describe('terminal empty text-table anchors', () => {
     );
   });
 
-  test('declines invalid positions, horizontal overflow, and paragraph spacing', () => {
+  test('declines invalid positions and horizontal overflow', () => {
     const anchors = [
       fixture(table().replace(/<w:tblpPr[^>]+\/>/, '<w:tblpPr/>')),
       fixture(table().replace(/<w:tblpPr[^>]+\/>/, '<w:tblpPr w:horzAnchor="margin"/>')),
@@ -193,16 +194,99 @@ describe('terminal empty text-table anchors', () => {
       fixture(table(230, 'w:topFromText="120"')),
       fixture(table(230, 'w:bottomFromText="720"')),
       fixture(table().replace('w:tblpXSpec="center"', 'w:tblpX="9000"')),
-      fixture(table(), p(31.2).replace('w:lineRule="exact"', 'w:lineRule="exact" w:before="120"')),
-      part(
-        p(595.2, 'Lead').replace('w:lineRule="exact"', 'w:lineRule="exact" w:after="120"') +
-          table() +
-          p(31.2) +
-          section()
-      ),
     ];
     for (const source of anchors)
       expect(tablesOf(render(source)).some(isOutOfFlowTableFragment)).toBe(false);
+  });
+
+  test('accepts Word bookmarks, proofing boundaries and formatting-only empty runs', () => {
+    for (const content of [
+      '<w:bookmarkStart w:id="0" w:name="_GoBack"/><w:bookmarkEnd w:id="0"/>',
+      '<w:proofErr w:type="spellStart"/><w:proofErr w:type="spellEnd"/>',
+      '<w:r><w:rPr><w:b/></w:rPr></w:r>',
+    ]) {
+      const source = fixture(table(), p(31.2).replace('</w:p>', content + '</w:p>'));
+      const original = serializeOoxmlPart(source);
+      const layout = render(source);
+      expect(layout.pages).toHaveLength(1);
+      expect(tablesOf(layout).every(isOutOfFlowTableFragment)).toBe(true);
+      expect(serializeOoxmlPart(source)).toBe(original);
+    }
+    for (const content of [
+      '<w:r><w:t> </w:t></w:r>',
+      '<w:r><w:tab/></w:r>',
+      '<w:r><w:rPr><w:vanish/></w:rPr></w:r>',
+    ]) {
+      const source = fixture(table(), p(31.2).replace('</w:p>', content + '</w:p>'));
+      expect(tablesOf(render(source)).some(isOutOfFlowTableFragment)).toBe(false);
+    }
+  });
+
+  test('collapses lead and anchor spacing while retaining one page', () => {
+    for (const [after, before] of [
+      [120, 0],
+      [0, 120],
+      [120, 240],
+    ]) {
+      const source = part(
+        p(595.2, 'Lead').replace('w:lineRule="exact"', `w:lineRule="exact" w:after="${after}"`) +
+          table() +
+          p(31.2).replace(
+            'w:lineRule="exact"',
+            `w:lineRule="exact" w:before="${before}" w:after="400"`
+          ) +
+          section()
+      );
+      const layout = render(source);
+      expect(layout.pages).toHaveLength(1);
+      const anchor = paragraphsOf(layout).at(-1)!;
+      const floating = tablesOf(layout)[0]!;
+      expect(isOutOfFlowTableFragment(floating)).toBe(true);
+      expect(anchor.lines[0]!.box.y).toBeCloseTo(595.2 + Math.max(after!, before!) / 20, 3);
+      expect(floating.box.y).toBeCloseTo(anchor.lines[0]!.box.y + 11.5, 3);
+    }
+  });
+
+  test('recomputes the terminal group across spacing and bookmark edits with a warm cache', () => {
+    const initial = fixture();
+    const bookmarked = replaceAnchor(
+      initial,
+      bodyOf(
+        fixture(
+          table(),
+          p(31.2).replace(
+            '</w:p>',
+            '<w:bookmarkStart w:id="0" w:name="_GoBack"/><w:bookmarkEnd w:id="0"/></w:p>'
+          )
+        )
+      ).children.at(-2) as OoxmlElement
+    );
+    const spaced = replaceAnchor(
+      bookmarked,
+      bodyOf(
+        fixture(table(), p(31.2).replace('w:lineRule="exact"', 'w:lineRule="exact" w:before="120"'))
+      ).children.at(-2) as OoxmlElement
+    );
+    const session = createLayoutSession();
+    const cache =
+      createParagraphLayoutCache<readonly import('../paragraph-flow.ts').PendingLine[]>();
+    for (const [revision, source] of [initial, bookmarked, spaced, initial].entries()) {
+      const warm = layoutSemanticDocument(source, revision, { measurer, session, cache });
+      const cold = layoutSemanticDocument(source, revision, { measurer });
+      expect(warm.pages).toEqual(cold.pages);
+      expect(warm.pages).toHaveLength(1);
+    }
+  });
+
+  test('retains each table cell cache only under its own table', () => {
+    const source = fixture(table(230) + table(1700), p(31.2), 400);
+    render(source, { cache: createParagraphLayoutCache() });
+    const [first, second] = bodyOf(source).children.filter((node) => node.kind === 'table');
+    const firstKeys = new Set(tableCellBreakKeysOf(first!)!);
+    const secondKeys = new Set(tableCellBreakKeysOf(second!)!);
+    expect(firstKeys.size).toBeGreaterThan(0);
+    expect(secondKeys.size).toBeGreaterThan(0);
+    expect([...firstKeys].some((key) => secondKeys.has(key))).toBe(false);
   });
 
   test('declines the whole group if any table or anchor exceeds the available band', () => {

--- a/packages/core/src/layout/__tests__/wrapped-space-run.test.ts
+++ b/packages/core/src/layout/__tests__/wrapped-space-run.test.ts
@@ -9,6 +9,8 @@ import type { ImageResourceState } from '../../store/package/image-resources.ts'
 import type { InlineDrawingLayoutContext } from '../drawing-layout.ts';
 import { createFixedMeasurer, layoutSemanticDocument, linesOf } from '../index.ts';
 import { spanOffsetX } from '../semantic-hit-test.ts';
+import { anchorLineStartsByModelOffset } from '../anchor-line-probe.ts';
+import { DEFAULT_RUN_STYLE } from '../run-style.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
@@ -136,5 +138,56 @@ describe('justified lines ending in clipped space runs', () => {
     // The last line stays flush left.
     expect(one[1]!.spans[0]!.box.x).toBe(0);
     expect(two[1]!.spans[0]!.box.x).toBe(0);
+  });
+});
+
+describe('same-run trailing spaces at a soft-wrap margin', () => {
+  test('keeps the word when only its same-run separator overflows', () => {
+    const lines = layout(run('XY AB CD'), 55);
+    expect(texts(lines)).toEqual(['XY AB ', 'CD']);
+    const fill = lines[0]!.spans.at(-1)!;
+    expect(fill.text).toBe(' ');
+    expect(fill.lineEndWhitespace).toBe(true);
+    expect(fill.box).toMatchObject({ x: 50, width: 5 });
+    expect(fill.range).toMatchObject({ start: 5, end: 6 });
+    expect(spanOffsetX(fill, 6, measurer)).toBe(55);
+  });
+  test('aligns the visible word and preserves a margin caret for the clipped fill', () => {
+    for (const [alignment, end] of [
+      ['center', 52.5],
+      ['right', 55],
+      ['both', 55],
+    ] as const) {
+      const lines = layout(run('XY AB CD'), 55, `<w:pPr><w:jc w:val="${alignment}"/></w:pPr>`);
+      expect(texts(lines)).toEqual(['XY AB ', 'CD']);
+      const word = lines[0]!.spans.find((span) => span.text === 'AB')!;
+      expect(word.box.x + word.box.width).toBe(end);
+      expect(word.lineEndWhitespace).toBeUndefined();
+      expect(spanOffsetX(word, word.range.end, measurer)).toBe(end);
+    }
+  });
+
+  test('keeps exact-fit words, repeated separators and drawing-led words on their line', () => {
+    expect(texts(layout(run('XY AB CD'), 50))).toEqual(['XY AB ', 'CD']);
+    expect(texts(layout(run('XY AB   CD'), 55))).toEqual(['XY AB   ', 'CD']);
+    expect(texts(layout(picture(30) + run('AB CD'), 55))).toEqual(['AB ', 'CD']);
+    expect(texts(layout(run('AB CD'), 25))).toEqual(['AB ', 'CD']);
+    expect(texts(layout(run('XY AB CD'), 60))).toEqual(['XY AB ', 'CD']);
+    expect(texts(layout(run('XY AB CD'), 45))).toEqual(['XY ', 'AB ', 'CD']);
+  });
+  test('predicts the same anchor line after a clipped same-run separator', () => {
+    const text = 'XY AB CD';
+    const starts = anchorLineStartsByModelOffset({
+      pieces: [{ text, start: 0, end: text.length, props: [], style: DEFAULT_RUN_STYLE }],
+      measurer,
+      available: 55,
+      firstLineOffset: 0,
+      anchorStarts: [3, 6],
+      equationLayoutOf: () => null,
+    });
+    const lines = layout(run(text), 55);
+    expect(starts.get(3)).toBe(lines[0]!.range.start);
+    expect(starts.get(6)).toBe(lines[1]!.range.start);
+    expect(starts.get(6)).toBe(6);
   });
 });

--- a/packages/core/src/layout/anchor-line-probe.ts
+++ b/packages/core/src/layout/anchor-line-probe.ts
@@ -21,6 +21,8 @@ import { measureInlineDrawing } from './drawing-layout.ts';
 import { styleForFontSlot } from './script-itemization.ts';
 import type { EquationSpanRecord } from './equation-layout.ts';
 import type { TextMeasurer } from './semantic-records.ts';
+import { displayText } from './run-style.ts';
+import { clipWordEnd, isCollapsibleLineEndWhitespace } from './line-end-whitespace.ts';
 
 /** Model offset of the first character of the line each anchor start falls on. */
 export function anchorLineStartsByModelOffset(input: {
@@ -88,7 +90,14 @@ export function anchorLineStartsByModelOffset(input: {
       const candidate = piece.text.slice(consumed, boundary);
       if (candidate.length === 0) continue;
       const style = styleForFontSlot(piece.style, piece.fontSlot);
-      const width = measurer.measure(candidate, style);
+      const measure = (text: string): number => measurer.measure(displayText(text, style), style);
+      let width = measure(piece.measureText ?? candidate);
+      if (!probePieceLayoutOwned && piece.measureText === undefined) {
+        const remaining = probeLineAvail() - probeWidth;
+        width = clipWordEnd(candidate, width, remaining, measure, 0.001)?.width ?? width;
+        if (probeWidth > 0 && isCollapsibleLineEndWhitespace(candidate))
+          width = Math.min(width, Math.max(0, remaining));
+      }
       const modelStart = piece.start + consumed;
       const probeDecision =
         input.cjkBreaks?.decision(piece, consumed) ??

--- a/packages/core/src/layout/drawing-layout.ts
+++ b/packages/core/src/layout/drawing-layout.ts
@@ -3,6 +3,7 @@
 // DOM-free points everywhere. `wp:extent` EMUs convert at this boundary; intrinsic pixel
 // dimensions never resize layout. Paint and hit testing consume the published records only.
 
+import type { DrawingImageEffects } from '../store/package/drawing-image-effects.ts';
 import type {
   DrawingAccessibility,
   DrawingHorizontalReferenceFrame,
@@ -65,7 +66,7 @@ const EMPTY_CROP: SourceCrop = Object.freeze({ left: 0, top: 0, right: 0, bottom
 
 function drawingPaintFields(projection: DrawingProjection): {
   readonly hyperlinkHref: string | null;
-  readonly effects: DrawingProjection['effects'];
+  readonly effects: DrawingImageEffects;
   readonly crop: SourceCrop;
   readonly transform: DrawingTransform;
   readonly placeholderGraphicKind: string | null;
@@ -317,7 +318,7 @@ export interface InlineDrawingRecord {
   readonly accessibility: DrawingAccessibility;
   /** Sanitized external hyperlink projection; inert until an explicit gesture activates it. */
   readonly hyperlinkHref: string | null;
-  readonly effects: DrawingProjection['effects'];
+  readonly effects: DrawingImageEffects;
   readonly crop: SourceCrop;
   readonly transform: DrawingTransform;
   /** Fixed non-picture graphic kind for refusal labels (`chart`, `group`, …); null for pictures. */

--- a/packages/core/src/layout/index.ts
+++ b/packages/core/src/layout/index.ts
@@ -718,3 +718,4 @@ export {
   type TableBorderStrokeRecord,
   type TableBorderStyle,
 } from './table-borders.ts';
+export type { DrawingImageEffects } from '../store/package/drawing-image-effects.ts';

--- a/packages/core/src/layout/legacy-footer-fixed-frame.ts
+++ b/packages/core/src/layout/legacy-footer-fixed-frame.ts
@@ -4,7 +4,7 @@ import {
   type OoxmlNode,
   type OoxmlPart,
 } from '../store/package/ooxml-tree.ts';
-import { allowlistedPageField } from './field-instruction.ts';
+import { readLegacyPageField } from './legacy-footer-page-field.ts';
 import { shiftParagraphFragment } from './note-fragment-geometry.ts';
 import type { BlockFragmentRecord, ParagraphFragmentRecord } from './semantic-records.ts';
 
@@ -24,69 +24,10 @@ function one(node: OoxmlElement, name: string): OoxmlElement | undefined {
   const matches = elements(node).filter((child) => child.localName === name);
   return matches.length === 1 && isW(matches[0]!, name) ? matches[0] : undefined;
 }
-/**
- * A PAGE instruction the live page-field projection evaluates: bare `PAGE`, with the
- * `\* MERGEFORMAT` Word appends, or a `\#` numeric picture. It is the allowlist
- * `field-instruction.ts` evaluates the projected value through, so the frame lanes never
- * claim a field whose result the page context will not refresh (`\* roman`, `\* Arabic`
- * and every other switch stay in ordinary flow with their cached text).
- */
-function isPageInstruction(instruction: string): boolean {
-  return allowlistedPageField(instruction) === 'PAGE';
-}
 function twips(value: string | undefined): number | undefined {
   if (value === undefined || !/^\d{1,5}$/.test(value)) return undefined;
   const pt = Number(value) / 20;
   return pt <= MAX_PT ? pt : undefined;
-}
-
-/** Bounded only-PAGE paragraphs; decoration is content, never a deduplication key. */
-function pageText(paragraph: OoxmlElement, leadingTab: boolean): string | undefined {
-  let state = 0,
-    instruction = '',
-    prefix = '',
-    suffix = '',
-    tabs = 0;
-  for (const run of elements(paragraph)) {
-    if (isW(run, 'pPr')) continue;
-    if (!isW(run, 'r')) return undefined;
-    for (const node of elements(run)) {
-      if (isW(node, 'rPr')) continue;
-      if (
-        isW(node, 'tab') &&
-        state === 0 &&
-        !prefix &&
-        !tabs &&
-        leadingTab &&
-        !node.children.length
-      ) {
-        tabs++;
-        continue;
-      }
-      if (isW(node, 'fldChar') && !node.children.length) {
-        const type = attr(node, 'fldCharType');
-        if (state === 0 && type === 'begin') state = 1;
-        else if (state === 1 && type === 'separate' && isPageInstruction(instruction)) state = 2;
-        else if (state === 2 && type === 'end') state = 3;
-        else return undefined;
-        continue;
-      }
-      if (node.children.some(isElement)) return undefined;
-      const value = node.children
-        .map((child) => (child.kind === 'textValue' ? child.value : ''))
-        .join('');
-      if (isW(node, 'instrText') && state === 1) instruction += value;
-      else if (isW(node, 't') && state === 0) prefix += value;
-      else if (isW(node, 't') && state === 3) suffix += value;
-      else if (!(isW(node, 't') && state === 2 && /^\d*$/.test(value))) return undefined;
-    }
-  }
-  return state === 3 &&
-    isPageInstruction(instruction) &&
-    tabs === Number(leadingTab) &&
-    ((!prefix && !suffix) || (prefix === '- ' && suffix === ' -'))
-    ? prefix + suffix
-    : undefined;
 }
 
 function simple(fragment: BlockFragmentRecord): fragment is ParagraphFragmentRecord {
@@ -189,10 +130,14 @@ export function positionFixedFooterPageFrame<
     elements(anchorProps).some((p) => !['pStyle', 'jc', 'ind', 'rPr'].some((name) => isW(p, name)))
   )
     return flow;
-  const decoration = pageText(paragraphs[0]!, true);
+  const decoration = readLegacyPageField(paragraphs[0]!, {
+    leadingTab: true,
+    allowDecoration: true,
+  });
   if (
     decoration === undefined ||
-    (pageText(paragraphs[1]!, false) === undefined && !emptyAnchor(paragraphs[1]!, anchor))
+    (readLegacyPageField(paragraphs[1]!, { allowDecoration: true }) === undefined &&
+      !emptyAnchor(paragraphs[1]!, anchor))
   )
     return flow;
   const frame = one(firstProps, 'framePr');

--- a/packages/core/src/layout/legacy-footer-page-field.ts
+++ b/packages/core/src/layout/legacy-footer-page-field.ts
@@ -1,0 +1,81 @@
+import {
+  WML_NAMESPACE_URI,
+  type OoxmlElement,
+  type OoxmlNode,
+} from '../store/package/ooxml-tree.ts';
+import { allowlistedPageField } from './field-instruction.ts';
+
+const isElement = (node: OoxmlNode): node is OoxmlElement => node.kind !== 'textValue';
+const isW = (node: OoxmlNode, name: string): boolean =>
+  isElement(node) && node.namespaceUri === WML_NAMESPACE_URI && node.localName === name;
+const elements = (node: OoxmlElement): OoxmlElement[] =>
+  (node.children as readonly OoxmlNode[]).filter(isElement);
+const attr = (node: OoxmlElement, name: string): string | undefined => {
+  const matches = node.attributes.filter((item) => item.localName === name);
+  return matches.length === 1 && matches[0]!.namespaceUri === WML_NAMESPACE_URI
+    ? matches[0]!.value
+    : undefined;
+};
+
+/**
+ * Recognize one supported PAGE field in an already bounded footer paragraph.
+ * Both frame lanes use the live page-field allowlist and the same instruction parser.
+ * Optional surrounding decoration is content, never a deduplication key.
+ */
+export function readLegacyPageField(
+  paragraph: OoxmlElement,
+  {
+    leadingTab = false,
+    allowDecoration = false,
+  }: {
+    readonly leadingTab?: boolean;
+    readonly allowDecoration?: boolean;
+  } = {}
+): string | undefined {
+  let state = 0,
+    instruction = '',
+    prefix = '',
+    suffix = '',
+    tabs = 0;
+  for (const run of elements(paragraph)) {
+    if (isW(run, 'pPr')) continue;
+    if (!isW(run, 'r')) return undefined;
+    for (const node of elements(run)) {
+      if (isW(node, 'rPr')) continue;
+      if (
+        isW(node, 'tab') &&
+        state === 0 &&
+        !prefix &&
+        !tabs &&
+        leadingTab &&
+        !node.children.length
+      ) {
+        tabs++;
+        continue;
+      }
+      if (isW(node, 'fldChar') && !node.children.length) {
+        const type = attr(node, 'fldCharType');
+        if (state === 0 && type === 'begin') state = 1;
+        else if (state === 1 && type === 'separate' && allowlistedPageField(instruction) === 'PAGE')
+          state = 2;
+        else if (state === 2 && type === 'end') state = 3;
+        else return undefined;
+        continue;
+      }
+      if (node.children.some(isElement)) return undefined;
+      const value = node.children
+        .map((child) => (child.kind === 'textValue' ? child.value : ''))
+        .join('');
+      if (isW(node, 'instrText') && state === 1) instruction += value;
+      else if (allowDecoration && isW(node, 't') && state === 0) prefix += value;
+      else if (allowDecoration && isW(node, 't') && state === 3) suffix += value;
+      else if (!(isW(node, 't') && state === 2 && /^\d*$/.test(value))) return undefined;
+    }
+  }
+  return state === 3 &&
+    allowlistedPageField(instruction) === 'PAGE' &&
+    tabs === Number(leadingTab) &&
+    ((!prefix && !suffix) || (prefix === '- ' && suffix === ' -'))
+    ? prefix + suffix
+    : undefined;
+}

--- a/packages/core/src/layout/legacy-footer-page-frame.ts
+++ b/packages/core/src/layout/legacy-footer-page-frame.ts
@@ -5,7 +5,7 @@ import {
   type OoxmlPart,
 } from '../store/package/ooxml-tree.ts';
 import { shiftParagraphFragment } from './note-fragment-geometry.ts';
-import { allowlistedPageField } from './field-instruction.ts';
+import { readLegacyPageField } from './legacy-footer-page-field.ts';
 import { positionFixedFooterPageFrame } from './legacy-footer-fixed-frame.ts';
 import type { BlockFragmentRecord, ParagraphFragmentRecord } from './semantic-records.ts';
 
@@ -56,45 +56,9 @@ function text(node: OoxmlElement): string | null {
   return value;
 }
 
-function containsOnlyPageField(paragraph: OoxmlElement): boolean {
-  let state = 0;
-  let instruction: string | null = null;
-  for (const run of elements(paragraph)) {
-    if (isW(run, 'pPr')) continue;
-    if (!isW(run, 'r')) return false;
-    for (const node of elements(run)) {
-      if (isW(node, 'rPr')) continue;
-      if (isW(node, 'fldChar') && node.children.length === 0) {
-        const kind = attr(node, 'fldCharType');
-        if (state === 0 && kind === 'begin') state = 1;
-        else if (
-          state === 1 &&
-          kind === 'separate' &&
-          instruction !== null &&
-          allowlistedPageField(instruction) === 'PAGE'
-        )
-          state = 2;
-        else if (state === 2 && kind === 'end') state = 3;
-        else return false;
-      } else if (isW(node, 'instrText') && state === 1) {
-        // Word may split one instruction across runs (` PAGE ` + `\* MERGEFORMAT`); the
-        // fixed-width lane and the field projection concatenate them, so this lane must too.
-        const value = text(node);
-        if (value === null) return false;
-        instruction = (instruction ?? '') + value;
-      } else if (isW(node, 't') && state === 2) {
-        const value = text(node);
-        if (value === null || !/^\d*$/.test(value)) return false;
-      } else return false;
-    }
-  }
-  return state === 3 && instruction !== null && allowlistedPageField(instruction) === 'PAGE';
-}
-
 function framePair(
   part: OoxmlPart
 ): { first: string; empty: string; y: number; decoration: string } | null {
-  if (!isW(part.root, 'ftr') || !bounded(part)) return null;
   const paragraphs = elements(part.root);
   if (paragraphs.length !== 2 || paragraphs.some((node) => node.kind !== 'paragraph')) return null;
   const [first, empty] = paragraphs as [OoxmlElement, OoxmlElement];
@@ -150,7 +114,7 @@ function framePair(
   )
     return null;
   const y = attr(frame, 'y') ?? '0';
-  if (!['0', '1'].includes(y) || !containsOnlyPageField(first)) return null;
+  if (!['0', '1'].includes(y) || readLegacyPageField(first) !== '') return null;
   return { first: first.id, empty: empty.id, y: Number(y) / 20, decoration };
 }
 
@@ -177,8 +141,9 @@ export function positionLegacyFooterPageFrame<
   contentWidth: number,
   pageGeometry?: { readonly marginLeft: number; readonly pageWidth: number }
 ): T {
+  if (!isW(part.root, 'ftr') || !bounded(part)) return flow;
   const pair = framePair(part);
-  if (!pair) return bounded(part) ? positionFixedFooterPageFrame(part, flow, pageGeometry) : flow;
+  if (!pair) return positionFixedFooterPageFrame(part, flow, pageGeometry);
   if (flow.blocks.length !== 2) return flow;
   const [first, empty] = flow.blocks;
   if (

--- a/packages/core/src/layout/line-end-whitespace.ts
+++ b/packages/core/src/layout/line-end-whitespace.ts
@@ -1,3 +1,5 @@
+import type { StyleSpanRecord } from './semantic-records.ts';
+
 /** Spaces Word may hang/clip at a line end instead of wrapping onto a new line. */
 export function isCollapsibleLineEndWhitespace(text: string): boolean {
   if (text.length === 0) return false;
@@ -5,4 +7,60 @@ export function isCollapsibleLineEndWhitespace(text: string): boolean {
     if (char !== ' ' && char !== '\u3000') return false;
   }
   return true;
+}
+
+interface ClippedWordEnd {
+  readonly length: number;
+  readonly visibleWidth: number;
+  readonly width: number;
+}
+
+/** Price only the ink when a word fits but its trailing separator crosses the margin. */
+export function clipWordEnd(
+  text: string,
+  width: number,
+  remaining: number,
+  measure: (text: string) => number,
+  tolerance: number
+): ClippedWordEnd | undefined {
+  if (width <= remaining + tolerance) return undefined;
+  let length = text.length;
+  // U+3000 participates in kinsoku groups; leave those authored groups to the CJK breaker.
+  while (length > 0 && text[length - 1] === ' ') length--;
+  if (length === 0 || length === text.length) return undefined;
+  const visibleWidth = measure(text.slice(0, length));
+  if (visibleWidth > remaining + tolerance) return undefined;
+  return { length, visibleWidth, width: Math.max(visibleWidth, remaining) };
+}
+
+/** Only the fill receives the clipping flag; alignment still sees the whole visible word. */
+export function appendWordEnd(
+  spans: StyleSpanRecord[],
+  span: StyleSpanRecord,
+  clipped: ClippedWordEnd | undefined
+): void {
+  if (!clipped) {
+    spans.push(span);
+    return;
+  }
+  const split = span.range.start + clipped.length;
+  spans.push(
+    {
+      ...span,
+      text: span.text.slice(0, clipped.length),
+      range: { ...span.range, end: split },
+      box: { ...span.box, width: clipped.visibleWidth },
+    },
+    {
+      ...span,
+      text: span.text.slice(clipped.length),
+      range: { ...span.range, start: split },
+      box: {
+        ...span.box,
+        x: span.box.x + clipped.visibleWidth,
+        width: Math.max(0, span.box.width - clipped.visibleWidth),
+      },
+      lineEndWhitespace: true,
+    }
+  );
 }

--- a/packages/core/src/layout/pagination-keeps.ts
+++ b/packages/core/src/layout/pagination-keeps.ts
@@ -24,6 +24,7 @@
 // a table it cannot fit beside.
 
 import type { OoxmlProperty } from '@docx-editor.dev/core/store';
+import { framedTokenJoin } from './layout-cache.ts';
 
 /**
  * How many blocks one `w:keepNext` chain may bind together before layout gives up.
@@ -386,6 +387,12 @@ export function keepNextFlowKeys(keys: string[], keepsNext: (index: number) => b
 
 /** The per-block answers {@link composeFlowKeys} folds over the break-cache keys. */
 export interface FlowKeyFoldInputs {
+  /** Shared token forces resume before every member of a terminal floating-table group. */
+  readonly terminalTableGroup?: {
+    readonly start: number;
+    readonly anchorIndex: number;
+    readonly token: string;
+  };
   readonly contextualSpacingAt: (index: number) => boolean;
   /** `null` for a block that can never match a neighbour — a table, or an unstyled paragraph. */
   readonly styleIdAt: (index: number) => string | null;
@@ -418,7 +425,15 @@ export interface FlowKeyFoldInputs {
  * `pagination-keeps.test.ts`.
  */
 export function composeFlowKeys(keys: string[], at: FlowKeyFoldInputs): string[] {
-  let flow = contextualSpacingFlowKeys(keys, at.contextualSpacingAt, at.styleIdAt);
+  const group = at.terminalTableGroup;
+  const grouped = group
+    ? keys.map((key, index) =>
+        index >= group.start && index <= group.anchorIndex
+          ? framedTokenJoin([key, group.token])
+          : key
+      )
+    : keys;
+  let flow = contextualSpacingFlowKeys(grouped, at.contextualSpacingAt, at.styleIdAt);
   flow = borderGroupFlowKeys(flow, at.borderGroupKeyAt);
   if (at.tocVerdicts.length > 0) flow = tocFieldFlowKeys(flow, (index) => at.tocVerdicts[index]!);
   flow = listMarkerFlowKeys(flow, at.markerTextAt);

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -83,7 +83,7 @@ import {
 } from './drawing-exclusion.ts';
 import { createEquationLayouter } from './equation-layout.ts';
 import { anchorLineStartsByModelOffset } from './anchor-line-probe.ts';
-import { isCollapsibleLineEndWhitespace } from './line-end-whitespace.ts';
+import * as lineEndSpaces from './line-end-whitespace.ts';
 import { chopOversizedWord } from './oversized-word-break.ts';
 
 /**
@@ -284,7 +284,8 @@ function placeableContentSuffixes(pieces: readonly Piece[]): readonly Uint8Array
       for (let cursor = piece.text.length - 1; cursor >= 0; cursor -= 1) {
         const ch = piece.text[cursor]!;
         if (ch === '\n' || ch === PAGE_BREAK_CHAR) suffix[cursor] = 0;
-        else if (ch !== '\t' && !isCollapsibleLineEndWhitespace(ch)) suffix[cursor] = 1;
+        else if (ch !== '\t' && !lineEndSpaces.isCollapsibleLineEndWhitespace(ch))
+          suffix[cursor] = 1;
         else suffix[cursor] = suffix[cursor + 1]!;
       }
     }
@@ -1504,9 +1505,20 @@ export function breakParagraph(
         wordStartEnd = line.end;
       }
       advancePastAnchorExclusionForPlacement(piece.start + consumed);
+      const clippedWordEnd =
+        !layoutOwned && piece.measureText === undefined
+          ? lineEndSpaces.clipWordEnd(
+              candidate,
+              width,
+              lineAvailable() - line.width,
+              (text) => measurer.measure(displayText(text, faceStyle), faceStyle),
+              OVERFLOW_TOLERANCE_PT
+            )
+          : undefined;
+      width = clippedWordEnd?.width ?? width;
       // Hang overflowing space runs on this line, preserving text/ranges and authored leading spaces.
       const lineEndWhitespace =
-        isCollapsibleLineEndWhitespace(candidate) &&
+        lineEndSpaces.isCollapsibleLineEndWhitespace(candidate) &&
         (placeableSuffixes[pieceIndex]![boundary] !== 1 ||
           (!layoutOwned &&
             (line.spans.length > 0 || line.drawings.length > 0) &&
@@ -1640,7 +1652,7 @@ export function breakParagraph(
       // The chop leaves its final protected group pending, including oversized groups
       // whose next run may start with another closing character or combining mark.
       if (remaining.length > 0) {
-        line.spans.push({
+        const span: StyleSpanRecord = {
           range: layoutOwned
             ? spanRange
             : { paragraphId, start: remainingStart, end: piece.start + boundary },
@@ -1659,7 +1671,8 @@ export function breakParagraph(
           ...(piece.fontSlot ? { fontSlot: piece.fontSlot } : {}),
           ...(lineEndWhitespace ? { lineEndWhitespace: true as const } : {}),
           ...revisionsOf(piece),
-        });
+        };
+        lineEndSpaces.appendWordEnd(line.spans, span, clippedWordEnd);
         line.width += remainingWidth;
         line.height = Math.max(line.height, metrics.height);
         line.baseline = Math.max(line.baseline, metrics.baseline);

--- a/packages/core/src/layout/script-itemization.ts
+++ b/packages/core/src/layout/script-itemization.ts
@@ -2,6 +2,7 @@ import type { BidiEmbeddingLevels } from './bidi.ts';
 import type { TextDirection } from './shaped-run.ts';
 import { withFontFamily, type ResolvedRunStyle } from './run-style.ts';
 import { isEastAsiaHintSymbol } from './east-asia-symbol-hint.ts';
+import { segmentGraphemes } from './grapheme.ts';
 
 /**
  * Which `w:rFonts` slot a character resolves its face through.
@@ -331,8 +332,19 @@ export function eastAsiaRunsOfSegments(
 
   /** Strongly classified text seen so far, or null while only Common text has streamed by. */
   let precedingStrong: Exclude<SlotClass, 'common'> | null = null;
-  // A w:t boundary does not end the preceding symbol's combining sequence.
-  let extendsHintedSymbol = false;
+  // Segment only when the hint can change a face. Joining once keeps clusters intact
+  // across w:t boundaries, without adding segmentation to ordinary Latin/CJK paragraphs.
+  const needsGraphemes = segments.some((text, index) => {
+    if (!hintedSegments[index] || pureAscii(text)) return false;
+    for (const character of text) {
+      if (isEastAsiaHintSymbol(character.codePointAt(0)!)) return true;
+    }
+    return false;
+  });
+  const graphemes = needsGraphemes ? segmentGraphemes(segments.join('')) : null;
+  let graphemeIndex = 0;
+  let segmentOffset = 0;
+  let clusterHinted = false;
   /** Leading Common units waiting for the FOLLOWING strong item; `ascii` blocks eastAsia. */
   const pending: { segment: number; from: number; to: number; ascii: boolean }[] = [];
   const resolvePending = (strong: Exclude<SlotClass, 'common'>): void => {
@@ -344,8 +356,9 @@ export function eastAsiaRunsOfSegments(
 
   for (let segment = 0; segment < segments.length; segment += 1) {
     const text = segments[segment]!;
-    if (pureAscii(text)) {
-      if (text.length > 0) extendsHintedSymbol = false;
+    const offset = segmentOffset;
+    segmentOffset += text.length;
+    if (!graphemes && pureAscii(text)) {
       // Never eastAsia, so only the strong/Common distinction matters: any alphanumeric
       // is a strong Latin item; pure punctuation and whitespace stay transparent.
       if (/[0-9A-Za-z]/.test(text)) {
@@ -355,28 +368,33 @@ export function eastAsiaRunsOfSegments(
       continue;
     }
     for (let from = 0; from < text.length; ) {
-      const codePoint = text.codePointAt(from)!;
-      const to = from + (codePoint > 0xffff ? 2 : 1);
-      // The hint changes this character's face, not its underlying script strength.
-      // Common symbols remain transparent; Greek and Cyrillic still stop surrounding
-      // Common characters from inheriting a preceding or following Han character.
-      // Combining marks and variation selectors retain their hinted base's face across
-      // segment boundaries without changing the preceding strong classification.
-      const hinted = hintedSegments[segment] && isEastAsiaHintSymbol(codePoint);
-      if (hinted || (extendsHintedSymbol && isClusterExtender(codePoint))) {
-        if (hinted) {
-          const underlyingClass = slotClassOf(codePoint);
-          if (underlyingClass !== 'common') {
-            resolvePending(underlyingClass);
-            precedingStrong = underlyingClass;
-          }
+      let codePoint = text.codePointAt(from)!;
+      let to = from + (codePoint > 0xffff ? 2 : 1);
+      let hinted = false;
+      if (graphemes) {
+        const position = offset + from;
+        while (graphemes[graphemeIndex]!.utf16To <= position) graphemeIndex += 1;
+        const cluster = graphemes[graphemeIndex]!;
+        codePoint = cluster.text.codePointAt(0)!;
+        to = Math.min(text.length, cluster.utf16To - offset);
+        if (position === cluster.utf16From) {
+          clusterHinted = !!hintedSegments[segment] && isEastAsiaHintSymbol(codePoint);
+        }
+        hinted = clusterHinted;
+      }
+      // The base selects the face for its whole cluster. Marks and ZWJ components
+      // cannot select another face, even when a cluster crosses a text segment.
+      // The hint changes the face, but preserves the base's script strength.
+      if (hinted) {
+        const underlyingClass = slotClassOf(codePoint);
+        if (underlyingClass !== 'common') {
+          resolvePending(underlyingClass);
+          precedingStrong = underlyingClass;
         }
         addEastAsia(segment, from, to);
-        extendsHintedSymbol = true;
         from = to;
         continue;
       }
-      extendsHintedSymbol = false;
       const slotClass = slotClassOf(codePoint);
       if (slotClass === 'common') {
         if (precedingStrong === null) {
@@ -411,21 +429,4 @@ export function eastAsiaRunsOfSegments(
     }
   }
   return merged;
-}
-
-/**
- * A code point that extends the grapheme cluster of the base before it: combining marks
- * and variation selectors. Kept deliberately narrow (no ZWJ sequences), because the only
- * job here is to keep a mark on the face of the symbol it decorates.
- */
-function isClusterExtender(codePoint: number): boolean {
-  return (
-    (codePoint >= 0x300 && codePoint <= 0x36f) ||
-    (codePoint >= 0x1ab0 && codePoint <= 0x1aff) ||
-    (codePoint >= 0x1dc0 && codePoint <= 0x1dff) ||
-    (codePoint >= 0x20d0 && codePoint <= 0x20ff) ||
-    (codePoint >= 0xfe00 && codePoint <= 0xfe0f) ||
-    (codePoint >= 0xfe20 && codePoint <= 0xfe2f) ||
-    (codePoint >= 0xe0100 && codePoint <= 0xe01ef)
-  );
 }

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -1343,15 +1343,6 @@ function layoutBlocksPass(
       displayMode,
       authorFilter
     );
-    // The anchor can change without changing any table. Resume before the whole
-    // group when typing into it, undoing, or changing another table in the group.
-    const terminalFlowKeys = terminalTextTables
-      ? keys.map((key, index) =>
-          index >= terminalTextTables.start && index <= terminalTextTables.anchorIndex
-            ? framedTokenJoin([key, terminalTextTables.token])
-            : key
-        )
-      : keys;
     const keepsNext = prepared.map((entry) => entry.kind === 'paragraph' && entry.keeps.keepNext);
     const markerTexts = prepared.map((entry) =>
       entry.kind === 'paragraph' ? listItems?.get(entry.paragraph.id)?.markerText : undefined
@@ -1380,7 +1371,8 @@ function layoutBlocksPass(
     // FLOW keys — what incremental resume compares. The composition, its fold order and
     // the argument for that order live with the folds in `pagination-keeps.ts`, where the
     // order is testable.
-    const flow = composeFlowKeys(terminalFlowKeys, {
+    const flow = composeFlowKeys(keys, {
+      terminalTableGroup: terminalTextTables,
       contextualSpacingAt: (index) => contextualSpacings[index]!,
       styleIdAt: (index) => styleIds[index] ?? null,
       borderGroupKeyAt: (index) => borderGroupKeys[index]!,
@@ -1537,6 +1529,7 @@ function layoutBlocksPass(
   const anchorPageDeferCounts = new Map<string, number>();
   const pendingFloatIds = new Set<string>();
   const floatSignals: tableFloat.PositionedTableAnchorSignal[] = [];
+  // Pass-local: the shared flow token prevents checkpoint resume inside this group.
   const terminalTextTableIds = new Set<string>();
   let terminalTextTableBottom = 0;
   // A continuous section resumes the previous section's column rather than opening a
@@ -2184,38 +2177,31 @@ function layoutBlocksPass(
         !options.drawingExclusionZonesByPage?.get(pages.length)?.length
       ) {
         const anchor = prepared[terminalTextTables.anchorIndex]!;
-        if (
-          anchor.kind === 'paragraph' &&
-          anchor.spacing.before === 0 &&
-          anchor.spacing.after === 0 &&
-          previousSpaceAfter === 0
-        ) {
+        if (anchor.kind === 'paragraph') {
           const anchorLines = breakBlock(anchor, terminalTextTables.anchorIndex);
           if (anchorLines.length === 1 && anchorLines[0]!.spans.length === 0) {
-            collectingCellBreakKeys = [];
-            try {
-              const placed = terminalTables.placeTerminalTextTables(terminalTextTables, {
-                cursorY,
-                anchorHeight: anchor.spacing.before + anchor.spacing.after + anchorLines[0]!.height,
-                contentWidth,
-                contentHeight: contentHeight(),
-                frames: anchorFrames(),
-                deps: tableDeps,
-                styleCascade,
-                displayMode,
-                authorFilter,
-              });
-              if (placed) {
-                for (const fragment of placed.fragments) pageFragments.push(fragment);
-                for (const table of terminalTextTables.tables) {
-                  terminalTextTableIds.add(table.id);
-                  registerTableCellBreakKeys(table, collectingCellBreakKeys);
-                }
-                terminalTextTableBottom = placed.bottom;
-                continue;
+            // The cursor already includes the lead paragraph's after-spacing. Use the
+            // same collapsed gap as anchor placement; after-spacing never decides fit.
+            const before = collapsedSpaceBefore(anchor.spacing.before, previousSpaceAfter);
+            const placed = terminalTables.placeTerminalTextTables(terminalTextTables, {
+              cursorY: cursorY + before,
+              anchorHeight: anchorLines[0]!.height,
+              contentWidth,
+              contentHeight: contentHeight(),
+              frames: anchorFrames(),
+              deps: tableDeps,
+              styleCascade,
+              displayMode,
+              authorFilter,
+            });
+            if (placed) {
+              for (const fragment of placed.fragments) pageFragments.push(fragment);
+              for (const [memberIndex, table] of terminalTextTables.tables.entries()) {
+                terminalTextTableIds.add(table.id);
+                registerTableCellBreakKeys(table, placed.cellBreakKeys[memberIndex]!);
               }
-            } finally {
-              collectingCellBreakKeys = null;
+              terminalTextTableBottom = placed.bottom;
+              continue;
             }
           }
         }

--- a/packages/core/src/layout/terminal-table-anchor.ts
+++ b/packages/core/src/layout/terminal-table-anchor.ts
@@ -17,6 +17,7 @@ import type { TableFragmentRecord } from './semantic-records.ts';
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const MAX_TERMINAL_TABLES = 32;
 const MAX_TABLE_NODES = 10000;
+const MAX_ANCHOR_NODES = 10000;
 type Block =
   | { readonly kind: 'table'; readonly table: OoxmlElement; readonly key: string }
   | {
@@ -38,7 +39,16 @@ export interface TerminalTextTableGroup {
 /** Raw content cannot disappear merely because the current revision view hides it. */
 function emptyAnchor(block: Block): boolean {
   if (block.kind !== 'paragraph' || block.listItem || block.shading) return false;
-  if (block.paragraph.children.some((node) => node.kind !== 'paragraphProperties')) return false;
+  if (
+    block.paragraph.children.some((node) => {
+      if (node.kind === 'paragraphProperties') return false;
+      if (node.kind === 'textValue' || node.namespaceUri !== W) return true;
+      if (['bookmarkStart', 'bookmarkEnd', 'proofErr'].includes(node.localName))
+        return node.children.length !== 0;
+      return node.kind !== 'run' || node.children.some((child) => child.kind !== 'runProperties');
+    })
+  )
+    return false;
   if (
     block.props.some((prop) =>
       ['framePr', 'numPr', 'pBdr', 'shd', 'pageBreakBefore'].includes(prop.localName)
@@ -49,7 +59,7 @@ function emptyAnchor(block: Block): boolean {
   let visits = 0;
   while (pending.length) {
     const node = pending.pop()!;
-    if (++visits > MAX_TABLE_NODES || node.namespaceUri !== W) return false;
+    if (++visits > MAX_ANCHOR_NODES || node.namespaceUri !== W) return false;
     if (
       [
         'ins',
@@ -63,7 +73,7 @@ function emptyAnchor(block: Block): boolean {
       ].includes(node.localName)
     )
       return false;
-    if (visits + pending.length + node.children.length > MAX_TABLE_NODES) return false;
+    if (visits + pending.length + node.children.length > MAX_ANCHOR_NODES) return false;
     for (const child of node.children) {
       if (child.kind === 'textValue') return false;
       pending.push(child);
@@ -197,6 +207,7 @@ export function terminalTextTableGroup(
 export interface TerminalTablePlacement {
   readonly fragments: readonly TableFragmentRecord[];
   readonly bottom: number;
+  readonly cellBreakKeys: readonly (readonly string[])[];
 }
 
 /** Decline the whole group unless its table/anchor union fits this content rectangle. */
@@ -236,6 +247,7 @@ export function placeTerminalTextTables(
   let probeLine = 0;
   const probeDeps: TableFlowDeps = {
     ...stripAnchorSinksForProbe(input.deps),
+    onCellBreakKey: undefined,
     borderOwnershipBudget: createTableBorderOwnershipBudget(),
     vMergeResolveBudget: createTableVMergeResolveBudget(),
     nextLineId: () => `terminal-table-probe-${probeLine++}`,
@@ -251,6 +263,7 @@ export function placeTerminalTextTables(
       width <= 0 ||
       left < 0 ||
       left + width > contentWidth + 0.001 ||
+      // Upward offsets need collision checks against preceding paragraph text.
       top < cursorY ||
       top > contentHeight
     )
@@ -279,18 +292,16 @@ export function placeTerminalTextTables(
     bottom = Math.max(bottom, probe.bottom);
     placements.push({ left, top, right: left + width, bottom: probe.bottom });
   }
+  const cellBreakKeys: string[][] = [];
   const fragments = structures.map((structure, index) => {
+    const keys: string[] = [];
+    cellBreakKeys.push(keys);
     const { left, top } = placements[index]!;
-    const placed = layoutTableFragment(
-      structure!,
-      left,
-      top,
-      0,
-      group.tables[index]!.id,
-      0,
-      input.deps
-    );
+    const placed = layoutTableFragment(structure!, left, top, 0, group.tables[index]!.id, 0, {
+      ...input.deps,
+      onCellBreakKey: (key) => keys.push(key),
+    });
     return { ...placed.fragment, outOfFlow: true as const };
   });
-  return { fragments, bottom };
+  return { fragments, bottom, cellBreakKeys };
 }

--- a/packages/core/src/store/package/drawing-image-effects.ts
+++ b/packages/core/src/store/package/drawing-image-effects.ts
@@ -1,6 +1,16 @@
 import { schemaAttributeValue } from './ooxml-drawing-rules.ts';
 import { DRAWINGML_MAIN_NAMESPACE_URI, type OoxmlElement } from './ooxml-tree.ts';
 
+/** Picture color adjustments shared by projection, layout, and paint.
+ * @public
+ */
+export interface DrawingImageEffects {
+  readonly grayscale: boolean;
+  readonly brightness: number;
+  readonly contrast: number;
+  readonly bilevel?: number;
+}
+
 function parseLumPercent(value: string | undefined): number | null {
   if (value === undefined || !/^-?\d+$/.test(value)) return null;
   const parsed = Number(value);
@@ -9,9 +19,7 @@ function parseLumPercent(value: string | undefined): number | null {
 }
 
 /** Bounded picture colour modes; projection never rewrites source media. */
-export function readBlipEffects(
-  blip: OoxmlElement
-): Readonly<{ grayscale: boolean; brightness: number; contrast: number; bilevel?: number }> {
+export function readBlipEffects(blip: OoxmlElement): DrawingImageEffects {
   let grayscale = false;
   let brightness = 0;
   let contrast = 0;

--- a/packages/core/src/store/package/drawing-projection.ts
+++ b/packages/core/src/store/package/drawing-projection.ts
@@ -4,7 +4,7 @@
 // projection-only — every authored branch stays in the tree on save.
 
 import { sanitizeHref } from './sinks.ts';
-import { readBlipEffects } from './drawing-image-effects.ts';
+import { readBlipEffects, type DrawingImageEffects } from './drawing-image-effects.ts';
 import { freezeVectorShapeComponent } from './drawing-vector-freeze.ts';
 import { HYPERLINK_RELATIONSHIP_TYPE, type RelationshipTargetResolver } from './hyperlink.ts';
 import { resolveRelationship } from './relationships.ts';
@@ -217,12 +217,7 @@ export interface DrawingProjection {
   readonly vectorShape: VectorShapeProjection | null;
   readonly textboxStory: TextboxStoryProjection | null;
   readonly locks: DrawingLocks;
-  readonly effects: Readonly<{
-    grayscale: boolean;
-    brightness: number;
-    contrast: number;
-    bilevel?: number;
-  }>;
+  readonly effects: DrawingImageEffects;
   readonly compatibilityBranchNodeId: string | null;
   readonly diagnostics: readonly DrawingDiagnostic[];
 }
@@ -1069,12 +1064,7 @@ function projectPicture(
 ): {
   readonly picture: PictureProjection | null;
   readonly relationshipId: string | null;
-  readonly effects: Readonly<{
-    grayscale: boolean;
-    brightness: number;
-    contrast: number;
-    bilevel?: number;
-  }>;
+  readonly effects: DrawingImageEffects;
   readonly diagnostic: DrawingDiagnostic | null;
 } {
   if (!visitNode(state, ctx.limits)) {

--- a/packages/core/src/store/package/drawing-shape-projection.ts
+++ b/packages/core/src/store/package/drawing-shape-projection.ts
@@ -2,6 +2,8 @@
 // stories. Split from drawing-projection.ts, which owns the drawing walk, MC selection, and
 // the assembled DrawingProjection; this module is pure direct-child reads with no walk state.
 
+import { parseEmu, findDirectChild } from './drawing-shape-readers.ts';
+export { MAX_EMU, parseEmu, findDirectChild } from './drawing-shape-readers.ts';
 import { findDirectKind, isElement } from './drawing-projection-walk.ts';
 import { schemaAttributeValue } from './ooxml-drawing-rules.ts';
 import { WML_NAMESPACE_URI } from './ooxml-shared.ts';
@@ -23,18 +25,6 @@ export type ShapeStyleMatrixResolver = (
   kind: 'fill' | 'line',
   index: number
 ) => OoxmlElement | null;
-
-export const MAX_EMU = 2 ** 31 - 1;
-
-export function parseEmu(value: string | undefined, clamp = true): number | null {
-  if (value === undefined || !/^-?\d{1,15}$/.test(value)) return null;
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed)) return null;
-  if (!clamp) return parsed;
-  if (parsed < 0) return 0;
-  if (parsed > MAX_EMU) return MAX_EMU;
-  return parsed;
-}
 
 /**
  * An `xsd:boolean` attribute read fail-closed.
@@ -96,30 +86,6 @@ function schemaAngleIsZero(value: string | undefined): boolean {
   const collapsed = collapseSchemaWhitespace(value);
   // Bounded digit count: `rot` is an int, and this only ever compares it against zero.
   return /^[+-]?\d{1,12}$/.test(collapsed) && Number(collapsed) === 0;
-}
-
-export function findDirectChild(
-  nodes: readonly OoxmlNode[],
-  options: {
-    readonly typedKind?: string;
-    readonly namespaceUri?: string;
-    readonly localName?: string;
-  }
-): OoxmlElement | null {
-  for (const node of nodes) {
-    if (!isElement(node)) continue;
-    if (options.typedKind !== undefined && node.kind === options.typedKind) return node;
-    if (
-      options.namespaceUri !== undefined &&
-      options.localName !== undefined &&
-      node.kind === 'generic' &&
-      node.namespaceUri === options.namespaceUri &&
-      node.localName === options.localName
-    ) {
-      return node;
-    }
-  }
-  return null;
 }
 
 /**

--- a/packages/core/src/store/package/drawing-shape-readers.ts
+++ b/packages/core/src/store/package/drawing-shape-readers.ts
@@ -1,0 +1,39 @@
+// Shared bounded scalar and direct-child readers for DrawingML geometry.
+import { isElement } from './drawing-projection-walk.ts';
+import type { OoxmlElement, OoxmlNode } from './ooxml-tree.ts';
+
+export const MAX_EMU = 2 ** 31 - 1;
+
+export function parseEmu(value: string | undefined, clamp = true): number | null {
+  if (value === undefined || !/^-?\d{1,15}$/.test(value)) return null;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return null;
+  if (!clamp) return parsed;
+  if (parsed < 0) return 0;
+  if (parsed > MAX_EMU) return MAX_EMU;
+  return parsed;
+}
+
+export function findDirectChild(
+  nodes: readonly OoxmlNode[],
+  options: {
+    readonly typedKind?: string;
+    readonly namespaceUri?: string;
+    readonly localName?: string;
+  }
+): OoxmlElement | null {
+  for (const node of nodes) {
+    if (!isElement(node)) continue;
+    if (options.typedKind !== undefined && node.kind === options.typedKind) return node;
+    if (
+      options.namespaceUri !== undefined &&
+      options.localName !== undefined &&
+      node.kind === 'generic' &&
+      node.namespaceUri === options.namespaceUri &&
+      node.localName === options.localName
+    ) {
+      return node;
+    }
+  }
+  return null;
+}

--- a/packages/core/src/store/package/drawing-vector-paths.ts
+++ b/packages/core/src/store/package/drawing-vector-paths.ts
@@ -1,11 +1,11 @@
+import { parseEmu, findDirectChild } from './drawing-shape-readers.ts';
 import { isElement } from './drawing-projection-walk.ts';
 import { schemaAttributeValue } from './ooxml-drawing-rules.ts';
 import { DRAWINGML_MAIN_NAMESPACE_URI, type OoxmlElement } from './ooxml-tree.ts';
 
 const MAX_VECTOR_SHAPE_SUBPATHS = 64;
 const CUBIC_BEZIER_SEGMENTS = 8;
-const readCoordinate = (value: string | undefined): number | null =>
-  value !== undefined && /^-?\d{1,15}$/.test(value) ? Number(value) : null;
+const readCoordinate = (value: string | undefined): number | null => parseEmu(value, false);
 
 /** Polygon subpaths of one `a:path` — move/line/close verbs only; anything else refuses. */
 export function readShapePathPolygons(
@@ -66,13 +66,11 @@ export function readShapePathPolygons(
       continue;
     }
     if (verb.localName !== 'moveTo' && verb.localName !== 'lnTo') return false;
-    const pt = verb.children.find(
-      (node) =>
-        node.kind === 'generic' &&
-        node.namespaceUri === DRAWINGML_MAIN_NAMESPACE_URI &&
-        node.localName === 'pt'
-    );
-    if (!pt || !isElement(pt)) return false;
+    const pt = findDirectChild(verb.children, {
+      namespaceUri: DRAWINGML_MAIN_NAMESPACE_URI,
+      localName: 'pt',
+    });
+    if (!pt) return false;
     const x = readCoordinate(schemaAttributeValue(pt.attributes, 'x'));
     const y = readCoordinate(schemaAttributeValue(pt.attributes, 'y'));
     if (x === null || y === null) return false;

--- a/packages/core/src/store/package/index.ts
+++ b/packages/core/src/store/package/index.ts
@@ -543,3 +543,4 @@ export {
   type CustomNodeExportRequest,
   type CustomNodeExportResult,
 } from './custom-node-export.ts';
+export type { DrawingImageEffects } from './drawing-image-effects.ts';

--- a/scripts/lib/packages.mjs
+++ b/scripts/lib/packages.mjs
@@ -251,7 +251,7 @@ export const PACKAGES = [
           'DrawingClipFallback',
           'DrawingInsets',
           'DrawingPoint',
-          'DrawingProjection',
+          'DrawingImageEffects',
           'FontOrigin',
           'HeaderFooterParts',
           'HeaderFooterSectionResolution',


### PR DESCRIPTION
Keep joined emoji and combining marks in one font under East Asian hints. Keep fitting words on their line when only their trailing spaces overflow, with matching anchor-line predictions. Preserve terminal floating tables when empty anchors contain bookmarks, formatting, or paragraph spacing.

Share PAGE-field and DrawingML readers, consolidate image-effect types, and correct rendering support claims.

Independent review reproduced the failures and verified the fixes. Regression tests cover font clusters, wrapping, anchor prediction, warm/cold pagination, and per-table cache ownership.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791303855&installation_model_id=422592&pr_number=761&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F761&signature=280f2f8fe627508350116bc93493fe992daa750b7dbfe7cadc9128c52defd74d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->