### PR TITLE
fix: dismiss content control menus on outside press

### DIFF
--- a/.changeset/cc-menu-dismiss.md
+++ b/.changeset/cc-menu-dismiss.md
@@ -1,0 +1,5 @@
+---
+'@docx-editor.dev/core': patch
+---
+
+Dismiss content-control dropdown and date menus on outside press or Escape; re-pressing the widget toggles the menu shut.

--- a/docs/site/content/guides/content-controls.mdx
+++ b/docs/site/content/guides/content-controls.mdx
@@ -247,9 +247,10 @@ the reason.
 ## Checkbox, dropdown, and date interactions
 
 Select the button at the upper-right corner of a control to toggle a checkbox,
-open a dropdown menu, or open a date picker. Each edit supports undo and requires
-no application event handler. Checkbox toggles use MS Gothic when the document
-omits the state font.
+open a dropdown menu, or open a date picker. A menu closes when you press outside
+it, press the control button again, or press Escape. Each edit supports undo and
+requires no application event handler. Checkbox toggles use MS Gothic when the
+document omits the state font.
 
 These interactions apply to content controls. For legacy Word form fields, see
 [Legacy text form fields](/docs/2.x/guides/fields#legacy-text-form-fields).

--- a/packages/core/src/editor/__tests__/content-control-surface.test.ts
+++ b/packages/core/src/editor/__tests__/content-control-surface.test.ts
@@ -236,10 +236,59 @@ describe('content-control surface chrome', () => {
           beforeTitle
         );
         expect(menu!.querySelector('.docx-content-control-calendar-input')).not.toBeNull();
-        document.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+        document.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
         expect(menu!.isConnected).toBe(false);
       }
     }
+  });
+
+  test('widget menus dismiss on outside press, Escape, and widget re-press', () => {
+    const body =
+      `<w:p>${sdt(
+        `<w:dropDownList><w:listItem w:displayText="One" w:value="1"/>` +
+          `<w:listItem w:displayText="Two" w:value="2"/></w:dropDownList>`,
+        `<w:r><w:t>One</w:t></w:r>`
+      )}</w:p>` +
+      `<w:p>${sdt(
+        `<w:dropDownList><w:listItem w:displayText="A" w:value="a"/></w:dropDownList>`,
+        `<w:r><w:t>A</w:t></w:r>`
+      )}</w:p>`;
+    const { container } = mount(body);
+    const widgets = [...container.querySelectorAll<HTMLElement>('[data-docx-cc-widget]')];
+    expect(widgets).toHaveLength(2);
+    const press = (node: EventTarget): void => {
+      node.dispatchEvent(
+        new PointerEvent('pointerdown', { bubbles: true, cancelable: true, button: 0 })
+      );
+    };
+    const menu = (): HTMLElement | null =>
+      container.querySelector<HTMLElement>('.docx-content-control-menu');
+
+    // An outside press dismisses without picking a value. `pointerdown`, not `mousedown`:
+    // the surface prevents the page press default, which suppresses the compatibility
+    // mouse events a `mousedown` listener would wait for.
+    press(widgets[0]!);
+    expect(menu()).not.toBeNull();
+    document.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+    expect(menu()).toBeNull();
+    expect(container.querySelector('.docx-page-content')?.textContent).toContain('One');
+
+    // Escape dismisses without picking a value.
+    press(widgets[0]!);
+    expect(menu()).not.toBeNull();
+    document.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'Escape' }));
+    expect(menu()).toBeNull();
+
+    // Re-pressing the owning widget toggles the menu shut.
+    press(widgets[0]!);
+    expect(menu()).not.toBeNull();
+    press(widgets[0]!);
+    expect(menu()).toBeNull();
+
+    // Pressing another widget switches menus.
+    press(widgets[0]!);
+    press(widgets[1]!);
+    expect(menu()?.textContent).toContain('A');
   });
 
   test('manual calendar entry commits an ISO date', () => {

--- a/packages/core/src/editor/paginated-surface.ts
+++ b/packages/core/src/editor/paginated-surface.ts
@@ -2208,9 +2208,52 @@ export function mountPaginatedSurface(
     if (controlId) setContentControlWidgetOpen(controlId, false);
   }
 
-  function removeExistingContentControlMenu(): void {
+  function removeExistingContentControlMenu(): HTMLElement | null {
     const existing = pagesLayer.querySelector<HTMLElement>('.docx-content-control-menu');
     if (existing) closeContentControlMenu(existing);
+    return existing;
+  }
+
+  /**
+   * Dismiss a widget menu on an outside press or Escape.
+   *
+   * `pointerdown`, not `mousedown`: the surface prevents the default on every page press,
+   * which suppresses the compatibility `mousedown` — a `mousedown` listener never fires for
+   * document clicks and the menu stands. The opening press cannot self-dismiss: it already
+   * passed document capture before this attached. A press on the owning widget is left for
+   * the opener, which toggles instead. Stale listeners (the menu closed through a commit)
+   * clean up silently so a later Escape still reaches the rest of the UI.
+   */
+  function armContentControlMenuDismiss(menu: HTMLElement, onOutsidePress: () => void): void {
+    const controlId = menu.dataset.docxCcId;
+    const cleanup = (): void => {
+      document.removeEventListener('pointerdown', onOutside, true);
+      document.removeEventListener('keydown', onKey, true);
+    };
+    const onOutside = (event: Event): void => {
+      if (menu.parentNode === null) {
+        cleanup();
+        return;
+      }
+      const target = event.target as Element | null;
+      const widget = target instanceof Element ? target.closest('[data-docx-cc-widget]') : null;
+      if (
+        target &&
+        (menu.contains(target) || widget?.getAttribute('data-docx-cc-id') === controlId)
+      )
+        return;
+      cleanup();
+      onOutsidePress();
+    };
+    const onKey = (event: KeyboardEvent): void => {
+      if (event.key !== 'Escape') return;
+      cleanup();
+      if (menu.parentNode === null) return;
+      event.stopPropagation();
+      closeContentControlMenu(menu);
+    };
+    document.addEventListener('pointerdown', onOutside, true);
+    document.addEventListener('keydown', onKey, true);
   }
 
   /**
@@ -2282,7 +2325,8 @@ export function mountPaginatedSurface(
       const items = listItemsOfControl(controlId);
       if (items.length === 0 && kind === 'dropdown') return;
       // Engine-level menu: no hardcoded English — displayText comes from the file.
-      removeExistingContentControlMenu();
+      // Re-pressing the owning widget toggles shut instead of reopening.
+      if (removeExistingContentControlMenu()?.dataset.docxCcId === controlId) return;
       const menu = document.createElement('div');
       menu.className = 'docx-content-control-menu';
       menu.dataset.docxMarker = '';
@@ -2339,16 +2383,11 @@ export function mountPaginatedSurface(
       }
       pagesLayer.append(menu);
       setContentControlWidgetOpen(controlId, true);
-      const dismiss = (event: Event): void => {
-        if (menu.contains(event.target as Node)) return;
-        closeContentControlMenu(menu);
-        document.removeEventListener('mousedown', dismiss, true);
-      };
-      document.addEventListener('mousedown', dismiss, true);
+      armContentControlMenuDismiss(menu, () => closeContentControlMenu(menu));
       return;
     }
     if (kind === 'date') {
-      removeExistingContentControlMenu();
+      if (removeExistingContentControlMenu()?.dataset.docxCcId === controlId) return;
       const menu = document.createElement('div');
       menu.className = 'docx-content-control-menu';
       menu.dataset.docxMarker = '';
@@ -2500,12 +2539,9 @@ export function mountPaginatedSurface(
       renderCalendar();
       pagesLayer.append(menu);
       setContentControlWidgetOpen(controlId, true);
-      const dismiss = (event: Event): void => {
-        if (menu.contains(event.target as Node)) return;
+      armContentControlMenuDismiss(menu, () => {
         if (!commitPendingManualDate?.()) closeContentControlMenu(menu);
-        document.removeEventListener('mousedown', dismiss, true);
-      };
-      document.addEventListener('mousedown', dismiss, true);
+      });
       menu
         .querySelector<HTMLElement>(
           '[data-selected], [data-today], .docx-content-control-calendar-day'

--- a/scripts/check-eslint-max-lines-globs.mjs
+++ b/scripts/check-eslint-max-lines-globs.mjs
@@ -42,7 +42,7 @@ const SLACK_EXEMPT = new Map([
  * diff where a reviewer sees it, instead of the file quietly gaining a thousand lines.
  */
 const BLANKET_DISABLES = new Map([
-  ['packages/core/src/editor/paginated-surface.ts', 6271],
+  ['packages/core/src/editor/paginated-surface.ts', 6307],
   ['packages/core/src/store/store/tree-op-apply.ts', 3495],
   ['packages/core/src/output/semantic-paint.ts', 3009],
   ['packages/core/src/layout/note-pagination.ts', 2954],


### PR DESCRIPTION
## Summary

- Content control dropdown and date menus now close on outside press, on Escape, and when you press the control button again.
- The old document-capture `mousedown` dismiss never fired, because the page layer calls `preventDefault()` on every pointerdown and suppresses the compatibility mouse events. Dismiss now listens on `pointerdown` capture instead.

## Test plan

- New `content-control-surface.test.ts` case covers outside press, Escape, widget re-press toggle, and cross-widget switch.
- `bun run lint`, `bun run format`, commit hooks (typecheck, parity, api:check) all pass.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eigenpal/codesmith/docx-editor/pr/801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791718177&installation_model_id=422592&pr_number=801&repository=eigenpal%2Fdocx-editor&return_to=https%3A%2F%2Fgithub.com%2Feigenpal%2Fdocx-editor%2Fpull%2F801&signature=4a6aec3888ac57cae9fb4e2fa8b9200a9fde75811c1e9b35a98c526cf2710315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->