### PR TITLE
feat: let hosts control the navigation pane

### DIFF
--- a/.changeset/controlled-navigation-pane.md
+++ b/.changeset/controlled-navigation-pane.md
@@ -1,0 +1,6 @@
+---
+'@docx-editor.dev/react': minor
+'@docx-editor.dev/vue': minor
+---
+
+Let `navigation` on `<DocxEditor>` pass through pane props so hosts can control open state and the active tab, and focus the find input when that tab is shown.

--- a/docs/CUSTOMIZING.md
+++ b/docs/CUSTOMIZING.md
@@ -52,25 +52,30 @@ can.
 
 Where a sub-element is rendered outside `children` and so cannot be composed — the
 navigation toggle, which has to stay clickable while the panel is `inert` — the prop takes
-props: `toggle={{ className }}`. `menu` and `contextMenu` on `<DocxEditor>` accept
-`boolean | Props` the same way.
+props: `toggle={{ className }}`. `menu`, `contextMenu` and `navigation` on `<DocxEditor>`
+accept `boolean | Props` the same way.
 
 **What you can pass**
 
-| Prop | Where | Notes |
-| --- | --- | --- |
-| `icon` | toolbar parts, menu rows, menu triggers, colour splits, context-menu rows | Any `ReactNode`. ~18px inline SVG matches the packaged controls |
-| `t` | any compound | Your i18n resolver. Without it the raw keys render, never English |
-| `preset={false}` | any compound | Renders your children verbatim, in your order |
-| `hidden` | any packaged part | Removes it from the default arrangement |
-| `className` | every part | Appended after the load-bearing classes |
-| `label`, `onSelect`, `disabled`, `disabledReason` | `Toolbar.Action`, `ContextMenu.Item`, `Menu.Row` | Host-owned actions |
+| Prop                                              | Where                                                                     | Notes                                                             |
+| ------------------------------------------------- | ------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `icon`                                            | toolbar parts, menu rows, menu triggers, colour splits, context-menu rows | Any `ReactNode`. ~18px inline SVG matches the packaged controls   |
+| `t`                                               | any compound                                                              | Your i18n resolver. Without it the raw keys render, never English |
+| `preset={false}`                                  | any compound                                                              | Renders your children verbatim, in your order                     |
+| `hidden`                                          | any packaged part                                                         | Removes it from the default arrangement                           |
+| `className`                                       | every part                                                                | Appended after the load-bearing classes                           |
+| `label`, `onSelect`, `disabled`, `disabledReason` | `Toolbar.Action`, `ContextMenu.Item`, `Menu.Row`                          | Host-owned actions                                                |
 
 **Host actions still ask the engine.** A control the registry does not describe has no
 enabled state of its own — but you can borrow the engine's:
 
 ```tsx
-const { isEnabled, disabledReason } = useEditorCommand({ type: 'setMarkAttr', mark: 'highlight', attr: 'val', value: 'cyan' });
+const { isEnabled, disabledReason } = useEditorCommand({
+  type: 'setMarkAttr',
+  mark: 'highlight',
+  attr: 'val',
+  value: 'cyan',
+});
 ```
 
 `useEditorCommand` takes a `ChromeSlotId` **or** a raw `EditorCommand`, so your own action
@@ -99,23 +104,23 @@ pane alone, and nothing else in the app changes.
 
 ### The palette
 
-| Token | Paints |
-| --- | --- |
-| `--doc-surface` | Panels, menus, dropdowns, cards |
-| `--doc-card` | Comment and suggestion cards |
-| `--doc-bg` | The workspace behind the page |
-| `--doc-bg-subtle`, `--doc-bg-input` | Section backgrounds, input fields |
-| `--doc-bg-hover` | Hover states — **and** the navigation toggle's resting plate |
-| `--doc-primary`, `--doc-primary-hover`, `--doc-primary-light` | Accent, selected states |
-| `--doc-accent`, `--doc-accent-bg` | Secondary accent |
-| `--doc-on-primary` | Text on an accent fill |
-| `--doc-text`, `--doc-text-muted`, `--doc-text-subtle`, `--doc-text-placeholder` | Text ramp. The rulers draw their ticks in the last two |
-| `--doc-border`, `--doc-border-light`, `--doc-border-dark`, `--doc-border-input` | Rules and outlines |
-| `--doc-link` | Hyperlinks in chrome |
-| `--doc-error`, `--doc-success`, `--doc-warning` (+ `-bg`) | Status |
-| `--doc-focus-ring`, `--doc-selection` | Focus and selection |
-| `--doc-shadow`, `--doc-shadow-strong`, `--doc-shadow-subtle`, `--doc-shadow-lg` | Elevation |
-| `--doc-overlay` | Modal backdrops |
+| Token                                                                           | Paints                                                       |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `--doc-surface`                                                                 | Panels, menus, dropdowns, cards                              |
+| `--doc-card`                                                                    | Comment and suggestion cards                                 |
+| `--doc-bg`                                                                      | The workspace behind the page                                |
+| `--doc-bg-subtle`, `--doc-bg-input`                                             | Section backgrounds, input fields                            |
+| `--doc-bg-hover`                                                                | Hover states — **and** the navigation toggle's resting plate |
+| `--doc-primary`, `--doc-primary-hover`, `--doc-primary-light`                   | Accent, selected states                                      |
+| `--doc-accent`, `--doc-accent-bg`                                               | Secondary accent                                             |
+| `--doc-on-primary`                                                              | Text on an accent fill                                       |
+| `--doc-text`, `--doc-text-muted`, `--doc-text-subtle`, `--doc-text-placeholder` | Text ramp. The rulers draw their ticks in the last two       |
+| `--doc-border`, `--doc-border-light`, `--doc-border-dark`, `--doc-border-input` | Rules and outlines                                           |
+| `--doc-link`                                                                    | Hyperlinks in chrome                                         |
+| `--doc-error`, `--doc-success`, `--doc-warning` (+ `-bg`)                       | Status                                                       |
+| `--doc-focus-ring`, `--doc-selection`                                           | Focus and selection                                          |
+| `--doc-shadow`, `--doc-shadow-strong`, `--doc-shadow-subtle`, `--doc-shadow-lg` | Elevation                                                    |
+| `--doc-overlay`                                                                 | Modal backdrops                                              |
 
 Dark mode is the same list re-declared under `.docx-editor.dark`.
 
@@ -129,7 +134,7 @@ Dark mode is the same list re-declared under `.docx-editor.dark`.
 ### What is deliberately not themeable
 
 **The document canvas.** Painter output stays Word-faithful — a page that matched your brand
-would be a lie about what the file contains. Theme the space *around* the page instead; Igloo
+would be a lie about what the file contains. Theme the space _around_ the page instead; Igloo
 puts the page on an iceberg rather than tinting it.
 
 ---
@@ -166,7 +171,7 @@ Both cost real debugging time in Igloo, and both are ordinary CSS a host would w
 **`backdrop-filter` captures `position: fixed` children.** An element with
 `backdrop-filter` (or `filter`, or `transform`) becomes the containing block for every fixed
 descendant. A frosted header containing the menu bar makes the Page Setup dialog's
-`inset: 0` overlay resolve against the *header*, so the dialog centres inside a 120px strip.
+`inset: 0` overlay resolve against the _header_, so the dialog centres inside a 120px strip.
 Put the effect on a `::before` pseudo-element instead.
 
 **`z-index` traps popovers.** A `z-index` on the wrapper around `Viewport` opens a stacking

--- a/docs/PROPS.md
+++ b/docs/PROPS.md
@@ -48,7 +48,7 @@ so they stay explicit instead of accidental.
 | `onTitleChange`                              | `(title: string) => void`               | Makes the title editable.                              |
 | `renderTitleBarLeft` / `renderTitleBarRight` | `() => ReactNode`                       | Host-owned title-bar slots.                            |
 | `menu`                                       | `boolean \| DocxEditorMenuProps`        | Toggle or customize the packaged menu row.             |
-| `navigation`                                 | `boolean`                               | Toggle the packaged navigation pane.                   |
+| `navigation`                                 | `boolean \| DocxEditorNavigationProps`  | Toggle or customize the packaged navigation pane.      |
 | `hyperlinkPopup`                             | `boolean`                               | Toggle the packaged link popover.                      |
 | `contextMenu`                                | `boolean \| DocxEditorContextMenuProps` | Toggle or customize the packaged context menu.         |
 | `children`                                   | `ReactNode`                             | Render host chrome inside the viewport.                |

--- a/docs/api/docx-editor-react/index.api.md
+++ b/docs/api/docx-editor-react/index.api.md
@@ -739,7 +739,7 @@ export interface DocxEditorProps {
     menu?: boolean | DocxEditorMenuProps;
     mode?: EditorMode;
     modules?: readonly EditorModule[];
-    navigation?: boolean;
+    navigation?: boolean | DocxEditorNavigationProps;
     onChange?: (change: DocumentChange) => void;
     onFontError?: (error: EditorFontError) => void;
     onOpen?: () => void;

--- a/docs/api/docx-editor-vue/index.api.md
+++ b/docs/api/docx-editor-vue/index.api.md
@@ -2874,7 +2874,7 @@ export interface DocxEditorProps {
     mode?: EditorMode;
     modules?: readonly EditorModule[];
     // (undocumented)
-    navigation?: boolean;
+    navigation?: boolean | DocxEditorNavigationProps;
     // (undocumented)
     rulers?: boolean;
     t?: (key: string, params?: Record<string, string | number>) => string;

--- a/docs/site/content/guides/toolbar.mdx
+++ b/docs/site/content/guides/toolbar.mdx
@@ -46,7 +46,7 @@ Use these root props to configure the packaged frame:
 | `renderTitleBarLeft` / `renderTitleBarRight` | `() => ReactNode`                       | Host-owned title bar slots.                        |
 | `menu`                                       | `boolean \| DocxEditorMenuProps`        | Toggle or customize the packaged menu row.         |
 | `chrome`                                     | `boolean`                               | Set `false` to remove the packaged frame entirely. |
-| `navigation`                                 | `boolean`                               | Toggle the packaged navigation pane.               |
+| `navigation`                                 | `boolean \| DocxEditorNavigationProps`  | Toggle or customize the packaged navigation pane.  |
 | `hyperlinkPopup`                             | `boolean`                               | Toggle the packaged link popover.                  |
 | `contextMenu`                                | `boolean \| DocxEditorContextMenuProps` | Toggle or customize the packaged context menu.     |
 
@@ -60,7 +60,7 @@ Use these root props to configure the packaged frame:
 | `#titleBarLeft` / `#titleBarRight` | slot                                    | Host-owned title bar slots.                        |
 | `menu`                             | `boolean \| DocxEditorMenuProps`        | Toggle or customize the packaged menu row.         |
 | `chrome`                           | `boolean`                               | Set `false` to remove the packaged frame entirely. |
-| `navigation`                       | `boolean`                               | Toggle the packaged navigation pane.               |
+| `navigation`                       | `boolean \| DocxEditorNavigationProps`  | Toggle or customize the packaged navigation pane.  |
 | `hyperlinkPopup`                   | `boolean`                               | Toggle the packaged link popover.                  |
 | `contextMenu`                      | `boolean \| DocxEditorContextMenuProps` | Toggle or customize the packaged context menu.     |
 

--- a/docs/site/content/react/props.mdx
+++ b/docs/site/content/react/props.mdx
@@ -85,7 +85,7 @@ These props control the packaged frame around the document.
 | `renderTitleBarLeft` / `renderTitleBarRight` | `() => ReactNode`                       | Renders host content in title-bar slots.                                        |
 | `colorMode`                                  | `'light' \| 'dark' \| 'system'`         | Sets the chrome theme. `'system'` follows the operating system.                 |
 | `menu`                                       | `boolean \| DocxEditorMenuProps`        | Shows, hides, or configures the packaged menu bar.                              |
-| `navigation`                                 | `boolean`                               | Shows or hides the packaged navigation pane.                                    |
+| `navigation`                                 | `boolean \| DocxEditorNavigationProps`  | Shows, hides, or configures the packaged navigation pane.                       |
 | `rulers`                                     | `boolean`                               | Shows or hides the horizontal and vertical rulers.                              |
 | `hyperlinkPopup`                             | `boolean`                               | Shows or hides the packaged hyperlink popover.                                  |
 | `contextMenu`                                | `boolean \| DocxEditorContextMenuProps` | Shows, hides, or configures the packaged context menu.                          |

--- a/docs/site/content/vue/props.mdx
+++ b/docs/site/content/vue/props.mdx
@@ -75,16 +75,16 @@ Pro entry also exports custom-node chip and context-menu chrome.
 
 These props control the packaged frame:
 
-| Prop             | Type                                    | Description                              |
-| ---------------- | --------------------------------------- | ---------------------------------------- |
-| `chrome`         | `boolean`                               | Toggles the packaged frame.              |
-| `menu`           | `boolean \| DocxEditorMenuProps`        | Toggles or configures the menu bar.      |
-| `navigation`     | `boolean`                               | Toggles the navigation pane.             |
-| `rulers`         | `boolean`                               | Toggles both packaged rulers.            |
-| `hyperlinkPopup` | `boolean`                               | Toggles the hyperlink popover.           |
-| `contextMenu`    | `boolean \| DocxEditorContextMenuProps` | Toggles or configures the context menu.  |
-| `t`              | `(key, params?) => string`              | Resolves live chrome and drawing labels. |
-| `i18n`           | `Translations`                          | Supplies a live catalog to this editor.  |
+| Prop             | Type                                    | Description                                |
+| ---------------- | --------------------------------------- | ------------------------------------------ |
+| `chrome`         | `boolean`                               | Toggles the packaged frame.                |
+| `menu`           | `boolean \| DocxEditorMenuProps`        | Toggles or configures the menu bar.        |
+| `navigation`     | `boolean \| DocxEditorNavigationProps`  | Toggles or configures the navigation pane. |
+| `rulers`         | `boolean`                               | Toggles both packaged rulers.              |
+| `hyperlinkPopup` | `boolean`                               | Toggles the hyperlink popover.             |
+| `contextMenu`    | `boolean \| DocxEditorContextMenuProps` | Toggles or configures the context menu.    |
+| `t`              | `(key, params?) => string`              | Resolves live chrome and drawing labels.   |
+| `i18n`           | `Translations`                          | Supplies a live catalog to this editor.    |
 
 Set `chrome` to `false` for the document surface without packaged chrome. You can
 then build the frame from the [composition primitives](/docs/2.x/vue/composition).

--- a/packages/react/src/components/DocxEditor.tsx
+++ b/packages/react/src/components/DocxEditor.tsx
@@ -390,7 +390,12 @@ const DocxEditorFrame = forwardRef<DocxEditorRef, DocxEditorProps>(
           leaves the page alone until the window is too narrow to hold both. Without a
           pane this wrapper is an inert flex row around the same viewport. */}
         <div style={WORKSPACE_STYLE}>
-          {navigation ? <DocxEditorNavigationCompound t={translate} /> : null}
+          {navigation === false ? null : (
+            <DocxEditorNavigationCompound
+              t={translate}
+              {...(typeof navigation === 'object' ? navigation : {})}
+            />
+          )}
           {viewport}
           <PageNumberTranslationContext.Provider value={translate}>
             <DocxEditorPageNumber />

--- a/packages/react/src/editor/navigation/parts.tsx
+++ b/packages/react/src/editor/navigation/parts.tsx
@@ -12,7 +12,7 @@ import type { DocxEditorChildren } from '../../docx-editor-children';
 // at the engine's derivation boundary (length-capped, control characters flattened). These
 // components put them in `textContent` only — never in a style string, never in markup.
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { CSSProperties, KeyboardEvent, ReactElement } from 'react';
 import type { TextMatch } from '@docx-editor.dev/core/contracts/editor';
 import { MaterialSymbol } from '../../components/ui/Icons';
@@ -174,10 +174,20 @@ function SearchBox({
   clearLabel: string;
   autoFocus?: boolean;
 }): ReactElement {
+  // The find panel stays mounted (hidden or inert) so a typed query survives a close.
+  // HTML `autoFocus` only runs on first mount, which is the closed pane — focus when
+  // the field actually becomes the visible target.
+  const inputRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (!autoFocus) return;
+    inputRef.current?.focus();
+  }, [autoFocus]);
+
   return (
     <div className="docx-nav__searchbox">
       <MaterialSymbol name="search" size={18} className="docx-nav__search-icon" />
       <input
+        ref={inputRef}
         type="search"
         className="docx-nav__search-input"
         value={value}
@@ -315,6 +325,7 @@ export function NavigationFind({ className, style }: NavigationPartProps): React
   const { pane, search, t } = useNavigationContext('Find');
   const hidden = pane.tab !== 'find';
   const hasQuery = search.query.trim().length > 0;
+  const autoFocus = pane.open && !hidden;
 
   // Before any navigation nothing is selected, so the readout is a TOTAL, not a position:
   // saying "Result 1 of 7" while the caret has not moved claims a selection that is not
@@ -347,6 +358,7 @@ export function NavigationFind({ className, style }: NavigationPartProps): React
         placeholder={t('navigation.find.placeholder')}
         label={t('navigation.find.inputAriaLabel')}
         clearLabel={t('navigation.find.clearAriaLabel')}
+        autoFocus={autoFocus}
       />
 
       <div

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -20,6 +20,7 @@ import type {
 import type { Translations } from '@docx-editor.dev/i18n';
 import type { DocxEditorMenuProps } from './editor/menu';
 import type { DocxEditorContextMenuProps } from './editor/contextmenu';
+import type { DocxEditorNavigationProps } from './editor/navigation';
 export { EditorFontError } from '@docx-editor.dev/core/contracts/editor';
 export type {
   EditorFontErrorCode,
@@ -167,8 +168,15 @@ export interface DocxEditorProps {
    * space that is already empty, and only moves the page when the window is genuinely too
    * narrow to hold both. Compose `DocxEditor.Navigation` yourself, or build on
    * `useNavigationPane` / `useDocumentOutline` / `useDocumentSearch`, for a different one.
+   *
+   * An object is `DocxEditorNavigationProps`, passed straight through, so a host can drive
+   * the pane from its own chrome without giving up the packaged one:
+   * `navigation={{ open, onOpenChange }}` toggles it, `navigation={{ tab: 'find', onTabChange }}`
+   * opens Find. Before this took an object the only way to change any of that was
+   * `navigation={false}` plus rebuilding the pane. `true`/undefined keep the packaged
+   * defaults.
    */
-  navigation?: boolean;
+  navigation?: boolean | DocxEditorNavigationProps;
   /**
    * Horizontal and vertical rulers, on by default with the packaged chrome.
    *

--- a/packages/react/test/navigation-pane.test.tsx
+++ b/packages/react/test/navigation-pane.test.tsx
@@ -18,7 +18,8 @@ import './dom-setup.ts';
 (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 import { afterEach, describe, expect, test } from 'bun:test';
-import { cleanup, render } from '@testing-library/react';
+import { act, cleanup, fireEvent, render } from '@testing-library/react';
+import { DocxEditor } from '../src/components/DocxEditor.tsx';
 import { DocxEditorRoot } from '../src/editor/DocxEditorRoot.tsx';
 import { DocxEditorNavigation } from '../src/editor/navigation/DocxEditorNavigation.tsx';
 import { NavigationHeadings } from '../src/editor/navigation/parts.tsx';
@@ -238,6 +239,53 @@ describe('DocxEditor.Navigation', () => {
     expect(seen).toEqual([true]);
     // Controlled: the pane does not move itself.
     expect(container.querySelector('.docx-nav')?.getAttribute('data-open')).toBe('false');
+  });
+
+  test('`<DocxEditor navigation={{...}}>` forwards pane props instead of forcing navigation={false}', () => {
+    const seen: boolean[] = [];
+    const { container } = render(
+      <DocxEditor
+        navigation={{ open: false, onOpenChange: (next) => seen.push(next), tab: 'find' }}
+      />
+    );
+    expect(container.querySelector('.docx-nav')).not.toBeNull();
+    expect(container.querySelector('.docx-nav')?.getAttribute('data-open')).toBe('false');
+    expect(container.querySelector('#docx-nav-tab-find')?.getAttribute('aria-selected')).toBe(
+      'true'
+    );
+    (container.querySelector('.docx-nav__toggle') as HTMLButtonElement).click();
+    expect(seen).toEqual([true]);
+    expect(container.querySelector('.docx-nav')?.getAttribute('data-open')).toBe('false');
+  });
+
+  test('navigation={false} removes the packaged pane', () => {
+    const { container } = render(<DocxEditor navigation={false} />);
+    expect(container.querySelector('.docx-nav')).toBeNull();
+  });
+
+  test('the find input is focused when the find tab is shown', () => {
+    const { container } = render(
+      <DocxEditorRoot>
+        <DocxEditorNavigation open tab="find" />
+      </DocxEditorRoot>
+    );
+    expect(document.activeElement).toBe(
+      container.querySelector('#docx-nav-panel-find .docx-nav__search-input')
+    );
+  });
+
+  test('switching to the find tab focuses the query input', () => {
+    const { container } = render(
+      <DocxEditorRoot>
+        <DocxEditorNavigation defaultOpen />
+      </DocxEditorRoot>
+    );
+    const input = container.querySelector('#docx-nav-panel-find .docx-nav__search-input');
+    expect(document.activeElement).not.toBe(input);
+    act(() => {
+      fireEvent.click(container.querySelector('#docx-nav-tab-find')!);
+    });
+    expect(document.activeElement).toBe(input);
   });
 
   test('a part outside its compound root fails loudly rather than rendering nothing', () => {

--- a/packages/vue/src/components/DocxEditor.tsx
+++ b/packages/vue/src/components/DocxEditor.tsx
@@ -24,6 +24,7 @@ import { DocxEditorMenu } from '../editor/menu';
 import { DocxEditorHorizontalRuler, DocxEditorVerticalRuler } from '../editor/DocxEditorRulers';
 import { DocxEditorDocumentOutline } from '../editor/DocxEditorOutline';
 import { DocxEditorNavigation, Navigation } from '../editor/navigation';
+import type { DocxEditorNavigationProps } from '../editor/navigation';
 import { DocxEditorPageSetupDialog } from '../editor/DocxEditorPageSetup';
 import { DocxEditorParagraphDialog } from '../editor/DocxEditorParagraphDialog';
 import { DocxEditorPageNumber, PageNumberTranslationContext } from '../editor/DocxEditorPageNumber';
@@ -193,7 +194,10 @@ const docxEditorFrameProps = {
     type: [Boolean, Object] as PropType<boolean | DocxEditorContextMenuProps>,
     default: undefined,
   },
-  navigation: { type: Boolean, default: undefined },
+  navigation: {
+    type: [Boolean, Object] as PropType<boolean | DocxEditorNavigationProps>,
+    default: undefined,
+  },
   rulers: { type: Boolean, default: undefined },
   mode: { type: String as PropType<DocxEditorProps['mode']>, default: undefined },
   zoom: { type: Number, default: undefined },
@@ -402,7 +406,12 @@ const DocxEditorFrame = defineComponent({
                 : null,
               h(DocxEditorFontNotice, { t }),
               h('div', { style: WORKSPACE_STYLE }, [
-                navigation.value ? h(DocxEditorNavigation, { t }) : null,
+                navigation.value === false
+                  ? null
+                  : h(DocxEditorNavigation, {
+                      t,
+                      ...(typeof navigation.value === 'object' ? navigation.value : {}),
+                    }),
                 viewport,
                 h(DocxEditorPageNumber),
                 h(DocxEditorLoading, { overlay: true }),

--- a/packages/vue/src/editor/navigation/parts.tsx
+++ b/packages/vue/src/editor/navigation/parts.tsx
@@ -1,4 +1,12 @@
-import { computed, defineComponent, ref, type CSSProperties, type PropType } from 'vue';
+import {
+  computed,
+  defineComponent,
+  onMounted,
+  ref,
+  watch,
+  type CSSProperties,
+  type PropType,
+} from 'vue';
 import type { TextMatch } from '@docx-editor.dev/core/contracts/editor';
 import { MaterialSymbol } from '../../components/ui/Icons';
 import { selectDocumentAbsent } from '../document-presence';
@@ -159,10 +167,20 @@ const SearchBox = defineComponent({
     autoFocus: { type: Boolean, default: undefined },
   },
   setup(props) {
+    // The find panel stays mounted (hidden or inert) so a typed query survives a close.
+    // HTML autofocus only runs on first mount, which is the closed pane — focus when
+    // the field actually becomes the visible target.
+    const inputRef = ref<HTMLInputElement | null>(null);
+    const focusIfRequested = () => {
+      if (props.autoFocus) inputRef.value?.focus();
+    };
+    onMounted(focusIfRequested);
+    watch(() => props.autoFocus, focusIfRequested, { flush: 'post' });
     return () => (
       <div class="docx-nav__searchbox">
         <MaterialSymbol name="search" size={18} className="docx-nav__search-icon" />
         <input
+          ref={inputRef}
           type="search"
           class="docx-nav__search-input"
           value={props.value}
@@ -294,6 +312,7 @@ export const NavigationFind = defineComponent({
     const { pane, search, t } = useNavigationContext('Find');
     return () => {
       const hidden = pane.tab.value !== 'find';
+      const autoFocus = pane.open.value && !hidden;
       const hasQuery = search.query.value.trim().length > 0;
       const counter =
         search.matches.value.length === 0
@@ -330,6 +349,7 @@ export const NavigationFind = defineComponent({
             placeholder={t('navigation.find.placeholder')}
             label={t('navigation.find.inputAriaLabel')}
             clearLabel={t('navigation.find.clearAriaLabel')}
+            autoFocus={autoFocus}
           />
           <div
             class="docx-nav__options"

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -17,6 +17,7 @@ import type {
 import type { Translations } from '@docx-editor.dev/i18n';
 import type { DocxEditorMenuProps } from './editor/menu';
 import type { DocxEditorContextMenuProps } from './editor/contextmenu';
+import type { DocxEditorNavigationProps } from './editor/navigation';
 
 export { EditorFontError } from '@docx-editor.dev/core/contracts/editor';
 export type {
@@ -41,7 +42,7 @@ export interface DocxEditorProps {
   menu?: boolean | DocxEditorMenuProps;
   hyperlinkPopup?: boolean;
   contextMenu?: boolean | DocxEditorContextMenuProps;
-  navigation?: boolean;
+  navigation?: boolean | DocxEditorNavigationProps;
   rulers?: boolean;
   document?: DocumentSource;
   /** Live host mode. */

--- a/packages/vue/test/runtime-audit.test.ts
+++ b/packages/vue/test/runtime-audit.test.ts
@@ -187,6 +187,56 @@ describe('controlled navigation props', () => {
     app.unmount();
     container.remove();
   });
+
+  test('the find input is focused when the find tab is shown', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const app = createApp({
+      render: () =>
+        h(
+          DocxEditorRoot,
+          { document: SOURCE },
+          {
+            default: () =>
+              h(DocxEditorNavigation, {
+                open: true,
+                tab: 'find',
+              }),
+          }
+        ),
+    });
+    app.mount(container);
+    await flush();
+    expect(document.activeElement).toBe(
+      container.querySelector('#docx-nav-panel-find .docx-nav__search-input')
+    );
+    app.unmount();
+    container.remove();
+  });
+
+  test('switching to the find tab focuses the query input', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const app = createApp({
+      render: () =>
+        h(
+          DocxEditorRoot,
+          { document: SOURCE },
+          {
+            default: () => h(DocxEditorNavigation, { open: true }),
+          }
+        ),
+    });
+    app.mount(container);
+    await flush();
+    const input = container.querySelector('#docx-nav-panel-find .docx-nav__search-input');
+    expect(document.activeElement).not.toBe(input);
+    (container.querySelector('#docx-nav-tab-find') as HTMLButtonElement).click();
+    await flush();
+    expect(document.activeElement).toBe(input);
+    app.unmount();
+    container.remove();
+  });
 });
 
 describe('useDocxSource stale clearing', () => {

--- a/packages/vue/test/sugar-host.test.ts
+++ b/packages/vue/test/sugar-host.test.ts
@@ -303,6 +303,30 @@ describe('DocxEditorNavigation composition', () => {
     expect(view.container.querySelector('.docx-nav')).not.toBeNull();
     view.unmount();
   });
+
+  test('`<DocxEditor navigation={{...}}>` forwards pane props instead of forcing navigation={false}', async () => {
+    const seen: boolean[] = [];
+    const view = await mountSugarAsync({
+      navigation: { open: false, onOpenChange: (next: boolean) => seen.push(next), tab: 'find' },
+    });
+    await view.flush();
+    expect(view.container.querySelector('.docx-nav')).not.toBeNull();
+    expect(view.container.querySelector('.docx-nav')?.getAttribute('data-open')).toBe('false');
+    expect(view.container.querySelector('#docx-nav-tab-find')?.getAttribute('aria-selected')).toBe(
+      'true'
+    );
+    (view.container.querySelector('.docx-nav__toggle') as HTMLButtonElement).click();
+    expect(seen).toEqual([true]);
+    expect(view.container.querySelector('.docx-nav')?.getAttribute('data-open')).toBe('false');
+    view.unmount();
+  });
+
+  test('navigation={false} removes the packaged pane', async () => {
+    const view = await mountSugarAsync({ navigation: false });
+    await view.flush();
+    expect(view.container.querySelector('.docx-nav')).toBeNull();
+    view.unmount();
+  });
 });
 
 describe('DocxEditorLoading composition', () => {


### PR DESCRIPTION
## Summary
- Allow `navigation` on `<DocxEditor>` to take `boolean | DocxEditorNavigationProps`, matching the existing `menu` and `contextMenu` object passthrough.
- Autofocus the find input when the Find tab becomes visible.

## Motivation
Hosts that embed the editor in custom shells — compact or embedded layouts, mobile webviews, keyboard-first and command-palette flows — need programmatic control of the pane: deep-link into Find, or toggle it from host chrome. Autofocus is keyboard accessibility. Controlled `open`/`tab` already existed on `DocxEditor.Navigation` and `useNavigationPane`; this wires the same props through the packaged host.

## Test plan
- [x] React navigation pane tests (object passthrough, `navigation={false}`, find autofocus on show and on tab switch)
- [x] Vue sugar-host and runtime-audit navigation tests
- [x] Typecheck `@docx-editor.dev/react` and `@docx-editor.dev/vue`
- [x] `api:check` for react and vue after regenerating API reports
- [x] Build affected packages (`core`, `react`, `vue`)


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791716774&installation_model_id=422592&pr_number=800&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F800&signature=33f2b8883ef87c791183a003e59231c81a8abb4aa917814c3021b2f12ed92841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->