### PR TITLE
test(markdown): fix stale release and documentation assertions

### DIFF
--- a/packages/docx-to-markdown/test/package-dependencies.test.ts
+++ b/packages/docx-to-markdown/test/package-dependencies.test.ts
@@ -42,12 +42,12 @@ describe('engine dependency integrity', () => {
     expect(manifest.devDependencies?.['@docx-editor.dev/core']).toBe('workspace:*');
   });
 
-  test('participates in public releases with compatible engine dependencies', () => {
+  test('stays private and outside release automation with compatible engine dependencies', () => {
     const packageName = '@docx-editor.dev/docx-to-markdown';
-    expect(manifest.private).not.toBe(true);
-    expect(manifest.publishConfig).toEqual({ access: 'public' });
-    expect(changesetConfig.fixed?.flat()).toContain(packageName);
-    expect(changesetConfig.ignore).not.toContain(packageName);
+    expect(manifest.private).toBe(true);
+    expect(manifest.publishConfig).toBeUndefined();
+    expect(changesetConfig.fixed?.flat()).not.toContain(packageName);
+    expect(changesetConfig.ignore).toContain(packageName);
     expect(changesetConfig.updateInternalDependencies).toBe('patch');
     expect(
       requiresSameMinor(manifest.peerDependencies?.['@docx-editor.dev/core'], coreManifest.version)
@@ -75,12 +75,10 @@ describe('engine dependency integrity', () => {
     );
     expect(coreExportSource).not.toMatch(/Markdown|\.\/markdown/);
     expect(existsSync(join(repositoryRoot, 'packages/core/src/export/markdown.ts'))).toBe(false);
-    expect(existsSync(join(repositoryRoot, 'docs/site/content/docx-to-markdown/index.mdx'))).toBe(
-      true
-    );
+    expect(existsSync(join(repositoryRoot, 'docs/site/content/export/markdown.mdx'))).toBe(true);
     expect(
       readFileSync(join(repositoryRoot, 'docs', 'site', 'content', 'meta.json'), 'utf8')
-    ).toContain('docx-to-markdown');
+    ).toContain('export/markdown');
   });
 
   test('confines packaged fonts through the fonts package asset-root contract', () => {


### PR DESCRIPTION
The CI test job failed after #769 kept `@docx-editor.dev/docx-to-markdown` private and moved its guide. Two package-integrity tests still expected public release participation and the previous documentation path.

Update the assertions to require a private package excluded from Changesets releases, and check the guide and navigation at `export/markdown`. Existing engine compatibility and API ownership checks remain in place.

Validation: reproduced both original failures; all 12,044 tests across 962 files pass. Package builds, workspace type checks, API snapshot checks, parity checks, and license checks pass.

Failing job: https://github.com/eigenpal/docx-editor/actions/runs/34084482070/job/101625788820

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791387383&installation_model_id=422592&pr_number=777&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F777&signature=50bf934bce7eecf01611e79b59fd2680fff24ae79df619d87cc55e5dc2bef2c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->