### PR TITLE
refactor(core): share paragraph break inputs and cache dependencies

### DIFF
--- a/packages/core/src/layout/__tests__/paragraph-break-request.test.ts
+++ b/packages/core/src/layout/__tests__/paragraph-break-request.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test } from 'bun:test';
+import { readOoxmlPart, type OoxmlElement } from '@docx-editor.dev/core/store';
+import { createFixedMeasurer } from '../index.ts';
+import { createParagraphLayoutCache, paragraphLayoutKey } from '../layout-cache.ts';
+import { breakParagraph, type PendingLine } from '../paragraph-flow.ts';
+import {
+  bodyParagraphBreakKey,
+  breakPreparedParagraph,
+  positionedParagraphExclusionToken,
+  prepareParagraphBreakInputs,
+  type ParagraphBreakDependencies,
+} from '../paragraph-break-request.ts';
+import { resolveParagraphLayoutInputs } from '../style-cascade.ts';
+import { resolveCjkTypography } from '../cjk-typography.ts';
+import { tabStopsFingerprint, withDefaultTabInterval } from '../paragraph-tabs.ts';
+
+function paragraph(): OoxmlElement {
+  const result = readOoxmlPart(
+    '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">' +
+      '<w:body><w:p><w:pPr><w:spacing w:line="360"/><w:rPr><w:sz w:val="32"/></w:rPr>' +
+      '<w:tabs><w:tab w:val="right" w:pos="1800"/></w:tabs></w:pPr>' +
+      '<w:r><w:t>one two</w:t><w:tab/><w:t>three four five</w:t></w:r></w:p></w:body></w:document>',
+    { name: '/word/document.xml', contentType: 'app/xml' }
+  );
+  if (!result.ok) throw new Error(result.reason);
+  return result.part.root.children[0]!.children[0]!;
+}
+
+const noDependencies: ParagraphBreakDependencies = {
+  listToken: undefined,
+  hostedListToken: '',
+  refToken: '',
+};
+
+describe('shared paragraph break dependencies', () => {
+  test('preserves legacy property order, empty-list inclusion and tab key framing', () => {
+    const node = paragraph();
+    const inputs = resolveParagraphLayoutInputs(node, 180);
+    for (const defaultTabStopPt of [undefined, 24]) {
+      for (const listToken of [undefined, '', 'list:1']) {
+        const deps = { listToken, hostedListToken: 'box:2', refToken: 'ref:3' };
+        const prepared = prepareParagraphBreakInputs(inputs, defaultTabStopPt, deps);
+        const tabs = withDefaultTabInterval(inputs.tabStops, defaultTabStopPt);
+        const legacyProperties = [
+          ...inputs.props,
+          ...inputs.inheritedRunProperties,
+          ...inputs.markRunProperties,
+          {
+            localName: 'tabStops',
+            attributes: {
+              token:
+                tabs === inputs.tabStops ? inputs.tabStopsCacheToken : tabStopsFingerprint(tabs),
+            },
+          },
+          ...(listToken !== undefined
+            ? [{ localName: 'list', attributes: { token: listToken } }]
+            : []),
+          { localName: 'txbxList', attributes: { token: deps.hostedListToken } },
+          { localName: 'refFields', attributes: { token: deps.refToken } },
+        ];
+        expect(prepared.properties).toEqual(legacyProperties);
+        expect(prepared.tabStops).toEqual(tabs);
+        const key = { paragraph: node, width: inputs.available, producer: 'fixed' };
+        expect(paragraphLayoutKey({ ...key, properties: prepared.properties })).toBe(
+          paragraphLayoutKey({ ...key, properties: legacyProperties })
+        );
+      }
+    }
+  });
+
+  test('each external dependency invalidates a stable source paragraph key', () => {
+    const node = paragraph();
+    const inputs = resolveParagraphLayoutInputs(node, 180);
+    const keyFor = (deps: ParagraphBreakDependencies, defaultTabStopPt?: number) =>
+      paragraphLayoutKey({
+        paragraph: node,
+        width: inputs.available,
+        producer: 'fixed',
+        properties: prepareParagraphBreakInputs(inputs, defaultTabStopPt, deps).properties,
+      });
+    const baseline = keyFor(noDependencies);
+    const variants: ParagraphBreakDependencies[] = [
+      { ...noDependencies, listToken: 'new marker' },
+      { ...noDependencies, hostedListToken: 'new textbox list' },
+      { ...noDependencies, refToken: 'new REF result' },
+    ];
+    for (const variant of variants) expect(keyFor(variant)).not.toBe(baseline);
+    expect(keyFor(noDependencies, 24)).not.toBe(baseline);
+    expect(keyFor(noDependencies)).toBe(baseline);
+  });
+
+  test('placement adapters preserve column, Y precision, suffix offset and empty-zone behavior', () => {
+    const placement = {
+      exclusionToken: 'zone',
+      paragraphStartY: 1.23456,
+      columnIndex: 2,
+      startOffset: 7,
+    };
+    expect(positionedParagraphExclusionToken('zone', placement.paragraphStartY)).toBe('1.235|zone');
+    expect(bodyParagraphBreakKey('base', placement)).toBe('base\0excl:2|1.235|zone\0from:7');
+    expect(
+      bodyParagraphBreakKey('base', { ...placement, exclusionToken: '', startOffset: 0 })
+    ).toBe('base');
+    expect(positionedParagraphExclusionToken('', 99)).toBe('');
+    for (const changed of [
+      { ...placement, paragraphStartY: 2 },
+      { ...placement, columnIndex: 3 },
+      { ...placement, exclusionToken: 'other' },
+      { ...placement, startOffset: 8 },
+    ])
+      expect(bodyParagraphBreakKey('base', changed)).not.toBe(
+        bodyParagraphBreakKey('base', placement)
+      );
+  });
+
+  test('named request preserves positional geometry and cached line identity', () => {
+    const node = paragraph();
+    const formatting = resolveParagraphLayoutInputs(node, 180);
+    const prepared = prepareParagraphBreakInputs(formatting, 24, noDependencies);
+    const measurer = createFixedMeasurer(6, 14);
+    const cache = createParagraphLayoutCache<readonly PendingLine[]>();
+    const key = paragraphLayoutKey({
+      paragraph: node,
+      properties: prepared.properties,
+      width: formatting.available,
+      producer: 'fixed',
+    });
+    const request = {
+      paragraph: node,
+      paragraphId: node.id,
+      indentLeft: formatting.indent.left,
+      available: formatting.available,
+      measurer,
+      cache,
+      cacheKey: key,
+      formatting,
+      producer: 'fixed',
+      styleCascade: undefined,
+      tabStops: prepared.tabStops,
+      flow: { firstLineOffset: 3, marginExtent: { left: 0, right: 180 } },
+    };
+    const legacy = breakParagraph(
+      node,
+      node.id,
+      formatting.indent.left,
+      formatting.available,
+      measurer,
+      undefined,
+      null,
+      formatting.inheritedRunProperties,
+      prepared.tabStops,
+      undefined,
+      undefined,
+      {
+        ...request.flow,
+        lineSpacing: formatting.lineSpacing,
+        typography: resolveCjkTypography(formatting.props),
+        equationCacheToken: 'fixed',
+        markRunProperties: formatting.markRunProperties,
+      }
+    );
+    const lines = breakPreparedParagraph(request);
+    expect(lines).toEqual(legacy);
+    const cached = breakPreparedParagraph(request);
+    expect(cached).toEqual(lines);
+    expect(breakPreparedParagraph(request)).toBe(cached);
+  });
+});

--- a/packages/core/src/layout/paragraph-break-request.ts
+++ b/packages/core/src/layout/paragraph-break-request.ts
@@ -1,0 +1,147 @@
+/** Internal contract shared by body flow and bounded/table stories. */
+import type { OoxmlNode, OoxmlProperty } from '@docx-editor.dev/core/store';
+import type { FieldPageContext } from './field-projection.ts';
+import type { ParagraphLayoutCache } from './layout-cache.ts';
+import { breakParagraph, type ParagraphFlowOptions, type PendingLine } from './paragraph-flow.ts';
+import {
+  tabStopsFingerprint,
+  withDefaultTabInterval,
+  type ResolvedTabStops,
+} from './paragraph-tabs.ts';
+import type { TextMeasurer } from './semantic-records.ts';
+import {
+  cascadeRunProperties,
+  type ParagraphLayoutInputs,
+  type StyleCascadeTable,
+} from './style-cascade.ts';
+import { resolveCjkTypography } from './cjk-typography.ts';
+
+/**
+ * External values can change while the source paragraph retains its identity.
+ * Lists move first-line text; hosted lists remeasure inline textbox stories; REF values
+ * change projected text. Empty optional tokens keep the historical key shape, while
+ * an existing list still contributes its property even when its token is empty.
+ */
+export interface ParagraphBreakDependencies {
+  readonly listToken: string | undefined;
+  readonly hostedListToken: string;
+  readonly refToken: string;
+}
+
+/**
+ * Keep measured tab stops and their key dependency together. The default interval comes
+ * from settings.xml, outside the paragraph cascade. Property order is deliberate.
+ */
+export function prepareParagraphBreakInputs(
+  inputs: ParagraphLayoutInputs,
+  defaultTabStopPt: number | undefined,
+  dependencies: ParagraphBreakDependencies
+): { readonly tabStops: ResolvedTabStops; readonly properties: readonly OoxmlProperty[] } {
+  const tabStops = withDefaultTabInterval(inputs.tabStops, defaultTabStopPt);
+  const token =
+    tabStops === inputs.tabStops ? inputs.tabStopsCacheToken : tabStopsFingerprint(tabStops);
+  return {
+    tabStops,
+    properties: [
+      ...inputs.props,
+      ...inputs.inheritedRunProperties,
+      ...inputs.markRunProperties,
+      { localName: 'tabStops', attributes: { token } },
+      ...(dependencies.listToken !== undefined
+        ? [{ localName: 'list', attributes: { token: dependencies.listToken } }]
+        : []),
+      ...(dependencies.hostedListToken
+        ? [{ localName: 'txbxList', attributes: { token: dependencies.hostedListToken } }]
+        : []),
+      ...(dependencies.refToken
+        ? [{ localName: 'refFields', attributes: { token: dependencies.refToken } }]
+        : []),
+    ],
+  };
+}
+
+/**
+ * Placement key adapters preserve the existing body suffix and cell key framing.
+ * Both consume the same paragraph-start Y precision. Body keys retain their original
+ * string on the ordinary path, including for key retention and cached string hashes.
+ * Y matters because exclusions remain page-content bands: identical content can cross
+ * a float at one position and clear it at another. NUL-framed suffixes cannot be forged
+ * by XML text, which cannot contain U+0000.
+ */
+export function positionedParagraphExclusionToken(
+  exclusionToken: string,
+  paragraphStartY: number
+): string {
+  return exclusionToken ? `${paragraphStartY.toFixed(3)}|${exclusionToken}` : '';
+}
+
+export function bodyParagraphBreakKey(
+  baseKey: string,
+  placement: {
+    readonly exclusionToken: string;
+    readonly paragraphStartY: number;
+    readonly columnIndex: number;
+    readonly startOffset: number;
+  }
+): string {
+  const positioned = positionedParagraphExclusionToken(
+    placement.exclusionToken,
+    placement.paragraphStartY
+  );
+  let key = baseKey;
+  if (positioned) key += `\0excl:${placement.columnIndex}|${positioned}`;
+  if (placement.startOffset > 0) key += `\0from:${placement.startOffset}`;
+  return key;
+}
+
+/** Named internal boundary; the exported positional breakParagraph API remains compatible. */
+export interface ParagraphBreakRequest {
+  readonly paragraph: OoxmlNode;
+  readonly paragraphId: string;
+  readonly indentLeft: number;
+  readonly available: number;
+  readonly measurer: TextMeasurer;
+  readonly cache: ParagraphLayoutCache<readonly PendingLine[]> | undefined;
+  readonly cacheKey: string | null;
+  readonly formatting: {
+    readonly props: readonly OoxmlProperty[];
+    readonly inheritedRunProperties: readonly OoxmlProperty[];
+    readonly markRunProperties: readonly OoxmlProperty[];
+    readonly lineSpacing: ParagraphLayoutInputs['lineSpacing'];
+  };
+  readonly producer: string;
+  readonly styleCascade: StyleCascadeTable | undefined;
+  readonly tabStops: ResolvedTabStops;
+  readonly pageContext?: FieldPageContext;
+  readonly flow: Omit<
+    ParagraphFlowOptions,
+    'lineSpacing' | 'typography' | 'equationCacheToken' | 'themeFonts' | 'markRunProperties'
+  >;
+}
+
+export function breakPreparedParagraph(request: ParagraphBreakRequest): readonly PendingLine[] {
+  const { formatting, styleCascade } = request;
+  return breakParagraph(
+    request.paragraph,
+    request.paragraphId,
+    request.indentLeft,
+    request.available,
+    request.measurer,
+    request.cache,
+    request.cacheKey,
+    formatting.inheritedRunProperties,
+    request.tabStops,
+    request.pageContext,
+    styleCascade
+      ? (inherited, direct) => cascadeRunProperties(inherited, direct, styleCascade)
+      : undefined,
+    {
+      ...request.flow,
+      lineSpacing: formatting.lineSpacing,
+      typography: resolveCjkTypography(formatting.props, styleCascade?.typography),
+      equationCacheToken: request.producer,
+      ...(styleCascade ? { themeFonts: styleCascade.themeFonts } : {}),
+      markRunProperties: formatting.markRunProperties,
+    }
+  );
+}

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -37,11 +37,9 @@ import {
   retainLiveBreakKeys,
   withDrawingContext,
 } from './layout-cache.ts';
-import { resolveCjkTypography } from './cjk-typography.ts';
 import {
   alignSpans,
   alignDrawings,
-  breakParagraph,
   pendingLineFlowExtentAtPlacement,
   type Alignment,
   type PendingLine,
@@ -71,16 +69,13 @@ import {
   type ParagraphKeeps,
 } from './pagination-keeps.ts';
 import { DEFAULT_RUN_STYLE, resolveRunStyle } from './run-style.ts';
+import type { ResolvedTabStops } from './paragraph-tabs.ts';
 import {
-  tabStopsFingerprint,
-  withDefaultTabInterval,
-  type ResolvedTabStops,
-} from './paragraph-tabs.ts';
-import {
-  resolveParagraphLayoutInputs,
-  cascadeRunProperties,
-  type StyleCascadeTable,
-} from './style-cascade.ts';
+  prepareParagraphBreakInputs,
+  bodyParagraphBreakKey,
+  breakPreparedParagraph,
+} from './paragraph-break-request.ts';
+import { resolveParagraphLayoutInputs, type StyleCascadeTable } from './style-cascade.ts';
 import { paragraphBorderGroupKey } from './cell-border-groups.ts';
 import { paragraphShadingBox } from './ooxml-shading.ts';
 import { type TableAnchorFrames } from './semantic-table.ts';
@@ -1113,12 +1108,11 @@ function layoutBlocksPass(
         block.children.find((child) => child.kind === 'paragraphProperties'),
         styleCascade
       );
-      // `w:defaultTabStop` lives in settings.xml, which the paragraph cascade never reads.
-      const tabStops = withDefaultTabInterval(preparedParagraph.tabStops, defaultTabStopPt);
-      const tabStopsCacheToken =
-        tabStops === preparedParagraph.tabStops
-          ? preparedParagraph.tabStopsCacheToken
-          : tabStopsFingerprint(tabStops);
+      const { tabStops, properties: breakProperties } = prepareParagraphBreakInputs(
+        preparedParagraph,
+        defaultTabStopPt,
+        { listToken: listItem?.cacheToken, hostedListToken, refToken }
+      );
       entry = {
         kind: 'paragraph',
         ...(frame ? { frame } : {}),
@@ -1150,19 +1144,7 @@ function layoutBlocksPass(
         ...(listItem ? { listItem } : {}),
         key: keyFor({
           paragraph: block,
-          properties: [
-            ...props,
-            ...inheritedRunProperties,
-            ...markRunProperties,
-            { localName: 'tabStops', attributes: { token: tabStopsCacheToken } },
-            ...(listItem
-              ? [{ localName: 'list', attributes: { token: listItem.cacheToken } }]
-              : []),
-            ...(hostedListToken
-              ? [{ localName: 'txbxList', attributes: { token: hostedListToken } }]
-              : []),
-            ...(refToken ? [{ localName: 'refFields', attributes: { token: refToken } }] : []),
-          ],
+          properties: breakProperties,
           width: available,
           producer,
           drawingToken: keyedDrawingToken,
@@ -1767,43 +1749,30 @@ function layoutBlocksPass(
     // what varies per PLACEMENT joins below; the common path must stay `entry.key` BY
     // IDENTITY, because retention names the prepass keys (suffixed and off-prepass-width
     // keys are transient by design) and V8 caches the shared string's hash.
-    // A new placement-varying input joins BOTH this suffix chain and the cell path's
-    // `paragraphLayoutKey` call in `semantic-table-layout.ts` — the roles map in
-    // `layout-cache.ts` guards only the typed inputs, not these suffixes.
     let cacheKey: string | null = null;
     if (cache && !suppressChrome) {
-      // `cursorY` belongs in the key: the zones are page-content bands, so the same text at
-      // the same width breaks differently depending on where down the page it starts. Keying
-      // on zone geometry alone lets a paragraph clear of the float reuse the wrapped break
-      // of an identical one that crosses it. NUL-framed: XML text cannot carry U+0000, so
-      // no file-derived token can forge a suffix boundary.
-      cacheKey = entry.key;
-      if (exclusionToken) {
-        cacheKey += `\0excl:${flowColumnIndex}|${cursorY.toFixed(3)}|${exclusionToken}`;
-      }
-      if (startOffset > 0) cacheKey += `\0from:${startOffset}`;
+      cacheKey = bodyParagraphBreakKey(entry.key, {
+        exclusionToken,
+        paragraphStartY: cursorY,
+        columnIndex: flowColumnIndex,
+        startOffset,
+      });
       rememberBreakKey(paragraphId, cacheKey);
     }
     const usePageColumnCoords = columnCount > 1;
-    return breakParagraph(
-      entry.paragraph,
+    return breakPreparedParagraph({
+      paragraph: entry.paragraph,
       paragraphId,
-      entry.indent.left,
+      indentLeft: entry.indent.left,
       available,
       measurer,
       cache,
       cacheKey,
-      entry.inheritedRunProperties,
-      entry.tabStops,
-      undefined,
-      styleCascade
-        ? (inherited: readonly OoxmlProperty[], direct: readonly OoxmlProperty[]) =>
-            cascadeRunProperties(inherited, direct, styleCascade)
-        : undefined,
-      {
-        lineSpacing: entry.lineSpacing,
-        typography: resolveCjkTypography(entry.props, styleCascade?.typography),
-        equationCacheToken: producer,
+      formatting: entry,
+      producer,
+      styleCascade,
+      tabStops: entry.tabStops,
+      flow: {
         firstLineOffset: startOffset === 0 ? firstLineOffsetOf(entry) : 0,
         startOffset,
         marginExtent: { left: 0, right: entry.indent.left + available + entry.indent.right },
@@ -1826,10 +1795,8 @@ function layoutBlocksPass(
         paragraphStartY: cursorY,
         ...(pageZones.length > 0 ? { pageExclusionZones: pageZones } : {}),
         ...(suppressChrome ? { suppressEmptyPlaceholderLine: true } : {}),
-        ...(styleCascade ? { themeFonts: styleCascade.themeFonts } : {}),
-        markRunProperties: entry.markRunProperties,
-      }
-    );
+      },
+    });
   };
 
   const pageExclusionZonesForEntry = (

--- a/packages/core/src/layout/semantic-table-layout.ts
+++ b/packages/core/src/layout/semantic-table-layout.ts
@@ -43,8 +43,7 @@ import {
   withDrawingContext,
   type ParagraphLayoutCache,
 } from './layout-cache.ts';
-import { alignDrawings, alignSpans, breakParagraph, type PendingLine } from './paragraph-flow.ts';
-import { resolveCjkTypography } from './cjk-typography.ts';
+import { alignDrawings, alignSpans, type PendingLine } from './paragraph-flow.ts';
 import { mergeBoundariesOf, remapMergedLines } from './merged-paragraph-ranges.ts';
 import { isEmptyCellTerminator, paragraphMergeGroupOf } from './story-roots.ts';
 import {
@@ -64,11 +63,14 @@ import {
   paragraphBorderExtentPt,
   paragraphBorderStrokeWidthPt,
 } from './paragraph-style.ts';
-import { tabStopsFingerprint, withDefaultTabInterval } from './paragraph-tabs.ts';
+import {
+  prepareParagraphBreakInputs,
+  positionedParagraphExclusionToken,
+  breakPreparedParagraph,
+} from './paragraph-break-request.ts';
 import { DEFAULT_RUN_STYLE } from './run-style.ts';
 import {
   resolveParagraphLayoutInputs,
-  cascadeRunProperties,
   type StyleCascadeTable,
   type TableCellStyleFormatting,
 } from './style-cascade.ts';
@@ -455,14 +457,9 @@ function placeCellParagraph(
     styleId,
     outlineLevel,
     spacing,
-    lineSpacing,
     bottomBorder,
     borders,
     shading,
-    inheritedRunProperties,
-    markRunProperties,
-    tabStops: cascadedTabStops,
-    tabStopsCacheToken: cascadedTabStopsCacheToken,
   } = layoutInputs;
   // `w:between` (§17.3.1.24): consecutive paragraphs with IDENTICAL border settings are ONE
   // bordered block — the box opens above the first and closes below the last, and each
@@ -483,10 +480,15 @@ function placeCellParagraph(
   const topEdge = continuesAbove ? undefined : borders.top;
   // What closes the paragraph: the bottom rule, or the `between` rule when the block runs on.
   const closingEdge = continuesBelow ? borders.between : bottomBorder;
-  // `w:defaultTabStop` lives in settings.xml, which the paragraph cascade never reads.
-  const tabStops = withDefaultTabInterval(cascadedTabStops, deps.defaultTabStopPt);
-  const tabStopsCacheToken =
-    tabStops === cascadedTabStops ? cascadedTabStopsCacheToken : tabStopsFingerprint(tabStops);
+  const { tabStops, properties: breakProperties } = prepareParagraphBreakInputs(
+    layoutInputs,
+    deps.defaultTabStopPt,
+    {
+      listToken: listItem?.cacheToken,
+      hostedListToken: deps.hostedStory?.hostedListTokenForParagraph?.(paragraph) ?? '',
+      refToken: deps.refFields?.tokenForParagraph(paragraphId) ?? '',
+    }
+  );
   // A cell paragraph breaks like a body paragraph: same line spacing, same first-line
   // offset. Contextual spacing is a body-flow question (it compares document neighbours),
   // so it is not applied per cell.
@@ -512,27 +514,10 @@ function placeCellParagraph(
   // otherwise share a cache entry and the one that sits clear of the picture would inherit
   // the wrapped break of the one that does not.
   const exclusionToken = exclusionLayoutToken(pageZones);
-  const positionedExclusionToken = exclusionToken ? `${top.toFixed(3)}|${exclusionToken}` : '';
-  // The cell paragraph's resolved REF values, keyed exactly as the body flow keys them: a
-  // renumbering edit moves the painted reference while the cell's subtree stays identical.
-  const refToken = deps.refFields?.tokenForParagraph(paragraphId) ?? '';
-  // The list state of any hosted text-box story, keyed as the body flow keys it: its own
-  // `txbxList` property. A numbering edit moves only this property while the host's
-  // subtree stays byte-identical; box-free paragraphs keep their pre-existing key shape.
-  const hostedListToken = deps.hostedStory?.hostedListTokenForParagraph?.(paragraph) ?? '';
+  const positionedExclusionToken = positionedParagraphExclusionToken(exclusionToken, top);
   const key = keyFor({
     paragraph,
-    properties: [
-      ...props,
-      ...inheritedRunProperties,
-      ...markRunProperties,
-      { localName: 'tabStops', attributes: { token: tabStopsCacheToken } },
-      ...(listItem ? [{ localName: 'list', attributes: { token: listItem.cacheToken } }] : []),
-      ...(hostedListToken
-        ? [{ localName: 'txbxList', attributes: { token: hostedListToken } }]
-        : []),
-      ...(refToken ? [{ localName: 'refFields', attributes: { token: refToken } }] : []),
-    ],
+    properties: breakProperties,
     width: available,
     producer: deps.producer,
     // The inline-drawing CONTEXT joins the token exactly as it does in the body flow: the
@@ -548,24 +533,20 @@ function placeCellParagraph(
     ...(positionedExclusionToken ? { exclusionToken: positionedExclusionToken } : {}),
   });
   if (deps.cache) deps.onCellBreakKey?.(key);
-  const lines = breakParagraph(
+  const lines = breakPreparedParagraph({
     paragraph,
     paragraphId,
-    indent.left,
+    indentLeft: indent.left,
     available,
-    deps.measurer,
-    deps.cache,
-    deps.cache ? key : null,
-    inheritedRunProperties,
+    measurer: deps.measurer,
+    cache: deps.cache,
+    cacheKey: deps.cache ? key : null,
+    formatting: layoutInputs,
+    producer: deps.producer,
+    styleCascade: deps.styleCascade,
     tabStops,
-    deps.pageContext,
-    deps.styleCascade
-      ? (inherited, direct) => cascadeRunProperties(inherited, direct, deps.styleCascade)
-      : undefined,
-    {
-      lineSpacing,
-      typography: resolveCjkTypography(props, deps.styleCascade?.typography),
-      equationCacheToken: deps.producer,
+    ...(deps.pageContext ? { pageContext: deps.pageContext } : {}),
+    flow: {
       firstLineOffset,
       // A cell's own content box is the column a positional tab measures against.
       marginExtent: { left: 0, right: indent.left + available + indent.right },
@@ -588,10 +569,8 @@ function placeCellParagraph(
         height: Math.max(1, available),
       }),
       ...(pageZones.length > 0 ? { pageExclusionZones: pageZones } : {}),
-      ...(deps.styleCascade ? { themeFonts: deps.styleCascade.themeFonts } : {}),
-      markRunProperties,
-    }
-  );
+    },
+  });
 
   const lineStart = options?.lineStart ?? 0;
   const fragmentIndex = options?.fragmentIndex ?? 0;


### PR DESCRIPTION
Body and table-cell paragraphs independently assembled tab/cache dependencies and positional line-break arguments, making new typography and inline features easy to wire differently across stories. This change introduces a shared internal paragraph break contract: measured tabs and ordered cache properties are prepared together, placement-key framing has one owner, and named requests share typography, run cascade, theme and paragraph-mark setup.

The plan was to extract the shared contract, migrate both callers, verify exact legacy key/geometry behavior, and independently review before publishing. Story-specific borders, anchors, page fields and placement policy remain in their adapters. The exported positional `breakParagraph` API and existing key framing are preserved; this PR makes no speedup claim.

Validation:
- 2,622 layout tests passed, including four new legacy-key, dependency-invalidation, placement-token and geometry/cache-identity tests.
- Core typecheck, changed-file ESLint and all five DOM-free lane checks passed.
- Eight fixed-measurer edit benchmark scenarios passed their clean-layout and deterministic-work gates (three runs, one warmup).
- Independent subagent review found no remaining medium-or-higher issues.
- Full package builds and normal repository commit hooks passed (all package typechecks, parity, license headers, API snapshots, formatting and lint).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/764"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791337056&installation_model_id=422592&pr_number=764&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F764&signature=5514cb6a694a3e24639657e5c8956ba5a27e6171273fd3557fe86bbf9c55a1c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->