### PR TITLE
fix: request SYMBOL field and numbering fonts

### DIFF
--- a/.changeset/symbol-field-marker-fonts.md
+++ b/.changeset/symbol-field-marker-fonts.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Request fonts used by SYMBOL fields and numbering markers when you open a document. Fixes #749.

--- a/docs/site/content/word-fidelity.mdx
+++ b/docs/site/content/word-fidelity.mdx
@@ -139,6 +139,10 @@ as DOM text, not a canvas bitmap.
 Usable font bytes are required for Word-accurate text measurement. See
 [Fonts and measurement](/docs/2.x/guides/fonts).
 
+The configured font resolver also receives faces used by SYMBOL fields and numbering markers.
+Your host must supply usable font bytes for those faces when they are unavailable locally.
+Unused numbering definitions do not add font requests.
+
 East Asian layout keeps punctuation, graphemes, and full-width number groups
 together across formatting changes. Justified lines distribute inter-character
 spacing through the same geometry used for paint and caret placement.

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -203,7 +203,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'Symbol runs render and survive editing and save. You can insert a symbol from the Insert menu. Existing symbol run properties are not editable.',
+      'Symbol runs render and survive editing and save. The editor requests fonts for symbol runs, SYMBOL fields, and used numbering markers through the configured font resolver. You can insert a symbol from the Insert menu. Existing symbol run properties are not editable.',
   },
 
   // --- Paragraphs & styles ---------------------------------------------

--- a/packages/core/src/editor/__tests__/symbol-field-marker-fonts.test.ts
+++ b/packages/core/src/editor/__tests__/symbol-field-marker-fonts.test.ts
@@ -1,0 +1,232 @@
+import { expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { strFromU8, strToU8, unzipSync, zipSync } from 'fflate';
+import { createDocxEditor } from '../docx-editor.ts';
+import type { FontResolutionRequest } from '../font-composition.ts';
+import { docx } from './paginated-surface-fixtures.ts';
+import { openTreeSession } from '../../binding/tree-session.ts';
+import { resolverGlyphFontFamilies } from '../resolver-glyph-font-families.ts';
+import {
+  symbolFieldFontFamilies,
+  usedNumberingFontFamilies,
+} from '../../layout/synthesized-font-families.ts';
+import { readOoxmlPart } from '../../store/package/ooxml-tree.ts';
+import { sha256FontBytes } from '../../layout/index.ts';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+
+function root(xml: string) {
+  const parsed = readOoxmlPart(xml, { name: '/word/test.xml', contentType: 'application/xml' });
+  if (!parsed.ok) throw new Error('Invalid test XML');
+  return parsed.part.root;
+}
+
+const symbolField = (font: string) =>
+  `<w:p><w:fldSimple w:instr='SYMBOL 0xF0FC \\f "${font}"'/></w:p>`;
+
+function withNumbering(body: string): Uint8Array {
+  const files = unzipSync(docx(body));
+  files['[Content_Types].xml'] = strToU8(
+    strFromU8(files['[Content_Types].xml']!).replace(
+      '</Types>',
+      '<Override PartName="/word/numbering.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml"/></Types>'
+    )
+  );
+  files['word/_rels/document.xml.rels'] = strToU8(
+    `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdNum" Type="${R}/numbering" Target="numbering.xml"/></Relationships>`
+  );
+  files['word/numbering.xml'] = strToU8(
+    `<w:numbering xmlns:w="${W}"><w:abstractNum w:abstractNumId="0"><w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="bullet"/><w:lvlText w:val="&#xF0FC;"/><w:rPr><w:rFonts w:ascii="Wingdings" w:hAnsi="Wingdings"/></w:rPr></w:lvl></w:abstractNum><w:num w:numId="1"><w:abstractNumId w:val="0"/></w:num></w:numbering>`
+  );
+  return zipSync(files);
+}
+
+async function requested(bytes: Uint8Array) {
+  const seen: FontResolutionRequest[] = [];
+  const editor = createDocxEditor({
+    container: document.createElement('div'),
+    document: bytes,
+    fonts: (request) => {
+      seen.push(request);
+      return undefined;
+    },
+  });
+  try {
+    for (let i = 0; i < 100 && seen.length === 0; i++)
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(seen).toHaveLength(1);
+    return {
+      families: seen[0]!.families,
+      declared: editor.getDocumentFonts(),
+      notice: editor.snapshot().fontSubstitutions,
+    };
+  } finally {
+    editor.destroy();
+  }
+}
+
+test('requests the font of a simple SYMBOL field without adding it to the declaration catalog', async () => {
+  const result = await requested(
+    docx(
+      '<w:p><w:fldSimple w:instr="SYMBOL 0xF0FC \\f &quot;Wingdings&quot;"><w:r><w:t/></w:r></w:fldSimple></w:p>'
+    )
+  );
+  expect(result.families).toContain('Wingdings');
+  expect(result.declared).not.toContain('Wingdings');
+  expect(result.notice).not.toContain('Wingdings');
+});
+
+test('requests a complex SYMBOL font when its instruction is split across runs', async () => {
+  const result = await requested(
+    docx(
+      '<w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r><w:r><w:instrText>SYMBOL 0xF0FC </w:instrText></w:r><w:r><w:instrText>\\f "Wingdings"</w:instrText></w:r><w:r><w:fldChar w:fldCharType="separate"/></w:r><w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>'
+    )
+  );
+  expect(result.families).toContain('Wingdings');
+});
+
+test('requests the font of a used numbering bullet', async () => {
+  const result = await requested(
+    withNumbering(
+      '<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr></w:pPr><w:r><w:t>Report item</w:t></w:r></w:p>'
+    )
+  );
+  expect(result.families).toContain('Wingdings');
+  expect(result.declared).not.toContain('Wingdings');
+});
+
+test('does not request an unused numbering font', async () => {
+  const result = await requested(withNumbering('<w:p><w:r><w:t>No list</w:t></w:r></w:p>'));
+  expect(result.families).not.toContain('Wingdings');
+});
+
+test.each(['field', 'marker'] as const)(
+  'installs resolver-supplied bytes for a %s face',
+  async (kind) => {
+    // A redistributable fixture verifies font plumbing, not Wingdings glyph coverage.
+    const bytes = new Uint8Array(
+      readFileSync(new URL('../../layout/__tests__/fixtures/fonts/DejaVuSans.ttf', import.meta.url))
+    );
+    const seen: FontResolutionRequest[] = [];
+    const editor = createDocxEditor({
+      container: document.createElement('div'),
+      document:
+        kind === 'field'
+          ? docx(symbolField('Wingdings'))
+          : withNumbering(
+              '<w:p><w:pPr><w:numPr><w:numId w:val="1"/></w:numPr></w:pPr><w:r><w:t>item</w:t></w:r></w:p>'
+            ),
+      fonts: (request) => {
+        seen.push(request);
+        return request.families.includes('Wingdings')
+          ? {
+              sources: [
+                {
+                  request: { family: 'Wingdings', weight: 400, style: 'normal' },
+                  id: `synthesized-${kind}`,
+                  bytes,
+                  hash: sha256FontBytes(bytes),
+                  faceIndex: 0,
+                },
+              ],
+            }
+          : undefined;
+      },
+    });
+    try {
+      for (let i = 0; i < 100 && editor.fontMeasurement().measurer !== 'shaped'; i++)
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(seen).toHaveLength(1);
+      expect(seen[0]!.families).toContain('Wingdings');
+      expect(editor.fontMeasurement()).toMatchObject({ measurer: 'shaped', resolving: false });
+      expect(editor.getDocumentFonts()).not.toContain('Wingdings');
+    } finally {
+      editor.destroy();
+    }
+  }
+);
+
+test('includes fields in headers, footers, notes, and nested text boxes', () => {
+  const roots = [
+    root(`<w:hdr xmlns:w="${W}">${symbolField('Header Face')}</w:hdr>`),
+    root(`<w:ftr xmlns:w="${W}">${symbolField('Footer Face')}</w:ftr>`),
+    root(
+      `<w:footnotes xmlns:w="${W}"><w:footnote w:id="1">${symbolField('Note Face')}</w:footnote></w:footnotes>`
+    ),
+    root(
+      `<w:document xmlns:w="${W}"><w:body><w:p><w:r><w:drawing><w:txbxContent>${symbolField('Textbox Face')}</w:txbxContent></w:drawing></w:r></w:p></w:body></w:document>`
+    ),
+  ];
+  expect(symbolFieldFontFamilies(roots)).toEqual([
+    'Header Face',
+    'Footer Face',
+    'Note Face',
+    'Textbox Face',
+  ]);
+});
+
+test('does not interpret arbitrary instruction text and rejects unsafe or overlong names', async () => {
+  const result = await requested(
+    docx(
+      symbolField('Bad;Face') +
+        symbolField('X'.repeat(129)) +
+        `<w:p><w:r><w:instrText>SYMBOL 65 \\f "Not A Field"</w:instrText></w:r></w:p>` +
+        `<w:p><w:fldSimple w:instr='SYMBOL ${' '.repeat(257)}65 \\f "Overflow Face"'/></w:p>` +
+        `<w:p><w:fldSimple w:instr='DDE "External Face"'/></w:p>`
+    )
+  );
+  expect(result.families).toEqual([]);
+});
+
+test('keeps field and bullet faces in the reserved share of a crowded request', async () => {
+  const declarations = Array.from(
+    { length: 80 },
+    (_, i) => `<w:p><w:r><w:rPr><w:rFonts w:ascii="Font ${i}"/></w:rPr><w:t>x</w:t></w:r></w:p>`
+  ).join('');
+  const result = await requested(
+    withNumbering(
+      declarations +
+        symbolField('Webdings') +
+        '<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr></w:pPr><w:r><w:t>item</w:t></w:r></w:p>'
+    )
+  );
+  expect(result.families).toHaveLength(64);
+  expect(result.families).toContain('Webdings');
+  expect(result.families).toContain('Wingdings');
+});
+
+test('deduplicates field, symbol, and marker faces without mutating the session', async () => {
+  const bytes = withNumbering(
+    symbolField('Wingdings') + '<w:p><w:r><w:sym w:font="wingdings" w:char="F0FC"/></w:r></w:p>'
+  );
+  const opened = openTreeSession(bytes);
+  if (!opened.ok) throw new Error(opened.reason);
+  const before = opened.session.currentPackage();
+  expect(resolverGlyphFontFamilies(opened.session).map((family) => family.toLowerCase())).toContain(
+    'wingdings'
+  );
+  expect(opened.session.currentPackage()).toBe(before);
+  const result = await requested(bytes);
+  expect(result.families.filter((family) => family.toLowerCase() === 'wingdings')).toHaveLength(1);
+});
+
+test('resolves a used marker through paragraph style and numbering-level override', () => {
+  const story = root(
+    `<w:document xmlns:w="${W}"><w:body><w:p><w:pPr><w:pStyle w:val="ListStyle"/></w:pPr><w:r><w:t>item</w:t></w:r></w:p></w:body></w:document>`
+  );
+  const styles = root(
+    `<w:styles xmlns:w="${W}"><w:style w:type="paragraph" w:styleId="ListStyle"><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr></w:pPr></w:style></w:styles>`
+  );
+  const numbering = root(
+    `<w:numbering xmlns:w="${W}"><w:abstractNum w:abstractNumId="0"><w:lvl w:ilvl="0"><w:numFmt w:val="bullet"/><w:lvlText w:val="x"/><w:rPr><w:rFonts w:ascii="Unused Base"/></w:rPr></w:lvl></w:abstractNum><w:num w:numId="1"><w:abstractNumId w:val="0"/><w:lvlOverride w:ilvl="0"><w:lvl w:ilvl="0"><w:numFmt w:val="bullet"/><w:lvlText w:val="x"/><w:rPr><w:rFonts w:ascii="Marker Face"/></w:rPr></w:lvl></w:lvlOverride></w:num></w:numbering>`
+  );
+  expect(
+    usedNumberingFontFamilies([story], numbering, styles, {
+      major: null,
+      minor: null,
+      majorEastAsia: null,
+      minorEastAsia: null,
+    })
+  ).toEqual(['Marker Face']);
+});

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -1,8 +1,7 @@
 // The `Editor` facade over the paginated surface.
 //
 // `createDocxEditor` implements the FULL `Editor` contract over the paginated surface —
-// the document session, semantic layout and painted pages. This is the composition root
-// the framework adapters mount.
+// the document session, semantic layout and painted pages that framework adapters mount.
 //
 // - REAL: load/save, the exec subset below (marks, mark attributes via `setMarkAttr`,
 //   alignment, indent, line break, undo/redo, semantic setSelection, selection-addressed
@@ -193,6 +192,7 @@ import {
   detectFontSubstitutions,
   fontResolverFamilies,
 } from './font-availability.ts';
+import { resolverGlyphFontFamilies } from './resolver-glyph-font-families.ts';
 import { tryCreateBrowserCanvasContext } from './browser-canvas-context.ts';
 import {
   registerEmbeddedFontFaces,
@@ -770,7 +770,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
               await configured({
                 families: fontResolverFamilies(
                   mounted.session.documentFonts(),
-                  mounted.session.symbolFontFamilies(),
+                  resolverGlyphFontFamilies(mounted.session),
                   MAX_RESOLVER_FAMILIES
                 ),
                 defaultFamily: configuredDefaultFontFamily(fontConfiguration()),

--- a/packages/core/src/editor/resolver-glyph-font-families.ts
+++ b/packages/core/src/editor/resolver-glyph-font-families.ts
@@ -1,0 +1,20 @@
+import type { TreeDocxSessionView } from '../binding/tree-session-contract.ts';
+import {
+  symbolFieldFontFamilies,
+  usedNumberingFontFamilies,
+} from '../layout/synthesized-font-families.ts';
+
+/** Glyph-only faces use the resolver's reserved share, not the declaration catalog. */
+export function resolverGlyphFontFamilies(session: TreeDocxSessionView): readonly string[] {
+  const roots = session.storyParts().map((part) => part.root);
+  return [
+    ...session.symbolFontFamilies(),
+    ...symbolFieldFontFamilies(roots),
+    ...usedNumberingFontFamilies(
+      roots,
+      session.numberingRoot(),
+      session.stylesRoot(),
+      session.documentThemeFonts()
+    ),
+  ];
+}

--- a/packages/core/src/export/document-export-shaping.ts
+++ b/packages/core/src/export/document-export-shaping.ts
@@ -14,11 +14,11 @@ import {
 } from '../layout/font-resolver.ts';
 import { prepareOwnedLayoutFontConfiguration } from '../layout/layout-shaping.ts';
 import { HARD_MAX_AGGREGATE_FONT_BYTES } from '../layout/font-resource.ts';
-import { buildNumberingIndex } from '../layout/numbering-index.ts';
-import { resolveStoryListItems } from '../layout/list-resolve.ts';
-import { buildStyleCascadeTable } from '../layout/style-cascade.ts';
+import {
+  complexSymbolFieldFonts,
+  usedNumberingFontFamilies,
+} from '../layout/synthesized-font-families.ts';
 import { EQUATION_FONT_FAMILY } from '../layout/equation-layout.ts';
-import { hostedTextboxContents, textboxStoryListItems } from '../layout/textbox-story-layout.ts';
 import {
   createFieldParseState,
   effectiveFieldInstruction,
@@ -37,7 +37,6 @@ import { parseSymbolInstruction } from '../layout/field-symbol.ts';
 import { collectNoteReferences, resolveNotesPart } from '../store/package/note-references.ts';
 import { noteIdOf, noteTypeOf, type NoteKind } from '../store/package/note-nodes.ts';
 import { hasLegacyFormFieldData } from '../store/package/field-nodes.ts';
-import { collectFlowBlocks } from '../store/package/content-control-walk.ts';
 import type { OoxmlElement } from '../store/package/ooxml-tree.ts';
 import { WML_NAMESPACE_URI } from '../store/package/ooxml-shared.ts';
 import {
@@ -795,59 +794,6 @@ function layoutSynthesizedFontFamilies(roots: readonly OoxmlElement[]): readonly
   return [...byFold.values()];
 }
 
-function complexSymbolFieldFonts(paragraph: OoxmlElement): readonly string[] {
-  const families: string[] = [];
-  const state = createFieldParseState();
-  const stack: OoxmlElement[] = [];
-  for (let index = paragraph.children.length - 1; index >= 0; index -= 1) {
-    const child = paragraph.children[index]!;
-    if (child.kind !== 'textValue') stack.push(child as OoxmlElement);
-  }
-  while (stack.length > 0) {
-    const node = stack.pop()!;
-    if (node.namespaceUri === WML_NAMESPACE_URI && node.localName === 'p') continue;
-    if (node.namespaceUri === WML_NAMESPACE_URI && node.localName === 'fldChar') {
-      const kind = attributeValue(node, 'fldCharType');
-      if (kind === 'begin') onFldCharBegin(state);
-      else if (kind === 'separate') {
-        if (state.nesting === 1) noteEffectiveSymbolFont(state, families);
-        onFldCharSeparate(state);
-      } else if (kind === 'end') {
-        if (state.nesting === 1) noteEffectiveSymbolFont(state, families);
-        onFldCharEnd(state);
-      }
-      continue;
-    }
-    if (
-      node.namespaceUri === WML_NAMESPACE_URI &&
-      (node.localName === 'instrText' || node.localName === 'delInstrText')
-    ) {
-      onInstrText(state, boundedTextContent(node), node.localName === 'delInstrText');
-      continue;
-    }
-    if (node.namespaceUri === WML_NAMESPACE_URI && node.localName === 'fldSimple') {
-      const spec = parseSymbolInstruction(attributeValue(node, 'instr') ?? '');
-      if (spec?.font) families.push(spec.font);
-    }
-    for (let index = node.children.length - 1; index >= 0; index -= 1) {
-      const child = node.children[index]!;
-      if (child.kind !== 'textValue') stack.push(child as OoxmlElement);
-    }
-  }
-  resetFieldParseState(state);
-  return families;
-}
-
-function noteEffectiveSymbolFont(
-  state: ReturnType<typeof createFieldParseState>,
-  families: string[]
-): void {
-  const effective = effectiveFieldInstruction(state);
-  if (effective.overflow) return;
-  const spec = parseSymbolInstruction(effective.instruction);
-  if (spec?.font) families.push(spec.font);
-}
-
 function boundedTextContent(root: OoxmlElement): string {
   let text = '';
   const stack = [...root.children].reverse();
@@ -861,84 +807,4 @@ function boundedTextContent(root: OoxmlElement): string {
     }
   }
   return text;
-}
-
-function usedNumberingFontFamilies(
-  storyRoots: readonly OoxmlElement[],
-  numberingRoot: OoxmlElement | null,
-  stylesRoot: OoxmlElement | null,
-  theme: {
-    readonly major: string | null;
-    readonly minor: string | null;
-    readonly majorEastAsia: string | null;
-    readonly minorEastAsia: string | null;
-  }
-): readonly string[] {
-  if (!numberingRoot) return [];
-  const numbering = buildNumberingIndex(numberingRoot);
-  const styles = buildStyleCascadeTable(stylesRoot, theme);
-  const byFold = new Map<string, string>();
-  for (const root of storyRoots) {
-    for (const container of storyFlowContainers(root)) {
-      const blocks = collectFlowBlocks(container.children);
-      const noteItems = (
-        items:
-          | ReadonlyMap<
-              string,
-              {
-                readonly markerStyle: {
-                  readonly fontFamily?: string | null;
-                  readonly fontFamilyEastAsia?: string | null;
-                };
-              }
-            >
-          | undefined
-      ): void => {
-        if (!items) return;
-        for (const item of items.values()) {
-          for (const candidate of [
-            item.markerStyle.fontFamily,
-            item.markerStyle.fontFamilyEastAsia,
-          ]) {
-            const family = validFontFamily(candidate ?? undefined);
-            if (family === null) continue;
-            const fold = family.toLowerCase();
-            if (!byFold.has(fold)) byFold.set(fold, family);
-          }
-        }
-      };
-      noteItems(resolveStoryListItems(blocks, numbering, styles));
-      for (const block of blocks) {
-        const hosted = hostedTextboxContents(block);
-        for (const content of hosted.contents) {
-          noteItems(textboxStoryListItems(content, numbering, styles));
-        }
-      }
-    }
-  }
-  return [...byFold.values()].sort((left, right) => left.localeCompare(right));
-}
-
-function storyFlowContainers(root: OoxmlElement): readonly OoxmlElement[] {
-  if (root.localName === 'document') {
-    for (const candidate of root.children) {
-      if (candidate.kind !== 'textValue' && candidate.localName === 'body') {
-        return [candidate as OoxmlElement];
-      }
-    }
-    return [];
-  }
-  if (root.localName === 'footnotes' || root.localName === 'endnotes') {
-    const notes: OoxmlElement[] = [];
-    for (const candidate of root.children) {
-      if (
-        candidate.kind !== 'textValue' &&
-        (candidate.localName === 'footnote' || candidate.localName === 'endnote')
-      ) {
-        notes.push(candidate as OoxmlElement);
-      }
-    }
-    return notes;
-  }
-  return [root];
 }

--- a/packages/core/src/layout/synthesized-font-families.ts
+++ b/packages/core/src/layout/synthesized-font-families.ts
@@ -1,0 +1,197 @@
+// Font needs synthesized by layout, shared by editor and export resolution.
+import type { OoxmlElement } from '../store/package/ooxml-tree.ts';
+import { WML_NAMESPACE_URI } from '../store/package/ooxml-shared.ts';
+import { validFontFamily } from '../store/package/run-defaults.ts';
+import { collectFlowBlocks } from '../store/package/content-control-walk.ts';
+import { buildNumberingIndex } from './numbering-index.ts';
+import { buildStyleCascadeTable } from './style-cascade.ts';
+import { resolveStoryListItems } from './list-resolve.ts';
+import { hostedTextboxContents, textboxStoryListItems } from './textbox-story-layout.ts';
+import { parseSymbolInstruction } from './field-symbol.ts';
+import {
+  createFieldParseState,
+  effectiveFieldInstruction,
+  onFldCharBegin,
+  onFldCharEnd,
+  onFldCharSeparate,
+  onInstrText,
+  resetFieldParseState,
+} from './field-instruction.ts';
+
+function attributeValue(node: OoxmlElement, localName: string): string | undefined {
+  return node.attributes.find((attribute) => attribute.localName === localName)?.value;
+}
+
+/** Valid SYMBOL field faces over body, furniture, notes, tables, and text boxes. */
+export function symbolFieldFontFamilies(roots: readonly OoxmlElement[]): readonly string[] {
+  const families = new Map<string, string>();
+  const add = (candidate: string | null | undefined): void => {
+    const family = validFontFamily(candidate ?? undefined);
+    if (family !== null && !families.has(family.toLowerCase()))
+      families.set(family.toLowerCase(), family);
+  };
+  for (const root of roots) {
+    const stack: OoxmlElement[] = [root];
+    while (stack.length) {
+      const node = stack.pop()!;
+      if (node.namespaceUri === WML_NAMESPACE_URI) {
+        if (node.localName === 'fldSimple')
+          add(parseSymbolInstruction(attributeValue(node, 'instr') ?? '')?.font);
+        if (node.localName === 'p') for (const family of complexSymbolFieldFonts(node)) add(family);
+      }
+      for (let i = node.children.length - 1; i >= 0; i--) {
+        const child = node.children[i]!;
+        if (child.kind !== 'textValue') stack.push(child as OoxmlElement);
+      }
+    }
+  }
+  return [...families.values()];
+}
+
+export function complexSymbolFieldFonts(paragraph: OoxmlElement): readonly string[] {
+  const families: string[] = [];
+  const state = createFieldParseState();
+  const stack: OoxmlElement[] = [];
+  for (let index = paragraph.children.length - 1; index >= 0; index -= 1) {
+    const child = paragraph.children[index]!;
+    if (child.kind !== 'textValue') stack.push(child as OoxmlElement);
+  }
+  while (stack.length > 0) {
+    const node = stack.pop()!;
+    if (node.namespaceUri === WML_NAMESPACE_URI && node.localName === 'p') continue;
+    if (node.namespaceUri === WML_NAMESPACE_URI && node.localName === 'fldChar') {
+      const kind = attributeValue(node, 'fldCharType');
+      if (kind === 'begin') onFldCharBegin(state);
+      else if (kind === 'separate') {
+        if (state.nesting === 1) noteEffectiveSymbolFont(state, families);
+        onFldCharSeparate(state);
+      } else if (kind === 'end') {
+        if (state.nesting === 1) noteEffectiveSymbolFont(state, families);
+        onFldCharEnd(state);
+      }
+      continue;
+    }
+    if (
+      node.namespaceUri === WML_NAMESPACE_URI &&
+      (node.localName === 'instrText' || node.localName === 'delInstrText')
+    ) {
+      onInstrText(state, boundedTextContent(node), node.localName === 'delInstrText');
+      continue;
+    }
+    if (node.namespaceUri === WML_NAMESPACE_URI && node.localName === 'fldSimple') {
+      const spec = parseSymbolInstruction(attributeValue(node, 'instr') ?? '');
+      if (spec?.font) families.push(spec.font);
+    }
+    for (let index = node.children.length - 1; index >= 0; index -= 1) {
+      const child = node.children[index]!;
+      if (child.kind !== 'textValue') stack.push(child as OoxmlElement);
+    }
+  }
+  resetFieldParseState(state);
+  return families;
+}
+
+function noteEffectiveSymbolFont(
+  state: ReturnType<typeof createFieldParseState>,
+  families: string[]
+): void {
+  const effective = effectiveFieldInstruction(state);
+  if (effective.overflow) return;
+  const spec = parseSymbolInstruction(effective.instruction);
+  if (spec?.font) families.push(spec.font);
+}
+
+function boundedTextContent(root: OoxmlElement): string {
+  let text = '';
+  const stack = [...root.children].reverse();
+  while (stack.length > 0 && text.length <= 256) {
+    const node = stack.pop()!;
+    if (node.kind === 'textValue') text += node.value;
+    else {
+      for (let index = node.children.length - 1; index >= 0; index -= 1) {
+        stack.push(node.children[index]!);
+      }
+    }
+  }
+  return text;
+}
+
+export function usedNumberingFontFamilies(
+  storyRoots: readonly OoxmlElement[],
+  numberingRoot: OoxmlElement | null,
+  stylesRoot: OoxmlElement | null,
+  theme: {
+    readonly major: string | null;
+    readonly minor: string | null;
+    readonly majorEastAsia: string | null;
+    readonly minorEastAsia: string | null;
+  }
+): readonly string[] {
+  if (!numberingRoot) return [];
+  const numbering = buildNumberingIndex(numberingRoot);
+  const styles = buildStyleCascadeTable(stylesRoot, theme);
+  const byFold = new Map<string, string>();
+  for (const root of storyRoots) {
+    for (const container of storyFlowContainers(root)) {
+      const blocks = collectFlowBlocks(container.children);
+      const noteItems = (
+        items:
+          | ReadonlyMap<
+              string,
+              {
+                readonly markerStyle: {
+                  readonly fontFamily?: string | null;
+                  readonly fontFamilyEastAsia?: string | null;
+                };
+              }
+            >
+          | undefined
+      ): void => {
+        if (!items) return;
+        for (const item of items.values()) {
+          for (const candidate of [
+            item.markerStyle.fontFamily,
+            item.markerStyle.fontFamilyEastAsia,
+          ]) {
+            const family = validFontFamily(candidate ?? undefined);
+            if (family === null) continue;
+            const fold = family.toLowerCase();
+            if (!byFold.has(fold)) byFold.set(fold, family);
+          }
+        }
+      };
+      noteItems(resolveStoryListItems(blocks, numbering, styles));
+      for (const block of blocks) {
+        const hosted = hostedTextboxContents(block);
+        for (const content of hosted.contents) {
+          noteItems(textboxStoryListItems(content, numbering, styles));
+        }
+      }
+    }
+  }
+  return [...byFold.values()].sort((left, right) => left.localeCompare(right));
+}
+
+function storyFlowContainers(root: OoxmlElement): readonly OoxmlElement[] {
+  if (root.localName === 'document') {
+    for (const candidate of root.children) {
+      if (candidate.kind !== 'textValue' && candidate.localName === 'body') {
+        return [candidate as OoxmlElement];
+      }
+    }
+    return [];
+  }
+  if (root.localName === 'footnotes' || root.localName === 'endnotes') {
+    const notes: OoxmlElement[] = [];
+    for (const candidate of root.children) {
+      if (
+        candidate.kind !== 'textValue' &&
+        (candidate.localName === 'footnote' || candidate.localName === 'endnote')
+      ) {
+        notes.push(candidate as OoxmlElement);
+      }
+    }
+    return notes;
+  }
+  return [root];
+}

--- a/packages/docx-to-markdown/test/package-dependencies.test.ts
+++ b/packages/docx-to-markdown/test/package-dependencies.test.ts
@@ -42,12 +42,12 @@ describe('engine dependency integrity', () => {
     expect(manifest.devDependencies?.['@docx-editor.dev/core']).toBe('workspace:*');
   });
 
-  test('participates in public releases with compatible engine dependencies', () => {
+  test('stays private and outside release automation with compatible engine dependencies', () => {
     const packageName = '@docx-editor.dev/docx-to-markdown';
-    expect(manifest.private).not.toBe(true);
-    expect(manifest.publishConfig).toEqual({ access: 'public' });
-    expect(changesetConfig.fixed?.flat()).toContain(packageName);
-    expect(changesetConfig.ignore).not.toContain(packageName);
+    expect(manifest.private).toBe(true);
+    expect(manifest.publishConfig).toBeUndefined();
+    expect(changesetConfig.fixed?.flat()).not.toContain(packageName);
+    expect(changesetConfig.ignore).toContain(packageName);
     expect(changesetConfig.updateInternalDependencies).toBe('patch');
     expect(
       requiresSameMinor(manifest.peerDependencies?.['@docx-editor.dev/core'], coreManifest.version)
@@ -75,12 +75,10 @@ describe('engine dependency integrity', () => {
     );
     expect(coreExportSource).not.toMatch(/Markdown|\.\/markdown/);
     expect(existsSync(join(repositoryRoot, 'packages/core/src/export/markdown.ts'))).toBe(false);
-    expect(existsSync(join(repositoryRoot, 'docs/site/content/docx-to-markdown/index.mdx'))).toBe(
-      true
-    );
+    expect(existsSync(join(repositoryRoot, 'docs/site/content/export/markdown.mdx'))).toBe(true);
     expect(
       readFileSync(join(repositoryRoot, 'docs', 'site', 'content', 'meta.json'), 'utf8')
-    ).toContain('docx-to-markdown');
+    ).toContain('export/markdown');
   });
 
   test('confines packaged fonts through the fonts package asset-root contract', () => {


### PR DESCRIPTION
## Summary

- include fonts referenced by simple and complex `SYMBOL` fields in editor resolver requests
- include the resolved fonts of numbering markers that are actually used by document stories and text boxes
- share the existing export-side collectors with the editor while preserving the resolver cap, reserved glyph-font share, and declared-font catalog
- reject unsafe font names and ignore unused numbering definitions

## Tests

- 146 focused editor, font, field, numbering, layout, and export tests passed
- package builds, type checks, ESLint, Prettier, API Extractor, i18n validation, lane-boundary compiles, and import-DAG checks passed
- full Windows suite: 11,984 passed; the existing 69 Windows-specific failures are the same count and failing-file set as the earlier validation checkout on the same `main` SHA

Fixes #749

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/776"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791379253&installation_model_id=422592&pr_number=776&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F776&signature=01e1095259114267d85ee5774b66f731e851491cff176180a3aeda5f66b7e95c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->