### PR TITLE
perf(core): reuse drawing membership across unchanged layout paints

### DIFF
--- a/e2e/drawing-keys-browser-bench.config.ts
+++ b/e2e/drawing-keys-browser-bench.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from '@playwright/test';
+import editBrowserBenchConfig from './edit-browser-bench.config.ts';
+
+export default defineConfig({
+  ...editBrowserBenchConfig,
+  testMatch: '**/drawing-keys-browser.bench.spec.ts',
+});

--- a/e2e/drawing-keys-browser.bench.spec.ts
+++ b/e2e/drawing-keys-browser.bench.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from '@playwright/test';
+import { writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { REPO_ROOT, summarize } from './edit-browser-bench-harness.ts';
+
+// Isolates drawing-key aggregation in Chromium. This is a work microbenchmark,
+// not an input-to-frame benchmark. Run the edit browser benchmark separately.
+test('drawing resource aggregation on repeated and changed layouts', async ({ page, browser }) => {
+  await page.goto('http://localhost:5275/@vite/client');
+  const moduleUrl = `/@fs/${resolve(REPO_ROOT, 'packages/core/src/output/semantic-paint-drawings.ts')}`;
+  const result = await page.evaluate(async (moduleUrl) => {
+    const { collectUsedDrawingResourceKeys, collectUsedDrawingElementKeys } = await import(
+      /* @vite-ignore */ moduleUrl
+    );
+    const pageCount = 500;
+    const iterations = 20_000;
+    const box = Object.freeze({ x: 0, y: 0, width: 612, height: 792 });
+    // Only fields read by the collector are needed for this synthetic workload.
+    const pages = Object.freeze(
+      Array.from({ length: pageCount }, (_, index) =>
+        Object.freeze({
+          index,
+          box,
+          contentBox: box,
+          fragments: Object.freeze([]),
+          anchoredDrawings: Object.freeze([
+            Object.freeze({
+              drawingNodeId: `drawing-${index}`,
+              resource: Object.freeze({ kind: 'ready', resourceKey: `resource-${index % 10}` }),
+            }),
+          ]),
+        })
+      )
+    );
+    const layout = Object.freeze({ revision: 1, pages });
+    const sample = (changed: boolean) => {
+      let checksum = 0;
+      const start = performance.now();
+      for (let i = 0; i < iterations; i++) {
+        const input = changed ? Object.freeze({ revision: i, pages }) : layout;
+        checksum += collectUsedDrawingResourceKeys(input).size;
+        checksum += collectUsedDrawingElementKeys(input).size;
+      }
+      return { ms: performance.now() - start, checksum };
+    };
+    sample(false);
+    sample(true);
+    const repeated = [];
+    const changed = [];
+    for (let round = 0; round < 7; round++) {
+      repeated.push(sample(false));
+      changed.push(sample(true));
+    }
+    return { pageCount, iterations, repeated, changed };
+  }, moduleUrl);
+  for (const sample of [...result.repeated, ...result.changed]) {
+    expect(sample.checksum).toBe(result.iterations * (result.pageCount + 10));
+  }
+  const report = {
+    browser: browser.version(),
+    ...result,
+    repeatedSummary: summarize(result.repeated.map(({ ms }) => ms)),
+    changedSummary: summarize(result.changed.map(({ ms }) => ms)),
+  };
+  console.log(JSON.stringify(report, null, 2));
+  if (process.env.DRAWING_KEYS_BROWSER_BENCH_OUTPUT) {
+    writeFileSync(process.env.DRAWING_KEYS_BROWSER_BENCH_OUTPUT, JSON.stringify(report, null, 2));
+  }
+});

--- a/packages/core/src/output/__tests__/semantic-paint-drawings.test.ts
+++ b/packages/core/src/output/__tests__/semantic-paint-drawings.test.ts
@@ -28,6 +28,8 @@ import { computeDrawingGeometry } from '../../layout/drawing-geometry.ts';
 import { createFixedMeasurer, layoutSemanticDocument } from '../../layout/semantic-layout.ts';
 import { paintSemanticLayout } from '../semantic-paint.ts';
 import {
+  collectUsedDrawingElementKeys,
+  collectUsedDrawingResourceKeys,
   DEFAULT_DRAWING_PAINT_STRINGS,
   detachDrawingUrlRegistry,
   drawingUrlRegistryFor,
@@ -789,5 +791,96 @@ describe('ready drawings with unavailable bytes', () => {
     expect(element?.classList.contains('docx-drawing-placeholder')).toBe(true);
     detachDrawingUrlRegistry(host);
     host.remove();
+  });
+});
+
+describe('drawing membership belongs to the immutable layout', () => {
+  function layoutWithResource(resource: ImageResourceState = READY_PNG) {
+    return layoutSemanticDocument(load(inlinePictureXml()), 1, {
+      measurer: createFixedMeasurer(6, 14),
+      inlineDrawingLayout: {
+        ownerPartName: OWNER,
+        project: (node) =>
+          projectDrawing(node, {
+            ownerPartName: OWNER,
+            limits: DEFAULT_DRAWING_PROJECTION_LIMITS,
+          }),
+        resourceOf: () => resource,
+      },
+    });
+  }
+
+  test('both collectors share one page-list visit, then skip unchanged-layout aggregation', () => {
+    const original = layoutWithResource();
+    let pageListReads = 0;
+    const layout = Object.freeze({
+      revision: original.revision,
+      get pages() {
+        pageListReads++;
+        return original.pages;
+      },
+    });
+    const elements = collectUsedDrawingElementKeys(layout);
+    const resources = collectUsedDrawingResourceKeys(layout);
+    expect(elements.size).toBe(1);
+    expect([...resources]).toEqual([READY_PNG.resourceKey]);
+    expect(pageListReads).toBe(1);
+    expect(collectUsedDrawingElementKeys(layout)).toBe(elements);
+    expect(collectUsedDrawingResourceKeys(layout)).toBe(resources);
+    expect(pageListReads).toBe(1);
+  });
+
+  test('reused drawings deduplicate resources but retain each page occurrence', () => {
+    const original = layoutWithResource();
+    const first = original.pages[0]!;
+    const shifted = Object.freeze({ ...first, index: 7 });
+    const layout = Object.freeze({ ...original, pages: Object.freeze([first, shifted]) });
+    const originalElements = collectUsedDrawingElementKeys(original);
+    expect([...collectUsedDrawingResourceKeys(layout)]).toEqual([READY_PNG.resourceKey]);
+    expect([...collectUsedDrawingElementKeys(layout)]).toEqual([
+      ...originalElements,
+      ...[...originalElements].map((key) => key.replace(/^p0\|/, 'p7|')),
+    ]);
+    const removed = Object.freeze({ ...layout, pages: Object.freeze([shifted]) });
+    expect([...collectUsedDrawingElementKeys(removed)]).toEqual(
+      [...originalElements].map((key) => key.replace(/^p0\|/, 'p7|'))
+    );
+    expect(collectUsedDrawingElementKeys(original)).toBe(originalElements);
+  });
+
+  test('new layouts invalidate ready membership even at the same document revision', () => {
+    const ready = layoutWithResource();
+    const pending = layoutWithResource(Object.freeze({ kind: 'pending', resourceKey: 'pending' }));
+    expect(ready.revision).toBe(pending.revision);
+    expect([...collectUsedDrawingResourceKeys(ready)]).toEqual([READY_PNG.resourceKey]);
+    expect(collectUsedDrawingResourceKeys(pending).size).toBe(0);
+    expect(collectUsedDrawingElementKeys(pending).size).toBe(1);
+    const replacement = layoutWithResource({ ...READY_PNG, resourceKey: 'replacement' });
+    expect([...collectUsedDrawingResourceKeys(replacement)]).toEqual(['replacement']);
+    expect([...collectUsedDrawingResourceKeys(ready)]).toEqual([READY_PNG.resourceKey]);
+  });
+
+  test('offscreen repaint retains resource and image until layout removal or detach', () => {
+    const layout = layoutWithResource();
+    const { port, revoked } = fakeUrlPort();
+    const container = document.createElement('div');
+    const options = { scale: 1, imageUrlPort: port };
+    paintSemanticLayout(container, layout, options);
+    const image = container.querySelector('img');
+    expect(image).not.toBeNull();
+    const url = image!.getAttribute('src');
+    paintSemanticLayout(container, layout, { ...options, materialize: new Set<number>() });
+    expect(container.querySelector('img')).toBeNull();
+    expect(revoked).toEqual([]);
+    expect(image!.getAttribute('src')).toBe(url);
+    paintSemanticLayout(container, layout, options);
+    expect(container.querySelector('img')).toBe(image);
+    expect(revoked).toEqual([]);
+    paintSemanticLayout(container, Object.freeze({ ...layout, pages: Object.freeze([]) }), options);
+    expect(revoked).toEqual([url!]);
+    expect(image!.getAttribute('src')).toBeNull();
+    paintSemanticLayout(container, layout, options);
+    detachDrawingUrlRegistry(container);
+    expect(revoked).toEqual([url!, url!]);
   });
 });

--- a/packages/core/src/output/semantic-paint-drawings.ts
+++ b/packages/core/src/output/semantic-paint-drawings.ts
@@ -896,20 +896,42 @@ function pageDrawingKeys(page: PageRecord): PageDrawingKeys {
   return keys;
 }
 
-export function collectUsedDrawingResourceKeys(layout: SemanticLayout): ReadonlySet<string> {
-  const keys = new Set<string>();
+interface LayoutDrawingKeys {
+  readonly resourceKeys: ReadonlySet<string>;
+  readonly elementKeys: ReadonlySet<string>;
+}
+
+/**
+ * Repaints and virtualization can reuse the same immutable layout. Aggregate both
+ * key sets once, including offscreen pages: materialization does not end a resource's
+ * lifetime. A new layout rebuilds membership while reusing unchanged page extraction.
+ * Weak ownership releases the aggregate with the layout; it retains no DOM or bytes.
+ */
+const drawingKeysByLayout = new WeakMap<SemanticLayout, LayoutDrawingKeys>();
+
+function layoutDrawingKeys(layout: SemanticLayout): LayoutDrawingKeys {
+  const cached = drawingKeysByLayout.get(layout);
+  if (cached) return cached;
+  const resourceKeys = new Set<string>();
+  const elementKeys = new Set<string>();
   for (const page of layout.pages) {
-    for (const key of pageDrawingKeys(page).resourceKeys) keys.add(key);
+    const keys = pageDrawingKeys(page);
+    for (const key of keys.resourceKeys) resourceKeys.add(key);
+    for (const key of keys.elementKeys) elementKeys.add(key);
   }
+  const keys: LayoutDrawingKeys = Object.freeze({ resourceKeys, elementKeys });
+  drawingKeysByLayout.set(layout, keys);
   return keys;
 }
 
+/** Shared read-only membership for this immutable layout. */
+export function collectUsedDrawingResourceKeys(layout: SemanticLayout): ReadonlySet<string> {
+  return layoutDrawingKeys(layout).resourceKeys;
+}
+
+/** Shared read-only membership for this immutable layout. */
 export function collectUsedDrawingElementKeys(layout: SemanticLayout): ReadonlySet<string> {
-  const keys = new Set<string>();
-  for (const page of layout.pages) {
-    for (const key of pageDrawingKeys(page).elementKeys) keys.add(key);
-  }
-  return keys;
+  return layoutDrawingKeys(layout).elementKeys;
 }
 
 export function drawingPaintStringsCacheToken(strings: DrawingPaintStrings): string {


### PR DESCRIPTION
Repeated paints rebuilt drawing resource and element sets across every layout page, even when the immutable layout did not change. Both collectors now share one weakly owned aggregate per `SemanticLayout`, while retaining the existing per-page extraction cache across layout revisions.

The bounded plan was to remove this repeated aggregation, preserve resource lifetime, and measure the change in Chromium. Offscreen drawings remain in the aggregate; materialization does not release their resources. New layouts rebuild membership, including resource changes at the same document revision and changed page occurrences. The cache holds key strings only, with no DOM, URL, or image-byte ownership. Public API and registry reconciliation remain unchanged.

Validation:

- Output suite: 234 passed across 24 files. Four added tests cover a single page-list visit, stable aggregate identity, shifted page occurrences, resource replacement, and image lifetime through virtualization, rematerialization, removal and detach.
- Core typecheck, repository formatting and lint passed. Full package build and normal commit hooks passed.
- Two independent reviews completed with no remaining medium-or-higher findings.
- Existing Chromium edit benchmark passed before and after: three samples, one warmup, 30 sustained edits. These short runs do **not** demonstrate faster typing. Measurements varied in both directions; other PR worktrees were active on the machine.

The new isolated Chromium benchmark uses 500 synthetic pages, one drawing per page, ten resource keys, and 20,000 collector pairs per batch. Seven batches follow warmup. Times below are batch medians, not input or paint latency:

| Collector workload | Before | After |
| --- | ---: | ---: |
| Repeated immutable layout | 738.9 ms | 0.2 ms |
| New layout per pair, reusing page records | 742.0 ms | 663.4 ms |

Representative full-browser frame/paint medians, in milliseconds:

| Edit scenario | Frame before/after | Paint before/after |
| --- | ---: | ---: |
| Pinned large fixture, character | 42.1 / 48.5 | 0.8 / 0.9 |
| Default fixture, character | 37.4 / 35.2 | 2.0 / 1.9 |
| Huge fixture, suggesting character | 77.5 / 86.1 | 0.7 / 0.8 |

Chromium 149.0.7827.55, macOS arm64. Reproduction (before uses base `d5cfeee05` with the new benchmark files):

```sh
DRAWING_KEYS_BROWSER_BENCH_OUTPUT=/tmp/drawing-keys.json \
  bunx playwright test --config e2e/drawing-keys-browser-bench.config.ts

EDIT_BROWSER_BENCH_RUNS=3 EDIT_BROWSER_BENCH_WARMUP=1 \
EDIT_BROWSER_BENCH_SUSTAINED_EDITS=30 \
EDIT_BROWSER_BENCH_OUTPUT=/tmp/edit-browser.json \
  bunx playwright test --config e2e/edit-browser-bench.config.ts \
  --grep 'browser editing latency is measurable and structurally stable'
```

This change adds aggregate key-set storage while a layout remains live. Weak ownership permits collection with the layout. Page reconciliation, local content-control chrome, and table row retention remain separate follow-ups requiring their own measurements.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791337320&installation_model_id=422592&pr_number=765&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F765&signature=905229b976ba9b3bc9d5d5eaaa40351919a1d2f794f1b9b697ad46acb16df0ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->