### PR TITLE
fix: avoid quadratic multi-image paste

### DIFF
--- a/.changeset/quick-paste-images.md
+++ b/.changeset/quick-paste-images.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Avoid quadratic merge time when you paste many distinct images. Fixes #502.

--- a/packages/core/src/store/__tests__/clipboard-fragment-dos.test.ts
+++ b/packages/core/src/store/__tests__/clipboard-fragment-dos.test.ts
@@ -30,27 +30,20 @@
 // tolerate it; what it must still catch is quadratic work, which lands at 64x before any of
 // that and only climbs from there.
 //
-// The MEDIA axis is not, and it is worth writing down why, because the obvious guard is wrong.
-// Merging 250 images costs ~38ms and merging 375 costs ~37.7ms — the small end is essentially
-// all fixed cost, so a ratio taken there is `large / constant`, not a measure of growth at all.
-// It moves with the machine: this harness read 34x locally and 81x on a CI runner for the same
-// code. So the media axis gets the absolute backstop only.
-//
-// Which leaves that axis with no growth guard, and it needs one, because it is QUADRATIC:
-//
-//   n       375     750     1500    3000    6000
-//   ms      41.5    128.9   402.8   1633.7  7555.9
-//   ms/n    0.111   0.172   0.269   0.545   1.259     <- doubles as n doubles
-//   exp     -       1.64    1.64    2.02    2.30
-//
-// The name of its old guard was `no O(media^2)` and the merge is O(media^2); the absolute
-// ceiling never noticed because 3000 images land at ~1.5s, comfortably under 4s. That curve is
-// identical on `main`, so it is long-standing rather than new. Fixing it is what earns this
-// axis a real growth guard, at two work-dominated sizes the way the style axis has one.
+// The media axis uses 1000 and 8000 distinct images. Fixture creation stays outside timing.
+// Both sizes do measurable merge work. Smaller fixtures can mostly measure fixed overhead.
+// Before the indexed content-type edit, this step grew by 68x on Windows; after it, by 7.8x.
+// Keep the same generous growth threshold as the style axis, plus the absolute backstop.
 
 import { describe, expect, test } from 'bun:test';
 import { zipSync, strToU8 } from 'fflate';
-import { readOoxmlPackage, type OoxmlPackage } from '../package/ooxml-package.ts';
+import {
+  readOoxmlPackage,
+  writeOoxmlPackage,
+  type OoxmlPackage,
+} from '../package/ooxml-package.ts';
+import { relationshipsOf, validatePackageInvariants } from '../package/package-edit.ts';
+import { resolveInternalTarget } from '../package/opc-names.ts';
 import { mergeFragmentIntoPackage } from '../store/clipboard-fragment-merge.ts';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
@@ -112,7 +105,7 @@ const NEAR_LINEAR_GROWTH = SIZE_FACTOR * 4;
  * A backstop no plausible machine reaches.
  *
  * It catches what a ratio cannot — a constant factor a hundred times worse grows at the same
- * rate — and it is the media axis's only guard until that axis is linear enough to measure.
+ * rate. Both axes also have a growth guard.
  * Two orders of magnitude above the ~1.5s the biggest of these merges takes, so a stalled
  * runner cannot reach it: the 12.9s stall that started all this would still pass.
  */
@@ -124,8 +117,7 @@ const ABSURD_MS = 60_000;
  * The minimum, not the mean: noise on a shared runner only ever adds time, so the best run is
  * the closest estimate of what the code costs and the outliers are exactly what should be
  * discarded. Five runs, because the ratio fails only when EVERY large run is slow while the
- * small ones are not, and the only merge measured this way tops out near 60ms, so the extra
- * runs cost a fraction of a second. The first run also warms the JIT, which otherwise lands
+ * small ones are not. The first run also warms the JIT, which otherwise lands
  * on the small measurement and deflates the ratio. `prepare` builds the inputs and returns
  * the call to time, so fixture construction stays outside the measurement.
  *
@@ -170,6 +162,17 @@ function growthOverSizeStep(
   };
   const smallMs = timeAt(small);
   const largeMs = timeAt(small * SIZE_FACTOR);
+  if (process.env.DOCX_PASTE_BENCH === '1') {
+    console.warn(
+      JSON.stringify({
+        small,
+        large: small * SIZE_FACTOR,
+        smallMs,
+        largeMs,
+        ratio: largeMs / smallMs,
+      })
+    );
+  }
   expect(largeMs).toBeLessThan(ABSURD_MS);
   // Guard the division: a small measurement of zero on a very fast machine is not a signal.
   return smallMs > 0 ? largeMs / smallMs : 0;
@@ -263,6 +266,10 @@ function styledTarget(): OoxmlPackage {
 }
 
 describe('how the paste merge grows with the fragment', () => {
+  test('distinct images have near-linear merge growth (no O(media^2))', () => {
+    expect(growthOverSizeStep(1000, mediaFragment, blankTarget)).toBeLessThan(NEAR_LINEAR_GROWTH);
+  }, 300_000);
+
   test('colliding style ids resolve in linear time (no O(style^2))', () => {
     // 1000 then 8000. The target's own `Normal` differs, so every one of them collides.
     expect(growthOverSizeStep(1000, collidingStyleFragment, styledTarget)).toBeLessThan(
@@ -271,10 +278,7 @@ describe('how the paste merge grows with the fragment', () => {
   }, 60_000);
 
   test('a fragment of distinct images merges at all, well inside any budget', () => {
-    // NO GROWTH ASSERTION on this axis, deliberately — see the file header. It is quadratic,
-    // and its small end is all fixed cost, so a ratio here measures the runner rather than the
-    // merge. What is left is worth keeping: 3000 images, the size the media budget is written
-    // against, must merge, and must not take a length of time that means something broke.
+    // Keep the absolute backstop and check that faster merging does not lose media.
     const fragment = mediaFragment(3000);
     const target = blankTarget();
     const start = performance.now();
@@ -282,5 +286,28 @@ describe('how the paste merge grows with the fragment', () => {
     const elapsed = performance.now() - start;
     expect(merged.ok).toBe(true);
     expect(elapsed).toBeLessThan(ABSURD_MS);
+    if (!merged.ok) return;
+    expect(merged.blocks).toHaveLength(3000);
+    expect(validatePackageInvariants(merged.pkg).ok).toBe(true);
+    const reopened = load(writeOoxmlPackage(merged.pkg));
+    const images = relationshipsOf(reopened, reopened.mainDocumentPart).filter(
+      (rel) => rel.type === `${R}/image`
+    );
+    expect(images).toHaveLength(3000);
+    const expected = new Set<string>();
+    for (const [name, bytes] of fragment.partBytes) {
+      if (name.includes('/media/')) expected.add(Array.from(bytes).join(','));
+    }
+    const actual = new Set<string>();
+    for (const rel of images) {
+      const targetName = resolveInternalTarget(rel.ownerPart, rel.rawTarget);
+      expect(targetName.ok).toBe(true);
+      if (!targetName.ok) continue;
+      const bytes = reopened.partBytes.get(targetName.partName)!;
+      actual.add(Array.from(bytes).join(','));
+      expect(reopened.contentTypes.overrides.get(targetName.partName)).toBe('image/png');
+    }
+    expect(actual.size).toBe(3000);
+    expect(actual).toEqual(expected);
   }, 60_000);
 });

--- a/packages/core/src/store/package/__tests__/package-edit-batch.test.ts
+++ b/packages/core/src/store/package/__tests__/package-edit-batch.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, test } from 'bun:test';
+import { strFromU8, strToU8, unzipSync, zipSync } from 'fflate';
+import { readOoxmlPackage, writeOoxmlPackage, type OoxmlPackage } from '../ooxml-package.ts';
+import { readOoxmlPart, serializeOoxmlPart } from '../ooxml-tree.ts';
+import { contentTypesPartBytes, withContentTypeOverrides } from '../package-edit.ts';
+import { withBinaryParts } from '../drawing-package-edit.ts';
+import {
+  observeCanonicalPrimitiveJournal,
+  runObservedStoreTransaction,
+} from '../canonical-primitive-capture.ts';
+import type { CanonicalPrimitiveJournal } from '../canonical-primitive-journal.ts';
+
+const CT = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const REL = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+type Entry = readonly [string, string];
+
+function open(extra = ''): OoxmlPackage {
+  const read = readOoxmlPackage(
+    zipSync({
+      '[Content_Types].xml': strToU8(
+        `<Types xmlns="${CT}" xmlns:x="urn:extension"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="png" ContentType="image/png"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>`
+      ),
+      '_rels/.rels': strToU8(
+        `<Relationships xmlns="${REL}"><Relationship Id="rId1" Type="${R}/officeDocument" Target="word/document.xml"/></Relationships>`
+      ),
+      'word/document.xml': strToU8(
+        `<w:document xmlns:w="${W}"><w:body><w:p/></w:body></w:document>`
+      ),
+    })
+  );
+  if (!read.ok) throw new Error(read.reason);
+  if (!extra) return read.package;
+  // Inject duplicate and extension records after the strict package read.
+  const entry = contentTypesPartBytes(read.package)!;
+  const partBytes = new Map(read.package.partBytes);
+  partBytes.set(
+    entry.storageKey,
+    strToU8(strFromU8(entry.bytes).replace('</Types>', `${extra}</Types>`))
+  );
+  const parsed = readOoxmlPart(strFromU8(partBytes.get(entry.storageKey)!), {
+    name: '/[Content_Types].xml',
+    contentType: 'application/xml',
+  });
+  if (!parsed.ok) throw new Error('Invalid test XML');
+  const overrides = new Map(read.package.contentTypes.overrides);
+  for (const node of parsed.part.root.children) {
+    if (node.kind !== 'generic' || node.namespaceUri !== CT || node.localName !== 'Override')
+      continue;
+    const name = node.attributes.find(
+      (a) => a.localName === 'PartName' && a.namespaceUri === ''
+    )?.value;
+    const type = node.attributes.find(
+      (a) => a.localName === 'ContentType' && a.namespaceUri === ''
+    )?.value;
+    if (name && type) overrides.set(name.toLowerCase(), type);
+  }
+  return { ...read.package, partBytes, contentTypes: { ...read.package.contentTypes, overrides } };
+}
+
+function xml(pkg: OoxmlPackage): string {
+  return strFromU8(contentTypesPartBytes(pkg)!.bytes);
+}
+
+function capture(run: () => OoxmlPackage) {
+  const store = {};
+  const journals: CanonicalPrimitiveJournal[] = [];
+  const stop = observeCanonicalPrimitiveJournal(store, (journal) => journals.push(journal));
+  try {
+    return { pkg: runObservedStoreTransaction(store, run, () => true), journals };
+  } finally {
+    stop();
+  }
+}
+
+describe('batched content-type overrides', () => {
+  test('preserves authored entries and matches ordered single-entry edits and journals', () => {
+    const before = open(
+      '<Override PartName="/word/media/A.png" ContentType="image/png" x:keep="first"><x:child/></Override>' +
+        '<x:Override PartName="/word/media/A.png" ContentType="foreign"/>' +
+        '<Override PartName="/word/media/a.PNG" ContentType="duplicate"/>' +
+        '<Override PartName="/word/media/b.png" ContentType="image/png"/>' +
+        '<Override PartName="/word/media/b.png" ContentType="untouched-duplicate"/>' +
+        '<Override PartName="/word/media/A.png" x:ContentType="malformed"/>'
+    );
+    const original = xml(before);
+    const entries: Entry[] = [
+      ['word/media/A.png', 'image/png'],
+      ['/word/media/new%20photo.png', 'image/png'],
+      ['/word/media/a.PNG', 'image/jpeg'],
+      ['/word/media/NEW photo.png', 'image/gif'],
+      ['/word/media/a.png', 'image/jpeg'],
+      ['/word/media/a.png', 'image/png'],
+    ];
+    const batch = capture(() => withContentTypeOverrides(before, entries));
+    const sequential = capture(() =>
+      entries.reduce((pkg, entry) => withContentTypeOverrides(pkg, [entry]), before)
+    );
+    expect(xml(batch.pkg)).toBe(xml(sequential.pkg));
+    expect(batch.pkg.contentTypes).toEqual(sequential.pkg.contentTypes);
+    expect(batch.journals).toEqual(sequential.journals);
+    expect(xml(before)).toBe(original);
+    expect(batch.pkg.parts).toBe(before.parts);
+    expect(batch.pkg.relationships).toBe(before.relationships);
+    expect(batch.pkg.contentTypes.defaults).toBe(before.contentTypes.defaults);
+    expect(xml(batch.pkg)).toContain('x:keep="first"');
+    expect(xml(batch.pkg)).toContain('ContentType="foreign"');
+    expect(xml(batch.pkg)).toContain('ContentType="untouched-duplicate"');
+    expect(xml(batch.pkg)).toContain('x:ContentType="malformed"');
+    expect(xml(batch.pkg)).not.toContain('ContentType="duplicate"');
+    expect(batch.pkg.contentTypes.overrides.get('/word/media/new photo.png')).toBe('image/gif');
+  });
+
+  test('an unchanged batch retains package identity and emits no effects', () => {
+    const before = open('<Override PartName="/word/media/A.png" ContentType="image/png"/>');
+    const result = capture(() =>
+      withContentTypeOverrides(before, [
+        ['/word/media/a.PNG', 'image/png'],
+        ['/word/media/A.png', 'image/png'],
+      ])
+    );
+    expect(result.pkg).toBe(before);
+    expect(result.journals).toEqual([{ effects: [] }]);
+    expect(withContentTypeOverrides(before, [])).toBe(before);
+  });
+
+  test('rejects unsafe and reserved names without adding overrides', () => {
+    const before = open();
+    const names = [
+      '../bad',
+      '/word/../bad',
+      '/word/%2e%2e/bad',
+      '/word/%2f/bad',
+      '/word/__proto__/bad',
+      '/[Content_Types].xml',
+      '/word/_rels/document.xml.rels',
+    ];
+    expect(
+      withContentTypeOverrides(
+        before,
+        names.map((name) => [name, 'image/png'])
+      )
+    ).toBe(before);
+    const after = withContentTypeOverrides(before, [
+      ...names.map((name): Entry => [name, 'image/png']),
+      ['/word/media/good.png', 'image/png'],
+    ]);
+    expect(after.contentTypes.overrides.size).toBe(before.contentTypes.overrides.size + 1);
+  });
+
+  test('forces an explicit override despite a matching Default and escapes XML values', () => {
+    const before = open();
+    const after = withContentTypeOverrides(before, [
+      ['/word/media/a.png', 'image/png'],
+      ['/word/media/a&b.bin', 'image/png'],
+    ]);
+    expect(after.contentTypes.overrides.get('/word/media/a.png')).toBe('image/png');
+    const reopened = readOoxmlPackage(writeOoxmlPackage(after));
+    expect(reopened.ok).toBe(true);
+    if (!reopened.ok) return;
+    expect(reopened.package.contentTypes).toEqual(after.contentTypes);
+    expect(xml(after)).toContain('a&amp;b.bin');
+    const escaped = withContentTypeOverrides(after, [['/word/media/a&b.bin', 'image/test&"value']]);
+    expect(xml(escaped)).toContain('image/test&amp;&quot;value');
+    expect(
+      readOoxmlPart(xml(escaped), { name: '/[Content_Types].xml', contentType: 'application/xml' })
+        .ok
+    ).toBe(true);
+  });
+
+  test('fails closed for missing or malformed content-type XML', () => {
+    const before = open();
+    const entry = contentTypesPartBytes(before)!;
+    for (const bytes of [undefined, strToU8('<Types')]) {
+      const partBytes = new Map(before.partBytes);
+      if (bytes) partBytes.set(entry.storageKey, bytes);
+      else partBytes.delete(entry.storageKey);
+      const pkg = { ...before, partBytes };
+      expect(withContentTypeOverrides(pkg, [['/word/media/a.png', 'image/png']])).toBe(pkg);
+    }
+  });
+
+  test('matches single-entry edits over repeated keys and authored duplicate sets', () => {
+    for (let seed = 0; seed < 12; seed++) {
+      const before = open(
+        Array.from(
+          { length: 16 },
+          (_, i) =>
+            `<Override PartName="/word/media/${i % 8}.png" ContentType="image/type${i % 3}"/>`
+        ).join('')
+      );
+      const entries: Entry[] = Array.from({ length: 45 }, (_, i) => [
+        `/word/media/${(i * 7 + seed) % 20}.png`,
+        `image/type${(i + seed) % 4}`,
+      ]);
+      const batch = capture(() => withContentTypeOverrides(before, entries));
+      const sequential = capture(() =>
+        entries.reduce((pkg, entry) => withContentTypeOverrides(pkg, [entry]), before)
+      );
+      expect(xml(batch.pkg)).toBe(xml(sequential.pkg));
+      expect(batch.pkg.contentTypes).toEqual(sequential.pkg.contentTypes);
+      expect(batch.journals).toEqual(sequential.journals);
+    }
+  });
+});
+
+describe('batched binary parts', () => {
+  test('removes replaced XML trees once and preserves saved bytes and input isolation', () => {
+    const before = open();
+    const parsed = readOoxmlPart('<old/>', {
+      name: '/word/media/a.png',
+      contentType: 'application/xml',
+    });
+    if (!parsed.ok) throw new Error(parsed.reason);
+    const parts = new Map(before.parts);
+    parts.set('/word/media/A.PNG', parsed.part);
+    parts.set('word/media/a.png', parsed.part);
+    parts.set('/word/keep.xml', { ...parsed.part, name: '/word/keep.xml' });
+    const pkg = { ...before, parts };
+    const input = new Uint8Array([1, 2, 3]);
+    const after = withBinaryParts(pkg, [
+      { partName: '/word/media/a.png', bytes: input, contentType: 'image/png' },
+      { partName: '/word/media/b.png', bytes: new Uint8Array([4, 5]), contentType: 'image/png' },
+    ]);
+    input[0] = 99;
+    expect(after.parts.has('/word/media/A.PNG')).toBe(false);
+    expect(after.parts.has('word/media/a.png')).toBe(false);
+    expect(after.parts.get('/word/keep.xml')).toBe(parts.get('/word/keep.xml'));
+    expect(pkg.parts.size).toBe(before.parts.size + 3);
+    const saved = unzipSync(writeOoxmlPackage(after));
+    expect(saved['word/media/a.png']).toEqual(new Uint8Array([1, 2, 3]));
+    expect(saved['word/media/b.png']).toEqual(new Uint8Array([4, 5]));
+    expect(strFromU8(saved['word/keep.xml']!)).toBe(
+      serializeOoxmlPart(parts.get('/word/keep.xml')!)
+    );
+    const reopened = readOoxmlPackage(writeOoxmlPackage(after));
+    expect(reopened.ok).toBe(true);
+    if (reopened.ok) expect(reopened.package.contentTypes).toEqual(after.contentTypes);
+  });
+});

--- a/packages/core/src/store/package/drawing-package-edit.ts
+++ b/packages/core/src/store/package/drawing-package-edit.ts
@@ -210,10 +210,15 @@ function partPresent(pkg: OoxmlPackage, partName: string): boolean {
   return false;
 }
 
-function storagePartName(canonical: string, pkg: OoxmlPackage): string {
-  for (const name of [...pkg.partBytes.keys(), ...pkg.parts.keys()]) {
-    if (name.startsWith('/')) return canonical;
+function usesAbsolutePartNames(pkg: OoxmlPackage): boolean {
+  for (const map of [pkg.partBytes, pkg.parts]) {
+    for (const name of map.keys()) if (name.startsWith('/')) return true;
   }
+  return false;
+}
+
+function storagePartName(canonical: string, pkg: OoxmlPackage): string {
+  if (usesAbsolutePartNames(pkg)) return canonical;
   return canonical.startsWith('/') ? canonical.slice(1) : canonical;
 }
 
@@ -499,18 +504,16 @@ export function withBinaryParts(
   const withBytes = runWithoutJournalCapture(() => {
     const partBytes = new Map(pkg.partBytes);
     const parts = new Map(pkg.parts);
+    const absoluteNames = usesAbsolutePartNames(pkg);
+    const replacedKeys = new Set<string>();
     for (const addition of additions) {
       const normalized = normalizePartName(addition.partName);
       if (!normalized.ok) continue;
-      const storedName = storagePartName(normalized.partName, pkg);
+      const storedName = absoluteNames ? normalized.partName : normalized.partName.slice(1);
       const copied = snapshotPartBytes(addition.bytes);
       partBytes.set(storedName, copied);
       const storedKey = canonicalPartKey(storedName);
-      if (storedKey !== null) {
-        for (const name of [...parts.keys()]) {
-          if (canonicalPartKey(name) === storedKey) parts.delete(name);
-        }
-      }
+      if (storedKey !== null) replacedKeys.add(storedKey);
       overrides.push([normalized.partName, addition.contentType]);
       if (capture) {
         recorded.push({
@@ -520,6 +523,10 @@ export function withBinaryParts(
           mediaType: addition.contentType,
         });
       }
+    }
+    for (const name of parts.keys()) {
+      const key = canonicalPartKey(name);
+      if (key !== null && replacedKeys.has(key)) parts.delete(name);
     }
     return Object.freeze({ ...pkg, partBytes, parts });
   });

--- a/packages/core/src/store/package/package-edit.ts
+++ b/packages/core/src/store/package/package-edit.ts
@@ -358,7 +358,7 @@ export function withContentTypeOverride(
  * Declare content types for MANY parts in one content-types tree edit — the batched twin
  * of {@link withContentTypeOverride}. A per-part call re-parses and re-serializes the whole
  * `[Content_Types].xml` each time, which is quadratic when a paste installs thousands of
- * media parts; this parses and serializes once.
+ * media parts; this indexes, edits, and serializes the children once.
  */
 export function withContentTypeOverrides(
   pkg: OoxmlPackage,
@@ -373,25 +373,80 @@ export function withContentTypeOverrides(
   });
   if (!parsed.ok) return pkg;
 
-  let part = parsed.part;
+  const part = parsed.part;
+  const root = part.root;
+  if (root.kind !== 'generic') return pkg;
+  const requests: Array<readonly [string, string, string]> = [];
+  const wanted = new Set<string>();
+  for (const [partName, contentType] of entries) {
+    const canonical = writablePartName(partName);
+    if (canonical === null) continue;
+    const key = partNameKey(canonical);
+    requests.push([canonical, key, contentType]);
+    wanted.add(key);
+  }
+  if (requests.length === 0) return pkg;
+
+  // Keep the first matching node in place. Remove only requested duplicates.
+  const children: OoxmlNode[] = [];
+  const positions = new Map<string, number>();
+  const duplicates = new Set<string>();
+  for (const child of root.children) {
+    const name = readUnqualifiedGenericAttribute(child, 'PartName');
+    const key = name === undefined ? undefined : partNameKey(name);
+    if (
+      name !== undefined &&
+      key !== undefined &&
+      wanted.has(key) &&
+      isContentTypeOverrideNode(child, name)
+    ) {
+      if (positions.has(key)) {
+        duplicates.add(key);
+        continue;
+      }
+      positions.set(key, children.length);
+    }
+    children.push(child);
+  }
+
   const overrides = new Map(pkg.contentTypes.overrides);
   const capture = isCanonicalPrimitiveCaptureActive();
   const recorded: Array<readonly [string, string]> = [];
   let changed = false;
-  for (const [partName, contentType] of entries) {
-    const canonical = writablePartName(partName);
-    if (canonical === null) continue;
-    const upserted = upsertContentTypeOverrideChildren(part, canonical, contentType);
-    if (!upserted.changed) continue;
-    part = upserted.part;
-    overrides.set(partNameKey(canonical), contentType);
+  for (const [canonical, key, contentType] of requests) {
+    const position = positions.get(key);
+    if (position === undefined) {
+      positions.set(key, children.length);
+      children.push(
+        element(mintedId(part, `override-${canonical}`), CONTENT_TYPES_NAMESPACE, 'Override', {
+          PartName: canonical,
+          ContentType: contentType,
+        })
+      );
+    } else {
+      const child = children[position] as OoxmlGenericElementNode;
+      const removedDuplicates = duplicates.delete(key);
+      if (readUnqualifiedGenericAttribute(child, 'ContentType') === contentType) {
+        if (!removedDuplicates) continue;
+      } else {
+        children[position] = withGenericAttributeValue(child, 'ContentType', contentType);
+      }
+    }
+    overrides.set(key, contentType);
     changed = true;
     if (capture) recorded.push([canonical, contentType]);
   }
   if (!changed) return pkg;
 
+  const replaced = runWithoutJournalCapture(() =>
+    replaceChildren(part, root.id, children, { deferValidation: true })
+  );
+  if (!replaced.ok) return pkg;
   const partBytes = new Map(pkg.partBytes);
-  partBytes.set(contentTypesEntry.storageKey, new TextEncoder().encode(serializeOoxmlPart(part)));
+  partBytes.set(
+    contentTypesEntry.storageKey,
+    new TextEncoder().encode(serializeOoxmlPart(replaced.part))
+  );
   const next = Object.freeze({
     ...pkg,
     partBytes,

--- a/packages/docx-to-markdown/test/package-dependencies.test.ts
+++ b/packages/docx-to-markdown/test/package-dependencies.test.ts
@@ -42,12 +42,12 @@ describe('engine dependency integrity', () => {
     expect(manifest.devDependencies?.['@docx-editor.dev/core']).toBe('workspace:*');
   });
 
-  test('participates in public releases with compatible engine dependencies', () => {
+  test('stays private and outside release automation with compatible engine dependencies', () => {
     const packageName = '@docx-editor.dev/docx-to-markdown';
-    expect(manifest.private).not.toBe(true);
-    expect(manifest.publishConfig).toEqual({ access: 'public' });
-    expect(changesetConfig.fixed?.flat()).toContain(packageName);
-    expect(changesetConfig.ignore).not.toContain(packageName);
+    expect(manifest.private).toBe(true);
+    expect(manifest.publishConfig).toBeUndefined();
+    expect(changesetConfig.fixed?.flat()).not.toContain(packageName);
+    expect(changesetConfig.ignore).toContain(packageName);
     expect(changesetConfig.updateInternalDependencies).toBe('patch');
     expect(
       requiresSameMinor(manifest.peerDependencies?.['@docx-editor.dev/core'], coreManifest.version)
@@ -75,12 +75,10 @@ describe('engine dependency integrity', () => {
     );
     expect(coreExportSource).not.toMatch(/Markdown|\.\/markdown/);
     expect(existsSync(join(repositoryRoot, 'packages/core/src/export/markdown.ts'))).toBe(false);
-    expect(existsSync(join(repositoryRoot, 'docs/site/content/docx-to-markdown/index.mdx'))).toBe(
-      true
-    );
+    expect(existsSync(join(repositoryRoot, 'docs/site/content/export/markdown.mdx'))).toBe(true);
     expect(
       readFileSync(join(repositoryRoot, 'docs', 'site', 'content', 'meta.json'), 'utf8')
-    ).toContain('docx-to-markdown');
+    ).toContain('export/markdown');
   });
 
   test('confines packaged fonts through the fonts package asset-root contract', () => {


### PR DESCRIPTION
Batch content-type updates and binary-part cleanup to avoid quadratic work when pasting distinct images. Preserve override order, duplicate cleanup, untouched XML, and journal effects.

The restored growth guard fails on the original source: 1,000 to 8,000 images grows by 68.0x. The fixed source grows by 7.8x on the same Windows machine with Bun 1.4.0. Set `DOCX_PASTE_BENCH=1` when running the clipboard growth test to print timings.

Validation: 87 focused tests pass, including saved media bytes, relationships, paste undo, and journal replay. Package builds, workspace type checks, API checks, formatting, lint, and i18n checks pass. Lint retains existing warnings.

The full Windows run has 11,983 passes and 69 failures across 963 files. These involve path separators, the Vue JSX test loader, symlink permissions, and existing Markdown publication assertions. The public-docs parity check also misclassifies Windows CHANGELOG paths; the remaining parity checks pass. This PR leaves those unrelated files unchanged.

Fixes #502

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791356458&installation_model_id=422592&pr_number=772&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F772&signature=bbd36ed8b146db12487d990fd744f3838170b013090c3826a1324c4fd18d3d6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->