### PR TITLE
refactor(core): give flow checkpoints explicit lifecycle ownership

### DIFF
--- a/packages/core/src/layout/__tests__/flow-checkpoint-guard.test.ts
+++ b/packages/core/src/layout/__tests__/flow-checkpoint-guard.test.ts
@@ -1,14 +1,7 @@
-// The flow-checkpoint guard map stays true (companion to flow-checkpoint-guards.ts).
-//
-// The map's `satisfies` clause catches a `FlowCheckpoint` field that was never classified.
-// These tests catch the two failures the compiler cannot see:
-//  - a checkpoint BUILT with a field the interface never declared (runtime walk), and
-//  - the convergence comparison in semantic-layout.ts silently dropping a `'compared'`
-//    field, or quietly starting to compare a `'restore-only'` one (source scan).
+// Behavioral coverage of every declared checkpoint role. A compared field must reject
+// a changed state, while page and line counts remain outside in-page convergence.
 
 import { describe, expect, test } from 'bun:test';
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
 import { readOoxmlPart, type OoxmlPart } from '@docx-editor.dev/core/store';
 import {
   createFixedMeasurer,
@@ -21,6 +14,17 @@ import {
   unguardedCheckpointFields,
   type FlowCheckpointGuard,
 } from '../flow-checkpoint-guards.ts';
+
+import { FlowCheckpointOwner, flowCheckpointsMatch } from '../flow-checkpoint.ts';
+import type { FlowCheckpoint } from '../layout-session.ts';
+import type { AnchoredDrawingRecord } from '../drawing-layout.ts';
+import { ParagraphFrameFlow } from '../paragraph-frame-flow.ts';
+import { readParagraphFrame } from '../paragraph-frame.ts';
+import {
+  positionedTableFlow,
+  type PositionedTableAnchor,
+  type PositionedTableAnchorSignal,
+} from '../table-float-position.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
@@ -56,41 +60,169 @@ describe('every checkpoint field is classified', () => {
   });
 });
 
+function populatedCheckpoint() {
+  const session = createLayoutSession();
+  layoutSemanticDocument(load(DOCUMENT), 1, { measurer, geometry: GEOMETRY, session });
+  const source = session.checkpoints.find((checkpoint) => checkpoint.pageFragments.length > 0)!;
+  const fragment = source.pageFragments[0]!;
+  if (fragment.kind !== 'paragraph') throw new Error('Expected paragraph fixture');
+  const paragraphFrames = new ParagraphFrameFlow();
+  const frame = readParagraphFrame([
+    { localName: 'framePr', attributes: { x: '400', y: '600', w: '2000' } },
+  ])!;
+  paragraphFrames.add(frame, fragment);
+  // Only the immutable table ID is consumed by this flow owner, as in positioned-table-flow.test.
+  const anchors = [
+    { table: { id: 'table' }, sourceIndex: 0, anchorId: 'anchor' },
+  ] as PositionedTableAnchor[];
+  const positionedFlow = positionedTableFlow(anchors, ['table-key']);
+  const pendingFloatIds = new Set<string>();
+  const floatSignals: PositionedTableAnchorSignal[] = [];
+  positionedFlow.add(pendingFloatIds, 'table');
+  positionedFlow.note(floatSignals, 'anchor', 0, 0, 12);
+  const anchorPageDeferCounts = new Map([['drawing', 1]]);
+  const owner = new FlowCheckpointOwner({
+    paragraphFrames,
+    positionedFlow,
+    pendingFloatIds,
+    floatSignals,
+    anchorPageDeferCounts,
+  });
+  // Drawing convergence is identity-only; the checkpoint owner never reads record contents.
+  const drawing = { kind: 'anchoredDrawing' } as AnchoredDrawingRecord;
+  const state = {
+    ...source,
+    pageFragments: [...source.pageFragments],
+    pendingAnchoredDrawings: [drawing],
+    deferredAnchoredDrawings: [drawing],
+  };
+  const checkpoint = owner.capture(state);
+  return {
+    owner,
+    state,
+    checkpoint,
+    paragraphFrames,
+    positionedFlow,
+    pendingFloatIds,
+    floatSignals,
+    anchorPageDeferCounts,
+  };
+}
+
+const changes = {
+  pageCount: (c) => ({ ...c, pageCount: c.pageCount + 1 }),
+  pageFragments: (c) => ({ ...c, pageFragments: [] }),
+  pendingParagraphFrames: (c) => ({ ...c, pendingParagraphFrames: undefined }),
+  pendingAnchoredDrawings: (c) => ({
+    ...c,
+    pendingAnchoredDrawings: [{ ...c.pendingAnchoredDrawings[0]! }],
+  }),
+  deferredAnchoredDrawings: (c) => ({ ...c, deferredAnchoredDrawings: [] }),
+  anchorPageDeferCounts: (c) => ({ ...c, anchorPageDeferCounts: new Map([['drawing', 2]]) }),
+  pendingPositionedTableTokens: (c) => ({ ...c, pendingPositionedTableTokens: undefined }),
+  positionedTableAnchorSignals: (c) => ({
+    ...c,
+    positionedTableAnchorSignals: [{ ...c.positionedTableAnchorSignals![0]!, anchorY: 99 }],
+  }),
+  cursorY: (c) => ({ ...c, cursorY: c.cursorY + 1 }),
+  lineCounter: (c) => ({ ...c, lineCounter: c.lineCounter + 1 }),
+  previousSpaceAfter: (c) => ({ ...c, previousSpaceAfter: c.previousSpaceAfter + 1 }),
+  flowColumnIndex: (c) => ({ ...c, flowColumnIndex: c.flowColumnIndex + 1 }),
+} satisfies Record<keyof FlowCheckpoint, (checkpoint: FlowCheckpoint) => FlowCheckpoint>;
+
 describe('the convergence comparison agrees with the map', () => {
-  // The comparison lives in semantic-layout.ts as a hand-written `mark && ...` condition.
-  // Slice the region from where the previous checkpoint is fetched to where the shift
-  // verdict is taken; every field's fate is decided inside it.
-  const source = readFileSync(
-    fileURLToPath(new URL('../semantic-layout.ts', import.meta.url)),
-    'utf8'
-  );
-  const start = source.indexOf('const mark = session.checkpoints[');
-  // The CALL, not the name: a comment inside the region mentions the function too.
-  const end = source.indexOf('convergenceTailShiftAllowed({', start);
-  expect(start).toBeGreaterThan(-1);
-  expect(end).toBeGreaterThan(start);
-  const region = source.slice(start, end);
-
-  const fields = Object.entries(FLOW_CHECKPOINT_GUARDS) as [string, FlowCheckpointGuard][];
-
-  for (const [field, guard] of fields) {
-    // Word boundary, not substring: a future `mark.pageFragmentsExtra` must not satisfy
-    // the `pageFragments` gate.
-    const reads = new RegExp(`\\bmark\\.${field}\\b`);
-    if (guard === 'restore-only') {
-      test(`'${field}' is restore-only and the convergence region never reads it`, () => {
-        // If convergence starts comparing it, the map (and its documented argument for
-        // never comparing it) is stale — reclassify it, do not just silence this. The
-        // region deliberately ends BEFORE convergenceTailShiftAllowed: the shift-delta
-        // arithmetic after the condition may read any field it likes.
-        expect(reads.test(region)).toBe(false);
-      });
-    } else {
-      test(`'${field}' (${guard}) is read by the convergence region`, () => {
-        // A 'compared' field that vanished from the condition converges a mismatched
-        // flow: the exact silent failure deferredAnchoredDrawings shipped once.
-        expect(reads.test(region)).toBe(true);
-      });
-    }
+  const { checkpoint } = populatedCheckpoint();
+  test('equivalent snapshots match', () => {
+    expect(flowCheckpointsMatch(checkpoint, checkpoint)).toBe(true);
+    expect(
+      flowCheckpointsMatch(checkpoint, {
+        ...checkpoint,
+        pageFragments: checkpoint.pageFragments.map((fragment) => ({ ...fragment })),
+        anchorPageDeferCounts: new Map(checkpoint.anchorPageDeferCounts),
+        pendingParagraphFrames: { ...checkpoint.pendingParagraphFrames! },
+        pendingPositionedTableTokens: { ...checkpoint.pendingPositionedTableTokens! },
+        positionedTableAnchorSignals: checkpoint.positionedTableAnchorSignals!.map((signal) => ({
+          ...signal,
+        })),
+      })
+    ).toBe(true);
+  });
+  for (const field of Object.keys(changes) as (keyof FlowCheckpoint)[]) {
+    const guard: FlowCheckpointGuard = FLOW_CHECKPOINT_GUARDS[field];
+    test(`${field}: ${guard}`, () => {
+      const changed = changes[field](checkpoint);
+      expect(flowCheckpointsMatch(checkpoint, changed)).toBe(guard !== 'compared');
+      expect(flowCheckpointsMatch(changed, checkpoint)).toBe(guard !== 'compared');
+    });
   }
+});
+
+test('capture and restore isolate mutable collections but preserve immutable records and prefixes', () => {
+  const fixture = populatedCheckpoint();
+  const {
+    owner,
+    checkpoint,
+    state,
+    paragraphFrames,
+    pendingFloatIds,
+    floatSignals,
+    anchorPageDeferCounts,
+  } = fixture;
+  const before = structuredClone(checkpoint);
+  state.pageFragments.length = 0;
+  state.pendingAnchoredDrawings.length = 0;
+  state.deferredAnchoredDrawings.length = 0;
+  paragraphFrames.restore(undefined);
+  pendingFloatIds.clear();
+  floatSignals.length = 0;
+  anchorPageDeferCounts.clear();
+  expect(checkpoint).toEqual(before);
+
+  const restored = owner.restore(checkpoint);
+  expect(owner.capture(restored)).toEqual(checkpoint);
+  expect(restored.pageFragments).not.toBe(checkpoint.pageFragments);
+  expect(restored.pageFragments[0]).toBe(checkpoint.pageFragments[0]);
+  expect(restored.pendingAnchoredDrawings[0]).toBe(checkpoint.pendingAnchoredDrawings[0]);
+  expect(paragraphFrames.checkpoint()).toBe(checkpoint.pendingParagraphFrames);
+  expect(
+    fixture.positionedFlow.checkpoint(pendingFloatIds, floatSignals).pendingPositionedTableTokens
+  ).toBe(checkpoint.pendingPositionedTableTokens);
+  expect([...pendingFloatIds]).toEqual(['table']);
+
+  restored.pageFragments.length = 0;
+  restored.pendingAnchoredDrawings.length = 0;
+  restored.deferredAnchoredDrawings.length = 0;
+  floatSignals.push({ anchorId: 'other', column: 1, fragmentIndex: 3, anchorY: 42 });
+  anchorPageDeferCounts.set('drawing', 9);
+  expect(checkpoint).toEqual(before);
+});
+
+test('restoring an empty checkpoint clears pending owners and keeps shared empty snapshots safe', () => {
+  const {
+    owner,
+    checkpoint,
+    paragraphFrames,
+    pendingFloatIds,
+    floatSignals,
+    anchorPageDeferCounts,
+  } = populatedCheckpoint();
+  const empty = {
+    ...checkpoint,
+    pendingParagraphFrames: undefined,
+    pendingPositionedTableTokens: undefined,
+    positionedTableAnchorSignals: undefined,
+    deferredAnchoredDrawings: [],
+    anchorPageDeferCounts: new Map<string, number>(),
+  };
+  const state = owner.restore(empty);
+  expect(paragraphFrames.checkpoint()).toBeUndefined();
+  expect(pendingFloatIds.size).toBe(0);
+  expect(floatSignals).toEqual([]);
+  expect(anchorPageDeferCounts.size).toBe(0);
+  const captured = owner.capture(state);
+  const restored = owner.restore(captured);
+  restored.deferredAnchoredDrawings.push(checkpoint.pendingAnchoredDrawings[0]!);
+  anchorPageDeferCounts.set('new', 1);
+  expect(captured.deferredAnchoredDrawings).toEqual([]);
+  expect(captured.anchorPageDeferCounts.size).toBe(0);
 });

--- a/packages/core/src/layout/flow-checkpoint-guards.ts
+++ b/packages/core/src/layout/flow-checkpoint-guards.ts
@@ -1,15 +1,15 @@
 // What convergence does with each field of a FLOW CHECKPOINT.
 //
 // A resumed pass converges when the in-page flow returns to exactly the state the previous
-// pass recorded at the same paragraph (`semantic-layout.ts`, the `mark &&` block). That
-// comparison is hand-written: a field captured by `checkpointNow` and restored on resume but
+// pass recorded at the same paragraph (`flowCheckpointsMatch` in `flow-checkpoint.ts`). That
+// comparison is explicit: a field captured and restored by `FlowCheckpointOwner` but
 // missing from the comparison converges a MISMATCHED flow, and ships the silent failure this
 // lane has been bitten by before — `deferredAnchoredDrawings` was exactly that field once
 // (see the comment on it in `layout-session.ts`).
 //
 // This is `PAGE_REUSE_GUARDS` for the checkpoint: the set, written down and type-checked. A
 // new `FlowCheckpoint` field is a type error here until somebody says what convergence does
-// with it, and the companion test asserts the comparison in the source agrees with the map.
+// with it, and the companion test changes every field to verify its declared convergence behavior.
 
 import type { FlowCheckpoint } from './layout-session.ts';
 
@@ -52,7 +52,7 @@ export const FLOW_CHECKPOINT_GUARDS = {
  * Fields a checkpoint actually carries that the table above does not classify.
  *
  * The `satisfies` clause catches a field added to the INTERFACE. This catches the other
- * direction — a checkpoint built by `checkpointNow` with a key the interface never declared.
+ * direction — a checkpoint built by `FlowCheckpointOwner.capture` with a key the interface never declared.
  */
 export function unguardedCheckpointFields(checkpoint: FlowCheckpoint): readonly string[] {
   return Object.keys(checkpoint).filter((key) => !(key in FLOW_CHECKPOINT_GUARDS));

--- a/packages/core/src/layout/flow-checkpoint.ts
+++ b/packages/core/src/layout/flow-checkpoint.ts
@@ -1,0 +1,116 @@
+// Checkpoint lifecycle for one body-flow pass. Placement remains locally mutable; only
+// immutable snapshots cross pass boundaries. Solvers and tail-shift policy stay outside.
+
+import type { AnchoredDrawingRecord } from './drawing-layout.ts';
+import type { FlowCheckpoint } from './layout-session.ts';
+import { samePendingParagraphFrames, type ParagraphFrameFlow } from './paragraph-frame-flow.ts';
+import type { BlockFragmentRecord } from './semantic-records.ts';
+import {
+  NO_DEFERRED_DRAWINGS,
+  NO_DEFER_COUNTS,
+  sameAnchoredDrawings,
+  sameDeferCounts,
+  sameFragments,
+} from './semantic-fragment-signature.ts';
+import {
+  samePositionedTableCheckpoints,
+  type positionedTableFlow,
+  type PositionedTableAnchorSignal,
+} from './table-float-position.ts';
+
+/** Mutable placement values held by the body pass, independent of pending story owners. */
+export interface FlowCheckpointPlacement {
+  pageCount: number;
+  pageFragments: BlockFragmentRecord[];
+  pendingAnchoredDrawings: AnchoredDrawingRecord[];
+  deferredAnchoredDrawings: AnchoredDrawingRecord[];
+  cursorY: number;
+  lineCounter: number;
+  previousSpaceAfter: number;
+  flowColumnIndex: number;
+}
+
+interface FlowCheckpointDependencies {
+  readonly paragraphFrames: ParagraphFrameFlow;
+  readonly positionedFlow: ReturnType<typeof positionedTableFlow>;
+  readonly pendingFloatIds: Set<string>;
+  readonly floatSignals: PositionedTableAnchorSignal[];
+  readonly anchorPageDeferCounts: Map<string, number>;
+}
+
+/** Owns capture, restoration and convergence for one pass's complete checkpoint state. */
+export class FlowCheckpointOwner {
+  constructor(private readonly dependencies: FlowCheckpointDependencies) {}
+
+  capture(state: FlowCheckpointPlacement): FlowCheckpoint {
+    const {
+      paragraphFrames,
+      positionedFlow,
+      pendingFloatIds,
+      floatSignals,
+      anchorPageDeferCounts,
+    } = this.dependencies;
+    return {
+      pageCount: state.pageCount,
+      pageFragments: [...state.pageFragments],
+      pendingAnchoredDrawings: [...state.pendingAnchoredDrawings],
+      pendingParagraphFrames: paragraphFrames.checkpoint(),
+      deferredAnchoredDrawings:
+        state.deferredAnchoredDrawings.length > 0
+          ? [...state.deferredAnchoredDrawings]
+          : NO_DEFERRED_DRAWINGS,
+      anchorPageDeferCounts:
+        anchorPageDeferCounts.size > 0 ? new Map(anchorPageDeferCounts) : NO_DEFER_COUNTS,
+      ...positionedFlow.checkpoint(pendingFloatIds, floatSignals),
+      cursorY: state.cursorY,
+      lineCounter: state.lineCounter,
+      previousSpaceAfter: state.previousSpaceAfter,
+      flowColumnIndex: state.flowColumnIndex,
+    };
+  }
+
+  /** Restore pending owners and return fresh mutable collections for resumed placement. */
+  restore(checkpoint: FlowCheckpoint): FlowCheckpointPlacement {
+    const {
+      paragraphFrames,
+      positionedFlow,
+      pendingFloatIds,
+      floatSignals,
+      anchorPageDeferCounts,
+    } = this.dependencies;
+    paragraphFrames.restore(checkpoint.pendingParagraphFrames);
+    anchorPageDeferCounts.clear();
+    for (const [id, count] of checkpoint.anchorPageDeferCounts)
+      anchorPageDeferCounts.set(id, count);
+    positionedFlow.restore(checkpoint, pendingFloatIds, floatSignals);
+    return {
+      pageCount: checkpoint.pageCount,
+      pageFragments: [...checkpoint.pageFragments],
+      pendingAnchoredDrawings: [...checkpoint.pendingAnchoredDrawings],
+      deferredAnchoredDrawings: [...checkpoint.deferredAnchoredDrawings],
+      cursorY: checkpoint.cursorY,
+      lineCounter: checkpoint.lineCounter,
+      previousSpaceAfter: checkpoint.previousSpaceAfter,
+      flowColumnIndex: checkpoint.flowColumnIndex,
+    };
+  }
+}
+
+/**
+ * Compare in-page flow, reusing the current block's captured snapshot rather than copying
+ * prefixes again. Page count is handled by the tail-shift policy; line count is restore-only.
+ * Pure comparison also keeps speculative passes independent of the active mutable owners.
+ */
+export function flowCheckpointsMatch(mark: FlowCheckpoint, current: FlowCheckpoint): boolean {
+  return (
+    mark.cursorY === current.cursorY &&
+    mark.previousSpaceAfter === current.previousSpaceAfter &&
+    mark.flowColumnIndex === current.flowColumnIndex &&
+    sameFragments(mark.pageFragments, current.pageFragments) &&
+    samePendingParagraphFrames(mark.pendingParagraphFrames, current.pendingParagraphFrames) &&
+    sameAnchoredDrawings(mark.pendingAnchoredDrawings, current.pendingAnchoredDrawings) &&
+    sameAnchoredDrawings(mark.deferredAnchoredDrawings, current.deferredAnchoredDrawings) &&
+    sameDeferCounts(mark.anchorPageDeferCounts, current.anchorPageDeferCounts) &&
+    samePositionedTableCheckpoints(mark, current)
+  );
+}

--- a/packages/core/src/layout/paragraph-frame-flow.ts
+++ b/packages/core/src/layout/paragraph-frame-flow.ts
@@ -47,6 +47,13 @@ export interface PendingParagraphFrames {
   readonly signature: string;
 }
 
+export function samePendingParagraphFrames(
+  left: PendingParagraphFrames | undefined,
+  right: PendingParagraphFrames | undefined
+): boolean {
+  return left === right || (left?.length === right?.length && left?.signature === right?.signature);
+}
+
 /** Local frame paragraphs wait for the actual page and origin of their next regular paragraph. */
 export class ParagraphFrameFlow {
   private pending: PendingParagraphFrames | undefined;
@@ -58,10 +65,7 @@ export class ParagraphFrameFlow {
     this.pending = pending;
   }
   same(pending: PendingParagraphFrames | undefined): boolean {
-    return (
-      this.pending === pending ||
-      (this.pending?.length === pending?.length && this.pending?.signature === pending?.signature)
-    );
+    return samePendingParagraphFrames(this.pending, pending);
   }
 
   start(

--- a/packages/core/src/layout/semantic-layout.ts
+++ b/packages/core/src/layout/semantic-layout.ts
@@ -189,13 +189,7 @@ import {
 import { noteRefNumberingFromNotes } from './field-noteref.ts';
 import { refTokenForTableBlock, resolveStoryRefFieldsWithNoteNumbers } from './field-ref.ts';
 import { publishListMarker } from './list-marker.ts';
-import {
-  NO_DEFERRED_DRAWINGS,
-  NO_DEFER_COUNTS,
-  sameAnchoredDrawings,
-  sameDeferCounts,
-  sameFragments,
-} from './semantic-fragment-signature.ts';
+import { FlowCheckpointOwner, flowCheckpointsMatch } from './flow-checkpoint.ts';
 import { createLayoutSession, type FlowCheckpoint, type LayoutSession } from './layout-session.ts';
 import { replaceLayoutSession } from './layout-session.ts';
 import { furnitureForSection, layoutMultiSectionDocument } from './multi-section-layout.ts';
@@ -1431,23 +1425,24 @@ function layoutBlocksPass(
   let lineCounter = lineCounterStart;
   let previousSpaceAfter = spaceBeforeCarry;
   const checkpoints: FlowCheckpoint[] = [];
-  /** The flow as it stands: what a later pass resumes from and converges against. The
-   * deferred anchor state is copied only when there is some — this runs once per block. */
-  const checkpointNow = (): FlowCheckpoint => ({
-    pageCount: pages.length,
-    pageFragments: [...pageFragments],
-    pendingAnchoredDrawings: [...pendingAnchoredDrawings],
-    pendingParagraphFrames: paragraphFrames.checkpoint(),
-    deferredAnchoredDrawings:
-      deferredAnchoredDrawings.length > 0 ? [...deferredAnchoredDrawings] : NO_DEFERRED_DRAWINGS,
-    anchorPageDeferCounts:
-      anchorPageDeferCounts.size > 0 ? new Map(anchorPageDeferCounts) : NO_DEFER_COUNTS,
-    ...positionedFlow.checkpoint(pendingFloatIds, floatSignals),
-    cursorY,
-    lineCounter,
-    previousSpaceAfter,
-    flowColumnIndex,
+  const checkpointOwner = new FlowCheckpointOwner({
+    paragraphFrames,
+    positionedFlow,
+    pendingFloatIds,
+    floatSignals,
+    anchorPageDeferCounts,
   });
+  const checkpointNow = (): FlowCheckpoint =>
+    checkpointOwner.capture({
+      pageCount: pages.length,
+      pageFragments,
+      pendingAnchoredDrawings,
+      deferredAnchoredDrawings,
+      cursorY,
+      lineCounter,
+      previousSpaceAfter,
+      flowColumnIndex,
+    });
   let startIndex = 0;
   let placed = 0;
   let reusedPages = 0;
@@ -1456,22 +1451,20 @@ function layoutBlocksPass(
   // RESUME. The checkpoint before the first changed paragraph describes a flow the new
   // document still agrees with, so the pages completed by then are carried over by
   // REFERENCE — unchanged pages keep their identity, which is what lets a consumer skip
-  // repainting them (task 9.4).
+  // repainting them.
   if (resumable && firstChanged > 0 && firstChanged < session.checkpoints.length) {
     const checkpoint = session.checkpoints[firstChanged]!;
     pages.push(...previous!.pages.slice(0, checkpoint.pageCount));
-    pageFragments = [...checkpoint.pageFragments];
-    pendingAnchoredDrawings = [...checkpoint.pendingAnchoredDrawings];
-    paragraphFrames.restore(checkpoint.pendingParagraphFrames);
-    deferredAnchoredDrawings = [...checkpoint.deferredAnchoredDrawings];
-    anchorPageDeferCounts.clear();
-    for (const [id, n] of checkpoint.anchorPageDeferCounts) anchorPageDeferCounts.set(id, n);
-    cursorY = checkpoint.cursorY;
-    flowColumnIndex = checkpoint.flowColumnIndex;
-    columnIndex = checkpoint.flowColumnIndex;
-    lineCounter = checkpoint.lineCounter;
-    previousSpaceAfter = checkpoint.previousSpaceAfter;
-    positionedFlow.restore(checkpoint, pendingFloatIds, floatSignals);
+    ({
+      pageFragments,
+      pendingAnchoredDrawings,
+      deferredAnchoredDrawings,
+      cursorY,
+      flowColumnIndex,
+      lineCounter,
+      previousSpaceAfter,
+    } = checkpointOwner.restore(checkpoint));
+    columnIndex = flowColumnIndex;
     startIndex = firstChanged;
     firstParagraphOfSection = false;
     reusedPages = pages.length;
@@ -2033,24 +2026,7 @@ function layoutBlocksPass(
     // into line once the page it disturbed has been completed.
     if (resumable && commonSuffix > 0 && index >= prepared.length - commonSuffix) {
       const mark = session.checkpoints[index + (session.keys.length - prepared.length)];
-      if (
-        mark &&
-        mark.cursorY === cursorY &&
-        mark.previousSpaceAfter === previousSpaceAfter &&
-        mark.flowColumnIndex === flowColumnIndex &&
-        sameFragments(mark.pageFragments, pageFragments) &&
-        paragraphFrames.same(mark.pendingParagraphFrames) &&
-        sameAnchoredDrawings(mark.pendingAnchoredDrawings, pendingAnchoredDrawings) &&
-        // A flow that still owes the next page a drawing is not one that owes it nothing.
-        sameAnchoredDrawings(mark.deferredAnchoredDrawings, deferredAnchoredDrawings) &&
-        sameDeferCounts(mark.anchorPageDeferCounts, anchorPageDeferCounts) &&
-        positionedFlow.same(
-          mark.pendingPositionedTableTokens,
-          mark.positionedTableAnchorSignals,
-          pendingFloatIds,
-          floatSignals
-        )
-      ) {
+      if (mark && flowCheckpointsMatch(mark, checkpoints[index]!)) {
         // The in-page flow matches. At delta 0 the previous pages are appended by identity;
         // at a nonzero delta the tail is identical content `delta` sheets away and is reused
         // through `remapPage`, gated by `convergenceTailShiftAllowed`.

--- a/packages/core/src/layout/table-float-position.ts
+++ b/packages/core/src/layout/table-float-position.ts
@@ -123,6 +123,19 @@ interface PositionedTableCheckpointState {
   readonly positionedTableAnchorSignals?: readonly PositionedTableAnchorSignal[];
 }
 
+export function samePositionedTableCheckpoints(
+  left: PositionedTableCheckpointState,
+  right: PositionedTableCheckpointState
+): boolean {
+  const pending = right.pendingPositionedTableTokens;
+  const priorTokens = left.pendingPositionedTableTokens;
+  return (
+    (pending === priorTokens ||
+      (pending?.length === priorTokens?.length && pending?.signature === priorTokens?.signature)) &&
+    sameAnchorSignals(left.positionedTableAnchorSignals, right.positionedTableAnchorSignals ?? [])
+  );
+}
+
 /** Capture, restore, and compare the deferred-table portion of a flow checkpoint. */
 export function positionedTableFlow(
   positionedTables: readonly PositionedTableAnchor[],
@@ -206,11 +219,9 @@ export function positionedTableFlow(
       signals: readonly PositionedTableAnchorSignal[]
     ): boolean {
       sync(pendingIds);
-      return (
-        (pending === priorTokens ||
-          (pending?.length === priorTokens?.length &&
-            pending?.signature === priorTokens?.signature)) &&
-        sameAnchorSignals(priorSignals, signals)
+      return samePositionedTableCheckpoints(
+        { pendingPositionedTableTokens: priorTokens, positionedTableAnchorSignals: priorSignals },
+        { pendingPositionedTableTokens: pending, positionedTableAnchorSignals: signals }
       );
     },
   };


### PR DESCRIPTION
Body flow previously captured, restored, and compared checkpoint fields in separate parts of its placement closure. A newly deferred state could therefore be restored but omitted from convergence, allowing stale tail reuse.

This PR gives checkpoint capture and restoration a typed `FlowCheckpointOwner` and extracts pure `flowCheckpointsMatch` comparison. The plan was a behavior-preserving ownership extraction: keep mutable placement local, preserve snapshot representation and pending-prefix sharing, and retain existing table/frame solvers and tail-shift policy. Comparison reuses the block's already captured snapshot. Shared domain equality helpers keep existing fragment, drawing-identity, frame-prefix, and table-token semantics.

Exhaustive field classification remains in place. Behavioral tests now mutate every checkpoint field and verify its compared/delta/restore-only role, instead of relying on source-text reads. Additional tests cover restoration isolation, immutable record/prefix identity, and clearing empty pending state.

Validation:
- 2,621 layout tests passed across 202 files; 19 focused checkpoint/frame/table tests passed.
- Core typecheck, all five DOM-free lane checks, and changed-file ESLint passed.
- Eight deterministic edit-benchmark scenarios passed their clean-layout and work gates (`--runs 3 --warmup 1`); no runtime speedup claim.
- Full package builds and repository commit hooks passed: workspace typechecks, parity, licenses, API snapshot, formatting, full lint, and lint-staged.
- Independent subagent review completed with zero remaining medium-or-higher findings.

Checkpoint storage optimization and speculative solver/adoption redesign are separate follow-ups; this PR establishes the lifecycle boundary without changing their algorithms.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/766"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791337323&installation_model_id=422592&pr_number=766&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F766&signature=32a3ec9fe4f055518fd816da6418739cdbabc2b8f0221cb9bded51425f2817ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->