### PR TITLE
feat(core): add on-demand paragraph cache diagnostics

### DIFF
--- a/packages/core/src/layout/__tests__/paragraph-cache-diagnostics.test.ts
+++ b/packages/core/src/layout/__tests__/paragraph-cache-diagnostics.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from 'bun:test';
+import { createParagraphLayoutCache } from '../layout-cache.ts';
+import {
+  paragraphBreakPayload,
+  paragraphCacheDiagnostics,
+} from '../paragraph-cache-diagnostics.ts';
+import type { PendingLine } from '../pending-line.ts';
+
+const snapshot = (cache: object) => paragraphCacheDiagnostics(cache)!;
+
+test('diagnostic reads do not count as hits or change LRU, and limits have distinct causes', () => {
+  const cache = createParagraphLayoutCache<number>({ maxEntries: 1 });
+  cache.set('old', 1);
+  cache.retain(new Set());
+  const before = cache.stats;
+  expect(snapshot(cache).keyTextBytes).toBe(6);
+  expect(cache.stats).toEqual(before);
+  cache.set('new', 2);
+  expect(snapshot(cache).softLimitEvictions).toBe(1);
+  for (let i = 0; i < 8; i++) cache.set(`key${i}`, i);
+  const current = snapshot(cache);
+  expect(current.size).toBe(8);
+  expect(current.hardLimitEvictions).toBe(1);
+  expect(current.evictions).toBe(
+    current.softLimitEvictions + current.hardLimitEvictions + current.staleEvictions
+  );
+  expect(Object.isFrozen(current)).toBe(true);
+});
+
+test('retention, overwrite, one-shot release and clear report their own lifetimes', () => {
+  const cache = createParagraphLayoutCache<number>({ retainAcrossPasses: false });
+  cache.set('same', 1);
+  cache.set('same', 2);
+  expect(snapshot(cache).keyTextBytes).toBe(8);
+  cache.release!('same');
+  cache.release!('same');
+  expect(snapshot(cache).releasedEntries).toBe(1);
+  expect(snapshot(cache).keyTextBytes).toBe(0);
+  cache.set('stale', 1);
+  for (let i = 0; i < 9; i++) cache.retain(new Set());
+  expect(snapshot(cache).staleEvictions).toBe(1);
+  cache.set('clear', 1);
+  cache.clear();
+  expect(snapshot(cache).clearedEntries).toBe(1);
+  expect(snapshot(cache).size).toBe(0);
+  expect(snapshot(cache).keyTextBytes).toBe(0);
+});
+
+test('live release is a no-op, separate caches stay separate, custom caches are unsupported', () => {
+  const live = createParagraphLayoutCache<number>();
+  live.set('x', 1);
+  live.release!('x');
+  expect(snapshot(live).releasedEntries).toBe(0);
+  expect(snapshot(live).size).toBe(1);
+  expect(snapshot(createParagraphLayoutCache()).size).toBe(0);
+  expect(paragraphCacheDiagnostics({})).toBeUndefined();
+});
+
+test('broken-line payloads deduplicate shared records and vanish after clear', () => {
+  const cache = createParagraphLayoutCache<readonly PendingLine[]>();
+  const span = { text: 'a😀' } as PendingLine['spans'][number];
+  const line = { spans: [span], drawings: [] } as unknown as PendingLine;
+  const second = { spans: [span], drawings: [] } as unknown as PendingLine;
+  cache.set('a', [line, second]);
+  cache.set('b', [line]);
+  const payload = paragraphBreakPayload(cache)!;
+  expect(payload).toEqual({ uniqueLines: 2, uniqueSpans: 1, spanTextBytes: 6, uniqueDrawings: 0 });
+  expect(Object.isFrozen(payload)).toBe(true);
+  expect(cache.stats.hits).toBe(0);
+  cache.clear();
+  expect(paragraphBreakPayload(cache)!.uniqueLines).toBe(0);
+  expect(payload.uniqueLines).toBe(2);
+});

--- a/packages/core/src/layout/layout-cache.ts
+++ b/packages/core/src/layout/layout-cache.ts
@@ -23,6 +23,7 @@
 // document around it did.
 
 import type { OoxmlNode, OoxmlProperty } from '@docx-editor.dev/core/store';
+import { registerParagraphCacheDiagnostics } from './paragraph-cache-diagnostics.ts';
 import { sha256FontBytes } from '../store/package/sha256.ts';
 
 /** A fingerprint over one paragraph's layout inputs. */
@@ -614,8 +615,13 @@ export function createParagraphLayoutCache<T>(
   let hits = 0;
   let misses = 0;
   let evictions = 0;
+  let softLimitEvictions = 0;
+  let hardLimitEvictions = 0;
+  let staleEvictions = 0;
+  let releasedEntries = 0;
+  let clearedEntries = 0;
 
-  return {
+  const cache: ParagraphLayoutCache<T> = {
     retainAcrossPasses,
     keyFor(inputs) {
       return paragraphLayoutKeyInScope(inputs, keyMemoScope);
@@ -643,13 +649,15 @@ export function createParagraphLayoutCache<T>(
         // after it is too, so the soft cap yields rather than thrash — up to the hard
         // ceiling, past which memory wins over reuse.
         if (oldest.value[1].generation >= generation && entries.size <= hardMaxEntries) break;
+        if (entries.size > hardMaxEntries) hardLimitEvictions += 1;
+        else softLimitEvictions += 1;
         entries.delete(oldest.value[0]);
         evictions += 1;
       }
     },
 
     release(key) {
-      if (!retainAcrossPasses) entries.delete(key);
+      if (!retainAcrossPasses && entries.delete(key)) releasedEntries += 1;
     },
 
     retentionPassDue() {
@@ -667,11 +675,13 @@ export function createParagraphLayoutCache<T>(
         if (generation - entry.generation > RETAIN_GENERATION_TTL) {
           entries.delete(key);
           evictions += 1;
+          staleEvictions += 1;
         }
       }
     },
 
     clear() {
+      clearedEntries += entries.size;
       entries.clear();
       // Reset both weak live-editor memos and strong one-shot memos. For byte exports this is
       // the phase boundary before review projection/publication, not merely cache housekeeping.
@@ -682,4 +692,28 @@ export function createParagraphLayoutCache<T>(
       return { hits, misses, evictions, size: entries.size };
     },
   };
+  registerParagraphCacheDiagnostics(cache, {
+    snapshot() {
+      let keyTextBytes = 0;
+      for (const key of entries.keys()) keyTextBytes += key.length * 2;
+      return {
+        hits,
+        misses,
+        evictions,
+        size: entries.size,
+        softLimit: maxEntries,
+        hardLimit: hardMaxEntries,
+        keyTextBytes,
+        softLimitEvictions,
+        hardLimitEvictions,
+        staleEvictions,
+        releasedEntries,
+        clearedEntries,
+      };
+    },
+    visit(consume) {
+      for (const entry of entries.values()) consume(entry.value);
+    },
+  });
+  return cache;
 }

--- a/packages/core/src/layout/paragraph-cache-diagnostics.ts
+++ b/packages/core/src/layout/paragraph-cache-diagnostics.ts
@@ -1,0 +1,73 @@
+import type { LayoutCacheStats, ParagraphLayoutCache } from './layout-cache.ts';
+import type { PendingLine } from './pending-line.ts';
+
+export interface ParagraphCacheDiagnostics extends LayoutCacheStats {
+  readonly softLimit: number;
+  readonly hardLimit: number;
+  /** UTF-16 payload estimate, excluding engine headers, interning and backing storage. */
+  readonly keyTextBytes: number;
+  readonly softLimitEvictions: number;
+  readonly hardLimitEvictions: number;
+  readonly staleEvictions: number;
+  readonly releasedEntries: number;
+  readonly clearedEntries: number;
+}
+
+interface Reader {
+  snapshot(): ParagraphCacheDiagnostics;
+  visit(consume: (value: unknown) => void): void;
+}
+const readers = new WeakMap<object, Reader>();
+
+/** Internal registration: no document/cache is rooted by diagnostic instrumentation. */
+export function registerParagraphCacheDiagnostics(cache: object, reader: Reader): void {
+  readers.set(cache, reader);
+}
+
+/** On-demand O(entries) inspection. Reading never changes cache recency or counters. */
+export function paragraphCacheDiagnostics(cache: object): ParagraphCacheDiagnostics | undefined {
+  const reader = readers.get(cache);
+  return reader ? Object.freeze(reader.snapshot()) : undefined;
+}
+
+export interface ParagraphBreakPayload {
+  readonly uniqueLines: number;
+  readonly uniqueSpans: number;
+  /** UTF-16 logical text payload; shared span objects count once, strings may be shared further. */
+  readonly spanTextBytes: number;
+  readonly uniqueDrawings: number;
+}
+
+/**
+ * Logical payload reachable through broken lines, deduplicated by object identity.
+ * Not a retained-heap estimate: properties, shapes, arrays, canonical trees and WASM
+ * resources are deliberately excluded. Call from diagnostics/benchmarks, not per paint.
+ */
+export function paragraphBreakPayload(
+  cache: ParagraphLayoutCache<readonly PendingLine[]>
+): ParagraphBreakPayload | undefined {
+  const reader = readers.get(cache);
+  if (!reader) return undefined;
+  const lines = new Set<object>();
+  const spans = new Set<object>();
+  const drawings = new Set<object>();
+  let spanTextBytes = 0;
+  reader.visit((value) => {
+    for (const line of value as readonly PendingLine[]) {
+      if (lines.has(line)) continue;
+      lines.add(line);
+      for (const span of line.spans) {
+        if (spans.has(span)) continue;
+        spans.add(span);
+        spanTextBytes += span.text.length * 2;
+      }
+      for (const drawing of line.drawings) drawings.add(drawing);
+    }
+  });
+  return Object.freeze({
+    uniqueLines: lines.size,
+    uniqueSpans: spans.size,
+    spanTextBytes,
+    uniqueDrawings: drawings.size,
+  });
+}

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -479,3 +479,23 @@ Not changed, deliberately: every convergence guard that must hold exactly (fragm
 signatures, anchor state, defer counts), every content-control lock semantic (the climb
 returns byte-identical chains), and the bench's round-0 oracle — every incremental result
 above is byte-identical to a clean full pass, asserted per scenario on every gate run.
+
+## Paragraph cache diagnostics
+
+The edit benchmark JSON includes `cacheDiagnostics` alongside each scenario's existing
+`work` counters. `beforeEdit` and `afterEdit` are lifetime-counter snapshots: subtract them
+to isolate the edit from cold layout and warmup. They distinguish soft/hard limit pressure,
+stale-generation eviction, one-shot releases and explicit clears. `payload` counts unique
+broken-line, span and drawing records reachable through the cache.
+
+These are on-demand inspections outside the measured transaction/layout windows. They do
+not touch LRU order or hit/miss counts. Key and span text bytes describe logical UTF-16
+payload, not retained JS heap: object headers, interning, shared backing storage, property
+graphs, DOM and WASM resources are excluded. Use the browser heap benchmark for retained
+heap comparisons; do not add these logical counts to post-GC heap totals.
+
+Internal callers can inspect built-in caches with `paragraphCacheDiagnostics(cache)` and
+line caches with `paragraphBreakPayload(cache)` from `layout/paragraph-cache-diagnostics.ts`.
+Custom cache implementations return `undefined`; the public cache interface is unchanged.
+Inspection walks the cache, so it belongs in an explicit diagnostic action rather than
+every keystroke or paint. Readers are weakly associated with their owning cache.

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -482,14 +482,16 @@ above is byte-identical to a clean full pass, asserted per scenario on every gat
 
 ## Paragraph cache diagnostics
 
-The edit benchmark JSON includes `cacheDiagnostics` alongside each scenario's existing
-`work` counters. `beforeEdit` and `afterEdit` are lifetime-counter snapshots: subtract them
+Run `bun scripts/bench/edit-bench.ts --cache-diagnostics --json` to include
+`cacheDiagnostics` alongside each scenario's existing `work` counters. Default benchmark
+runs perform no cache inspections. `beforeEdit` and `afterEdit` are lifetime-counter snapshots: subtract them
 to isolate the edit from cold layout and warmup. They distinguish soft/hard limit pressure,
 stale-generation eviction, one-shot releases and explicit clears. `payload` counts unique
 broken-line, span and drawing records reachable through the cache.
 
-These are on-demand inspections outside the measured transaction/layout windows. They do
-not touch LRU order or hit/miss counts. Key and span text bytes describe logical UTF-16
+These inspections run in a separate replay after all scenarios finish their timing rounds,
+so diagnostic allocations cannot disturb later measurements. Replay work counters must
+match the measured scenario. Inspections do not touch LRU order or hit/miss counts. Key and span text bytes describe logical UTF-16
 payload, not retained JS heap: object headers, interning, shared backing storage, property
 graphs, DOM and WASM resources are excluded. Use the browser heap benchmark for retained
 heap comparisons; do not add these logical counts to post-GC heap totals.

--- a/scripts/bench/edit-bench-diagnostics.test.ts
+++ b/scripts/bench/edit-bench-diagnostics.test.ts
@@ -1,0 +1,106 @@
+import { expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { createRequire } from 'node:module';
+
+import type {
+  ParagraphBreakPayload,
+  ParagraphCacheDiagnostics,
+} from '../../packages/core/src/layout/paragraph-cache-diagnostics.ts';
+import type { LayoutCacheStats } from '../../packages/core/src/layout/layout-cache.ts';
+
+// fflate is a core workspace dependency, not a root script dependency.
+const { strToU8, zipSync } = createRequire(
+  new URL('../../packages/core/package.json', import.meta.url)
+)('fflate') as {
+  strToU8(value: string): Uint8Array;
+  zipSync(files: Record<string, Uint8Array>): Uint8Array;
+};
+
+interface Scenario {
+  name: string;
+  target: { paragraphIndex: number; paragraphId: string };
+  work: { cache: LayoutCacheStats };
+  cacheDiagnostics?: {
+    beforeEdit: ParagraphCacheDiagnostics;
+    afterEdit: ParagraphCacheDiagnostics;
+    payload: ParagraphBreakPayload;
+  };
+}
+
+// Exercise the actual CLI and replay with a small real DOCX, keeping this independent
+// of the large performance fixtures and their hardware-sensitive timing values.
+test('cache diagnostics are opt-in and preserve each measured scenario’s work', () => {
+  const directory = mkdtempSync(join(tmpdir(), 'edit-bench-diagnostics-'));
+  try {
+    const fixture = join(directory, 'fixture.docx');
+    const paragraphs = Array.from(
+      { length: 24 },
+      (_, index) => `<w:p><w:r><w:t>paragraph ${index} ${'word '.repeat(20)}</w:t></w:r></w:p>`
+    ).join('');
+    writeFileSync(
+      fixture,
+      zipSync({
+        '[Content_Types].xml': strToU8(
+          '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+            '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+            '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+            '</Types>'
+        ),
+        '_rels/.rels': strToU8(
+          '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+            '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>' +
+            '</Relationships>'
+        ),
+        'word/document.xml': strToU8(
+          '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>' +
+            paragraphs +
+            '<w:sectPr><w:pgSz w:w="6000" w:h="2400"/><w:pgMar w:top="200" w:right="200" w:bottom="200" w:left="200"/></w:sectPr>' +
+            '</w:body></w:document>'
+        ),
+      })
+    );
+    const run = (flags: string[]) => {
+      const child = Bun.spawnSync({
+        cmd: [
+          process.execPath,
+          'scripts/bench/edit-bench.ts',
+          fixture,
+          '--runs',
+          '2',
+          '--warmup',
+          '1',
+          '--json',
+          ...flags,
+        ],
+        cwd: resolve(import.meta.dir, '../..'),
+        stdout: 'pipe',
+        stderr: 'pipe',
+      });
+      expect(child.exitCode, child.stderr.toString()).toBe(0);
+      return JSON.parse(child.stdout.toString()) as { scenarios: Scenario[] };
+    };
+    const baseline = run([]);
+    const inspected = run(['--cache-diagnostics']);
+    expect(baseline.scenarios.length).toBeGreaterThan(1);
+    expect(inspected.scenarios.length).toBe(baseline.scenarios.length);
+    for (const [index, scenario] of baseline.scenarios.entries()) {
+      expect(Object.hasOwn(scenario, 'cacheDiagnostics')).toBe(false);
+      const replay = inspected.scenarios[index]!;
+      expect(replay.name).toBe(scenario.name);
+      expect(replay.target).toEqual(scenario.target);
+      expect(replay.work).toEqual(scenario.work);
+      const diagnostics = replay.cacheDiagnostics!;
+      expect(diagnostics).toBeDefined();
+      const { hits, misses, evictions, size } = diagnostics.afterEdit;
+      expect({ hits, misses, evictions, size }).toEqual(replay.work.cache);
+      expect(diagnostics.afterEdit.misses).toBeGreaterThanOrEqual(diagnostics.beforeEdit.misses);
+      expect(diagnostics.payload.uniqueLines).toBeGreaterThan(0);
+      expect(diagnostics.payload.uniqueSpans).toBeGreaterThan(0);
+      expect(diagnostics.payload.spanTextBytes).toBeGreaterThan(0);
+    }
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}, 30_000);

--- a/scripts/bench/edit-bench.ts
+++ b/scripts/bench/edit-bench.ts
@@ -37,6 +37,13 @@ import {
   type LayoutCacheStats,
 } from '../../packages/core/src/layout/layout-cache.ts';
 
+import {
+  paragraphCacheDiagnostics,
+  paragraphBreakPayload,
+  type ParagraphCacheDiagnostics,
+  type ParagraphBreakPayload,
+} from '../../packages/core/src/layout/paragraph-cache-diagnostics.ts';
+
 interface Args {
   fixture: string;
   runs: number;
@@ -65,6 +72,12 @@ interface ScenarioResult {
   layout: TimingSummary;
   total: TimingSummary;
   work: WorkSummary;
+  /** On-demand snapshots outside timed work; lifetime counters include initial layout. */
+  cacheDiagnostics: {
+    beforeEdit: ParagraphCacheDiagnostics;
+    afterEdit: ParagraphCacheDiagnostics;
+    payload: ParagraphBreakPayload;
+  };
 }
 
 interface BenchmarkReport {
@@ -366,6 +379,7 @@ function runScenario(scenario: Scenario): ScenarioResult {
   const layoutTimes: number[] = [];
   const totalTimes: number[] = [];
   let work: WorkSummary | null = null;
+  let cacheDiagnostics: ScenarioResult['cacheDiagnostics'] | undefined;
   const rounds = args.warmup + args.runs;
 
   for (let round = 0; round < rounds; round += 1) {
@@ -388,6 +402,7 @@ function runScenario(scenario: Scenario): ScenarioResult {
       producer: 'edit-bench',
     });
 
+    const beforeEdit = paragraphCacheDiagnostics(cache)!;
     const transactionStart = performance.now();
     const transaction = bodyStore.transact((ctx) => ctx.apply(scenario.op(target)));
     const transactionMs = performance.now() - transactionStart;
@@ -404,6 +419,11 @@ function runScenario(scenario: Scenario): ScenarioResult {
       producer: 'edit-bench',
     });
     const layoutMs = performance.now() - layoutStart;
+    cacheDiagnostics = {
+      beforeEdit,
+      afterEdit: paragraphCacheDiagnostics(cache)!,
+      payload: paragraphBreakPayload(cache)!,
+    };
     const currentWork: WorkSummary = {
       ...session.stats,
       pagesBefore: before.pages.length,
@@ -439,6 +459,7 @@ function runScenario(scenario: Scenario): ScenarioResult {
     layout: summarize(layoutTimes),
     total: summarize(totalTimes),
     work: work!,
+    cacheDiagnostics: cacheDiagnostics!,
   };
 }
 

--- a/scripts/bench/edit-bench.ts
+++ b/scripts/bench/edit-bench.ts
@@ -5,7 +5,7 @@
 // hardware-independent work counters that tell us whether an optimization changed complexity.
 //
 // Usage:
-//   bun scripts/bench/edit-bench.ts [fixture] [--runs 9] [--warmup 2] [--json]
+//   bun scripts/bench/edit-bench.ts [fixture] [--runs 9] [--warmup 2] [--json] [--cache-diagnostics]
 //   bun scripts/bench/edit-bench.ts [fixture] --compare /tmp/edit-before.json
 
 import { readFileSync } from 'node:fs';
@@ -49,6 +49,7 @@ interface Args {
   runs: number;
   warmup: number;
   json: boolean;
+  cacheDiagnostics: boolean;
   compare?: string;
 }
 
@@ -72,8 +73,8 @@ interface ScenarioResult {
   layout: TimingSummary;
   total: TimingSummary;
   work: WorkSummary;
-  /** On-demand snapshots outside timed work; lifetime counters include initial layout. */
-  cacheDiagnostics: {
+  /** Separate replay after all timing rounds; lifetime counters include initial layout. */
+  cacheDiagnostics?: {
     beforeEdit: ParagraphCacheDiagnostics;
     afterEdit: ParagraphCacheDiagnostics;
     payload: ParagraphBreakPayload;
@@ -216,11 +217,14 @@ function parseArgs(argv: readonly string[]): Args {
   let runs = 9;
   let warmup = 2;
   let json = false;
+  let cacheDiagnostics = false;
   let compare: string | undefined;
   for (let index = 0; index < argv.length; index += 1) {
     const value = argv[index]!;
     if (value === '--json') {
       json = true;
+    } else if (value === '--cache-diagnostics') {
+      cacheDiagnostics = true;
     } else if (value === '--runs') {
       runs = positiveInteger(argv[++index], runs, '--runs');
     } else if (value === '--warmup') {
@@ -239,6 +243,7 @@ function parseArgs(argv: readonly string[]): Args {
     runs,
     warmup,
     json,
+    cacheDiagnostics,
     ...(compare ? { compare: resolve(compare) } : {}),
   };
 }
@@ -353,7 +358,7 @@ function sameWork(a: WorkSummary, b: WorkSummary): boolean {
   );
 }
 
-function runScenario(scenario: Scenario): ScenarioResult {
+function runScenario(scenario: Scenario, diagnosticsOnly = false): ScenarioResult {
   let paragraphIndex: number;
   let target: ScenarioTarget;
   if (scenario.target === 'adjacent-body-pair') {
@@ -380,7 +385,8 @@ function runScenario(scenario: Scenario): ScenarioResult {
   const totalTimes: number[] = [];
   let work: WorkSummary | null = null;
   let cacheDiagnostics: ScenarioResult['cacheDiagnostics'] | undefined;
-  const rounds = args.warmup + args.runs;
+  const warmup = diagnosticsOnly ? 0 : args.warmup;
+  const rounds = diagnosticsOnly ? 1 : warmup + args.runs;
 
   for (let round = 0; round < rounds; round += 1) {
     const store = new TreePackageStore(normalizedPackage, normalizedPart);
@@ -402,7 +408,7 @@ function runScenario(scenario: Scenario): ScenarioResult {
       producer: 'edit-bench',
     });
 
-    const beforeEdit = paragraphCacheDiagnostics(cache)!;
+    const beforeEdit = diagnosticsOnly ? paragraphCacheDiagnostics(cache) : undefined;
     const transactionStart = performance.now();
     const transaction = bodyStore.transact((ctx) => ctx.apply(scenario.op(target)));
     const transactionMs = performance.now() - transactionStart;
@@ -419,11 +425,13 @@ function runScenario(scenario: Scenario): ScenarioResult {
       producer: 'edit-bench',
     });
     const layoutMs = performance.now() - layoutStart;
-    cacheDiagnostics = {
-      beforeEdit,
-      afterEdit: paragraphCacheDiagnostics(cache)!,
-      payload: paragraphBreakPayload(cache)!,
-    };
+    if (beforeEdit) {
+      cacheDiagnostics = {
+        beforeEdit,
+        afterEdit: paragraphCacheDiagnostics(cache)!,
+        payload: paragraphBreakPayload(cache)!,
+      };
+    }
     const currentWork: WorkSummary = {
       ...session.stats,
       pagesBefore: before.pages.length,
@@ -445,7 +453,7 @@ function runScenario(scenario: Scenario): ScenarioResult {
     }
     work = currentWork;
 
-    if (round >= args.warmup) {
+    if (round >= warmup) {
       transactionTimes.push(transactionMs);
       layoutTimes.push(layoutMs);
       totalTimes.push(transactionMs + layoutMs);
@@ -459,7 +467,7 @@ function runScenario(scenario: Scenario): ScenarioResult {
     layout: summarize(layoutTimes),
     total: summarize(totalTimes),
     work: work!,
-    cacheDiagnostics: cacheDiagnostics!,
+    ...(cacheDiagnostics ? { cacheDiagnostics } : {}),
   };
 }
 
@@ -474,8 +482,21 @@ const report: BenchmarkReport = {
     warmup: args.warmup,
     measurer: 'fixed(6px,14px)',
   },
-  scenarios: SCENARIOS.map(runScenario),
+  scenarios: SCENARIOS.map((scenario) => runScenario(scenario)),
 };
+
+// Cache walks allocate and change cache temperature even outside a timer. Complete
+// every measured scenario before replaying any diagnostic inspection.
+if (args.cacheDiagnostics) {
+  for (const [index, scenario] of SCENARIOS.entries()) {
+    const replay = runScenario(scenario, true);
+    const measured = report.scenarios[index]!;
+    if (!sameWork(measured.work, replay.work)) {
+      throw new Error(`${scenario.name}: diagnostic replay changed deterministic work counters`);
+    }
+    measured.cacheDiagnostics = replay.cacheDiagnostics;
+  }
+}
 
 if (args.compare) {
   const baseline = JSON.parse(readFileSync(args.compare, 'utf8')) as BenchmarkReport;


### PR DESCRIPTION
Paragraph cache entry counts currently cannot distinguish stale-generation eviction from capacity pressure or show how much key and broken-line text the cache holds. This adds internal, on-demand diagnostics for built-in caches without changing the public cache interface or existing stats shape.

Snapshots report soft/hard limits, attributed evictions, releases, clears and logical key text bytes. A specialized broken-line inspection deduplicates line/span/drawing records by identity. Readers are weakly associated with their cache; inspection leaves LRU order, generations and hit/miss counters untouched. No cache traversal is added to normal typing or paint. Logical UTF-16 payload counts are explicitly not retained-heap estimates.

The edit benchmark accepts `--cache-diagnostics` to collect before/after cache snapshots and payload counts in a separate replay after every measured scenario has finished. Default runs perform no inspection; replay work counters must match the measured scenario. Documentation explains how to isolate edit deltas and interpret the memory limits.

Validation:
- 2,622 layout tests passed; core typecheck passed.
- Tests cover all eviction causes, overwrite/release/clear behavior, per-cache isolation, unsupported custom caches, immutable snapshots and shared payload deduplication.
- Eight deterministic benchmark scenarios completed with clean-layout equality and existing work checks; the first scenario reports one edit miss separately from 3,200 cold misses.
- Extensive review verified unchanged cache behavior against the original implementation across 100,000 randomized operations and confirmed weak ownership with forced-GC probes.
- Review identified diagnostic allocations between benchmark rounds; moved inspection to an opt-in replay after all timing rounds, with CLI regression coverage.

Plan completed: add weakly owned inspection, attribute cache lifetime events, integrate benchmark diagnostics and document payload semantics. Cache capacity and eviction policy are unchanged.
