### PR TITLE
fix(core): preserve outside focus during font remounts

### DIFF
--- a/.changeset/quiet-font-remount-focus.md
+++ b/.changeset/quiet-font-remount-focus.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Keep focus in outside controls when fonts finish loading, while preserving the editor's saved selection across the font remount.

--- a/e2e/font-remount-focus.interaction.spec.ts
+++ b/e2e/font-remount-focus.interaction.spec.ts
@@ -1,0 +1,114 @@
+import { expect, test } from '@playwright/test';
+import { resolve } from 'node:path';
+import type { DocxEditorInstance } from '../packages/core/src/editor/docx-editor.ts';
+
+// Real Chromium is required: happy-dom does not move focus when setBaseAndExtent
+// writes a selection into a contenteditable. Gate the resolver so the remount
+// happens after the focus transfer, independently of network/CI timing.
+declare global {
+  interface Window {
+    __fontFocus: {
+      editor: DocxEditorInstance;
+      releaseFonts(): void;
+      oldPages: Element;
+    };
+  }
+}
+
+for (const target of ['textarea', 'input', 'button', 'button-empty-selection', 'editor'] as const) {
+  test(`font remount preserves ${target} focus and the saved editor range`, async ({ page }) => {
+    await page.goto('http://localhost:5273/@vite/client');
+    await page.evaluate(
+      async (root) => {
+        const { createDocxEditor } = await import(
+          `${root}/packages/core/src/editor/docx-editor.ts`
+        );
+        const { blankDocumentBytes } = await import(
+          `${root}/packages/core/src/editor/blank-document.ts`
+        );
+        const { sha256FontBytes } = await import(`${root}/packages/core/src/layout/index.ts`);
+        const bytes = new Uint8Array(
+          await (
+            await fetch(`${root}/packages/core/src/layout/__tests__/fixtures/fonts/DejaVuSans.ttf`)
+          ).arrayBuffer()
+        );
+        document.body.innerHTML =
+          '<div id="editor"></div><textarea id="box"></textarea><input id="input"><button id="button">Outside</button>';
+        const container = document.getElementById('editor')!;
+        container.style.height = '400px';
+        container.style.overflow = 'auto';
+        let releaseFonts!: () => void;
+        const ready = new Promise<void>((resolve) => {
+          releaseFonts = resolve;
+        });
+        const editor = createDocxEditor({
+          container,
+          document: blankDocumentBytes(),
+          fonts: async () => {
+            await ready;
+            return {
+              sources: [
+                {
+                  request: { family: 'DejaVu Sans', weight: 400, style: 'normal' },
+                  id: 'focus-test',
+                  bytes,
+                  hash: sha256FontBytes(bytes),
+                  faceIndex: 0,
+                },
+              ],
+            };
+          },
+        });
+        const surface = editor.surface!;
+        surface.type('Contratto di locazione');
+        const paragraphId = surface.session.paragraphIds()[0]!;
+        surface.setSelection({
+          anchor: { paragraphId, offset: 3 },
+          head: { paragraphId, offset: 8 },
+        });
+        window.__fontFocus = {
+          editor,
+          releaseFonts,
+          oldPages: container.querySelector('.docx-pages')!,
+        };
+      },
+      `/@fs/${resolve(import.meta.dirname, '..')}`
+    );
+
+    const selector =
+      target === 'editor'
+        ? '.docx-pages'
+        : target === 'textarea'
+          ? '#box'
+          : target === 'input'
+            ? '#input'
+            : '#button';
+    await page.locator(selector).focus();
+    if (target === 'button-empty-selection') {
+      await page.evaluate(() => document.getSelection()?.removeAllRanges());
+    }
+    const before = await page.evaluate(() => window.__fontFocus.editor.surface!.state().selection);
+    await page.evaluate(() => window.__fontFocus.releaseFonts());
+    await page.waitForFunction(
+      () =>
+        !window.__fontFocus.oldPages.isConnected &&
+        window.__fontFocus.editor.fontMeasurement().measurer === 'shaped' &&
+        !window.__fontFocus.editor.fontMeasurement().resolving
+    );
+    await expect(page.locator(selector)).toBeFocused();
+    expect(await page.evaluate(() => window.__fontFocus.editor.surface!.state().selection)).toEqual(
+      before
+    );
+    if (target === 'editor') {
+      expect(await page.evaluate(() => document.getSelection()?.toString())).toBe('tratt');
+    } else if (target === 'textarea' || target === 'input') {
+      await page.keyboard.press('Delete');
+      await page.keyboard.type('hello');
+      await expect(page.locator(selector)).toHaveValue('hello');
+      expect(await page.evaluate(() => window.__fontFocus.editor.surface!.session.bodyText())).toBe(
+        'Contratto di locazione'
+      );
+    }
+    await page.evaluate(() => window.__fontFocus.editor.destroy());
+  });
+}

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -46,6 +46,7 @@ import {
   type ReviewRange,
   type SemanticLayout,
   type SemanticPosition,
+  type SemanticSelection,
 } from '../layout/index.ts';
 import {
   createStableReviewAuthorSlots,
@@ -490,7 +491,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
   });
   const scaleOf = (): number => zoomLane.scale();
 
-  function mountBytes(bytes: Uint8Array): void {
+  function mountBytes(bytes: Uint8Array, initialSelection?: SemanticSelection): void {
     if (!container) {
       // Detached: no DOM work. The bytes wait for `attach`, which mounts them under
       // whatever measurer has resolved by then. A previous document's parse failure is
@@ -520,6 +521,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
       reviewAuthorSlots,
       revisionAuthorVisibility: reviewAuthorVisibility,
       initialDrawingSelectionIntent: remountDrawingIntent,
+      initialSelection,
       editingMode:
         editingMode === 'suggesting' ? 'suggest' : editingMode === 'viewing' ? 'view' : 'edit',
       // The free engine renders the FINAL-STATE projection (Word's "No Markup"):
@@ -1025,27 +1027,25 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
         // highlight when this remount replaced the surface.
         const savedSelection = surface.state().selection;
         remountDrawingIntent = surface.drawingSelectionIntent();
-        // A remount replaces the whole subtree, so focus lands on `document.body` — the
-        // user typing while fonts resolved would silently stop being able to type.
-        // Restore it when the OLD surface had it; never steal it otherwise.
-        const hadFocus =
-          typeof document !== 'undefined' &&
-          document.activeElement !== null &&
-          container !== null &&
-          container.contains(document.activeElement);
+        const activeElement = container?.ownerDocument.activeElement;
+        const hadFocus = !!activeElement && !!container?.contains(activeElement);
         try {
-          mountBytes(saved);
+          mountBytes(saved, savedSelection);
         } catch (remountError) {
           shapedMeasurer = undefined;
           shapedProducer = undefined;
           if (!surface) {
             pendingBytes = saved;
-            mountBytes(saved);
+            mountBytes(saved, savedSelection);
           }
           reportFontError(toEditorFontError(remountError));
         }
-        if (hadFocus) surface?.focus();
-        surface?.setSelection(savedSelection);
+        // Mount seeds the saved range without claiming focus. Chromium focuses editable
+        // DOM selections, so only explicitly restore one when the old surface had focus.
+        if (hadFocus) {
+          surface?.focus();
+          surface?.setSelection(savedSelection);
+        }
         remountDrawingIntent = { kind: 'none' }; // consumed; a plain open starts deselected
       } else bump();
     } catch (error) {

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -298,12 +298,12 @@ export function mountPaginatedSurface(
     readonly reviewAuthorSlots?: StableReviewAuthorSlots;
     readonly revisionAuthorVisibility?: RevisionAuthorVisibility;
     /**
-     * Start with this drawing-selection intent. The facade's font-load remount carries the
-     * old surface's intent through here, because its caret restore is a same-position
-     * `setSelection` whenever the saved caret sits at the mount default — which must stay
-     * `none` for a plain open, and so cannot restore a genuinely selected drawing.
+     * Carry drawing intent alongside the range on a font remount. A plain open starts
+     * with no drawing selected, even when the default caret sits at its anchor.
      */
     readonly initialDrawingSelectionIntent?: DrawingSelectionIntent;
+    /** Restore the model range on a font remount without claiming DOM selection/focus. */
+    readonly initialSelection?: SemanticSelection;
   };
   const opened = openTreeSession(
     bytes,
@@ -481,7 +481,7 @@ export function mountPaginatedSurface(
     paragraphIds.find((paragraphId) => !initialTocParagraphs.has(paragraphId)) ??
     paragraphIds[0] ??
     '';
-  let selection: SemanticSelection = {
+  let selection: SemanticSelection = runtimeOptions.initialSelection ?? {
     anchor: { paragraphId: firstParagraph, offset: 0 },
     head: { paragraphId: firstParagraph, offset: 0 },
   };
@@ -3491,7 +3491,8 @@ export function mountPaginatedSurface(
     // sits outside these pages, which is exactly the case when the request came from the
     // host's own chrome (a rail card takes focus on mousedown), and the range the caller
     // asked to SHOW then highlighted nothing at all. A pointer or keyboard move already owns
-    // the selection, so claiming changes nothing for them. Focus is never moved.
+    // the selection, so claiming changes nothing for them. In Chromium this write can
+    // also focus the contenteditable; passive remounts must not claim the selection.
     selectionSync.mirrorToDom(true);
     followCaretIntoView(true);
     renderOverlay();

--- a/packages/core/src/editor/surface-selection-sync.ts
+++ b/packages/core/src/editor/surface-selection-sync.ts
@@ -170,7 +170,8 @@ export interface SurfaceSelectionSync {
    * ordinary write refuses whenever the DOM selection lives outside these pages, which is
    * the normal state when the request came from the host's own chrome: the caret moved and
    * the model held a range that nothing on screen highlighted. Claiming writes the range
-   * anyway; it never moves FOCUS, so the host's own control keeps it.
+   * anyway; in Chromium this can also focus the contenteditable. Passive restoration
+   * must use an unclaimed write.
    */
   mirrorToDom(claim?: boolean): void;
   /**
@@ -300,11 +301,14 @@ export function createSurfaceSelectionSync(deps: SurfaceSelectionSyncDeps): Surf
    * True when focus or the selection is already inside these pages, and also when NOTHING
    * holds a selection — writing one then takes it from nobody. What this refuses is the case
    * that matters: a caret living in another element, which a repaint here would otherwise
-   * yank away with no focus change and no interaction.
+   * yank away without an interaction.
    */
   function ownsSelection(): boolean {
     const active = document.activeElement;
     if (active && pagesLayer.contains(active)) return true;
+    // Text inputs can own focus while the document Selection is empty or still
+    // points into our pages. Their native caret is not represented by that Selection.
+    if (active && active !== document.body && active !== document.documentElement) return false;
     const domSelection = document.getSelection();
     if (!domSelection || domSelection.rangeCount === 0) return true;
     const anchor = domSelection.anchorNode;


### PR DESCRIPTION
Closes #779.

When fonts finish loading, restoring the DOM selection can focus the editor in Chromium even if the user has moved to an outside field. Seed the saved semantic range during remount and explicitly restore focus/DOM selection only when the editor previously held focus. Unclaimed selection writes also respect an outside focused control when the native selection is empty or stale.

Adds deterministic Chromium regressions for textareas, text inputs, buttons, empty native selection, and an editor that remains focused. The textarea and button cases fail on the original code and pass with this fix; outside typing leaves the document unchanged, and the saved editor range survives.

Validation:
- Five Chromium regression cases and 74 focused unit tests pass.
- Full suite: 12,063 tests across 964 files, zero failures.
- Typecheck, lint (zero errors; existing warnings), formatting, parity, i18n validation, package builds, and API compatibility checks pass.
- Two reviewer passes completed with no remaining medium-or-higher findings.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/782"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791408800&installation_model_id=422592&pr_number=782&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F782&signature=d1d65d65169f5491cb016207ff5fefe276abc18c04693947119ac2535a1640ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->