### PR TITLE
fix(core): add Word-like gap below tracked insertion underlines

### DIFF
--- a/.changeset/revision-underline-offset.md
+++ b/.changeset/revision-underline-offset.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Set tracked insertion underlines slightly below the text like Word, with a CSS token for the gap.

--- a/docs/site/content/pro/review-styling.mdx
+++ b/docs/site/content/pro/review-styling.mdx
@@ -42,6 +42,7 @@ change presentation only.
 .docx-editor {
   --doc-revision-insertion-decoration-style: dashed;
   --doc-revision-insertion-decoration-thickness: 0.08em;
+  --doc-revision-insertion-underline-offset: 0.2em;
 }
 ```
 

--- a/packages/core/src/output/__tests__/revision-paint.test.ts
+++ b/packages/core/src/output/__tests__/revision-paint.test.ts
@@ -65,6 +65,7 @@ describe('the reader can see which text is tracked', () => {
     expect(span.style.textDecorationThickness).toBe(
       'var(--doc-revision-insertion-decoration-thickness)'
     );
+    expect(span.style.textUnderlineOffset).toBe('var(--doc-revision-insertion-underline-offset)');
     // Coloured by AUTHOR by default, as Word does — the decoration is what says "added".
     expect(span.style.color).toBe('var(--doc-review-author-0)');
   });

--- a/packages/core/src/output/semantic-paint.ts
+++ b/packages/core/src/output/semantic-paint.ts
@@ -909,6 +909,7 @@ function applyRevisionPresentation(
         element.style.textDecorationStyle = 'var(--doc-revision-insertion-decoration-style)';
         element.style.textDecorationThickness =
           'var(--doc-revision-insertion-decoration-thickness)';
+        element.style.textUnderlineOffset = 'var(--doc-revision-insertion-underline-offset)';
       } else {
         element.style.textDecorationStyle = presentation.decorationStyle;
       }

--- a/packages/core/src/styles/__tests__/stylesheet-parses.test.ts
+++ b/packages/core/src/styles/__tests__/stylesheet-parses.test.ts
@@ -68,10 +68,11 @@ describe('the shipped stylesheets parse', () => {
     const css = readFileSync(resolve(repositoryRoot, STYLESHEETS[0]!), 'utf8');
     const root = postcss.parse(css);
     const values = new Map<string, string>();
-    root.walkDecls(/^--doc-revision-insertion-decoration-/, (declaration) => {
+    root.walkDecls(/^--doc-revision-insertion-/, (declaration) => {
       values.set(declaration.prop, declaration.value);
     });
     expect(values.get('--doc-revision-insertion-decoration-style')).toBe('solid');
     expect(values.get('--doc-revision-insertion-decoration-thickness')).toBe('0.06em');
+    expect(values.get('--doc-revision-insertion-underline-offset')).toBe('0.15em');
   });
 });

--- a/packages/core/src/styles/editor.css
+++ b/packages/core/src/styles/editor.css
@@ -147,10 +147,12 @@
   --doc-revision-deletion: #c62828;
   --doc-revision-insertion-tint: rgba(46, 125, 50, 0.09);
   --doc-revision-deletion-tint: rgba(198, 40, 40, 0.09);
-  /* Word marks inserted text with a thin solid underline. Hosts can change these two
-     presentation tokens without changing revision data or editor configuration. */
+  /* Word marks inserted text with a thin solid underline that sits slightly below the
+     glyphs. Hosts can change these three presentation tokens without changing revision
+     data or editor configuration. */
   --doc-revision-insertion-decoration-style: solid;
   --doc-revision-insertion-decoration-thickness: 0.06em;
+  --doc-revision-insertion-underline-offset: 0.15em;
   /* THE HIGHLIGHT LAYER, which reads the same for tracked changes and for comments:
      `-bg` is the band's fill and `-border` the rule under it, and an `-active-` pair is
      the same two for the one the reader has open. The comment family is below.


### PR DESCRIPTION
## Summary
- Set tracked insertion underlines slightly below the text, like Word.
- Add a CSS token for the gap alongside the existing style and thickness tokens.

## Test plan
- [x] Run the tracked revision paint tests.
- [x] Run the stylesheet parse tests.
- [x] Run type checks, lint, formatting, parity checks, and API checks.
- [x] Verify the default gap and an override render in the demo app.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/799"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791713849&installation_model_id=422592&pr_number=799&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F799&signature=363745959fa878631fb773a9d016e0a23c794cb36d21e738274611a40079a815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->