### PR TITLE
fix: resolve 2.16 release regressions

### DIFF
--- a/.changeset/steady-release-boundaries.md
+++ b/.changeset/steady-release-boundaries.md
@@ -1,0 +1,6 @@
+---
+'@docx-editor.dev/core': patch
+'@docx-editor.dev/editor-api': patch
+---
+
+Preserve pending date input when fonts load, wrap long words after protected text boundaries, and keep default document loads compatible with browser runtimes.

--- a/e2e/text-form-field-font-remount.interaction.spec.ts
+++ b/e2e/text-form-field-font-remount.interaction.spec.ts
@@ -1,0 +1,80 @@
+import { expect, test } from '@playwright/test';
+import { resolve } from 'node:path';
+import type { DocxEditorInstance } from '../packages/core/src/editor/docx-editor.ts';
+
+declare global {
+  interface Window {
+    __dateRemount: { editor: DocxEditorInstance; release(): void; previous: Element };
+  }
+}
+
+test('regional date input keeps its meaning when fonts replace the focused surface', async ({
+  page,
+}) => {
+  await page.goto('http://localhost:5273/@vite/client');
+  await page.evaluate(
+    async (root) => {
+      const { createDocxEditor } = await import(`${root}/packages/core/src/editor/docx-editor.ts`);
+      const { formFieldDocx } = await import(
+        `${root}/packages/core/src/editor/__tests__/form-field-docx.fixture.ts`
+      );
+      const { sha256FontBytes } = await import(`${root}/packages/core/src/layout/index.ts`);
+      const bytes = new Uint8Array(
+        await (
+          await fetch(`${root}/packages/core/src/layout/__tests__/fixtures/fonts/DejaVuSans.ttf`)
+        ).arrayBuffer()
+      );
+      document.body.innerHTML = '<div id="editor" style="height:400px;overflow:auto"></div>';
+      const container = document.getElementById('editor')!;
+      let release!: () => void;
+      const ready = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const editor = createDocxEditor({
+        container,
+        document: formFieldDocx(true),
+        locale: 'en-GB',
+        fonts: async () => {
+          await ready;
+          return {
+            sources: [
+              {
+                request: { family: 'DejaVu Sans', weight: 400, style: 'normal' },
+                id: 'date-remount',
+                bytes,
+                hash: sha256FontBytes(bytes),
+                faceIndex: 0,
+              },
+            ],
+          };
+        },
+      });
+      const paragraphId = editor.surface!.session.paragraphIds()[0]!;
+      editor.surface!.setSelection({
+        anchor: { paragraphId, offset: 0 },
+        head: { paragraphId, offset: 10 },
+      });
+      window.__dateRemount = { editor, release, previous: container.querySelector('.docx-pages')! };
+    },
+    `/@fs/${resolve(import.meta.dirname, '..')}`
+  );
+
+  await page.keyboard.insertText('03/04/2030');
+  await page.evaluate(() => window.__dateRemount.release());
+  await page.waitForFunction(
+    () =>
+      !window.__dateRemount.previous.isConnected &&
+      window.__dateRemount.editor.fontMeasurement().measurer === 'shaped'
+  );
+  await expect(page.locator('.docx-pages')).toBeFocused();
+  await page.evaluate(() => {
+    const surface = window.__dateRemount.editor.surface!;
+    const paragraphId = surface.session.paragraphIds()[0]!;
+    const position = { paragraphId, offset: 13 };
+    surface.setSelection({ anchor: position, head: position });
+  });
+  expect(await page.evaluate(() => window.__dateRemount.editor.surface!.session.bodyText())).toBe(
+    '04/03/2030 tail'
+  );
+  await page.evaluate(() => window.__dateRemount.editor.destroy());
+});

--- a/packages/core/src/editor/__tests__/text-form-field-font-remount.test.ts
+++ b/packages/core/src/editor/__tests__/text-form-field-font-remount.test.ts
@@ -1,0 +1,178 @@
+import { expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { strFromU8, strToU8, unzipSync, zipSync } from 'fflate';
+import { sha256FontBytes } from '../../layout/index.ts';
+import { createDocxEditor, type DocxEditorInstance } from '../docx-editor.ts';
+import { formFieldDocx } from './form-field-docx.fixture.ts';
+
+const fontBytes = new Uint8Array(
+  readFileSync(new URL('../../layout/__tests__/fixtures/fonts/DejaVuSans.ttf', import.meta.url))
+);
+
+function open(bytes = formFieldDocx(true)) {
+  const container = document.createElement('div');
+  document.body.append(container);
+  let release!: () => void;
+  const ready = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const editor = createDocxEditor({
+    container,
+    document: bytes,
+    locale: 'en-GB',
+    fonts: async () => {
+      await ready;
+      return {
+        sources: [
+          {
+            request: { family: 'DejaVu Sans', weight: 400, style: 'normal' as const },
+            id: 'form-remount-dejavu',
+            bytes: fontBytes,
+            hash: sha256FontBytes(fontBytes),
+            faceIndex: 0,
+          },
+        ],
+      };
+    },
+  });
+  return {
+    container,
+    editor,
+    async resolveFonts() {
+      const previous = editor.surface;
+      release();
+      for (let attempt = 0; attempt < 200 && editor.fontMeasurement().resolving; attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      expect(editor.fontMeasurement().measurer).toBe('shaped');
+      expect(editor.surface).not.toBe(previous);
+    },
+    dispose() {
+      release();
+      editor.destroy();
+      container.remove();
+    },
+  };
+}
+
+function enterDate(editor: DocxEditorInstance, text: string) {
+  const surface = editor.surface!;
+  const paragraphId = surface.session.paragraphIds()[0]!;
+  surface.setSelection({ anchor: { paragraphId, offset: 0 }, head: { paragraphId, offset: 10 } });
+  surface.pasteRich(text, null);
+}
+
+function leaveField(editor: DocxEditorInstance) {
+  const surface = editor.surface!;
+  const paragraphId = surface.session.paragraphIds()[0]!;
+  const position = { paragraphId, offset: surface.session.bodyText().length - 1 };
+  surface.setSelection({ anchor: position, head: position });
+}
+
+for (const changeLocale of [false, true]) {
+  test(`font remount preserves pending date input (locale changed: ${changeLocale})`, async () => {
+    const { editor, resolveFonts, dispose } = open();
+    try {
+      enterDate(editor, '03/04/2030'); // April 3 in en-GB; stored picture is MM/dd/yyyy.
+      if (changeLocale) editor.setLocale('en-US');
+      await resolveFonts();
+      leaveField(editor);
+      expect(editor.surface!.session.bodyText()).toBe('04/03/2030 tail');
+      const saved = editor.surface!.session.save();
+      editor.load(saved);
+      expect(editor.surface!.session.bodyText()).toBe('04/03/2030 tail');
+    } finally {
+      dispose();
+    }
+  });
+}
+
+test('font remount preserves date input when an earlier field changes serialized node IDs', async () => {
+  const entries = unzipSync(formFieldDocx(true));
+  const xml = strFromU8(entries['word/document.xml']!);
+  const dateField = xml.match(/<w:p>(.*?)<w:r><w:t xml:space=/)![1]!;
+  const emptyField = dateField
+    .replace('w:val="Date"', 'w:val="Empty"')
+    .replace('w:val="date"', 'w:val="regular"')
+    .replace('<w:r><w:t>01/02/2030</w:t></w:r>', '')
+    .replace('<w:format w:val="MM/dd/yyyy"/>', '');
+  entries['word/document.xml'] = strToU8(
+    xml.replace('<w:p>', `<w:p>${emptyField}<w:r><w:t xml:space="preserve"> and </w:t></w:r>`)
+  );
+  const { editor, resolveFonts, dispose } = open(zipSync(entries));
+  try {
+    const surface = editor.surface!;
+    const paragraphId = surface.session.paragraphIds()[0]!;
+    const start = { paragraphId, offset: 0 };
+    surface.setSelection({ anchor: start, head: start });
+    surface.pasteRich('A', null);
+    surface.setSelection({ anchor: { paragraphId, offset: 6 }, head: { paragraphId, offset: 16 } });
+    surface.pasteRich('03/04/2030', null);
+    await resolveFonts();
+    leaveField(editor);
+    expect(editor.surface!.session.bodyText()).toBe('A and 04/03/2030 tail');
+  } finally {
+    dispose();
+  }
+});
+
+test('font remount preserves invalid date validation', async () => {
+  const { container, editor, resolveFonts, dispose } = open();
+  try {
+    enterDate(editor, 'invalid');
+    await resolveFonts();
+    leaveField(editor);
+    expect(container.querySelector('dialog[role="alertdialog"]')).not.toBeNull();
+    expect(editor.surface!.session.bodyText()).toBe('invalid tail');
+  } finally {
+    dispose();
+  }
+});
+
+test('font remount does not reinterpret a date whose edit was undone', async () => {
+  const { editor, resolveFonts, dispose } = open();
+  try {
+    enterDate(editor, '03/04/2030');
+    editor.surface!.undo();
+    await resolveFonts();
+    leaveField(editor);
+    expect(editor.surface!.session.bodyText()).toBe('01/02/2030 tail');
+  } finally {
+    dispose();
+  }
+});
+
+test('undo after a remount restores the pending date and its input locale', async () => {
+  const { editor, resolveFonts, dispose } = open();
+  try {
+    enterDate(editor, '03/04/2030');
+    editor.setLocale('en-US');
+    await resolveFonts();
+    leaveField(editor);
+    expect(editor.surface!.session.bodyText()).toBe('04/03/2030 tail');
+    editor.surface!.undo();
+    expect(editor.surface!.session.bodyText()).toBe('03/04/2030 tail');
+    const paragraphId = editor.surface!.session.paragraphIds()[0]!;
+    editor.surface!.setSelection({
+      anchor: { paragraphId, offset: 0 },
+      head: { paragraphId, offset: 10 },
+    });
+    leaveField(editor);
+    expect(editor.surface!.session.bodyText()).toBe('04/03/2030 tail');
+  } finally {
+    dispose();
+  }
+});
+
+test('loading another document clears pending date input before fonts resolve', async () => {
+  const { editor, resolveFonts, dispose } = open();
+  try {
+    enterDate(editor, '03/04/2030');
+    editor.load(formFieldDocx(true));
+    await resolveFonts();
+    leaveField(editor);
+    expect(editor.surface!.session.bodyText()).toBe('01/02/2030 tail');
+  } finally {
+    dispose();
+  }
+});

--- a/packages/core/src/editor/docx-editor.ts
+++ b/packages/core/src/editor/docx-editor.ts
@@ -101,6 +101,7 @@ import {
   type TextMeasurer,
 } from '@docx-editor.dev/core/layout';
 import { createAnchorIndex } from './docx-editor-anchors.ts';
+import { snapshotTextFormInput, type PendingTextFormInput } from './surface-text-form-fields.ts';
 import {
   enterStoryPosition,
   leaveScopeForBodyParagraph,
@@ -494,7 +495,11 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
   });
   const scaleOf = (): number => zoomLane.scale();
 
-  function mountBytes(bytes: Uint8Array, initialSelection?: SemanticSelection): void {
+  function mountBytes(
+    bytes: Uint8Array,
+    initialSelection?: SemanticSelection,
+    initialTextFormInput?: PendingTextFormInput
+  ): void {
     if (!container) {
       // Detached: no DOM work. The bytes wait for `attach`, which mounts them under
       // whatever measurer has resolved by then. A previous document's parse failure is
@@ -527,6 +532,7 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
       revisionAuthorVisibility: reviewAuthorVisibility,
       initialDrawingSelectionIntent: remountDrawingIntent,
       initialSelection,
+      initialTextFormInput,
       editingMode:
         editingMode === 'suggesting' ? 'suggest' : editingMode === 'viewing' ? 'view' : 'edit',
       // The free engine renders the FINAL-STATE projection (Word's "No Markup"):
@@ -1020,28 +1026,22 @@ export function createDocxEditor(config: DocxEditorConfig): DocxEditorInstance {
         `+fallback:${fallbackResolution.producer}@scale:${scaleOf()}`;
       fontsResolving = false;
       if (surface) {
-        // The remount tears the surface down BEFORE building the replacement, so the
-        // saved bytes are the only copy of the live document while it runs. Hold them:
-        // a mount that throws must leave a recoverable editor, not an empty container
-        // with the document gone. Font fidelity is never worth losing the document.
+        // Retain the document and pending field input before the remount destroys the surface.
         surface.flushPendingInput();
         const saved = surface.session.save();
-        // Selection is facade state just like the live tree. In particular, `onReady` can
-        // set and reveal a range while embedded fonts are still resolving; keeping only the
-        // scroller's offset made that first call travel to the right text and then lose its
-        // highlight when this remount replaced the surface.
+        const savedTextFormInput = container ? snapshotTextFormInput(container) : undefined;
         const savedSelection = surface.state().selection;
         remountDrawingIntent = surface.drawingSelectionIntent();
         const activeElement = container?.ownerDocument.activeElement;
         const hadFocus = !!activeElement && !!container?.contains(activeElement);
         try {
-          mountBytes(saved, savedSelection);
+          mountBytes(saved, savedSelection, savedTextFormInput);
         } catch (remountError) {
           shapedMeasurer = undefined;
           shapedProducer = undefined;
           if (!surface) {
             pendingBytes = saved;
-            mountBytes(saved, savedSelection);
+            mountBytes(saved, savedSelection, savedTextFormInput);
           }
           reportFontError(toEditorFontError(remountError));
         }

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -1,6 +1,9 @@
 import { applyTextFormOperation } from './surface-text-form-apply.ts';
 import { createSurfaceDateLocale } from './surface-date-locale.ts';
-import { createTextFormFieldInteraction } from './surface-text-form-fields.ts';
+import {
+  createTextFormFieldInteraction,
+  type PendingTextFormInput,
+} from './surface-text-form-fields.ts';
 import { formsProtectionEnabled, sectionProtectsForms } from '@docx-editor.dev/core/store';
 // Engine-owned paginated paragraph surface (composition root).
 // Painted pages are the editable surface; seams live in sibling surface-*.ts modules.
@@ -310,6 +313,7 @@ export function mountPaginatedSurface(
     readonly initialDrawingSelectionIntent?: DrawingSelectionIntent;
     /** Restore the model range on a font remount without claiming DOM selection/focus. */
     readonly initialSelection?: SemanticSelection;
+    readonly initialTextFormInput?: PendingTextFormInput;
   };
   const opened = openTreeSession(
     bytes,
@@ -5877,20 +5881,24 @@ export function mountPaginatedSurface(
    * the DOM guessed.
    */
   let pointer: PointerController | null = null;
-  textFormInteraction = createTextFormFieldInteraction({
-    locale: dateLocale.get,
-    translate: (key, params) => translate?.(key, params) ?? key,
-    pagesLayer,
-    container,
-    part: () => partOfNodeId(session, selection.head.paragraphId) ?? session.part(),
-    protected: (paragraphId = selection.head.paragraphId) =>
-      formsProtectionEnabled(session.settingsRoot()) &&
-      sectionProtectsForms(partOfNodeId(session, paragraphId) ?? session.part(), paragraphId),
-    selection: () => selection,
-    select: (next) => setSelection(next),
-    editable: () => editingMode === 'edit',
-    apply: (op) => applyTextFormOperation(op, commit, applyOps),
-  });
+  textFormInteraction = createTextFormFieldInteraction(
+    {
+      locale: dateLocale.get,
+      translate: (key, params) => translate?.(key, params) ?? key,
+      pagesLayer,
+      container,
+      part: () => partOfNodeId(session, selection.head.paragraphId) ?? session.part(),
+      parts: () => session.storyParts(),
+      protected: (paragraphId = selection.head.paragraphId) =>
+        formsProtectionEnabled(session.settingsRoot()) &&
+        sectionProtectsForms(partOfNodeId(session, paragraphId) ?? session.part(), paragraphId),
+      selection: () => selection,
+      select: (next) => setSelection(next),
+      editable: () => editingMode === 'edit',
+      apply: (op) => applyTextFormOperation(op, commit, applyOps),
+    },
+    runtimeOptions.initialTextFormInput
+  );
   const dispatchKeyDown = createKeyDownHandler(
     surface,
     options.onRequestHyperlink ? { onRequestHyperlink: options.onRequestHyperlink } : {}

--- a/packages/core/src/editor/surface-text-form-fields.ts
+++ b/packages/core/src/editor/surface-text-form-fields.ts
@@ -8,6 +8,7 @@ import { refreshTextFormLabels, textFormTranslate } from './text-form-field-tran
 import type { EditorTranslate } from './docx-editor-host-config.ts';
 import {
   findNode,
+  deepParagraphOrderOfPart,
   paragraphTextOf,
   validateTreeOp,
   textFormFieldsOf,
@@ -17,12 +18,34 @@ import {
 } from '@docx-editor.dev/core/store';
 import type { SemanticSelection } from '@docx-editor.dev/core/layout';
 
+/** Input provenance belongs to the open document, including during a font remount. */
+export type PendingTextFormInput = readonly {
+  readonly partName: string;
+  readonly fieldIndex: number;
+  readonly text: string;
+  readonly locale: string;
+}[];
+const inputSnapshots = new WeakMap<HTMLElement, () => PendingTextFormInput>();
+
+function fieldsInPart(part: OoxmlPart): TextFormFieldRange[] {
+  return [...deepParagraphOrderOfPart(part).keys()].flatMap((id) => {
+    const paragraph = findNode(part, id);
+    return paragraph?.kind === 'paragraph' ? textFormFieldsOf(paragraph) : [];
+  });
+}
+
+/** Capture pending input before the current surface is destroyed. */
+export function snapshotTextFormInput(container: HTMLElement): PendingTextFormInput | undefined {
+  return inputSnapshots.get(container)?.();
+}
+
 interface Host {
   translate?: EditorTranslate;
   locale?(): string;
   readonly pagesLayer: HTMLElement;
   readonly container: HTMLElement;
   part(): OoxmlPart;
+  parts?(): readonly OoxmlPart[];
   protected(paragraphId?: string): boolean;
   selection(): SemanticSelection;
   select(selection: SemanticSelection): void;
@@ -31,7 +54,10 @@ interface Host {
 }
 
 /** Shared field interaction for all editor hosts. */
-export function createTextFormFieldInteraction(host: Host): {
+export function createTextFormFieldInteraction(
+  host: Host,
+  initialInput?: PendingTextFormInput
+): {
   fieldId(): string | null;
   keydown(event: KeyboardEvent): boolean;
   doubleClick(event: MouseEvent): boolean;
@@ -52,6 +78,18 @@ export function createTextFormFieldInteraction(host: Host): {
   let committing = false;
   type DirtyFields = Map<string, { text: string; locale: string }>;
   let dirtyBaseline: DirtyFields = new Map();
+  const parts = () => host.parts?.() ?? [host.part()];
+  if (initialInput?.length) {
+    for (const part of parts()) {
+      const saved = initialInput.filter((input) => input.partName === part.name);
+      if (!saved.length) continue;
+      const fields = fieldsInPart(part);
+      for (const input of saved) {
+        const field = fields[input.fieldIndex];
+        if (field) dirtyBaseline.set(field.fieldNodeId, { text: input.text, locale: input.locale });
+      }
+    }
+  }
   // Store history restores immutable part identities. Keep input provenance with those
   // snapshots so undo restores a clean date and redo restores the original input locale.
   const inputHistory = new WeakMap<OoxmlPart, DirtyFields>();
@@ -65,6 +103,19 @@ export function createTextFormFieldInteraction(host: Host): {
     dirtyBaseline.delete(id);
     rememberInput();
   };
+  rememberInput();
+  const snapshotInput = (): PendingTextFormInput => {
+    if (!dirtyBaseline.size) return [];
+    // Node IDs encode parse paths and can change when an earlier field gains a result run.
+    // Field order within the same saved story remains stable across serialization.
+    return parts().flatMap((part) =>
+      fieldsInPart(part).flatMap((field, fieldIndex) => {
+        const input = dirtyBaseline.get(field.fieldNodeId);
+        return input ? [{ partName: part.name, fieldIndex, ...input }] : [];
+      })
+    );
+  };
+  inputSnapshots.set(host.container, snapshotInput);
   let incoming: { paragraphId: string; fieldNodeId: string } | null | undefined;
   const rawValue = (paragraphId: string, field: TextFormFieldRange) =>
     (paragraphTextOf(host.part(), paragraphId) ?? '').slice(field.start, field.end);
@@ -612,6 +663,8 @@ export function createTextFormFieldInteraction(host: Host): {
       return true;
     },
     destroy() {
+      if (inputSnapshots.get(host.container) === snapshotInput)
+        inputSnapshots.delete(host.container);
       document.removeEventListener('pointermove', move);
       document.removeEventListener('pointercancel', cancelPress);
       host.pagesLayer.removeEventListener('click', singleClick);

--- a/packages/core/src/layout/__tests__/cjk-followups.test.ts
+++ b/packages/core/src/layout/__tests__/cjk-followups.test.ts
@@ -56,12 +56,34 @@ describe('CJK follow-up: protected groups across every run seam', () => {
     expect(textLines(parts, width)).toEqual([...expected]);
   });
 
+  test('long Latin words wrap after a protected opening or combining seam', () => {
+    for (const [parts, expected] of [
+      [
+        ['（', 'ABCDEFGHIJK'],
+        ['（ABC', 'DEFG', 'HIJK'],
+      ],
+      [
+        ['A', '\u0301BCDEFGHIJ中'],
+        ['A\u0301BC', 'DEFG', 'HIJ中'],
+      ],
+    ] as const) {
+      const lines = layout(parts, 24);
+      expect(lines.map((line) => line.spans.map((span) => span.text).join(''))).toEqual([
+        ...expected,
+      ]);
+      for (const line of lines) expect(line.width).toBeLessThanOrEqual(24);
+      expect(textLines([parts.join('')], 24)).toEqual([...expected]);
+    }
+  });
+
   test('formatting seams cannot change line breaks or lose source offsets', () => {
     for (const text of [
       '甲方（以下简称「买方」）应当按照本合同第３条、第４条之约定，支付０．５％。',
       '甲か\u3099\u309a月𠀋乙',
       '甲👩‍👩‍👧‍👦乙',
       '甲ＡＢＣ乙１２，３４５．６７％丙',
+      '（ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+      '甲A\u0301BCDEFGHIJKLMNOPQRSTUVWXYZ中',
     ]) {
       for (const width of [7, 13, 25, 36, 60]) {
         const expected = textLines([text], width);

--- a/packages/core/src/layout/oversized-word-break.ts
+++ b/packages/core/src/layout/oversized-word-break.ts
@@ -55,6 +55,8 @@ export function chopOversizedWord(
     readonly appendPrefix: (prefix: OversizedWordPrefix) => void;
     readonly closeLine: () => void;
     readonly overflowTolerancePt: number;
+    /** Keep the leading fragment with the preceding text when their seam is protected. */
+    readonly keepWithPrevious?: boolean;
     /**
      * Whether the cut at a UTF-16 index is allowed on top of grapheme safety — the kinsoku
      * sets, for CJK text. A rejected cut shrinks to the nearest accepted one; when none is
@@ -78,7 +80,7 @@ export function chopOversizedWord(
   ) {
     const graphemesLeft = graphemes.length - graphemeFrom;
     if (graphemesLeft === 1) {
-      if (options.lineHasText()) {
+      if (options.lineHasText() && !(utf16From === 0 && options.keepWithPrevious)) {
         options.closeLine();
         brokeLine = true;
         continue;
@@ -103,13 +105,17 @@ export function chopOversizedWord(
       }
     }
 
-    if (fitTo === graphemeFrom && options.lineHasText()) {
+    if (
+      fitTo === graphemeFrom &&
+      options.lineHasText() &&
+      !(utf16From === 0 && options.keepWithPrevious)
+    ) {
       options.closeLine();
       brokeLine = true;
       continue;
     }
-    // An empty line that cannot fit one grapheme must overflow by that whole grapheme, never
-    // by one UTF-16 code unit (which could split a surrogate pair or combining sequence).
+    // Overflow by one whole grapheme when none fits an empty line or a protected seam
+    // prevents moving it. The accepted cut also preserves clusters split across pieces.
     if (fitTo === graphemeFrom) fitTo += 1;
     fitTo = acceptedCut(text, graphemes, graphemeFrom, fitTo, options.cutAllowedAt);
     // The final group may continue in the next run. Keep it on the pending line;

--- a/packages/core/src/layout/paragraph-flow.ts
+++ b/packages/core/src/layout/paragraph-flow.ts
@@ -1525,12 +1525,8 @@ export function breakParagraph(
         (line.spans.length > 0 || line.drawings.length > 0)
       ) {
         if (openDecision === 'forbidden' && wordStartSpan <= 0) {
-          // The group starts this line and a rule forbids opening before it: a kinsoku seam,
-          // or one inside a grapheme cluster split across pieces. There is nothing to carry
-          // down, and chopping is the very break the rule forbids, so it is pushed out past
-          // the measure — Word's kinsoku push-out, and what the chop below reaches by itself
-          // when no accepted cut is left. `wordBoundaries` already cut at the next legal seam
-          // inside the piece, so what overflows is one protected group, not the clause.
+          // Keep the protected seam on this line. The chop below may still use later safe
+          // cuts inside an oversized Latin word; only its leading fragment must stay here.
         } else if (!opensWord && wordStartSpan === 0) {
           // Prefer a later float passage; otherwise fill this one's remainder in the chop below.
           tryAdvanceToNextPassage();
@@ -1588,8 +1584,7 @@ export function breakParagraph(
       if (
         canChopWord &&
         !hangs &&
-        (line.spans.length === 0 ||
-          (!opensWord && wordStartSpan === 0 && openDecision !== 'forbidden')) &&
+        (line.spans.length === 0 || (!opensWord && wordStartSpan === 0)) &&
         width > remainingLineWidth() + OVERFLOW_TOLERANCE_PT
       ) {
         const chopped = chopOversizedWord(candidate, remainingStart, width, {
@@ -1624,6 +1619,7 @@ export function breakParagraph(
           },
           closeLine,
           overflowTolerancePt: OVERFLOW_TOLERANCE_PT,
+          keepWithPrevious: openDecision === 'forbidden',
           // The measured fit knows nothing about kinsoku: at a one-character measure
           // 天。地。人。 chopped every other line onto a leading 。.
           cutAllowedAt: cjkBreaks

--- a/packages/editor-api/compat/manifest.json
+++ b/packages/editor-api/compat/manifest.json
@@ -438,7 +438,7 @@
   "divergences": [
     {
       "uid": "Word.Document#changeTrackingMode",
-      "note": "Server and collaborative hosts support Off and TrackMineOnly. The setting is queued, atomic with edits, and retained per host across runs; it is not a persisted document-wide policy. TrackMineOnly uses the configured runtime author and does not change peers. TrackAll and browser-host mode control refuse with NotSupported. Tracked inline text operations support one paragraph and refuse touching pending revisions. Structural and formatting mutations while tracking refuse; comments and revision decisions remain available."
+      "note": "Server and collaborative hosts support Off and TrackMineOnly. Load changeTrackingMode explicitly before reading; Document.load() retains its empty default property set on every host. The setting is queued, atomic with edits, and retained per host across runs; it is not a persisted document-wide policy. TrackMineOnly uses the configured runtime author and does not change peers. TrackAll and browser-host mode control refuse with NotSupported. Tracked inline text operations support one paragraph and refuse touching pending revisions. Structural and formatting mutations while tracking refuse; comments and revision decisions remain available."
     },
     {
       "uid": "Word.Comment#creationDate",

--- a/packages/editor-api/src/model/document.ts
+++ b/packages/editor-api/src/model/document.ts
@@ -82,7 +82,8 @@ export class Document extends ModelObject {
   }
 
   /**
-   * Tracking for this server host. Load before reading. Assignments take effect at sync.
+   * Tracking for this server host. Load 'changeTrackingMode' explicitly before reading.
+   * Document.load() keeps an empty default property set across hosts. Assignments take effect at sync.
    * TrackMineOnly tracks this runtime's inline text edits using its configured author.
    * TrackAll and browser-host mode control are not supported. Unsupported tracked mutation
    * kinds refuse; the setting is session-local and is not saved as a document-wide policy.
@@ -199,6 +200,8 @@ export class Document extends ModelObject {
 
   /** @internal Plan the read this object's `load(...)` asked for. */
   protected override onLoad(request: ResolvedLoadOptions): void {
+    // Keep the default load valid across hosts; tracking requires an explicit property load.
+    if (request.select.length === 0) return;
     const selected = this.selection(request, ['changeTrackingMode']);
     if (selected.includes('changeTrackingMode'))
       this.loadTextInto('changeTrackingMode', () => ({ op: 'getChangeTrackingMode' }));

--- a/packages/editor-api/src/runtime/__tests__/runtime-document-load.test.ts
+++ b/packages/editor-api/src/runtime/__tests__/runtime-document-load.test.ts
@@ -1,0 +1,69 @@
+/*
+Copyright (c) 2026 EigenPal, Inc. All rights reserved.
+Licensed under the EigenPal Pro Evaluation License 1.0 — see packages/editor-api/LICENSE.md.
+Production use requires a commercial agreement: licensing@eigenpal.com
+*/
+import { expect, test } from 'bun:test';
+import { createDocxEditor } from '@docx-editor.dev/core/editor';
+import { DocxEditor } from '../../index.ts';
+import { DocxEditor as DocxEditorBrowser } from '../../browser.ts';
+import { docx, p } from './support/docx.ts';
+
+const bytes = docx(p('Original'));
+
+for (const host of ['browser', 'server'] as const) {
+  test(`${host} default document loads preserve other reads and writes`, async () => {
+    const editor =
+      host === 'browser'
+        ? createDocxEditor({ container: document.createElement('div'), document: bytes })
+        : undefined;
+    const runtime = editor
+      ? DocxEditorBrowser.createBrowser(editor)
+      : await DocxEditor.createServer(bytes);
+    try {
+      await runtime.run(async (context) => {
+        context.document.load();
+        context.document.body.load('text');
+        await context.sync();
+        expect(context.document.body.text).toBe('Original');
+        expect(() => context.document.changeTrackingMode).toThrow(
+          expect.objectContaining({ code: 'PropertyNotLoaded' })
+        );
+
+        context.document.load({});
+        context.document.body.insertText(' added', 'End');
+        await context.sync();
+        context.document.body.load('text');
+        await context.sync();
+        expect(context.document.body.text).toBe('Original added');
+      });
+    } finally {
+      runtime.dispose();
+      editor?.destroy();
+    }
+  });
+}
+
+test('browser explicit tracking loads and assignments still refuse', async () => {
+  const editor = createDocxEditor({ container: document.createElement('div'), document: bytes });
+  const runtime = DocxEditorBrowser.createBrowser(editor, { author: 'Agent' });
+  try {
+    await runtime.run(async (context) => {
+      context.document.load('changeTrackingMode');
+      await expect(context.sync()).rejects.toMatchObject({
+        code: 'NotSupported',
+        target: 'document.changeTrackingMode',
+      });
+      for (const mode of ['Off', 'TrackMineOnly', 'TrackAll'] as const) {
+        context.document.changeTrackingMode = mode;
+        await expect(context.sync()).rejects.toMatchObject({
+          code: 'NotSupported',
+          target: 'document.changeTrackingMode',
+        });
+      }
+    });
+  } finally {
+    runtime.dispose();
+    editor.destroy();
+  }
+});


### PR DESCRIPTION
Fix three regressions found during the 2.16 release review:

- Keep default `Document.load()` calls valid in browser runtimes; tracking still requires an explicit property load.
- Wrap oversized words after protected punctuation or grapheme boundaries without splitting those boundaries.
- Preserve pending date input and its original locale when fonts replace the editing surface, including when saving changes field IDs.

Adds regression coverage and a patch changeset. Three reviewers found no remaining issues in the fixes. Package builds, six browser tests, and all pre-commit checks pass.

The full suite reports 12,529 passing tests and one out-of-memory failure in the existing 364 MiB heap test. Its entire seven-test file passes on rerun, and the failing case passes a second isolated run. CI is pending.
