### PR TITLE
fix(core): make tracked insertion underlines Word-like

### DIFF
--- a/.changeset/thin-revision-underlines.md
+++ b/.changeset/thin-revision-underlines.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Use a thin solid underline for tracked insertions and add CSS tokens for its style and thickness.

--- a/docs/site/content/pro/review-styling.mdx
+++ b/docs/site/content/pro/review-styling.mdx
@@ -204,9 +204,10 @@ receive its configured image. Do not use review styling as identity proof.
 `data-review-author-slot` wraps to `0` through `7`. Calculate it as `slot % 8`
 when you build selectors from `useReviewAuthors()`.
 
-Painted spans use an inline ink color. CSS cannot override that color or its text
-decoration. Use a declaration or ramp token for ink. Use `currentColor` for
-metric-safe span effects.
+Painted spans use inline ink and text decoration. CSS selectors cannot override
+those properties. Use a declaration or ramp token for ink. Use the insertion
+decoration tokens for insertion underlines. Use `currentColor` for metric-safe
+span effects.
 
 ```css
 .docx-editor [data-review-author='Jess Lin'] {

--- a/docs/site/content/pro/review-styling.mdx
+++ b/docs/site/content/pro/review-styling.mdx
@@ -17,7 +17,7 @@ and [comments](/docs/2.x/pro/comments).
 | Author assignment       | Authors receive slots in first-appearance order.                 |
 | Color ramp              | `--doc-review-author-0` through `--doc-review-author-7`          |
 | More than eight authors | The ramp repeats after eight authors.                            |
-| Change type             | Insertions stay underlined. Deletions stay struck through.       |
+| Change type             | Insertions use a thin solid underline. Deletions use a strike.   |
 | Review sidebar          | Cards use the author color for the leading edge and avatar disc. |
 | Comment highlights      | All authors use the same yellow highlight by default.            |
 
@@ -33,11 +33,23 @@ Override ramp tokens under `.docx-editor`. Load your stylesheet after
 
 The document filter handles dark mode. Review chrome adjusts separately.
 
+### Customize insertion underlines
+
+Override the insertion decoration tokens under `.docx-editor`. These tokens
+change presentation only.
+
+```css
+.docx-editor {
+  --doc-revision-insertion-decoration-style: dashed;
+  --doc-revision-insertion-decoration-thickness: 0.08em;
+}
+```
+
 ## Choose a styling API
 
 | API                             | Use                                                              |
 | ------------------------------- | ---------------------------------------------------------------- |
-| CSS tokens                      | Replace the shared eight-color ramp.                             |
+| CSS tokens                      | Replace the color ramp or insertion underline.                   |
 | `AuthorStyle` declaration       | Set one author's color, background, classes, or avatar.          |
 | `ColorByChangeType` declaration | Color unmatched insertions green and deletions red.              |
 | `setRevisionStyles`             | Control the same state from an editor instance or headless host. |

--- a/packages/core/src/output/__tests__/revision-paint.test.ts
+++ b/packages/core/src/output/__tests__/revision-paint.test.ts
@@ -54,14 +54,17 @@ function trackedSpans(root: HTMLElement): HTMLElement[] {
 }
 
 describe('the reader can see which text is tracked', () => {
-  test('an insertion is underlined, dashed so it cannot be read as authored w:u', () => {
+  test('an insertion uses the configurable thin Word-like underline', () => {
     const root = paint(`<w:p>${run('keep ')}${ins('1', run('added'))}</w:p>`);
     const spans = trackedSpans(root);
     expect(spans.length).toBeGreaterThan(0);
     const span = spans[0]!;
     expect(span.textContent).toBe('added');
     expect(span.style.textDecorationLine).toBe('underline');
-    expect(span.style.textDecorationStyle).toBe('dashed');
+    expect(span.style.textDecorationStyle).toBe('var(--doc-revision-insertion-decoration-style)');
+    expect(span.style.textDecorationThickness).toBe(
+      'var(--doc-revision-insertion-decoration-thickness)'
+    );
     // Coloured by AUTHOR by default, as Word does — the decoration is what says "added".
     expect(span.style.color).toBe('var(--doc-review-author-0)');
   });

--- a/packages/core/src/output/revision-presentation.ts
+++ b/packages/core/src/output/revision-presentation.ts
@@ -639,12 +639,9 @@ export function revisionPresentationOf(
     // A deletion nested in an insertion still reads as removed: the strike wins over the
     // underline its container would have drawn.
     line: deleted && line === 'underline' ? 'line-through' : line,
-    // An insertion's rule is DASHED. A solid one is hard to tell from an authored `w:u`, which
-    // underlines plenty of ordinary text in a contract, so two different statements would be
-    // drawn identically. A strike has no such clash and stays solid; a move stays double,
-    // because it is one decision with two halves.
-    decorationStyle:
-      kind === 'moveFrom' || kind === 'moveTo' ? 'double' : kind === 'insert' ? 'dashed' : 'solid',
+    // An insertion follows Word with a solid rule. Colour and the revision wash distinguish it
+    // from an authored `w:u`; a move stays double because it is one decision with two halves.
+    decorationStyle: kind === 'moveFrom' || kind === 'moveTo' ? 'double' : 'solid',
     // Coloured by KIND, not by author: a reader scanning a page needs "added" and "removed"
     // to be the two things they can tell apart at a glance, and Word's own default view draws
     // them that way. The per-author ramp stays available for the review cards, where the

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -897,8 +897,7 @@ function applyRevisionPresentation(
     // The wash keeps the KIND pair under either scheme — unless the host's style for this
     // author says otherwise. At its faint strength an author-mixed wash is
     // indistinguishable anyway, and the kind pair keeps "added" and "removed" scannable
-    // while the ink answers "whose". It also needs no `color-mix()`, which a host-supplied
-    // literal colour would have forced on every painted run.
+    // while the ink answers "whose". It also avoids per-run `color-mix()` for host colours.
     element.style.backgroundColor =
       authorStyle?.background ??
       (presentation.deleted
@@ -906,7 +905,13 @@ function applyRevisionPresentation(
         : 'var(--doc-revision-insertion-wash)');
     if (presentation.line) {
       element.style.textDecorationLine = presentation.line;
-      element.style.textDecorationStyle = presentation.decorationStyle;
+      if (attribution.kind === 'insert' && presentation.line === 'underline') {
+        element.style.textDecorationStyle = 'var(--doc-revision-insertion-decoration-style)';
+        element.style.textDecorationThickness =
+          'var(--doc-revision-insertion-decoration-thickness)';
+      } else {
+        element.style.textDecorationStyle = presentation.decorationStyle;
+      }
       element.style.textDecorationColor = color;
     }
     return;

--- a/packages/core/src/styles/__tests__/stylesheet-parses.test.ts
+++ b/packages/core/src/styles/__tests__/stylesheet-parses.test.ts
@@ -63,4 +63,15 @@ describe('the shipped stylesheets parse', () => {
       expect(selectorMentions(fragment), fragment).toBe(true);
     }
   });
+
+  test('tracked insertions default to a thin solid underline', () => {
+    const css = readFileSync(resolve(repositoryRoot, STYLESHEETS[0]!), 'utf8');
+    const root = postcss.parse(css);
+    const values = new Map<string, string>();
+    root.walkDecls(/^--doc-revision-insertion-decoration-/, (declaration) => {
+      values.set(declaration.prop, declaration.value);
+    });
+    expect(values.get('--doc-revision-insertion-decoration-style')).toBe('solid');
+    expect(values.get('--doc-revision-insertion-decoration-thickness')).toBe('0.06em');
+  });
 });

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -147,6 +147,10 @@
   --doc-revision-deletion: #c62828;
   --doc-revision-insertion-tint: rgba(46, 125, 50, 0.09);
   --doc-revision-deletion-tint: rgba(198, 40, 40, 0.09);
+  /* Word marks inserted text with a thin solid underline. Hosts can change these two
+     presentation tokens without changing revision data or editor configuration. */
+  --doc-revision-insertion-decoration-style: solid;
+  --doc-revision-insertion-decoration-thickness: 0.06em;
   /* THE HIGHLIGHT LAYER, which reads the same for tracked changes and for comments:
      `-bg` is the band's fill and `-border` the rule under it, and an `-active-` pair is
      the same two for the one the reader has open. The comment family is below.


### PR DESCRIPTION
## Summary
- Use a thin solid underline for tracked insertions.
- Add CSS tokens for insertion underline style and thickness.

## Test plan
- [x] Run the tracked revision paint tests.
- [x] Run the stylesheet parse tests.
- [x] Run type checks, lint, formatting, parity checks, and API checks.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791700853&installation_model_id=422592&pr_number=797&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F797&signature=eafe4baf16f1ff857c0203220c0f3b52a631bbe9ad7723703d07234dd04f6041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->