### PR TITLE
docs: clarify feature support and developer guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ bun run typecheck
 
 Try unreleased changes in the [preview of `main`](https://latest.docx-editor.dev/).
 
-Examples: [Vite](examples/vite) | [DOCX to Markdown](examples/docx-to-markdown) | [Next.js](examples/nextjs) | [Remix](examples/remix) | [Astro](examples/astro) | [Vue](examples/vue) | [Collaboration](examples/collaboration)
+Examples: [Vite](examples/vite) | [DOCX to Markdown](examples/docx-to-markdown) | [Next.js](examples/nextjs) | [Remix](examples/remix) | [Astro](examples/astro) | [Vue](examples/vue) | [Collaboration](examples/collaboration) | [Server agent review](examples/server-agent-review)
 
 **[Documentation](https://www.docx-editor.dev/docs)** | **[React props and ref methods](https://www.docx-editor.dev/docs/2.x/react/props)** | **[Vue props and ref methods](https://www.docx-editor.dev/docs/2.x/vue/props)**
 

--- a/docs/PROPS.md
+++ b/docs/PROPS.md
@@ -23,21 +23,21 @@ so they stay explicit instead of accidental.
 
 ### Shared root props
 
-| Prop          | Type                                             | Package(s) | Description                                      |
-| ------------- | ------------------------------------------------ | ---------- | ------------------------------------------------ |
-| `document`    | `DocumentSource`                                 | React, Vue | DOCX bytes or an existing `DocumentHandle`.      |
-| `fonts`       | `FontConfiguration \| FontConfigurationFragment` | React, Vue | Font bytes used for shaping and pagination.      |
-| `author`      | `string`                                         | React, Vue | Ambient author for authored commands.            |
-| `mode`        | `'edit' \| 'view' \| 'suggesting'`               | React, Vue | Mount-time editing mode.                         |
-| `zoom`        | `number`                                         | React, Vue | Mount-time zoom value.                           |
-| `zoomMode`    | `ZoomMode \| 'auto'`                             | React, Vue | Automatic or fixed zoom behavior.                |
-| `locale`      | `string`                                         | React, Vue | Locale passed to the underlying editor instance. |
-| `i18n`        | `Translations`                                   | React, Vue | Translation overrides for editor chrome.         |
-| `t`           | `(key, params?) => string`                       | React, Vue | Host translation function for editor chrome.     |
-| `colorMode`   | `'light' \| 'dark' \| 'system'`                  | React, Vue | Color mode for editor chrome.                    |
-| `rulers`      | `boolean`                                        | React, Vue | Toggles the packaged rulers.                     |
-| `modules`     | `readonly EditorModule[]`                        | React, Vue | Feature modules applied at mount.                |
-| `onFontError` | `(error: EditorFontError) => void`               | React, Vue | Reports typed font-resolution failures.          |
+| Prop          | Type                                             | Package(s) | Description                                                       |
+| ------------- | ------------------------------------------------ | ---------- | ----------------------------------------------------------------- |
+| `document`    | `DocumentSource`                                 | React, Vue | DOCX bytes or an existing `DocumentHandle`.                       |
+| `fonts`       | `FontConfiguration \| FontConfigurationFragment` | React, Vue | Font bytes used for shaping and pagination.                       |
+| `author`      | `string`                                         | React, Vue | Ambient author for authored commands.                             |
+| `mode`        | `'edit' \| 'view' \| 'suggesting'`               | React, Vue | Editing mode; changes apply without remounting.                   |
+| `zoom`        | `number`                                         | React, Vue | Fixed zoom scale; changes apply without remounting.               |
+| `zoomMode`    | `ZoomMode \| 'auto'`                             | React, Vue | Automatic or fixed zoom behavior.                                 |
+| `locale`      | `string`                                         | React, Vue | Regional date input and generated labels; defaults to `en-US`.    |
+| `i18n`        | `Translations`                                   | React, Vue | UI translations, including form controls; separate from `locale`. |
+| `t`           | `(key, params?) => string`                       | React, Vue | Host translation function for editor chrome.                      |
+| `colorMode`   | `'light' \| 'dark' \| 'system'`                  | React, Vue | Color mode for editor chrome.                                     |
+| `rulers`      | `boolean`                                        | React, Vue | Toggles the packaged rulers.                                      |
+| `modules`     | `readonly EditorModule[]`                        | React, Vue | Feature modules applied at mount.                                 |
+| `onFontError` | `(error: EditorFontError) => void`               | React, Vue | Reports typed font-resolution failures.                           |
 
 ### React root chrome props
 

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -1,6 +1,7 @@
-# Internationalization (i18n) Guide
+# Internationalization (i18n)
 
-This document explains how the i18n system works, how to contribute translations, and how locale files stay in sync.
+Use `i18n` for UI translations and `locale` for regional date input and generated labels.
+To contribute a translation, update the locale JSON files and run the validation commands below.
 
 ## Overview
 
@@ -14,20 +15,24 @@ packages/i18n/
   ...
 ```
 
-## How It Works
+## Configure translations
 
-### For Consumers
+### In your application
 
 Import a locale file and pass it to `<DocxEditor>`:
 
 ```tsx
 import { DocxEditor } from '@docx-editor.dev/react';
-import { de } from '@docx-editor.dev/i18n';
+import de from '@docx-editor.dev/i18n/de';
 
-<DocxEditor i18n={de} />;
+<DocxEditor document={bytes} i18n={de} locale="de-DE" />;
 ```
 
-### For Developers (Internal)
+`i18n` translates menus, dialogs, and form controls. `locale` selects regional date
+input and engine-generated labels; it defaults to `en-US`. Changing `locale` does
+not load translations. The locale file's `_lang` field selects plural rules.
+
+### In editor components
 
 Use the `useTranslation()` hook inside any component:
 
@@ -44,7 +49,7 @@ t('navigation.find.counter', { current: 3, total: 15 });
 // → "Result 3 of 15"
 ```
 
-## Key States in Locale Files
+## Translation states
 
 Every key in a community locale file can be in one of three states:
 
@@ -54,15 +59,12 @@ Every key in a community locale file can be in one of three states:
 | **Not yet translated** | `null`          | Falls back to English                  |
 | **Missing**            | _(key absent)_  | **CI fails** — must be added as `null` |
 
-### Why `null` Instead of Missing Keys?
+### Mark untranslated keys with `null`
 
 When a new English string is added to `en.json`, every community locale file must have that key present — even if no translation exists yet. This is enforced by CI.
 
-Setting a key to `null` means:
-
-- "I know this key exists, but it hasn't been translated yet"
-- The editor will display the English string as a fallback
-- Translators can find untranslated strings by searching for `null`
+Use `null` until a translation is available. The editor falls back to English,
+and translators can search for `null` to find incomplete entries.
 
 **Example:**
 
@@ -78,7 +80,7 @@ Setting a key to `null` means:
 
 Here, "Bold" shows as "Pogrubienie", while "Italic" and "Underline" show in English until someone translates them.
 
-## Contributing a New Locale
+## Add a locale
 
 ### 1. Scaffold a new locale
 
@@ -88,7 +90,9 @@ bun run i18n:new pt-BR     # Brazilian Portuguese
 bun run i18n:new zh-CN     # Simplified Chinese
 ```
 
-This creates `packages/i18n/<lang>.json` with all keys set to `null` AND wires the locale into the typed exports in `packages/i18n/src/index.ts` (extends the `LocaleCode` union, adds a typed `export const`, slots it into the `locales` record). You only edit the JSON. Use a [BCP 47](https://en.wikipedia.org/wiki/IETF_language_tag) language tag.
+This creates `packages/i18n/<lang>.json` with untranslated keys set to `null` and
+updates the typed exports in `packages/i18n/src/index.ts`. Edit the generated JSON.
+Use a BCP 47 language tag for `<lang>`.
 
 ### 2. Translate strings
 
@@ -146,7 +150,7 @@ Select `@docx-editor.dev/i18n` with a `patch` bump and write a one-line summary 
 
 Include your coverage (e.g., "German: 100% translated" or "Japanese: toolbar + dialogs translated, errors section still null").
 
-## Adding New English Strings
+## Add English strings
 
 When adding a new feature with user-facing text:
 
@@ -183,14 +187,14 @@ bun run i18n:fix
 
 This adds your new keys as `null` in all community locale files. CI will fail if you skip this step.
 
-### Key Naming Conventions
+### Name translation keys
 
 - Nest by feature area: `toolbar.*`, `navigation.find.*`, `comments.*`
 - Use camelCase for keys: `counter`, `insertRowAbove`
 - Shared strings go in `common.*`: Cancel, Insert, Apply, Close, Delete
 - Don't duplicate — if a string exists in `common.*`, use it
 
-## CI Validation
+## CI validation
 
 The `i18n:validate` script runs in CI and ensures:
 
@@ -206,15 +210,13 @@ git add packages/i18n/
 git commit -m "fix: sync i18n locale files"
 ```
 
-Rule 3 is why a key must be added and USED in the same change, not added ahead of the
-component that renders it: an unused key is one every locale has to carry and every
-translator is asked for. `bun run i18n:unused` lists what it is complaining about. It
-reads only shipping source — tests, comments and docs do not count as a reference, and
-neither do the Vue and Nuxt adapters while they are unshipped. A key built at runtime is
-fine as long as the static part is one literal (``t(`navigation.tabs.${id}`)``); a key
-assembled from fragments is invisible to it and will report as unused.
+Add each key in the same change as the code that uses it. Run `bun run i18n:unused`
+to list unreferenced keys. The checker excludes tests, comments, docs, and the Vue
+and Nuxt adapter directories. For dynamic keys, keep the prefix in one literal,
+such as ``t(`navigation.tabs.${id}`)``. The checker cannot detect prefixes assembled
+from fragments.
 
-## CLI Reference
+## CLI reference
 
 | Command                   | Description                                                                                               |
 | ------------------------- | --------------------------------------------------------------------------------------------------------- |
@@ -240,7 +242,7 @@ scripts/validate-i18n.mjs            → CI/pre-commit validation
 - **Tree-shakeable** — only the imported locale gets bundled
 - **Null = untranslated** — deep merge skips nulls, falls back to English
 
-## Interpolation and Pluralization
+## Interpolation and pluralization
 
 ### Interpolation
 
@@ -303,3 +305,8 @@ Since plurals are inline strings, **locale file keys stay identical across all l
 ## Limitations
 
 - **No RTL layout** — String translation works, but the editor UI layout is not RTL-ready. RTL support is a separate effort.
+
+## Next steps
+
+- [Configure editor languages](https://www.docx-editor.dev/docs/2.x/i18n)
+- [Locale package](../packages/i18n/README.md)

--- a/docs/site/README.md
+++ b/docs/site/README.md
@@ -101,10 +101,14 @@ never hand-write support claims in prose.
 
 ## Conventions
 
-Write instructions, not essays. Lead with what the reader does; state facts
-flat (sentence or table); no conceptual framing headings ("The trust
-model"), no enumerated abstractions ("Two corollaries"), no aphorisms.
-Shorter is better.
+Follow the [Google developer documentation style guide](https://developers.google.com/style/highlights).
+Lead with the task or behavior. Use active voice, address the reader as "you,"
+and use sentence case for headings. Keep paragraphs short and remove repeated
+explanations. Format identifiers as code and UI labels in bold.
+
+Check feature claims and examples against the public API. State prerequisites,
+defaults, and limits where readers need them. Link to detailed references
+instead of repeating them in overview pages.
 
 - Links between docs pages are root-relative with the version prefix:
   `[React props](/docs/2.x/react/props)`.

--- a/docs/site/content/build-a-docx-agent.mdx
+++ b/docs/site/content/build-a-docx-agent.mdx
@@ -19,13 +19,19 @@ clarity**.
 The demo uses the Vercel AI SDK. The document tools work with any tool-calling
 framework.
 
+For an agent that continues working after the browser closes, run the
+[server agent review example](https://github.com/eigenpal/docx-editor/tree/main/examples/server-agent-review).
+Its worker joins a shared Hocuspocus room and publishes suggestions for browser
+peers to accept or reject. Scripted review works without a model API key.
+
 ## Before you start
 
 - You need `@docx-editor.dev/editor-api` and `@docx-editor.dev/core`.
 - If you show the document in a page, install `@docx-editor.dev/react` or
   `@docx-editor.dev/vue`.
-- If the agent writes comments or tracked changes, install
-  `@docx-editor.dev/pro` and pass a non-empty `author`.
+- For comments or tracked changes, pass a non-empty `author`. Browser review
+  also requires `@docx-editor.dev/pro` and its review module. The server runtime
+  provides these writes without a browser review module.
 
 <Steps>
 
@@ -58,7 +64,7 @@ npm install @docx-editor.dev/vue
 </Framework>
 </FrameworkTabs>
 
-If you record comments or tracked changes, also install Pro:
+If you display or edit comments and tracked changes in the browser, also install Pro:
 
 ```bash
 npm install @docx-editor.dev/pro
@@ -227,6 +233,11 @@ Read the user request, then pick tools:
   insertion, or deletion.
 - If the user says "suggest", "review", or "redline", call tracked proposal
   tools.
+
+On a server, set `context.document.changeTrackingMode = 'TrackMineOnly'` and use
+`range.insertText()` or `range.delete()` to record tracked text edits. See the
+[server tracking example](/docs/2.x/editor-api#create-tracked-changes-on-a-server)
+for prerequisites and limits.
 
 Leave accept and reject off the agent allowlist. The reader decides in the
 editor.

--- a/docs/site/content/editor-api/index.mdx
+++ b/docs/site/content/editor-api/index.mdx
@@ -8,9 +8,13 @@ seoTitle: 'Office.js-compatible DOCX editing API'
 
 <PackageStats name="@docx-editor.dev/editor-api" />
 
-`@docx-editor.dev/editor-api` is an **Office.js-compatible editing API** for DOCX. It implements the same object model (`context.document.body.paragraphs`, `load()` then `sync()`, `search()`, `getFirstOrNullObject()`) so code written for a Word add-in compiles and runs here.
+`@docx-editor.dev/editor-api` edits DOCX files through a supported subset of Word's
+JavaScript object model, including paragraphs, ranges, comments, and revisions.
+Use `load()` to queue reads and `sync()` to apply each batch atomically.
 
-You describe work against objects (paragraphs, ranges, comments, revisions, content controls) and one `sync()` sends it as a single ordered batch that either applies whole or not at all. The same code runs in two places: on a server over DOCX bytes, or in a page against a document a reader already has open.
+Run the API on a server over DOCX bytes or in the browser against an open editor.
+See [Office.js compatibility](/docs/2.x/editor-api/office-js-api)
+for supported members and differences from Word.
 
 ```bash
 npm install @docx-editor.dev/editor-api @docx-editor.dev/core
@@ -18,16 +22,6 @@ npm install @docx-editor.dev/editor-api @docx-editor.dev/core
 
 `@docx-editor.dev/core` is a peer dependency: the engine holds identity-keyed state, so your
 project must resolve exactly one copy of it, shared with any editor adapter you install.
-
-`DocxEditor.createServer` rejects with error code `ResourceLimitExceeded` when opening exceeds a resource cap.
-Catch `DocxEditorError` and inspect its `limit` field, such as `xml.maxElements` or `zip.maxRatio`.
-The XML reader uses the engine's default budget of 10,000,000 elements per part.
-Set `limits.xml.maxElements` to lower that budget for untrusted input or raise it for larger documents,
-up to the engine ceiling of 50,000,000. Set `limits.xml.maxBytes` alongside it.
-The 64 MiB per-part byte ceiling and 256-level depth ceiling still apply.
-These budgets do not guarantee that a document fits in the host's memory.
-Counts and byte budgets must be finite nonnegative integers; compression ratios may be fractional.
-Malformed input and invalid budget options reject with `InvalidArgument`.
 
 ## Choose a host
 
@@ -122,6 +116,33 @@ await runtime.run(async (context) => {
 `document.body.bookmarks` covers only the main body story. A header or footer `Body` has its own
 collection; this accessor never combines separate stories into a document-wide answer.
 
+### Handle resource limits
+
+`DocxEditor.createServer` rejects with error code `ResourceLimitExceeded` when opening exceeds a resource cap.
+Catch `DocxEditorError` and inspect its `limit` field, such as `xml.maxElements` or `zip.maxRatio`.
+The XML reader uses the engine's default budget of 10,000,000 elements per part.
+Set `limits.xml.maxElements` to lower that budget for untrusted input or raise it for larger documents,
+up to the engine ceiling of 50,000,000. Set `limits.xml.maxBytes` alongside it.
+The 64 MiB per-part byte ceiling and 256-level depth ceiling still apply.
+These budgets do not guarantee that a document fits in the host's memory.
+Counts and byte budgets must be finite nonnegative integers; compression ratios may be fractional.
+Malformed input and invalid budget options reject with `InvalidArgument`.
+
+## Create tracked changes on a server
+
+Set `context.document.changeTrackingMode = 'TrackMineOnly'` before calling
+`range.insertText()` or `range.delete()`. Configure an `author` when you create
+the runtime. The mode applies to that runtime and persists across `run()` calls.
+
+Tracked edits support text within one paragraph, including table cells. Edits
+that touch pending revisions, structural edits, and formatting edits are rejected
+atomically. `TrackAll` and browser runtime tracking-mode control are unsupported.
+
+For a complete example, see the
+[server agent guide](https://github.com/eigenpal/docx-editor/blob/main/packages/editor-api/OFFICE_JS_GUIDE.md).
+To publish suggestions to a shared document, use
+[`DocxEditor.createCollaborative`](/docs/2.x/pro/collaboration#let-a-server-agent-propose-redlines).
+
 ## In the browser
 
 The browser entry takes an editor the host already created (from `@docx-editor.dev/react` or a plain page) and drives it in place. Edits apply to the open document with the reader's undo stack intact, so there is no `save()`: the host continues to call its existing save path.
@@ -144,7 +165,7 @@ The `/browser` entry includes integration with the painted engine. Import the ro
 to keep that browser code out of the bundle.
 
 The optional `author` has the same meaning as it does for `createServer`.
-It supplies the identity for comment writes.
+It supplies the identity for comments. Server runtimes also require it for tracked text edits.
 
 ## Delete comments and Undo
 

--- a/docs/site/content/guides/content-controls.mdx
+++ b/docs/site/content/guides/content-controls.mdx
@@ -5,18 +5,21 @@ category: 'Guides'
 seoTitle: 'Content controls (SDTs)'
 ---
 
-Word content controls (`w:sdt`, Structured Document Tags) are labeled, bounded regions of a document. A control carries a stable `tag`, `title`, and `id`. Use those identifiers as addresses for templates and programmatic filling: design the template in Word, tag the fillable regions, then fill them by tag from code.
+Word content controls (`w:sdt`, structured document tags) mark regions you can
+fill from code. Create a template in Word, tag its fillable regions, and use
+`tag`, `title`, or `id` to find each control.
 
-The editor parses controls into the canonical tree, keeps them editable, renders their boundary, and round-trips them with structural fidelity. Properties it does not model, such as `w:dataBinding` and `w15:repeatingSection`, remain as generic nodes and survive editing and save.
+The editor displays control boundaries and supports the editing operations below.
+It preserves unsupported properties, including `w:dataBinding` and
+`w15:repeatingSection`, when you save.
 
 <Callout>
   Content controls are addressed by `tag`, `title`, or `id`. They are not `{{ mustache }}` template
   variables; the two systems can coexist in one document.
 </Callout>
 
-For cross-feature support levels, see the authoritative
-[Word fidelity matrix](/docs/2.x/word-fidelity). This guide covers content
-control tasks and operational refusals.
+See the [Word fidelity matrix](/docs/2.x/word-fidelity) for support levels across
+features.
 
 ## Filling a template from a server
 
@@ -241,9 +244,15 @@ the reason.
 | Create       | The selection crosses paragraphs                             | Inline controls cannot wrap block content     |
 | Create       | The position is inside a hyperlink, field, or inline control | The new control has no valid sibling position |
 
-## Typed control chrome
+## Checkbox, dropdown, and date interactions
 
-In the editor, typed controls get an interactive trigger at the top-right of their box: it toggles the checkbox, opens the dropdown's item menu, or opens a date picker, each as a normal undoable edit. These controls work without host event handlers. When you toggle a checkbox, an omitted state font defaults to MS Gothic.
+Select the button at the upper-right corner of a control to toggle a checkbox,
+open a dropdown menu, or open a date picker. Each edit supports undo and requires
+no application event handler. Checkbox toggles use MS Gothic when the document
+omits the state font.
+
+These interactions apply to content controls. For legacy Word form fields, see
+[Legacy text form fields](/docs/2.x/guides/fields#legacy-text-form-fields).
 
 ## Operational limits
 

--- a/docs/site/content/guides/fields.mdx
+++ b/docs/site/content/guides/fields.mdx
@@ -95,9 +95,10 @@ macros, DDE instructions, OLE content, or external include instructions.
 
 ## Legacy text form fields
 
-Click a `FORMTEXT` field to select it. Double-click or choose **Edit field…** to
-set its default value, type, maximum length, format, and **Fill-in enabled**.
-A maximum length of zero means unlimited. React and Vue use the same dialog.
+Select a `FORMTEXT` field, then double-click it or choose **Edit field…** from
+the context menu. Set its default value, type (regular text, number, or date),
+maximum length, format, and **Fill-in enabled** setting. A maximum length of
+zero means unlimited. React and Vue use the same dialog.
 
 In an unprotected document, partial edits keep the field definition; replacing
 its whole result removes it. In a document protected for forms, editing keeps
@@ -113,7 +114,7 @@ it clears the input, which can be restored with Undo.
 the default English UI, use:
 
 ```tsx
-<DocxEditor locale="pl-PL" />
+<DocxEditor document={bytes} locale="pl-PL" />
 ```
 
 With `pl-PL`, `01.02.2030` means February 1. The default `en-US` interprets
@@ -125,8 +126,10 @@ Date input supports Gregorian numeric dates, regional digits, and full English
 month names. Localized month names and non-Gregorian dates are not supported.
 
 Only plain text results and the dialog's listed types and formats support editing
-and protected filling. Other field structures are preserved. Checkbox and dropdown
-interactions are not supported, and entry or exit macros never run.
+and protected filling. The editor preserves other field structures. Legacy
+checkbox and dropdown form fields are not interactive; use
+[content controls](/docs/2.x/guides/content-controls) for those interactions.
+Entry and exit macros never run.
 
 ## Next steps
 

--- a/docs/site/content/guides/fonts.mdx
+++ b/docs/site/content/guides/fonts.mdx
@@ -33,21 +33,22 @@ const { document, fonts } = useDocxSource(url, {
 ```
 
 The list is a precedence order: the first origin that supplies a face wins, and
-later origins are told which faces are already covered so they don't load them
-again. Put the origin you'd rather pay for first.
+later origins receive the resolved faces so they can skip duplicate downloads.
+Put preferred sources first.
 
-`googleFonts()` fetches from a content delivery network. Nothing else here
-touches the network, and no origin is on by default.
+`googleFonts()` fetches from a content delivery network. `packagedFonts()` and
+`defaultFonts()` load assets shipped with the package, typically from your own
+origin in a browser. No optional font source is enabled by default.
 
 ## Choose a font source
 
-| Source                     | Network on document open     | Loads                                               | Measurement                        |
+| Source                     | Third-party requests         | Loads                                               | Measurement                        |
 | -------------------------- | ---------------------------- | --------------------------------------------------- | ---------------------------------- |
 | Fonts embedded in the DOCX | No                           | The faces in the file                               | Uses the embedded bytes            |
 | `packagedFonts()`          | No                           | The packaged families in use, plus the default face | Uses metric-compatible substitutes |
 | `defaultFonts()`           | No                           | All 20 faces of the five defaults, every time       | Uses metric-compatible substitutes |
 | `googleFonts()`            | Yes, for catalogued families | The catalog families in use, plus the default face  | Uses the fetched faces             |
-| `loadFonts` with your URLs | Only when your code calls it | The URLs you list                                   | Uses admitted files                |
+| `loadFonts` with your URLs | Depends on your URLs         | The URLs you list                                   | Uses admitted files                |
 | No usable source           | No                           | Nothing                                             | Canvas or fixed fallback           |
 
 Embedded fonts load automatically. The editor registers them under internal
@@ -62,9 +63,10 @@ compatible face. It excludes metric-compatible substitutions.
 The notice also excludes font declarations that rendered text does not use. The
 font picker can still list those declared families.
 
-The notice excludes symbol faces too, such as the MS Gothic face a Word checkbox
-names in `w:sym`. A symbol run paints one character, and the editor resolves it
-to its Unicode equivalent wherever one exists, so any face can draw it.
+The notice also excludes symbol faces, such as MS Gothic in a Word checkbox
+(`w:sym`). The editor maps symbols to Unicode where a mapping exists. Rendering
+still depends on the available font glyphs; a missing notice does not guarantee
+that every symbol can render.
 
 The font picker is a separate list. It offers the families your configuration
 supplies and the families the document declares in `w:rFonts`, so a symbol face
@@ -442,11 +444,11 @@ const brandFonts = defineFontResolver(async ({ families, defaultFamily, resolved
 The request carries `families`, the names that document declares, and `defaultFamily`,
 the face a run naming no font resolves to. Both count as declared.
 
-`families` ends with the symbol faces the document names in `w:sym`, after the
-declared ones. Supply those to paint a symbol in the authored face: the editor
-maps a private-use character to its Unicode equivalent where one exists, and
-keeps the original character otherwise. A face you supply this way becomes
-offerable in the font picker, like any other family you supply.
+`families` also includes faces used by `w:sym`, `SYMBOL` fields, and numbering
+markers. Unused numbering definitions do not add requests. Supply usable bytes
+for these faces to render their authored glyphs. The editor maps private-use
+symbols to Unicode where a mapping exists and preserves the character otherwise.
+Supplied faces are also available in the font picker.
 
 `resolvedFaces` lists the faces earlier origins in the same composition can already
 paint. It reports faces rather than families, and only faces backed by bytes, so

--- a/docs/site/content/guides/headers-footers.mdx
+++ b/docs/site/content/guides/headers-footers.mdx
@@ -12,11 +12,11 @@ header or footer area to edit it in place.
 
 Double-click inside the header or footer band to enter edit mode. From there, editing follows the same model as the document body: click to place the caret, drag to select, double- and triple-click for word and paragraph selection, right-click menus, hyperlinks, image selection, and table row, column, and edge resize all work identically. Undo and redo cover header and footer edits.
 
-While editing, a separator bar labels the region (Header or Footer) and shows an Options menu:
+While editing, a separator bar labels the region (**Header** or **Footer**) and shows an **Options** menu:
 
-- **Insert current page number** inserts a PAGE field.
-- **Insert total page count** inserts a NUMPAGES field.
-- **Insert section page count** inserts a SECTIONPAGES field.
+- **Insert current page number** inserts a `PAGE` field.
+- **Insert total page count** inserts a `NUMPAGES` field.
+- **Insert section page count** inserts a `SECTIONPAGES` field.
 - **Remove header/footer** clears the region.
 
 Press Escape or click the close action to save and leave header/footer editing.
@@ -70,11 +70,12 @@ Documents using any of these render and round-trip correctly; editing a header e
 
 ## Watermarks
 
-Watermarks live in header parts (that is how Word models them). Their VML or
-DrawingML markup and image payloads are preserved through editing and save.
+Word stores watermarks in header parts. The editor renders the supported
+unrotated [legacy VML subset](/docs/2.x/guides/images#legacy-vml-previews) there.
+Rotated or curved watermark templates remain opaque.
 
-Dedicated watermark rendering, insertion, editing, and headless authoring are not
-supported. Existing watermarks remain inert rather than being dropped.
+Watermark insertion, editing, and headless authoring are not supported. The editor
+preserves the original VML or DrawingML markup and image payloads when you save.
 
 ## Next steps
 

--- a/docs/site/content/guides/images.mdx
+++ b/docs/site/content/guides/images.mdx
@@ -196,6 +196,16 @@ PDF export does not apply these adjustments.
 | Tracked image property edits                            | Stay unavailable in suggesting mode                  |
 | Artistic effects (`a:effectLst`)                        | Do not render; authored markup round-trips           |
 
+## Find text in text boxes
+
+**Find** searches anchored text boxes in the body, headers, and footers.
+Selecting a match selects its text box; the content remains read-only. Inline
+text boxes and text boxes in footnotes or endnotes are not searched.
+
+Use `useDocumentSearch` to add Find navigation to a custom
+[React](/docs/2.x/react/hooks#usedocumentsearch) or
+[Vue](/docs/2.x/vue/composables#usedocumentsearch) interface.
+
 ## Legacy VML previews
 
 Standalone `w:pict` can render unrotated embedded photos and bounded groups of photos,
@@ -204,14 +214,15 @@ WordArt (`_x0000_t136`). Group-local coordinates, picture crops, supported text 
 and source order are retained. WordArt uses the authored font when available on the host;
 curved or rotated WordArt is not supported.
 
-The preview is one read-only drawing atom. Original VML, media, and relationships remain
-canonical: saving does not add generated SVG parts or replace the source with DrawingML.
-Shared photo relationships remain protected when another picture is deleted. Unsupported
-or oversized groups remain opaque as a whole, including groups whose members or ink would
-be clipped by the preview extent. Custom templates, text boxes, curves, image effects,
-rotation, and mixed unsupported members are not partially rendered. Only recognized
-standard shape templates are accepted. An already-selected DrawingML MC branch never
-paints its dead VML fallback too; VML-only MC fallback support is unchanged.
+Previews are read-only. Saving preserves the original VML, media, and
+relationships without adding generated SVG parts or converting the source to
+DrawingML. Deleting another picture preserves shared photo relationships.
+
+The editor does not partially render unsupported, oversized, or clipped groups.
+Custom templates, text boxes, curves, image effects, rotation, and unsupported
+group members prevent a group preview. Only recognized standard shape templates
+are supported. When a document supplies DrawingML and VML alternatives, the
+editor displays only the selected alternative.
 
 Standalone photos reuse validated image resources and retain their authored crop. Groups, WordArt, and color-key previews use bounded static SVG resources. Embedded members still pass the
 normal image validation and decode limits; an external or missing member never triggers

--- a/docs/site/content/pro/collaboration.mdx
+++ b/docs/site/content/pro/collaboration.mdx
@@ -739,7 +739,8 @@ const runtime = await DocxEditor.createCollaborative(room.document, room.session
 });
 ```
 
-Call `room.destroy()` to stop the replica.
+When the job finishes, call `runtime.dispose()` and then `room.destroy()` to release
+the runtime and stop the replica.
 
 ## Let a server agent propose redlines
 
@@ -747,13 +748,15 @@ A background worker can join the same Hocuspocus room as the browser peers with
 `role: 'agent'`, then attach `DocxEditor.createCollaborative` as above. The worker
 owns its connection, so closing the initiating browser does not stop its job.
 
-Use Office-shaped tracking mode and standard edits to create Word tracked changes:
+Set the tracking mode before editing to create Word tracked changes:
 
 ```ts
 await runtime.run(async (context) => {
-  const range = context.document.body.search('within 7 days').getFirstOrNullObject();
+  const matches = context.document.body.search('within 7 days', { matchCase: true });
+  matches.load('items');
   await context.sync();
-  if (range.isNullObject) return;
+  if (matches.items.length !== 1) throw new Error('Choose a unique target');
+  const range = matches.items[0]!;
   range.load('text');
   await context.sync();
 

--- a/docs/site/data/word-features.ts
+++ b/docs/site/data/word-features.ts
@@ -1063,7 +1063,7 @@ export const wordFeatures: WordFeature[] = [
     roundTrip: 'full',
     tier: 'community',
     notes:
-      'Searches headers, footers, footnotes, endnotes, body, header, and footer text boxes, table cells, and saved field results. Only anchored text boxes are searched, because an inline one paints no story. Note-owned text boxes are excluded until their drawings are selectable. A text-box match selects the text box instead of placing the caret inside it.',
+      'Searches the body, headers, footers, footnotes, and endnotes, including table cells and saved field results. Find also searches anchored text boxes in the body, headers, and footers. Inline text boxes and text boxes in notes are excluded. Selecting a text-box match selects its drawing; the content remains read-only.',
   },
   {
     id: 'collab.clipboard',

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,12 +27,16 @@ bun run dev:astro           # Astro
 bun run dev:agent           # Document review agent
 bun run dev:write-agent     # Document writing agent
 bun run dev:collaboration   # Peer-to-peer collaboration
+bun run dev:server-agent-review # Server agent and shared review room
 ```
 
 Set `OPENAI_API_KEY` as described in each agent example before you run `dev:agent` or
 `dev:write-agent`.
 
-Install Node 22.18 or later for the Hocuspocus server. Run the server and app in
+The [server agent review example](server-agent-review/README.md) requires Node.js 22.18 or later.
+It starts the app, Hocuspocus, and a worker together. Scripted review works without a model API key.
+
+Install Node.js 22.18 or later for the standalone Hocuspocus server. Run the server and app in
 separate terminals:
 
 ```bash
@@ -83,6 +87,8 @@ Stop one server before you start the other.
 - `astro/` shows an Astro page with a React island.
 - `agent/` uses an AI agent to read and comment on an open document.
 - `write-agent/` uses an AI agent to create a document and propose tracked changes.
+- [server-agent-review/](server-agent-review/README.md) runs a background agent that proposes
+  tracked changes in a shared Hocuspocus room. Browser peers review the suggestions.
 - `automation/` fills a DOCX template with `@docx-editor.dev/editor-api`.
 - `collaboration/` uses `y-webrtc` for peer-to-peer collaboration without an application
   server.

--- a/examples/server-agent-review/README.md
+++ b/examples/server-agent-review/README.md
@@ -1,12 +1,14 @@
-# Margin: a server-side AI reviewer in a shared document
+# Server agent review
 
-A runnable collaborative review room. A Node worker joins Hocuspocus as **Review agent** and proposes real Word insertions, deletions, and replacements. Open the room in two browsers to watch the same redlines arrive, then accept or reject them from either browser.
+Run a Node.js worker that joins a Hocuspocus room as **Review agent** and proposes
+Word tracked changes. Open the room in two browsers, then accept or reject
+suggestions from either browser.
 
 The browser renders the editor and requests jobs. All model calls and proposal execution happen on the worker. The job continues if its initiating browser closes.
 
 ## Run
 
-Use Node **22.18 or later** and Bun for workspace installation/builds. The worker uses Node's native WebSocket and TypeScript stripping; the client uses the Hocuspocus provider.
+Use Node.js 22.18 or later and Bun for workspace installation and builds. The worker uses native WebSocket support and TypeScript stripping in Node.js; the client uses the Hocuspocus provider.
 
 ```sh
 bun install
@@ -14,15 +16,13 @@ cp examples/server-agent-review/.env.example examples/server-agent-review/.env
 bun run dev:server-agent-review
 ```
 
-Open **http://localhost:5180**. This command builds the workspace packages and starts Vite, Hocuspocus, and the worker. Stop all three with Ctrl+C.
+Open [localhost:5180](http://localhost:5180). This command builds the workspace packages and starts Vite, Hocuspocus, and the worker. Stop all three with Ctrl+C.
 
 1. Enter your display name and open the sample agreement, or upload a DOCX (up to 10 MiB) to create a new room.
-2. Copy the invite link into another browser/profile and join under a different name.
+2. Copy the invite link into another browser or browser profile and join under a different name.
 3. Choose **Scripted review** to demonstrate four edits without a model key. This mode only targets clauses from the sample; missing clauses in uploads are skipped.
 4. To use AI, set `OPENAI_API_KEY` in `.env`, restart, and select **AI review**. `OPENAI_MODEL` defaults to `gpt-5.4-mini`. Give the agent a review instruction.
-5. Open **Changes** to accept/reject suggestions. Download exports the current shared document, including pending revisions.
-
-The page offers no promise that AI suggestions are correct; the document remains reviewable and human decisions use the engine's existing review API.
+5. Open **Changes** to accept or reject suggestions. **Download** exports the current shared document, including pending revisions.
 
 ## Architecture
 
@@ -46,7 +46,9 @@ Job state and room files live in ignored `.data/`. Override the directory with `
 
 ## Copyable server integration
 
-This is the essential integration; `generateReplacement` is your model call. The example's complete tool loop adds snapshot validation, cancellation, bounded retries, and tool-call deduplication.
+Join an existing room, generate one replacement, and commit it as a tracked change.
+Provide `roomId`, `instruction`, and your `generateReplacement` function. The complete
+example adds snapshot validation, cancellation, bounded retries, and tool-call deduplication.
 
 ```ts
 import { DocxEditor } from '@docx-editor.dev/editor-api';
@@ -99,7 +101,7 @@ try {
 ```
 
 For insertions use `range.insertText(text, 'Before' | 'After')`. For deletions use `range.delete()`.
-These public methods follow Office.js shape. Supply an `author` and enable `TrackMineOnly` before editing.
+These methods follow the supported Office.js subset. Supply an `author` and enable `TrackMineOnly` before editing.
 The mode persists for the runtime session. `Off` makes ordinary edits. `TrackAll` is explicitly unsupported,
 as are structural or formatting mutations while tracking. Other peers keep their own editing mode.
 The saved redlines are Word revisions; the local tracking setting is not a document-wide saved policy.
@@ -113,9 +115,8 @@ Each model tool has a focused schema: insertion requires text and an explicit po
 and deletion accepts only its snapshot and quote. Refusals include the public error target and recovery guidance.
 They never tell the model to disable tracking or blindly repeat a refused edit.
 
-The worker batches paragraph loads before each `sync()`. It reads only the requested page's text and identity.
-It serializes tool calls and commits one completed suggestion at a time. These write boundaries intentionally
-make each suggestion visible and reviewable; they are not per-item read round trips.
+The worker batches paragraph reads, serializes tool calls, and commits one suggestion
+at a time. Each commit becomes available for review while the job continues.
 
 ## Client integration
 
@@ -144,7 +145,7 @@ function SharedDocument({ room }) {
 
 Pass a stable `room` configuration with the same room ID and server URL, `bootstrap: { kind: 'join' }`, and a unique actor ID for each browser attachment. Add font configuration as in the runnable app.
 
-## Guarantees and limits
+## Behavior and limits
 
 - Each proposal is one atomic document transaction. Replacement creates deletion and insertion revisions together; the review engine derives their decision cards.
 - The worker’s proposal tools support only single-paragraph text ranges, including table-cell paragraphs. Cross-paragraph ranges, paragraph-break text, missing authors, empty replacement/insertion text, and touching or overlapping pending revisions refuse. A paragraph may receive only one proposal/edit per batch; use separate syncs for sequential edits.
@@ -170,3 +171,8 @@ Build the workspace packages before running Node or the browser suite. The deter
 CI runs the Node lifecycle integration in its build job, after workspace packages exist; the source-only Bun suite runs the unit tests. To run the integration alone after building, use `bun run --filter './examples/server-agent-review' test:lifecycle`.
 
 The Node lifecycle test also kills the collaboration transport and restarts the worker, checking failure, persisted-room recovery, and interrupted-job handling without replay.
+
+## Next steps
+
+- [Server agent API patterns](../../packages/editor-api/OFFICE_JS_GUIDE.md)
+- [Collaboration reference](https://www.docx-editor.dev/docs/2.x/pro/collaboration)

--- a/packages/editor-api/README.md
+++ b/packages/editor-api/README.md
@@ -14,13 +14,13 @@
 
 # @docx-editor.dev/editor-api
 
-An **Office.js-compatible editing API** for DOCX. It implements the Word JavaScript object model —
-`context.document.body.paragraphs`, `load()` then `sync()`, `search()`, `getFirstOrNullObject()` —
-so code written for a Word add-in compiles and runs here.
+`@docx-editor.dev/editor-api` edits DOCX files through a supported subset of Word's
+JavaScript object model, including paragraphs, ranges, comments, and revisions.
+Use `load()` to queue reads and `sync()` to apply each batch atomically.
 
-Describe work against objects, and one `sync()` sends it as a single ordered batch that either
-applies whole or not at all. The same code drives bytes on a server and a document a reader
-already has open in a page.
+Run the API on a server over DOCX bytes or in the browser against an open editor.
+See [Office.js compatibility](https://www.docx-editor.dev/docs/2.x/editor-api/office-js-api)
+for supported members and differences from Word.
 
 ```bash
 npm install @docx-editor.dev/editor-api @docx-editor.dev/core
@@ -63,6 +63,43 @@ caller-owned `Uint8Array`, so transferring or mutating one result does not affec
 later save. Detached edits remain detached until your application explicitly loads the returned
 bytes into a live editor.
 
+## Create tracked changes on a server
+
+Start with the [Office.js developer guide](https://github.com/eigenpal/docx-editor/blob/main/packages/editor-api/OFFICE_JS_GUIDE.md) for a complete server example and batching conventions.
+
+Set `document.changeTrackingMode = 'TrackMineOnly'`, then use standard Word editing methods.
+Supply the agent's `author` when opening the server or collaborative runtime:
+
+```ts
+await runtime.run(async (context) => {
+  const matches = context.document.body.search('within 7 days');
+  matches.load('items');
+  await context.sync();
+  if (matches.items.length !== 1) throw new Error('Choose a unique target');
+
+  context.document.changeTrackingMode = 'TrackMineOnly';
+  const replacement = matches.items[0]!.insertText('within 30 days', 'Replace');
+  await context.sync();
+  replacement.load('text');
+  await context.sync();
+});
+```
+
+Use `range.insertText(text, 'Before' | 'After')` for insertions, and `range.delete()` or
+`range.clear()` for deletions. `insertText()` returns the inserted range. Mode assignments
+and edits commit together at `sync()`; failed batches preserve the previous mode and document.
+Load `document.changeTrackingMode` before reading it. `Off` is the initial mode.
+
+This is a supported Office.js subset. `TrackMineOnly` applies to this server host and persists
+across its `run()` calls. It does not change peers' tracking settings or save a document-wide
+tracking policy. `TrackAll` and browser-host mode control explicitly refuse with `NotSupported`.
+Tracked text edits support one paragraph, including table-cell text. They refuse targets touching
+pending revisions. Structural and formatting mutations under tracking also refuse. Comments and
+revision decisions remain available. Set `Off` explicitly when permanent edits are intended.
+
+See the [server-agent review example](../../examples/server-agent-review/README.md) for Hocuspocus,
+stale-read handling, and the review lifecycle.
+
 ## In the browser
 
 The browser entry takes an editor the host already created, from `@docx-editor.dev/react` or a
@@ -83,11 +120,11 @@ await runtime.run(async (context) => {
 });
 ```
 
-Import it from `/browser` deliberately: reaching a live editor means reaching the painted engine,
-and a server holding bytes should not pay for that.
+Use the `/browser` entry for an open editor. Use the root entry on servers to exclude
+browser rendering code from the bundle.
 
-`author` is optional for source compatibility and ordinary edits, but required by
-`Range.insertComment()` and `Comment.reply()`. A missing identity refuses with `NotSupported`; a
+`author` is optional for ordinary edits. Supply it for `Range.insertComment()`,
+`Comment.reply()`, and server-side `TrackMineOnly` mode. A missing identity refuses with `NotSupported`; a
 live comment write also requires the Pro review module and a writable editing mode. There is no
 static comment-write capability because those conditions are dynamic, so callers should handle the
 typed refusal from the call or `sync()`.
@@ -118,9 +155,9 @@ decisions join the editor's Undo stack, with one collection decision as one Undo
   the read rather than producing a wrong document later.
 - `sync()` is the only round trip. Everything queued between two syncs is one ordered batch,
   applied atomically.
-- Objects are proxies into a document the runtime owns and live inside `run`. Keeping one past
-  the callback, or past `dispose()`, is an error rather than a stale read; to keep one across
-  syncs deliberately, hand it to `context.trackedObjects`.
+- Proxies remain valid across `sync()` calls within a `run()`. To reuse a proxy in a later
+  run, add it to `context.trackedObjects` and pass it to `runtime.run(object, callback)`.
+  No proxy remains valid after `dispose()`.
 - `getFirstOrNullObject` / `getLastOrNullObject` answer an object whose `isNullObject` is
   `true`, which is the difference between "no such heading" and a crash.
 - Review timestamps come from untrusted, optional OOXML attributes. `Comment.creationDate`,
@@ -173,44 +210,7 @@ This package is licensed under the [EigenPal Pro License](https://github.com/eig
 
 Contributions welcome. See [CONTRIBUTING.md](https://github.com/eigenpal/docx-editor/blob/main/CONTRIBUTING.md) for setup, tests, and the one-time CLA signature.
 
-## Commercial Support
+## Commercial support
 
 > [!TIP]
 > Questions or custom features? Email **[docx-editor@eigenpal.com](mailto:docx-editor@eigenpal.com)**.
-
-## Office-shaped redlines on the server
-
-Start with the [Office.js developer guide](https://github.com/eigenpal/docx-editor/blob/main/packages/editor-api/OFFICE_JS_GUIDE.md) for a complete server example and batching conventions.
-
-Set `document.changeTrackingMode = 'TrackMineOnly'`, then use standard Word editing methods.
-Supply the agent's `author` when opening the server or collaborative runtime:
-
-```ts
-await runtime.run(async (context) => {
-  const matches = context.document.body.search('within 7 days');
-  matches.load('items');
-  await context.sync();
-  if (matches.items.length !== 1) throw new Error('Choose a unique target');
-
-  context.document.changeTrackingMode = 'TrackMineOnly';
-  const replacement = matches.items[0]!.insertText('within 30 days', 'Replace');
-  await context.sync();
-  replacement.load('text');
-  await context.sync();
-});
-```
-
-Use `range.insertText(text, 'Before' | 'After')` for insertions, and `range.delete()` or
-`range.clear()` for deletions. `insertText()` returns the inserted range. Mode assignments
-and edits commit together at `sync()`; failed batches preserve the previous mode and document.
-Load `document.changeTrackingMode` before reading it. `Off` is the initial mode.
-
-This is a supported Office.js subset. `TrackMineOnly` applies to this server host and persists
-across its `run()` calls. It does not change peers' tracking settings or save a document-wide
-tracking policy. `TrackAll` and browser-host mode control explicitly refuse with `NotSupported`.
-Tracked text edits support one paragraph, including table-cell text. They refuse targets touching
-pending revisions. Structural and formatting mutations under tracking also refuse. Comments and
-revision decisions remain available. Set `Off` explicitly when permanent edits are intended.
-
-See the [server-agent review example](../../examples/server-agent-review/README.md) for Hocuspocus,
-stale-read handling, and the review lifecycle.


### PR DESCRIPTION
Updates developer documentation for features and behavior added since v2.15.1. Clarifies server agent redlining, form controls, regional date input, text-box search, font loading, and watermark rendering, and fixes stale prop and Office.js compatibility descriptions.

Tightens prose and adds Google developer style guidance for future contributions. Links the server review example from the main documentation and example catalog. Markdown package documentation remains unchanged.

Validation:
- Documentation MDX, chrome-slot, Vue-ref, and public-surface checks pass.
- Feature matrix tests: 11 passed, 144 assertions.
- Local documentation link targets and `git diff --check` pass.
- Full pre-commit checks pass: workspace type checks, parity, license headers, API snapshots, formatting, lint, and staged-file checks.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791474603&installation_model_id=422592&pr_number=788&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F788&signature=d2a1e35e0517ad687bfa63e03bfd1c1c2a63e52a8b826ecd1e0329c51c09da41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->