### PR TITLE
fix: use Word defaults for checkbox symbols

### DIFF
--- a/.changeset/fontless-checkbox-glyphs.md
+++ b/.changeset/fontless-checkbox-glyphs.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Render a checkbox state that omits its optional font as the Unicode character named by its hexadecimal value. Fixes #752.

--- a/.changeset/fontless-checkbox-glyphs.md
+++ b/.changeset/fontless-checkbox-glyphs.md
@@ -2,4 +2,4 @@
 '@docx-editor.dev/core': patch
 ---
 
-Render a checkbox state that omits its optional font as the Unicode character named by its hexadecimal value. Fixes #752.
+Render checkbox states that omit their font with Word's default MS Gothic font instead of literal hexadecimal text. Fixes #752.

--- a/docs/site/content/guides/content-controls.mdx
+++ b/docs/site/content/guides/content-controls.mdx
@@ -243,7 +243,7 @@ the reason.
 
 ## Typed control chrome
 
-In the editor, typed controls get an interactive trigger at the top-right of their box: it toggles the checkbox, opens the dropdown's item menu, or opens a date picker, each as a normal undoable edit. These controls work without host event handlers.
+In the editor, typed controls get an interactive trigger at the top-right of their box: it toggles the checkbox, opens the dropdown's item menu, or opens a date picker, each as a normal undoable edit. These controls work without host event handlers. When you toggle a checkbox, an omitted state font defaults to MS Gothic.
 
 ## Operational limits
 

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -993,7 +993,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'Each control accepts only the value its own type allows. A dropdown must name an item it declares, and a combo box also takes free text. A date validates an ISO instant and writes both `w:fullDate` and the formatted text. A checkbox writes its declared glyph and its state together. The first write replaces a literal prompt whole, so clearing the value later leaves the control empty. A `w:temporary` control removes its own wrapper on the first edit and keeps the content.',
+      'Each control accepts only the value its own type allows. A dropdown must name an item it declares, and a combo box also takes free text. A date validates an ISO instant and writes both `w:fullDate` and the formatted text. A checkbox writes its declared glyph and its state together. Editor checkbox toggles use MS Gothic when the state omits its font. The first write replaces a literal prompt whole, so clearing the value later leaves the control empty. A `w:temporary` control removes its own wrapper on the first edit and keeps the content.',
     docsLink: '/docs/2.x/guides/content-controls',
   },
   {

--- a/packages/core/src/store/__tests__/content-control-checkbox-defaults.test.ts
+++ b/packages/core/src/store/__tests__/content-control-checkbox-defaults.test.ts
@@ -1,0 +1,124 @@
+import { expect, test } from 'bun:test';
+import { readOoxmlPart, serializeOoxmlPart, type OoxmlNode, type OoxmlPart } from '../index.ts';
+import { applyTreeOp } from '../store/tree-op-apply.ts';
+import type { TreeDocOp } from '../store/tree-op-types.ts';
+
+const V2_W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const V2_W14 = 'http://schemas.microsoft.com/office/word/2010/wordml';
+const V2_W15 = 'http://schemas.microsoft.com/office/word/2012/wordml';
+
+function loadV2(body: string, extra = ''): OoxmlPart {
+  const result = readOoxmlPart(
+    `<w:document xmlns:w="${V2_W}" xmlns:w14="${V2_W14}" xmlns:w15="${V2_W15}"${extra}><w:body>${body}</w:body></w:document>`,
+    { name: '/word/document.xml', contentType: 'app/xml' }
+  );
+  if (!result.ok) throw new Error(result.reason);
+  return result.part;
+}
+
+function applyV2(part: OoxmlPart, op: TreeDocOp): OoxmlPart {
+  const result = applyTreeOp(part, op);
+  if (!result.ok) throw new Error(`${result.reason}: ${result.detail ?? ''}`);
+  return result.part;
+}
+
+function firstSdtV2(part: OoxmlPart): OoxmlNode {
+  const walk = (node: OoxmlNode): OoxmlNode | null => {
+    if (node.kind === 'textValue') return null;
+    if (node.localName === 'sdt') return node;
+    for (const child of node.children) {
+      const found = walk(child);
+      if (found) return found;
+    }
+    return null;
+  };
+  const found = walk(part.root);
+  if (!found) throw new Error('no sdt');
+  return found;
+}
+
+function attributeOfV2(node: OoxmlNode, localName: string): string | undefined {
+  if (node.kind === 'textValue') return undefined;
+  return node.attributes.find((attribute) => attribute.localName === localName)?.value;
+}
+
+function childNamedV2(parent: OoxmlNode, localName: string): OoxmlNode | undefined {
+  if (parent.kind === 'textValue') return undefined;
+  return parent.children.find(
+    (child) => child.kind !== 'textValue' && child.localName === localName
+  );
+}
+
+test.each([
+  [
+    'font omitted',
+    '<w14:checkedState w14:val="2612"/><w14:uncheckedState w14:val="2610"/>',
+    '2612',
+    '2610',
+    'MS Gothic',
+    'MS Gothic',
+  ],
+  [
+    'custom glyphs',
+    '<w14:checkedState w14:val="2714"/><w14:uncheckedState w14:val="2718"/>',
+    '2714',
+    '2718',
+    'MS Gothic',
+    'MS Gothic',
+  ],
+  ['states omitted', '', '2612', '2610', 'MS Gothic', 'MS Gothic'],
+  [
+    'values omitted',
+    '<w14:checkedState/><w14:uncheckedState/>',
+    '2612',
+    '2610',
+    'MS Gothic',
+    'MS Gothic',
+  ],
+  [
+    'mixed fonts',
+    '<w14:checkedState w14:val="F0FE" w14:font="Wingdings"/><w14:uncheckedState w14:val="2610"/>',
+    'F0FE',
+    '2610',
+    'Wingdings',
+    'MS Gothic',
+  ],
+])(
+  'checkbox applies symbol defaults: %s',
+  (_label, states, checkedGlyph, uncheckedGlyph, checkedFont, uncheckedFont) => {
+    let part = loadV2(
+      '<w:p><w:sdt><w:sdtPr><w14:checkbox>' +
+        '<w14:checked w14:val="0"/>' +
+        states +
+        '</w14:checkbox></w:sdtPr>' +
+        '<w:sdtContent><w:r><w:rPr><w:rFonts w:ascii="Arial" w:hAnsi="Arial"/></w:rPr><w:t>☐</w:t></w:r></w:sdtContent>' +
+        '</w:sdt></w:p>'
+    );
+    for (const checked of [true, false]) {
+      const control = firstSdtV2(part);
+      const next = applyV2(part, {
+        op: 'setContentControlValue',
+        controlId: control.id,
+        value: String(checked),
+      });
+      const xml = serializeOoxmlPart(next);
+      const reopened = readOoxmlPart(xml, { name: '/word/document.xml', contentType: 'app/xml' });
+      if (!reopened.ok) throw new Error(reopened.reason);
+      part = reopened.part;
+      const updated = firstSdtV2(part);
+      const properties = childNamedV2(updated, 'sdtPr')!;
+      const checkbox = childNamedV2(properties, 'checkbox')!;
+      expect(attributeOfV2(childNamedV2(checkbox, 'checked')!, 'val')).toBe(checked ? '1' : '0');
+      const run = childNamedV2(childNamedV2(updated, 'sdtContent')!, 'r')!;
+      const symbol = childNamedV2(run, 'sym')!;
+      const font = checked ? checkedFont : uncheckedFont;
+      expect(attributeOfV2(symbol, 'char')).toBe(checked ? checkedGlyph : uncheckedGlyph);
+      expect(attributeOfV2(symbol, 'font')).toBe(font);
+      const fonts = childNamedV2(childNamedV2(run, 'rPr')!, 'rFonts')!;
+      for (const slot of ['ascii', 'hAnsi', 'eastAsia']) {
+        expect(attributeOfV2(fonts, slot)).toBe(font);
+      }
+      expect(childNamedV2(run, 't')).toBeUndefined();
+    }
+  }
+);

--- a/packages/core/src/store/__tests__/content-control-ops.test.ts
+++ b/packages/core/src/store/__tests__/content-control-ops.test.ts
@@ -991,6 +991,22 @@ describe('setContentControlValue', () => {
     expect(attributeOfV2(list, 'lastValue')).toBe('custom');
   });
 
+  test('combo keeps four-digit hexadecimal text unchanged', () => {
+    const part = loadV2(
+      '<w:sdt><w:sdtPr><w:comboBox/></w:sdtPr>' +
+        '<w:sdtContent><w:p><w:r><w:t>old</w:t></w:r></w:p></w:sdtContent></w:sdt>'
+    );
+    const control = firstSdtV2(part);
+    const next = applyV2(part, {
+      op: 'setContentControlValue',
+      controlId: control.id,
+      value: '2612',
+    });
+    expect(collectTextV2(childNamedV2(findContentControl(next, control.id)!, 'sdtContent')!)).toBe(
+      '2612'
+    );
+  });
+
   test('checkbox toggles w14:checked and rewrites the glyph', () => {
     const part = loadV2(
       '<w:p><w:sdt><w:sdtPr><w14:checkbox>' +
@@ -1023,6 +1039,31 @@ describe('setContentControlValue', () => {
       return null;
     };
     expect(attributeOfV2(walk(findContentControl(next, control.id)!)!, 'char')).toBe('2612');
+  });
+
+  test('checkbox writes a fontless state code point as Unicode text', () => {
+    const part = loadV2(
+      '<w:p><w:sdt><w:sdtPr><w14:checkbox>' +
+        '<w14:checked w14:val="0"/>' +
+        '<w14:checkedState w14:val="2612"/>' +
+        '<w14:uncheckedState w14:val="2610"/>' +
+        '</w14:checkbox></w:sdtPr>' +
+        '<w:sdtContent><w:r><w:t>☐</w:t></w:r></w:sdtContent>' +
+        '</w:sdt></w:p>'
+    );
+    const control = firstSdtV2(part);
+    const next = applyV2(part, {
+      op: 'setContentControlValue',
+      controlId: control.id,
+      value: 'true',
+    });
+    const updated = findContentControl(next, control.id)!;
+    const content = childNamedV2(updated, 'sdtContent')!;
+    const xml = serializeOoxmlPart(next);
+    expect(collectTextV2(content)).toBe('☒');
+    expect(xml).toContain('<w:t>☒</w:t>');
+    expect(xml).not.toContain('<w:t>2612</w:t>');
+    expect(xml).not.toContain('<w:sym');
   });
 
   test('date writes fullDate and formatted display text', () => {

--- a/packages/core/src/store/__tests__/content-control-ops.test.ts
+++ b/packages/core/src/store/__tests__/content-control-ops.test.ts
@@ -1041,31 +1041,6 @@ describe('setContentControlValue', () => {
     expect(attributeOfV2(walk(findContentControl(next, control.id)!)!, 'char')).toBe('2612');
   });
 
-  test('checkbox writes a fontless state code point as Unicode text', () => {
-    const part = loadV2(
-      '<w:p><w:sdt><w:sdtPr><w14:checkbox>' +
-        '<w14:checked w14:val="0"/>' +
-        '<w14:checkedState w14:val="2612"/>' +
-        '<w14:uncheckedState w14:val="2610"/>' +
-        '</w14:checkbox></w:sdtPr>' +
-        '<w:sdtContent><w:r><w:t>☐</w:t></w:r></w:sdtContent>' +
-        '</w:sdt></w:p>'
-    );
-    const control = firstSdtV2(part);
-    const next = applyV2(part, {
-      op: 'setContentControlValue',
-      controlId: control.id,
-      value: 'true',
-    });
-    const updated = findContentControl(next, control.id)!;
-    const content = childNamedV2(updated, 'sdtContent')!;
-    const xml = serializeOoxmlPart(next);
-    expect(collectTextV2(content)).toBe('☒');
-    expect(xml).toContain('<w:t>☒</w:t>');
-    expect(xml).not.toContain('<w:t>2612</w:t>');
-    expect(xml).not.toContain('<w:sym');
-  });
-
   test('date writes fullDate and formatted display text', () => {
     const part = loadV2(
       '<w:sdt><w:sdtPr><w:date w:fullDate="2020-01-01T00:00:00Z">' +

--- a/packages/core/src/store/store/tree-op-apply.ts
+++ b/packages/core/src/store/store/tree-op-apply.ts
@@ -2211,7 +2211,13 @@ function applySetContentControlValue(
       });
       const glyph = checked ? payload.checkedGlyph : payload.uncheckedGlyph;
       const font = checked ? payload.checkedFont : payload.uncheckedFont;
-      setTextContent(glyph, font);
+      // A fontless checkbox state still stores a hexadecimal Unicode code point. Decode it
+      // here, so four-digit text in another content-control type stays unchanged.
+      const display =
+        !font && /^[0-9A-Fa-f]{4}$/.test(glyph)
+          ? String.fromCodePoint(Number.parseInt(glyph, 16))
+          : glyph;
+      setTextContent(display, font);
       break;
     }
     case 'date': {

--- a/packages/core/src/store/store/tree-op-apply.ts
+++ b/packages/core/src/store/store/tree-op-apply.ts
@@ -2211,13 +2211,7 @@ function applySetContentControlValue(
       });
       const glyph = checked ? payload.checkedGlyph : payload.uncheckedGlyph;
       const font = checked ? payload.checkedFont : payload.uncheckedFont;
-      // A fontless checkbox state still stores a hexadecimal Unicode code point. Decode it
-      // here, so four-digit text in another content-control type stays unchanged.
-      const display =
-        !font && /^[0-9A-Fa-f]{4}$/.test(glyph)
-          ? String.fromCodePoint(Number.parseInt(glyph, 16))
-          : glyph;
-      setTextContent(display, font);
+      setTextContent(glyph, font);
       break;
     }
     case 'date': {

--- a/packages/core/src/store/store/tree-op-nodes.ts
+++ b/packages/core/src/store/store/tree-op-nodes.ts
@@ -408,14 +408,14 @@ export function listItemsOf(control: OoxmlNode): readonly { displayText: string;
   return items;
 }
 
-/** `w14:checkbox` payload pieces. */
+/** `w14:checkbox` payload with the MS-DOCX §2.6.3.29 symbol defaults. */
 export function checkboxPayloadOf(control: OoxmlNode): {
   readonly checkbox: OoxmlElement;
   readonly checked: boolean;
   readonly checkedGlyph: string;
   readonly uncheckedGlyph: string;
-  readonly checkedFont: string | undefined;
-  readonly uncheckedFont: string | undefined;
+  readonly checkedFont: string;
+  readonly uncheckedFont: string;
 } | null {
   const checkbox = sdtPrChild(contentControlPropertiesOf(control), 'checkbox');
   if (!checkbox) return null;
@@ -446,8 +446,8 @@ export function checkboxPayloadOf(control: OoxmlNode): {
     checked,
     checkedGlyph: attributeValueOf(checkedState, 'val') ?? '2612',
     uncheckedGlyph: attributeValueOf(uncheckedState, 'val') ?? '2610',
-    checkedFont: attributeValueOf(checkedState, 'font'),
-    uncheckedFont: attributeValueOf(uncheckedState, 'font'),
+    checkedFont: attributeValueOf(checkedState, 'font') ?? 'MS Gothic',
+    uncheckedFont: attributeValueOf(uncheckedState, 'font') ?? 'MS Gothic',
   };
 }
 


### PR DESCRIPTION
When you toggle a checkbox whose state omits `w14:font`, the editor now uses Word's default MS Gothic font. This renders the hexadecimal glyph as a symbol instead of literal text. Explicit state fonts remain unchanged.

Regression tests cover both states, omitted fonts and values, custom glyphs, mixed fonts, and save/reopen. All 133 focused tests and full lint pass.

Fixes #752
